### PR TITLE
chore: remove api-docs.ts from linting

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -154,7 +154,7 @@ gulp.task('tdd', ['clean:build-tests'], function(done) {
 // Formatting
 
 gulp.task('lint', function() {
-  return gulp.src([PATHS.src, PATHS.demo])
+  return gulp.src([PATHS.src, PATHS.demo, '!demo/src/api-docs.ts'])
       .pipe(tslint({configuration: require('./tslint.json'), formatter: 'prose'}))
       .pipe(tslint.report({summarizeFailureOutput: true}));
 });


### PR DESCRIPTION
Since this is a generated file, we just exclude it. We shouldn't worry to lint something that is generated with a tool that is not under our control.

Fixes #504 