### PR TITLE
feat(typeahead): custom value accessor with optional formatting

### DIFF
--- a/src/typeahead/typeahead-valueaccessor.spec.ts
+++ b/src/typeahead/typeahead-valueaccessor.spec.ts
@@ -1,0 +1,61 @@
+import {inject, async} from '@angular/core/testing';
+import {TestComponentBuilder} from '@angular/compiler/testing';
+import {Component} from '@angular/core';
+import {NgbTypeaheadValueAccessor} from './typeahead-valueaccessor';
+
+
+function expectInputValue(element: HTMLElement, value: string) {
+  expect((<HTMLInputElement>element.querySelector('input')).value).toBe(value);
+}
+
+describe('ngb-typeahead-valueaccessor', () => {
+
+  it('should format values when no formatter provided', async(inject([TestComponentBuilder], (tcb) => {
+       const html = '<input [(ngModel)]="model" ngbTypeahead />';
+
+       tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
+         fixture.detectChanges();
+         const el = fixture.nativeElement;
+         const comp = fixture.componentInstance;
+         expectInputValue(el, '');
+
+         comp.model = 'text';
+         fixture.detectChanges();
+         expectInputValue(el, 'text');
+
+         comp.model = null;
+         fixture.detectChanges();
+         expectInputValue(el, '');
+
+         comp.model = {};
+         fixture.detectChanges();
+         expectInputValue(el, '[object Object]');
+       });
+     })));
+
+  it('should format values with custom formatter provided', async(inject([TestComponentBuilder], (tcb) => {
+       const html = '<input [(ngModel)]="model" ngbTypeahead [inputFormatter]="formatter"/>';
+
+       tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
+         fixture.detectChanges();
+         const el = fixture.nativeElement;
+         const comp = fixture.componentInstance;
+         expectInputValue(el, '');
+
+         comp.model = null;
+         fixture.detectChanges();
+         expectInputValue(el, '');
+
+         comp.model = {value: 'text'};
+         fixture.detectChanges();
+         expectInputValue(el, 'TEXT');
+       });
+     })));
+});
+
+@Component({selector: 'test-cmp', directives: [NgbTypeaheadValueAccessor], template: ''})
+class TestComponent {
+  model = '';
+
+  formatter = (result: {value: string}) => { return result.value.toUpperCase(); };
+}

--- a/src/typeahead/typeahead-valueaccessor.ts
+++ b/src/typeahead/typeahead-valueaccessor.ts
@@ -1,0 +1,39 @@
+import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/common';
+import {forwardRef, Directive, Input, ElementRef, Renderer} from '@angular/core';
+
+const NGB_TYPEAHEAD_VALUE_ACCESSOR = {
+  provide: NG_VALUE_ACCESSOR,
+  useExisting: forwardRef(() => NgbTypeaheadValueAccessor),
+  multi: true
+};
+
+/**
+ * Typeahead value accessor that knows how to convert ngModel to string to display in the input field
+ */
+@Directive({selector: 'input[ngbTypeahead][ngModel]', providers: [NGB_TYPEAHEAD_VALUE_ACCESSOR]})
+export class NgbTypeaheadValueAccessor implements ControlValueAccessor {
+  /**
+   * A function to convert a given value into string to display in the input field
+   */
+  @Input() inputFormatter: (value) => string;
+
+  constructor(private _elementRef: ElementRef, private _renderer: Renderer) {}
+
+  onChange = (_: any) => {};
+  onTouched = () => {};
+
+  registerOnChange(fn: (value: any) => any): void { this.onChange = fn; }
+
+  registerOnTouched(fn: () => any): void { this.onTouched = fn; }
+
+  writeValue(value) {
+    if (!value) {
+      value = '';
+    } else if (this.inputFormatter) {
+      value = this.inputFormatter(value);
+    } else {
+      value = `${value}`;
+    }
+    this._renderer.setElementProperty(this._elementRef.nativeElement, 'value', value);
+  }
+}


### PR DESCRIPTION
Custom value value accessor for the future `typeahead` component

- bypasses `string` values as is
- accepts optional `inputFormatter` function that does `object` -> `string` conversion

