### PR TITLE
chore(tabset): removes capitalization for string type

### DIFF
--- a/src/tabset/tabset.ts
+++ b/src/tabset/tabset.ts
@@ -55,8 +55,8 @@ export class NgbTab {
  * The payload of the tab change event
  */
 export interface NgbTabChangeEvent {
-  activeId: String;
-  nextId: String;
+  activeId: string;
+  nextId: string;
   preventDefault();
 }
 


### PR DESCRIPTION
`String` → `string` in the tabset.ts
