### PR TITLE
fix(typeahead): replace 'click' with 'mousedown'

### DIFF
--- a/src/typeahead/typeahead-window.spec.ts
+++ b/src/typeahead/typeahead-window.spec.ts
@@ -114,7 +114,7 @@ describe('ngb-typeahead-window', () => {
 
            expectResults(fixture.nativeElement, ['+bar', 'baz']);
 
-           links[1].triggerEventHandler('click', {});
+           links[1].triggerEventHandler('mousedown', {});
            fixture.detectChanges();
            expect(fixture.componentInstance.selected).toBe('baz');
          });

--- a/src/typeahead/typeahead-window.ts
+++ b/src/typeahead/typeahead-window.ts
@@ -18,7 +18,7 @@ export class ResultTplCtx {
     <template ngFor [ngForOf]="results" let-result let-idx="index">
       <button class="dropdown-item" [class.active]="idx === _activeIdx" 
         (mouseenter)="markActive(idx)" 
-        (click)="select(result)">
+        (mousedown)="select(result)">
           <template [ngTemplateOutlet]="resultTemplate || rt" [ngOutletContext]="_prepareTplCtx(result)"></template>
       </button>
     </template>

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -183,7 +183,7 @@ describe('ngb-typeahead', () => {
          });
        })));
 
-    it('should select the result on click, close window and fill the input',
+    it('should select the result on mousedown, close window and fill the input',
        async(inject([TestComponentBuilder], (tcb) => {
          const html = `<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`;
 
@@ -196,7 +196,7 @@ describe('ngb-typeahead', () => {
            fixture.detectChanges();
            expectWindowResults(compiled, ['+one', 'one more']);
 
-           getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
+           getWindowLinks(fixture.debugElement)[0].triggerEventHandler('mousedown', {});
            fixture.detectChanges();
            expect(getWindow(compiled)).toBeNull();
            expectInputValue(compiled, 'one');
@@ -208,7 +208,7 @@ describe('ngb-typeahead', () => {
            expectWindowResults(compiled, ['+one', 'one more']);
            expectInputValue(compiled, 'o');
 
-           getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
+           getWindowLinks(fixture.debugElement)[0].triggerEventHandler('mousedown', {});
            fixture.detectChanges();
            expect(getWindow(compiled)).toBeNull();
            expectInputValue(compiled, 'one');


### PR DESCRIPTION
Addresses the issue with Chrome and Safari `(click)` not executing with complex templates until the focus is inside the dropdown.

Suggestion is to replace `(click)` with `(mousedown)` to prevent browser attempts to set focus on the dropdown item.

Fixes #523

P.S. I still have no explanation on why the original issue happens though...