### PR TITLE
demo(typeahead): load flag icons via https

### DIFF
--- a/demo/src/app/components/typeahead/demos/template/typeahead-template.html
+++ b/demo/src/app/components/typeahead/demos/template/typeahead-template.html
@@ -1,7 +1,7 @@
 <p>A typeahead example that uses custom template for results display and uses object as a model</p>
 
 <template #rt let-r="result" let-t="term">
-  <img [src]="'http://upload.wikimedia.org/wikipedia/commons/thumb/' + r.flag" width="16">
+  <img [src]="'https://upload.wikimedia.org/wikipedia/commons/thumb/' + r.flag" width="16">
   {{ r.name}}
 </template>
 


### PR DESCRIPTION
Load icons via https to avoid mixed content warning
