### PR TITLE
demo: change the demo theme to the default one

### DIFF
--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -3,8 +3,6 @@ import {ROUTER_DIRECTIVES} from '@angular/router';
 
 import {SideNavComponent} from './shared';
 
-import 'prismjs/themes/prism-okaidia.css';
-import 'bootstrap/dist/css/bootstrap.css';
 import '../style/app.scss';
 
 @Component({

--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -181,3 +181,8 @@ section h3 {
   margin-bottom: 10px;
 }
 
+// override prism theme background color to inline it with bootstrap colors
+code[class*="language-"],
+pre[class*="language-"] {
+  background-color: #f5f5f5; // same as bootstrap card header
+}

--- a/demo/src/vendor.ts
+++ b/demo/src/vendor.ts
@@ -10,3 +10,6 @@ import 'rxjs';
 
 // Other vendors for example jQuery, Lodash or Bootstrap
 // You can import js, ts, css, sass, ...
+
+import 'prismjs/themes/prism.css';
+import 'bootstrap/dist/css/bootstrap.css';


### PR DESCRIPTION
This changes the demo theme from the dark one to the default one, and sets the background to the same color as the bootstrap card header, to make it look more integrated with bootstrap.

Also moved the vendor CSS to the vendor bundle. Not really important for our demo but I like to keep the things clean.

Fixes #414