### PR TITLE
fix(popup): makes popup content optional

### DIFF
--- a/src/util/popup.ts
+++ b/src/util/popup.ts
@@ -18,7 +18,7 @@ export class PopupService<T> {
     this._windowFactory = componentFactoryResolver.resolveComponentFactory<T>(type);
   }
 
-  open(content: string | TemplateRef<any>): ComponentRef<T> {
+  open(content?: string | TemplateRef<any>): ComponentRef<T> {
     if (!this._windowRef) {
       const nodes = this._getContentNodes(content);
       this._windowRef = this._viewContainerRef.createComponent(this._windowFactory, 0, this._injector, nodes);
@@ -35,7 +35,9 @@ export class PopupService<T> {
   }
 
   private _getContentNodes(content: string | TemplateRef<any>) {
-    if (content instanceof TemplateRef) {
+    if (!content) {
+      return [];
+    } else if (content instanceof TemplateRef) {
       return [this._viewContainerRef.createEmbeddedView(<TemplateRef<T>>content).rootNodes];
     } else {
       return [[this._renderer.createText(null, `${content}`)]];


### PR DESCRIPTION
Does what it says in the title; ex. `typeahead-window` will not have any `<ng-content>`