### PR TITLE
demo: adjust URL of the demo page

### DIFF
--- a/demo/src/app/app.component.html
+++ b/demo/src/app/app.component.html
@@ -1,7 +1,7 @@
 <header>
   <div class="container">
     <nav class="navbar navbar-light navbar-fixed-top">
-      <a class="navbar-brand" href="https://ng-bootstrap.io">
+      <a class="navbar-brand" href="https://ng-bootstrap.github.io/">
         <img class="nav-logo" src="img/ngb-logo.png"/> ng-bootstrap
       </a>
       <ul class="nav navbar-nav">


### PR DESCRIPTION
This is the very minimum we should do...

@wesleycho it looks like both https://ng-bootstrap.github.io and http://ng-bootstrap.github.io now redirects (?) to http://ng-bootstrap.io/. But since http://ng-bootstrap.io/ doesn't work with HTTPS I'm really worried about exposing http://ng-bootstrap.io/ as an address....

Maybe we should revert all the domain config for now and just promote https://ng-bootstrap.github.io till we've got things sorted out?