### PR TITLE
Fix memory leak from un-removed event listeners

### DIFF
--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -5,6 +5,7 @@ import {
   ChangeDetectionStrategy,
   OnInit,
   AfterViewChecked,
+  OnDestroy,
   Injector,
   Renderer,
   ComponentRef,
@@ -36,7 +37,7 @@ export class NgbPopoverWindow {
  * A lightweight, extensible directive for fancy popover creation.
  */
 @Directive({selector: '[ngbPopover]', exportAs: 'ngbPopover'})
-export class NgbPopover implements OnInit, AfterViewChecked {
+export class NgbPopover implements OnInit, AfterViewChecked, OnDestroy {
   /**
    * Content to be displayed as popover.
    */
@@ -57,6 +58,7 @@ export class NgbPopover implements OnInit, AfterViewChecked {
   private _popupService: PopupService<NgbPopoverWindow>;
   private _positioning = new Positioning();
   private _windowRef: ComponentRef<NgbPopoverWindow>;
+  private _listeners = [];
 
   constructor(
       private _elementRef: ElementRef, private _renderer: Renderer, injector: Injector,
@@ -93,10 +95,14 @@ export class NgbPopover implements OnInit, AfterViewChecked {
 
     triggers.forEach((trigger: Trigger) => {
       if (trigger.open === trigger.close) {
-        this._renderer.listen(this._elementRef.nativeElement, trigger.open, () => { this.toggle(); });
+        this._listeners.push(
+          this._renderer.listen(this._elementRef.nativeElement, trigger.open, this.toggle.bind(this))
+        );
       } else {
-        this._renderer.listen(this._elementRef.nativeElement, trigger.open, () => { this.open(); });
-        this._renderer.listen(this._elementRef.nativeElement, trigger.close, () => { this.close(); });
+        this._listeners.push(
+          this._renderer.listen(this._elementRef.nativeElement, trigger.open, this.open.bind(this)),
+          this._renderer.listen(this._elementRef.nativeElement, trigger.close, this.close.bind(this))
+        );
       }
     });
   }
@@ -110,6 +116,10 @@ export class NgbPopover implements OnInit, AfterViewChecked {
       targetStyle.top = `${targetPosition.top}px`;
       targetStyle.left = `${targetPosition.left}px`;
     }
+  }
+
+  ngOnDestroy() {
+    this._listeners.forEach(unsubscribe => unsubscribe());
   }
 }
 

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -96,13 +96,11 @@ export class NgbPopover implements OnInit, AfterViewChecked, OnDestroy {
     triggers.forEach((trigger: Trigger) => {
       if (trigger.open === trigger.close) {
         this._listeners.push(
-          this._renderer.listen(this._elementRef.nativeElement, trigger.open, this.toggle.bind(this))
-        );
+            this._renderer.listen(this._elementRef.nativeElement, trigger.open, this.toggle.bind(this)));
       } else {
         this._listeners.push(
-          this._renderer.listen(this._elementRef.nativeElement, trigger.open, this.open.bind(this)),
-          this._renderer.listen(this._elementRef.nativeElement, trigger.close, this.close.bind(this))
-        );
+            this._renderer.listen(this._elementRef.nativeElement, trigger.open, this.open.bind(this)),
+            this._renderer.listen(this._elementRef.nativeElement, trigger.close, this.close.bind(this)));
       }
     });
   }
@@ -118,9 +116,7 @@ export class NgbPopover implements OnInit, AfterViewChecked, OnDestroy {
     }
   }
 
-  ngOnDestroy() {
-    this._listeners.forEach(unsubscribe => unsubscribe());
-  }
+  ngOnDestroy() { this._listeners.forEach(unsubscribe => unsubscribe()); }
 }
 
 export const NGB_POPOVER_DIRECTIVES = [NgbPopover];

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -5,6 +5,7 @@ import {
   ChangeDetectionStrategy,
   OnInit,
   AfterViewChecked,
+  OnDestroy,
   Injector,
   Renderer,
   ComponentRef,
@@ -35,7 +36,7 @@ export class NgbTooltipWindow {
  * A lightweight, extensible directive for fancy tooltip creation.
  */
 @Directive({selector: '[ngbTooltip]', exportAs: 'ngbTooltip'})
-export class NgbTooltip implements OnInit, AfterViewChecked {
+export class NgbTooltip implements OnInit, AfterViewChecked, OnDestroy {
   /**
    * Content to be displayed as tooltip.
    */
@@ -52,6 +53,7 @@ export class NgbTooltip implements OnInit, AfterViewChecked {
   private _popupService: PopupService<NgbTooltipWindow>;
   private _positioning = new Positioning();
   private _windowRef: ComponentRef<NgbTooltipWindow>;
+  private _listeners = [];
 
   constructor(
       private _elementRef: ElementRef, private _renderer: Renderer, injector: Injector,
@@ -86,10 +88,14 @@ export class NgbTooltip implements OnInit, AfterViewChecked {
 
     triggers.forEach((trigger: Trigger) => {
       if (trigger.open === trigger.close) {
-        this._renderer.listen(this._elementRef.nativeElement, trigger.open, () => { this.toggle(); });
+        this._listeners.push(
+          this._renderer.listen(this._elementRef.nativeElement, trigger.open, this.toggle.bind(this))
+        );
       } else {
-        this._renderer.listen(this._elementRef.nativeElement, trigger.open, () => { this.open(); });
-        this._renderer.listen(this._elementRef.nativeElement, trigger.close, () => { this.close(); });
+        this._listeners.push(
+          this._renderer.listen(this._elementRef.nativeElement, trigger.open, this.open.bind(this)),
+          this._renderer.listen(this._elementRef.nativeElement, trigger.close, this.close.bind(this))
+        );
       }
     });
   }
@@ -103,6 +109,10 @@ export class NgbTooltip implements OnInit, AfterViewChecked {
       targetStyle.top = `${targetPosition.top}px`;
       targetStyle.left = `${targetPosition.left}px`;
     }
+  }
+
+  ngOnDestroy() {
+    this._listeners.forEach(unsubscribe => unsubscribe());
   }
 }
 

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -89,13 +89,11 @@ export class NgbTooltip implements OnInit, AfterViewChecked, OnDestroy {
     triggers.forEach((trigger: Trigger) => {
       if (trigger.open === trigger.close) {
         this._listeners.push(
-          this._renderer.listen(this._elementRef.nativeElement, trigger.open, this.toggle.bind(this))
-        );
+            this._renderer.listen(this._elementRef.nativeElement, trigger.open, this.toggle.bind(this)));
       } else {
         this._listeners.push(
-          this._renderer.listen(this._elementRef.nativeElement, trigger.open, this.open.bind(this)),
-          this._renderer.listen(this._elementRef.nativeElement, trigger.close, this.close.bind(this))
-        );
+            this._renderer.listen(this._elementRef.nativeElement, trigger.open, this.open.bind(this)),
+            this._renderer.listen(this._elementRef.nativeElement, trigger.close, this.close.bind(this)));
       }
     });
   }
@@ -111,9 +109,7 @@ export class NgbTooltip implements OnInit, AfterViewChecked, OnDestroy {
     }
   }
 
-  ngOnDestroy() {
-    this._listeners.forEach(unsubscribe => unsubscribe());
-  }
+  ngOnDestroy() { this._listeners.forEach(unsubscribe => unsubscribe()); }
 }
 
 export const NGB_TOOLTIP_DIRECTIVES = [NgbTooltip];


### PR DESCRIPTION
[Renderer](https://angular.io/docs/ts/latest/api/core/index/Renderer-class.html).listen / .listenGlobal returns a function that you need to call in order to remove the attached event listener.

