### PR TITLE
fix: use proper styling on accordions and tabs

### DIFF
--- a/src/accordion/accordion.ts
+++ b/src/accordion/accordion.ts
@@ -82,7 +82,7 @@ export interface NgbPanelChangeEvent {
   <div class="card">
     <template ngFor let-panel [ngForOf]="_panels">
       <div [class]="'card-header ' + (panel.type ? 'card-'+panel.type: type ? 'card-'+type : '')" [class.active]="_isOpen(panel.id)">
-        <a tabindex="0" (click)="toggle(panel.id)" [class.text-muted]="panel.disabled">
+        <a tabindex="0" href (click)="!!toggle(panel.id)" [class.text-muted]="panel.disabled">
           {{panel.title}}<template [ngTemplateOutlet]="panel.titleTpl?.templateRef"></template>          
         </a>
       </div>

--- a/src/tabset/tabset.ts
+++ b/src/tabset/tabset.ts
@@ -69,7 +69,8 @@ export interface NgbTabChangeEvent {
   template: `
     <ul [class]="'nav nav-' + type" role="tablist">
       <li class="nav-item" *ngFor="let tab of tabs">
-        <a [id]="tab.id" class="nav-link" [class.active]="tab.id === activeId" [class.disabled]="tab.disabled" (click)="select(tab.id)">
+        <a [id]="tab.id" class="nav-link" [class.active]="tab.id === activeId" [class.disabled]="tab.disabled" 
+          href (click)="!!select(tab.id)">
           {{tab.title}}<template [ngTemplateOutlet]="tab.titleTpl?.templateRef"></template>
         </a>
       </li>


### PR DESCRIPTION
I've tried to use `<button>` elements styled with `btn-link` and it works _mostly_ fine. The only real downside is that `<button>`s leave an unpleasant "halo effect" when a given button is clicked. 

My attempt at removing this effect might have a11y ramifications - see discussion in https://github.com/ng-bootstrap/ng-bootstrap/pull/491#discussion-diff-72609319

As the result of all the discussions we had so far I'm leaning to the approach from this PR as:
* it improves the situation (proper styling and cursor)
* doesn't introduce _new_ a11y issues

The bitter truth is that I'm not a11y expert so I can't fully assess all the consequences of choices we are making here. Alternative proposals are more than welcomed.