### PR TITLE
chore: fix build (missing NgbTypeahead import)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import {NgbRating, NGB_RATING_DIRECTIVES} from './rating/rating';
 import {NgbTabset, NgbTab, NgbTabContent, NgbTabTitle, NgbTabChangeEvent, NGB_TABSET_DIRECTIVES} from './tabset/tabset';
 import {NgbTimepicker, NGB_TIMEPICKER_DIRECTIVES} from './timepicker/timepicker';
 import {NgbTooltip, NgbTooltipWindow, NGB_TOOLTIP_DIRECTIVES} from './tooltip/tooltip';
-import {NGB_TYPEAHEAD_DIRECTIVES} from './typeahead/typeahead';
+import {NgbTypeahead, NGB_TYPEAHEAD_DIRECTIVES} from './typeahead/typeahead';
 import {NgbTypeaheadWindow} from './typeahead/typeahead-window';
 import {NgbPopover, NgbPopoverWindow, NGB_POPOVER_DIRECTIVES} from './popover/popover';
 import {NgbRadioGroup, NgbRadioLabel, NgbRadio, NGB_RADIO_DIRECTIVES} from './buttons/radio';


### PR DESCRIPTION
Build is currently failing with the following error:
```
src/index.ts(48,14): error TS4023: Exported variable 'NGB_DIRECTIVES' has or is using name 'NgbTypeahead' from external module "/Users/mlaval/dev/github/ng-bootstrap/ng-bootstrap_mlaval/src/typeahead/typeahead" but cannot be named.
```

