### PR TITLE
chore(tooltip): refactor tooltip and popover to share common code

### DIFF
--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -3,20 +3,15 @@ import {
   Directive,
   Input,
   ChangeDetectionStrategy,
-  OnInit,
-  AfterViewChecked,
   Injector,
   Renderer,
-  ComponentRef,
   ElementRef,
   TemplateRef,
   ViewContainerRef,
-  ComponentFactoryResolver,
-  ComponentFactory
+  ComponentFactoryResolver
 } from '@angular/core';
 
-import {parseTriggers, Trigger} from '../util/triggers';
-import {Positioning} from '../util/positioning';
+import {ITooltipWindow, NgbAbstractTooltip} from '../tooltip/abstract-tooltip';
 
 @Component({
   selector: 'ngb-popover-window',
@@ -27,7 +22,7 @@ import {Positioning} from '../util/positioning';
     <h3 class="popover-title">{{title}}</h3><div class="popover-content"><ng-content></ng-content></div>
     `
 })
-export class NgbPopoverWindow {
+export class NgbPopoverWindow implements ITooltipWindow {
   @Input() placement: string = 'top';
   @Input() title: string;
 }
@@ -36,7 +31,7 @@ export class NgbPopoverWindow {
  * A lightweight, extensible directive for fancy popover creation.
  */
 @Directive({selector: '[ngbPopover]', exportAs: 'ngbPopover'})
-export class NgbPopover implements OnInit, AfterViewChecked {
+export class NgbPopover extends NgbAbstractTooltip<NgbPopoverWindow> {
   /**
    * Content to be displayed as popover.
    */
@@ -54,75 +49,19 @@ export class NgbPopover implements OnInit, AfterViewChecked {
    */
   @Input() triggers = 'click';
 
-  private _positioning = new Positioning();
-  private _windowFactory: ComponentFactory<NgbPopoverWindow>;
-  private _windowRef: ComponentRef<NgbPopoverWindow>;
-
   constructor(
-      private _elementRef: ElementRef, private _viewContainerRef: ViewContainerRef, private _injector: Injector,
-      private _renderer: Renderer, componentFactoryResolver: ComponentFactoryResolver) {
-    this._windowFactory = componentFactoryResolver.resolveComponentFactory(NgbPopoverWindow);
+      elementRef: ElementRef, viewContainerRef: ViewContainerRef, injector: Injector, renderer: Renderer,
+      componentFactoryResolver: ComponentFactoryResolver) {
+    super(elementRef, viewContainerRef, injector, renderer, componentFactoryResolver, NgbPopoverWindow);
   }
 
-  open() {
-    if (!this._windowRef) {
-      const nodes = this._getContentNodes();
-      this._windowRef = this._viewContainerRef.createComponent(this._windowFactory, 0, this._injector, nodes);
-      this._windowRef.instance.placement = this.placement;
-      this._windowRef.instance.title = this.title;
-    }
-  }
+  protected customizeWindowRefInstance(window: NgbPopoverWindow) { window.title = this.title; }
 
-  close(): void {
-    if (this._windowRef) {
-      this._viewContainerRef.remove(this._viewContainerRef.indexOf(this._windowRef.hostView));
-      this._windowRef = null;
-    }
-  }
+  protected getTooltipInput(): string | TemplateRef<any> { return this.ngbPopover; }
 
-  toggle(): void {
-    if (this._windowRef) {
-      this.close();
-    } else {
-      this.open();
-    }
-  }
+  protected getPlacementInput(): string { return this.placement; }
 
-  ngOnInit() {
-    const triggers = parseTriggers(this.triggers);
-
-    if (triggers.length === 1 && triggers[0].isManual()) {
-      return;
-    }
-
-    triggers.forEach((trigger: Trigger) => {
-      if (trigger.open === trigger.close) {
-        this._renderer.listen(this._elementRef.nativeElement, trigger.open, () => { this.toggle(); });
-      } else {
-        this._renderer.listen(this._elementRef.nativeElement, trigger.open, () => { this.open(); });
-        this._renderer.listen(this._elementRef.nativeElement, trigger.close, () => { this.close(); });
-      }
-    });
-  }
-
-  ngAfterViewChecked() {
-    if (this._windowRef) {
-      const targetPosition = this._positioning.positionElements(
-          this._elementRef.nativeElement, this._windowRef.location.nativeElement, this.placement, false);
-
-      const targetStyle = this._windowRef.location.nativeElement.style;
-      targetStyle.top = `${targetPosition.top}px`;
-      targetStyle.left = `${targetPosition.left}px`;
-    }
-  }
-
-  private _getContentNodes() {
-    if (this.ngbPopover instanceof TemplateRef) {
-      return [this._viewContainerRef.createEmbeddedView(<TemplateRef<NgbPopoverWindow>>this.ngbPopover).rootNodes];
-    } else {
-      return [[this._renderer.createText(null, `${this.ngbPopover}`)]];
-    }
-  }
+  protected getTriggersInput(): string { return this.triggers; }
 }
 
 export const NGB_POPOVER_DIRECTIVES = [NgbPopover];

--- a/src/tooltip/abstract-tooltip.ts
+++ b/src/tooltip/abstract-tooltip.ts
@@ -1,0 +1,122 @@
+import {
+  OnInit,
+  AfterViewChecked,
+  Injector,
+  Renderer,
+  ComponentRef,
+  ElementRef,
+  TemplateRef,
+  ViewContainerRef,
+  ComponentFactoryResolver,
+  ComponentFactory
+} from '@angular/core';
+
+import {parseTriggers, Trigger} from '../util/triggers';
+import {Positioning} from '../util/positioning';
+
+/**
+ * The interface that concrete tooltip-like window components must implement
+ */
+export interface ITooltipWindow { placement: string; }
+
+/**
+ * Base abstract class for tooltip-like components (i.e. tooltip and popover)
+ */
+export abstract class NgbAbstractTooltip<W extends ITooltipWindow> implements OnInit, AfterViewChecked {
+  private _positioning = new Positioning();
+  private _windowFactory: ComponentFactory<W>;
+  private _windowRef: ComponentRef<W>;
+
+  constructor(
+      private _elementRef: ElementRef, private _viewContainerRef: ViewContainerRef, private _injector: Injector,
+      /* tslint:disable because tslint rule contradicts clang rule regarding white space after `W;` */
+      private _renderer: Renderer, componentFactoryResolver: ComponentFactoryResolver, windowType: {new (): W;}) {
+    /* tslint:enable */
+    this._windowFactory = componentFactoryResolver.resolveComponentFactory(windowType);
+  }
+
+  open() {
+    if (!this._windowRef) {
+      const nodes = this._getContentNodes();
+      this._windowRef = this._viewContainerRef.createComponent(this._windowFactory, 0, this._injector, nodes);
+      this._windowRef.instance.placement = this.getPlacementInput();
+      this.customizeWindowRefInstance(this._windowRef.instance);
+    }
+  }
+
+  /**
+   * allows subclasses to customize the window instance after its placement has been set.
+   * Does nothing by default.
+   * @param window the window to customize
+   */
+  protected customizeWindowRefInstance(window: W) {
+    // nothing to do
+  }
+
+  close(): void {
+    if (this._windowRef) {
+      this._viewContainerRef.remove(this._viewContainerRef.indexOf(this._windowRef.hostView));
+      this._windowRef = null;
+    }
+  }
+
+  toggle(): void {
+    if (this._windowRef) {
+      this.close();
+    } else {
+      this.open();
+    }
+  }
+
+  ngOnInit() {
+    const triggers = parseTriggers(this.getTriggersInput());
+
+    if (triggers.length === 1 && triggers[0].isManual()) {
+      return;
+    }
+
+    triggers.forEach((trigger: Trigger) => {
+      if (trigger.open === trigger.close) {
+        this._renderer.listen(this._elementRef.nativeElement, trigger.open, () => { this.toggle(); });
+      } else {
+        this._renderer.listen(this._elementRef.nativeElement, trigger.open, () => { this.open(); });
+        this._renderer.listen(this._elementRef.nativeElement, trigger.close, () => { this.close(); });
+      }
+    });
+  }
+
+  ngAfterViewChecked() {
+    if (this._windowRef) {
+      const targetPosition = this._positioning.positionElements(
+          this._elementRef.nativeElement, this._windowRef.location.nativeElement, this.getPlacementInput(), false);
+
+      const targetStyle = this._windowRef.location.nativeElement.style;
+      targetStyle.top = `${targetPosition.top}px`;
+      targetStyle.left = `${targetPosition.left}px`;
+    }
+  }
+
+  /**
+   * Returns the value of the input containing the text or template to display
+   */
+  protected abstract getTooltipInput(): string | TemplateRef<any>;
+
+  /**
+   * Returns the value of the input containing the placement
+   */
+  protected abstract getPlacementInput(): string;
+
+  /**
+   * Returns the value of the input containing the triggers
+   */
+  protected abstract getTriggersInput(): string;
+
+  private _getContentNodes() {
+    const tooltipInput = this.getTooltipInput();
+    if (tooltipInput instanceof TemplateRef) {
+      return [this._viewContainerRef.createEmbeddedView(<TemplateRef<W>>tooltipInput).rootNodes];
+    } else {
+      return [[this._renderer.createText(null, `${tooltipInput}`)]];
+    }
+  }
+}


### PR DESCRIPTION
I haven't touched the unit tests at all. That at least proves that the refactoring doesn't break existing tests, but work still needs to be done in order to cut the repetitions. I have no clear idea how to modify them to reduce repetitions without making them hard to understand, though.

Notes regarding the implementation:
 - I had to disabled tslint on one line of code because it contradicts with clang-format, making it impossible to build without one of them complaining
 - My initial idea was to declare the common `@Input` fields in the abstract base class (and use an abstract class instead of an interface for ITooltipWindow), but that doesn't work. Decorators seem to be ignored if they are in the base class. Hence the need to declare them in the subclasses and provide `getXxxInput()` methods to make them available for the base class methods.
 - if you find a better name for the common base class and interface, please suggest
 - I wasn't sure where to put the common classes, so I created a separate file in tooltip, but if you think that should go in util or somewhere else, please say.