### PR TITLE
demo: add solarized light

### DIFF
--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -3,8 +3,6 @@ import {ROUTER_DIRECTIVES} from '@angular/router';
 
 import {SideNavComponent} from './shared';
 
-import 'prismjs/themes/prism-okaidia.css';
-import 'bootstrap/dist/css/bootstrap.css';
 import '../style/app.scss';
 
 @Component({

--- a/demo/src/vendor.ts
+++ b/demo/src/vendor.ts
@@ -10,3 +10,6 @@ import 'rxjs';
 
 // Other vendors for example jQuery, Lodash or Bootstrap
 // You can import js, ts, css, sass, ...
+
+import 'prismjs/themes/prism-solarizedlight.css';
+import 'bootstrap/dist/css/bootstrap.css';


### PR DESCRIPTION
This changes the demo themes from the dark one to solarized light.

Also moved the vendor CSS to the vendor bundle. Not really important for our demo but I like to keep the things clean.

Fixes #414 