### PR TITLE
test: add minimal tests for form validation

### DIFF
--- a/src/buttons/radio.ts
+++ b/src/buttons/radio.ts
@@ -12,7 +12,7 @@ const NGB_RADIO_VALUE_ACCESSOR = {
  * specified via ngModel.
  */
 @Directive({
-  selector: '[ngbRadioGroup][ngModel]',
+  selector: '[ngbRadioGroup]',
   host: {'data-toggle': 'buttons', 'class': 'btn-group'},
   providers: [NGB_RADIO_VALUE_ACCESSOR]
 })


### PR DESCRIPTION
Minimal validation tests for `required` validatior (both template-driven and model-driven forms) for:

- buttons
- timepicker
- typeahead

as a part of investigation for #469