### PR TITLE
chore(demo): make the demo code for alerts more straightforward

### DIFF
--- a/demo/src/app/components/alert/demos/closeable/alert-closeable.html
+++ b/demo/src/app/components/alert/demos/closeable/alert-closeable.html
@@ -1,5 +1,5 @@
 <p *ngFor="let alert of alerts">
-  <ngb-alert [type]="alert.type" (close)="closeAlert(alert.id)">{{ alert.message }}</ngb-alert>
+  <ngb-alert [type]="alert.type" (close)="closeAlert(alert)">{{ alert.message }}</ngb-alert>
 </p>
 <p>
   <button type="button" class="btn btn-primary" (click)="reset()">Reset</button>

--- a/demo/src/app/components/alert/demos/closeable/alert-closeable.ts
+++ b/demo/src/app/components/alert/demos/closeable/alert-closeable.ts
@@ -35,8 +35,8 @@ export class NgbdAlertCloseable {
     this.backup = this.alerts.map((alert: IAlert) => Object.assign({}, alert))
   }
 
-  public closeAlert(id: number) {
-    const index: number = this.alerts.findIndex((alert: IAlert) => alert.id === id);
+  public closeAlert(alert: IAlert) {
+    const index: number = this.alerts.indexOf(alert);
     this.alerts.splice(index, 1);
   }
 


### PR DESCRIPTION
The code used to close an alert passes the ID of the alert to close, which is then
searched for in the array of alerts.

This commit simplifies the code by just passing the alert itself and using `indexOf` to find the index of the alert to close.