### PR TITLE
demo: set pointer cursor on links

### DIFF
--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -181,3 +181,6 @@ section h3 {
   margin-bottom: 10px;
 }
 
+a {
+  cursor: pointer;
+}


### PR DESCRIPTION
Many components (tabs, pager, etc.) use links without any href attributes. Browsers (Chrome at least) don't set a pointer cursor by default on such links, which make them look weird and non-clikable.
This commit just adds a CSS rule in the demo to style links with a pointer cursor.