### PR TITLE
fix(build): generate changelog without 'v' version prefix

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -104,7 +104,11 @@ gulp.task('npm', function() {
 gulp.task('changelog', function() {
   var conventionalChangelog = require('gulp-conventional-changelog');
   return gulp.src('CHANGELOG.md', {})
-      .pipe(conventionalChangelog({preset: 'angular', releaseCount: 1}))
+      .pipe(conventionalChangelog({preset: 'angular', releaseCount: 1}, {
+        // Override release version to avoid `v` prefix for git comparison
+        // See https://github.com/conventional-changelog/conventional-changelog-core/issues/10
+        currentTag: require('./package.json').version
+      }))
       .pipe(gulp.dest('./'));
 });
 


### PR DESCRIPTION
Fixes release version generation with 'v' prefix
Takes release version from `package.json`

Closes #506 