### PR TITLE
demo(typeahead): add form-control class to inputs

### DIFF
--- a/demo/src/app/components/typeahead/demos/basic/typeahead-basic.html
+++ b/demo/src/app/components/typeahead/demos/basic/typeahead-basic.html
@@ -5,6 +5,6 @@ A typeahead example that gets values from a static <code>string[]</code>
   <li>limits to 10 results</li>
 </ul>
 
-<input type="text" [(ngModel)]="model" [ngbTypeahead]="search" />
+<input type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search" />
 <hr>
 <pre>Model: {{ model | json }}</pre>

--- a/demo/src/app/components/typeahead/demos/basic/typeahead-basic.ts
+++ b/demo/src/app/components/typeahead/demos/basic/typeahead-basic.ts
@@ -18,7 +18,8 @@ const states = ['Alabama', 'Alaska', 'American Samoa', 'Arizona', 'Arkansas', 'C
   selector: 'ngbd-typeahead-basic',
   template: require('./typeahead-basic.html'),
   directives: [NGB_TYPEAHEAD_DIRECTIVES],
-  precompile: [NGB_PRECOMPILE]
+  precompile: [NGB_PRECOMPILE],
+  styles: [`.form-control { width: 300px; }`]
 })
 export class NgbdTypeaheadBasic {
 

--- a/demo/src/app/components/typeahead/demos/format/typeahead-format.html
+++ b/demo/src/app/components/typeahead/demos/format/typeahead-format.html
@@ -1,5 +1,5 @@
 <p>A typeahead example that uses a formatter function for string results</p>
 
-<input type="text" [(ngModel)]="model" [ngbTypeahead]="search" [resultFormatter]="formatter" />
+<input type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search" [resultFormatter]="formatter" />
 <hr>
 <pre>Model: {{ model | json }}</pre>

--- a/demo/src/app/components/typeahead/demos/format/typeahead-format.ts
+++ b/demo/src/app/components/typeahead/demos/format/typeahead-format.ts
@@ -17,7 +17,8 @@ const states = ['Alabama', 'Alaska', 'American Samoa', 'Arizona', 'Arkansas', 'C
   selector: 'ngbd-typeahead-format',
   template: require('./typeahead-format.html'),
   directives: [NGB_TYPEAHEAD_DIRECTIVES],
-  precompile: [NGB_PRECOMPILE]
+  precompile: [NGB_PRECOMPILE],
+  styles: [`.form-control { width: 300px; }`]
 })
 export class NgbdTypeaheadFormat {
 

--- a/demo/src/app/components/typeahead/demos/http/typeahead-http.html
+++ b/demo/src/app/components/typeahead/demos/http/typeahead-http.html
@@ -7,6 +7,6 @@ A typeahead example that gets values from the <code>WikipediaService</code>
   <li><code>switchMap</code> operator</li>
 </ul>
 
-<input type="text" [(ngModel)]="model" [ngbTypeahead]="search" placeholder="Wikipedia search" /><span *ngIf="_searching"> searching...</span>
+<input type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search" placeholder="Wikipedia search" /><span *ngIf="_searching"> searching...</span>
 <hr>
 <pre>Model: {{ model | json }}</pre>

--- a/demo/src/app/components/typeahead/demos/http/typeahead-http.ts
+++ b/demo/src/app/components/typeahead/demos/http/typeahead-http.ts
@@ -33,7 +33,8 @@ export class WikipediaService {
   template: require('./typeahead-http.html'),
   directives: [NGB_TYPEAHEAD_DIRECTIVES],
   precompile: [NGB_PRECOMPILE],
-  providers: [HTTP_PROVIDERS, JSONP_PROVIDERS, WikipediaService]
+  providers: [HTTP_PROVIDERS, JSONP_PROVIDERS, WikipediaService],
+  styles: [`.form-control { width: 300px; display: inline; }`]
 })
 export class NgbdTypeaheadHttp {
 

--- a/demo/src/app/components/typeahead/demos/template/typeahead-template.html
+++ b/demo/src/app/components/typeahead/demos/template/typeahead-template.html
@@ -5,6 +5,6 @@
   {{ r.name}}
 </template>
 
-<input type="text" [(ngModel)]="model" [ngbTypeahead]="search" [resultTemplate]="rt" [inputFormatter]="formatter" />
+<input type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search" [resultTemplate]="rt" [inputFormatter]="formatter" />
 <hr>
 <pre>Model: {{ model | json }}</pre>

--- a/demo/src/app/components/typeahead/demos/template/typeahead-template.ts
+++ b/demo/src/app/components/typeahead/demos/template/typeahead-template.ts
@@ -62,7 +62,8 @@ const statesWithFlags = [
   selector: 'ngbd-typeahead-template',
   template: require('./typeahead-template.html'),
   directives: [NGB_TYPEAHEAD_DIRECTIVES],
-  precompile: [NGB_PRECOMPILE]
+  precompile: [NGB_PRECOMPILE],
+  styles: [`.form-control { width: 300px; }`]
 })
 export class NgbdTypeaheadTemplate {
 


### PR DESCRIPTION
Minor fix → adding `form-control` class to demos with typeahead to inputs