### PR TITLE
reafctor: use forms 0.2.0

### DIFF
--- a/demo/src/app/components/timepicker/demos/validation/timepicker-validation.html
+++ b/demo/src/app/components/timepicker/demos/validation/timepicker-validation.html
@@ -1,13 +1,12 @@
 <p>Illustrates custom validation, you have to select time between 12:00 and 13:59</p>
 
-<div class="form-group" [class.has-success]="c.valid" [class.has-danger]="!c.valid">
-  <ngb-timepicker [(ngModel)]="time" #c="ngForm" [ngFormControl]="lunchControl" required></ngb-timepicker>
+<div class="form-group" [class.has-success]="ctrl.valid" [class.has-danger]="!ctrl.valid">
+  <ngb-timepicker [(ngModel)]="time" [formControl]="ctrl" required></ngb-timepicker>
   <div class="form-control-feedback">
-    <div *ngIf="c.valid">Great choice</div>
-    <div *ngIf="c.errors?.required">Select some time during lunchtime</div>
-    <div *ngIf="c.errors?.tooLate">Oh no, it's way too late</div>
-    <div *ngIf="c.errors?.tooEarly">It's a bit too early</div>
-    <div *ngIf="c.errors?.noMinutesSet">And don't forget to set minutes</div>
+    <div *ngIf="ctrl.valid">Great choice</div>
+    <div *ngIf="ctrl.errors?.required">Select some time during lunchtime</div>
+    <div *ngIf="ctrl.errors?.tooLate">Oh no, it's way too late</div>
+    <div *ngIf="ctrl.errors?.tooEarly">It's a bit too early</div>
   </div>
 </div>
 

--- a/demo/src/app/components/timepicker/demos/validation/timepicker-validation.ts
+++ b/demo/src/app/components/timepicker/demos/validation/timepicker-validation.ts
@@ -1,36 +1,29 @@
 import {Component} from '@angular/core';
 import {NGB_TIMEPICKER_DIRECTIVES} from '@ng-bootstrap/ng-bootstrap';
-import {Control} from '@angular/common';
-
-const check = (c: boolean) => c ? true : undefined;
+import {FormControl, REACTIVE_FORM_DIRECTIVES} from '@angular/forms';
 
 @Component({
   selector: 'ngbd-timepicker-validation',
   template: require('./timepicker-validation.html'),
-  directives: [NGB_TIMEPICKER_DIRECTIVES]
+  directives: [NGB_TIMEPICKER_DIRECTIVES, REACTIVE_FORM_DIRECTIVES]
 })
 export class NgbdTimepickerValidation {
   time;
 
-  lunchControl = new Control('', (control: Control) => {
+  ctrl = new FormControl('', (control: FormControl) => {
     const value = control.value;
 
     if (!value) {
       return null;
     }
 
-    const result = {};
-
     if (value.hour < 12) {
-      result['tooEarly'] = true;
+      return {tooEarly: true};
     }
     if (value.hour > 13) {
-      result['tooLate'] = true;
-    }
-    if (isNaN(value.minute)) {
-      result['noMinutesSet'] = true;
+      return {tooLate: true};
     }
 
-    return Object.keys(result).length > 0 ? result : null;
+    return null;
   });
 }

--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -7,6 +7,7 @@ import {Angulartics2GoogleAnalytics} from 'angulartics2/src/providers/angulartic
 import {APP_ROUTER_PROVIDERS} from './app/app.routes';
 import {AppComponent} from './app/app.component';
 import {Angulartics} from './angulartics2.workaround';
+import {disableDeprecatedForms, provideForms} from '@angular/forms';
 
 // depending on the env mode, enable prod mode or add debugging modules
 if (process.env.ENV === 'build') {
@@ -17,6 +18,10 @@ bootstrap(AppComponent, [
   // core dependencies
   APP_ROUTER_PROVIDERS,
   {provide: LocationStrategy, useClass: HashLocationStrategy},
+
+  // forms
+  disableDeprecatedForms(),
+  provideForms(),
 
   // google analytics dependencies
   {provide: Angulartics2, useClass: Angulartics},

--- a/demo/src/vendor.ts
+++ b/demo/src/vendor.ts
@@ -4,6 +4,7 @@ import '@angular/platform-browser-dynamic';
 import '@angular/core';
 import '@angular/common';
 import '@angular/router';
+import '@angular/forms';
 
 // RxJS
 import 'rxjs';

--- a/karma-test-shim.js
+++ b/karma-test-shim.js
@@ -16,6 +16,7 @@ System.config({
     '@angular/core': {main: 'index.js', defaultExtension: 'js'},
     '@angular/compiler': {main: 'index.js', defaultExtension: 'js'},
     '@angular/common': {main: 'index.js', defaultExtension: 'js'},
+    '@angular/forms': {main: 'index.js', defaultExtension: 'js'},
     '@angular/platform-browser': {main: 'index.js', defaultExtension: 'js'},
     '@angular/platform-browser-dynamic': {main: 'index.js', defaultExtension: 'js'},
     'rxjs': {defaultExtension: 'js'}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@angular/compiler": "2.0.0-rc.4",
+    "@angular/forms": "0.2.0",
     "@angular/http": "2.0.0-rc.4",
     "@angular/platform-browser": "2.0.0-rc.4",
     "@angular/platform-browser-dynamic": "2.0.0-rc.4",

--- a/src/buttons/radio.spec.ts
+++ b/src/buttons/radio.spec.ts
@@ -1,10 +1,16 @@
-import {inject, async} from '@angular/core/testing';
+import {inject, async, addProviders} from '@angular/core/testing';
 import {TestComponentBuilder} from '@angular/compiler/testing';
 import {Component} from '@angular/core';
 
 import {NGB_RADIO_DIRECTIVES} from './radio';
-import {Control, Validators, FormBuilder} from '@angular/common';
-
+import {
+  Validators,
+  provideForms,
+  disableDeprecatedForms,
+  FormControl,
+  REACTIVE_FORM_DIRECTIVES,
+  FormGroup
+} from '@angular/forms';
 
 function expectRadios(element: HTMLElement, states: number[]) {
   const labels = element.querySelectorAll('label');
@@ -30,6 +36,9 @@ function getInput(nativeEl: HTMLElement, idx: number): HTMLInputElement {
 }
 
 describe('ngbRadioGroup', () => {
+
+  beforeEach(() => { addProviders([disableDeprecatedForms(), provideForms()]); });
+
   const defaultHtml = `<div [(ngModel)]="model" ngbRadioGroup>
       <label class="btn">
         <input type="radio" name="radio" [value]="values[0]"/> {{ values[0] }}
@@ -39,6 +48,7 @@ describe('ngbRadioGroup', () => {
       </label>
     </div>`;
 
+  // TODO: remove 'whenStable' once 'core/testing' is fixed
   it('toggles radio inputs based on model changes', async(inject([TestComponentBuilder], (tcb) => {
        tcb.overrideTemplate(TestComponent, defaultHtml).createAsync(TestComponent).then((fixture) => {
 
@@ -53,22 +63,34 @@ describe('ngbRadioGroup', () => {
          // checking null
          fixture.componentInstance.model = null;
          fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0, 0]);
+         fixture.whenStable().then(() => {
+           fixture.detectChanges();
+           expectRadios(fixture.nativeElement, [0, 0]);
 
-         // checking first radio
-         fixture.componentInstance.model = values[0];
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [1, 0]);
+           // checking first radio
+           fixture.componentInstance.model = values[0];
+           fixture.detectChanges();
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             expectRadios(fixture.nativeElement, [1, 0]);
 
-         // checking second radio
-         fixture.componentInstance.model = values[1];
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0, 1]);
+             // checking second radio
+             fixture.componentInstance.model = values[1];
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
+               fixture.detectChanges();
+               expectRadios(fixture.nativeElement, [0, 1]);
 
-         // checking non-matching value
-         fixture.componentInstance.model = values[3];
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0, 0]);
+               // checking non-matching value
+               fixture.componentInstance.model = values[3];
+               fixture.detectChanges();
+               fixture.whenStable().then(() => {
+                 fixture.detectChanges();
+                 expectRadios(fixture.nativeElement, [0, 0]);
+               });
+             });
+           });
+         });
        });
      })));
 
@@ -92,6 +114,7 @@ describe('ngbRadioGroup', () => {
        });
      })));
 
+  // TODO: remove 'whenStable' once 'core/testing' is fixed
   it('can be used with objects as values', async(inject([TestComponentBuilder], (tcb) => {
        tcb.overrideTemplate(TestComponent, defaultHtml).createAsync(TestComponent).then((fixture) => {
 
@@ -109,16 +132,20 @@ describe('ngbRadioGroup', () => {
          // checking model -> radio input
          fixture.componentInstance.model = one;
          fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [1, 0]);
+         fixture.whenStable().then(() => {
+           fixture.detectChanges();
+           expectRadios(fixture.nativeElement, [1, 0]);
 
-         // checking radio click -> model
-         getInput(fixture.nativeElement, 1).click();
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0, 1]);
-         expect(fixture.componentInstance.model).toBe(two);
+           // checking radio click -> model
+           getInput(fixture.nativeElement, 1).click();
+           fixture.detectChanges();
+           expectRadios(fixture.nativeElement, [0, 1]);
+           expect(fixture.componentInstance.model).toBe(two);
+         });
        });
      })));
 
+  // TODO: remove 'whenStable' once 'core/testing' is fixed
   it('updates radio input values dynamically', async(inject([TestComponentBuilder], (tcb) => {
        tcb.overrideTemplate(TestComponent, defaultHtml).createAsync(TestComponent).then((fixture) => {
 
@@ -127,26 +154,30 @@ describe('ngbRadioGroup', () => {
          // checking first radio
          fixture.componentInstance.model = values[0];
          fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [1, 0]);
-         expect(fixture.componentInstance.model).toEqual(values[0]);
+         fixture.whenStable().then(() => {
+           fixture.detectChanges();
+           expectRadios(fixture.nativeElement, [1, 0]);
+           expect(fixture.componentInstance.model).toEqual(values[0]);
 
-         // updating first radio value -> expecting none selected
-         let initialValue = values[0];
-         values[0] = 'ten';
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0, 0]);
-         expect(getInput(fixture.nativeElement, 0).value).toEqual('ten');
-         expect(fixture.componentInstance.model).toEqual(initialValue);
+           // updating first radio value -> expecting none selected
+           let initialValue = values[0];
+           values[0] = 'ten';
+           fixture.detectChanges();
+           expectRadios(fixture.nativeElement, [0, 0]);
+           expect(getInput(fixture.nativeElement, 0).value).toEqual('ten');
+           expect(fixture.componentInstance.model).toEqual(initialValue);
 
-         // updating values back -> expecting initial state
-         values[0] = initialValue;
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [1, 0]);
-         expect(getInput(fixture.nativeElement, 0).value).toEqual(values[0]);
-         expect(fixture.componentInstance.model).toEqual(values[0]);
+           // updating values back -> expecting initial state
+           values[0] = initialValue;
+           fixture.detectChanges();
+           expectRadios(fixture.nativeElement, [1, 0]);
+           expect(getInput(fixture.nativeElement, 0).value).toEqual(values[0]);
+           expect(fixture.componentInstance.model).toEqual(values[0]);
+         });
        });
      })));
 
+  // TODO: remove 'whenStable' once 'core/testing' is fixed
   it('can be used with ngFor', async(inject([TestComponentBuilder], (tcb) => {
 
        const forHtml = `<div [(ngModel)]="model" ngbRadioGroup>
@@ -164,10 +195,14 @@ describe('ngbRadioGroup', () => {
 
          fixture.componentInstance.model = values[1];
          fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0, 1, 0]);
+         fixture.whenStable().then(() => {
+           fixture.detectChanges();
+           expectRadios(fixture.nativeElement, [0, 1, 0]);
+         });
        });
      })));
 
+  // TODO: remove 'whenStable' once 'core/testing' is fixed
   it('cleans up the model when radio inputs are added / removed', async(inject([TestComponentBuilder], (tcb) => {
 
        const ifHtml = `<div [(ngModel)]="model" ngbRadioGroup>
@@ -200,17 +235,21 @@ describe('ngbRadioGroup', () => {
          // hiding/showing selected radio -> expecting model to unchange, but none selected
          fixture.componentInstance.model = values[1];
          fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0, 1]);
+         fixture.whenStable().then(() => {
+           fixture.detectChanges();
+           expectRadios(fixture.nativeElement, [0, 1]);
 
-         fixture.componentInstance.shown = false;
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0]);
-         expect(fixture.componentInstance.model).toEqual(values[1]);
+           fixture.componentInstance.shown = false;
+           fixture.detectChanges();
+           expectRadios(fixture.nativeElement, [0]);
+           expect(fixture.componentInstance.model).toEqual(values[1]);
 
-         fixture.componentInstance.shown = true;
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0, 1]);
-         expect(fixture.componentInstance.model).toEqual(values[1]);
+           fixture.componentInstance.shown = true;
+           fixture.detectChanges();
+           expectRadios(fixture.nativeElement, [0, 1]);
+           expect(fixture.componentInstance.model).toEqual(values[1]);
+         });
+
        });
      })));
 
@@ -225,10 +264,11 @@ describe('ngbRadioGroup', () => {
        });
      })));
 
+  // TODO: remove 'whenStable' once 'core/testing' is fixed
   it('should work with template-driven form validation', async(inject([TestComponentBuilder], (tcb) => {
        const html = `
         <form>
-          <div ngbRadioGroup [(ngModel)]="model" required>
+          <div ngbRadioGroup [(ngModel)]="model" name="control" required>
             <label class="btn">
               <input type="radio" value="foo"/>
             </label>          
@@ -237,20 +277,23 @@ describe('ngbRadioGroup', () => {
 
        tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
          fixture.detectChanges();
-         expect(getGroupElement(fixture.nativeElement)).toHaveCssClass('ng-invalid');
-         expect(getGroupElement(fixture.nativeElement)).not.toHaveCssClass('ng-valid');
+         fixture.whenStable().then(() => {
+           fixture.detectChanges();
+           expect(getGroupElement(fixture.nativeElement)).toHaveCssClass('ng-invalid');
+           expect(getGroupElement(fixture.nativeElement)).not.toHaveCssClass('ng-valid');
 
-         getInput(fixture.nativeElement, 0).click();
-         fixture.detectChanges();
-         expect(getGroupElement(fixture.nativeElement)).toHaveCssClass('ng-valid');
-         expect(getGroupElement(fixture.nativeElement)).not.toHaveCssClass('ng-invalid');
+           getInput(fixture.nativeElement, 0).click();
+           fixture.detectChanges();
+           expect(getGroupElement(fixture.nativeElement)).toHaveCssClass('ng-valid');
+           expect(getGroupElement(fixture.nativeElement)).not.toHaveCssClass('ng-invalid');
+         });
        });
      })));
 
   it('should work with model-driven form validation', async(inject([TestComponentBuilder], (tcb) => {
        const html = `
-        <form [ngFormModel]="form">
-          <div ngbRadioGroup ngControl="control">
+        <form [formGroup]="form">
+          <div ngbRadioGroup formControlName="control">
             <label class="btn">
               <input type="radio" value="foo"/>
             </label>          
@@ -270,13 +313,11 @@ describe('ngbRadioGroup', () => {
      })));
 });
 
-@Component({selector: 'test-cmp', directives: [NGB_RADIO_DIRECTIVES], template: ''})
+@Component({selector: 'test-cmp', directives: [NGB_RADIO_DIRECTIVES, REACTIVE_FORM_DIRECTIVES], template: ''})
 class TestComponent {
-  form = this._builder.group({control: new Control('', Validators.required)});
+  form = new FormGroup({control: new FormControl('', Validators.required)});
 
   model;
   values = ['one', 'two', 'three'];
   shown = true;
-
-  constructor(private _builder: FormBuilder) {}
 }

--- a/src/buttons/radio.ts
+++ b/src/buttons/radio.ts
@@ -1,5 +1,5 @@
 import {Directive, forwardRef, Optional, Input, Renderer, ElementRef, OnDestroy} from '@angular/core';
-import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/common';
+import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 
 const NGB_RADIO_VALUE_ACCESSOR = {
   provide: NG_VALUE_ACCESSOR,

--- a/src/timepicker/timepicker.spec.ts
+++ b/src/timepicker/timepicker.spec.ts
@@ -5,7 +5,14 @@ import {By} from '@angular/platform-browser';
 import {Component} from '@angular/core';
 
 import {NgbTimepicker} from './timepicker';
-import {Validators, FormBuilder, Control} from '@angular/common';
+import {
+  Validators,
+  provideForms,
+  disableDeprecatedForms,
+  FormControl,
+  REACTIVE_FORM_DIRECTIVES,
+  FormGroup
+} from '@angular/forms';
 
 function getTimepicker(el: HTMLElement) {
   return el.querySelector('ngb-timepicker');
@@ -47,79 +54,114 @@ function expectToDisplayTime(el: HTMLElement, time: string) {
 
 describe('ngb-timepicker', () => {
 
+  beforeEach(() => { addProviders([disableDeprecatedForms(), provideForms()]); });
+
   describe('rendering based on model', () => {
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should render hour and minute inputs', async(inject([TestComponentBuilder], (tcb) => {
          const html = `<ngb-timepicker [ngModel]="model"></ngb-timepicker>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: 13, minute: 30};
            fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '13:30');
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => { expectToDisplayTime(fixture.nativeElement, '13:30'); });
+           });
          });
        })));
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should update inputs value on model change', async(inject([TestComponentBuilder], (tcb) => {
          const html = `<ngb-timepicker [ngModel]="model"></ngb-timepicker>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: 13, minute: 30};
            fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '13:30');
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
+               expectToDisplayTime(fixture.nativeElement, '13:30');
 
-           fixture.componentInstance.model = {hour: 14, minute: 40};
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '14:40');
+               fixture.componentInstance.model = {hour: 14, minute: 40};
+               fixture.detectChanges();
+               fixture.whenStable().then(() => {
+                 fixture.detectChanges();
+                 fixture.whenStable().then(() => { expectToDisplayTime(fixture.nativeElement, '14:40'); });
+               });
+             });
+           });
          });
        })));
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should render hour and minute inputs with padding', async(inject([TestComponentBuilder], (tcb) => {
          const html = `<ngb-timepicker [ngModel]="model"></ngb-timepicker>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: 1, minute: 3};
            fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '01:03');
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => { expectToDisplayTime(fixture.nativeElement, '01:03'); });
+           });
          });
        })));
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should render hour, minute and seconds inputs with padding', async(inject([TestComponentBuilder], (tcb) => {
          const html = `<ngb-timepicker [ngModel]="model" [seconds]="true"></ngb-timepicker>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: 10, minute: 3, second: 4};
            fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '10:03:04');
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => { expectToDisplayTime(fixture.nativeElement, '10:03:04'); });
+           });
          });
        })));
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should render invalid or empty hour and minute as blank string', async(inject([TestComponentBuilder], (tcb) => {
          const html = `<ngb-timepicker [ngModel]="model"></ngb-timepicker>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: undefined, minute: 'aaa'};
            fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, ':');
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => { expectToDisplayTime(fixture.nativeElement, ':'); });
+           });
          });
        })));
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should render invalid or empty second as blank string', async(inject([TestComponentBuilder], (tcb) => {
          const html = `<ngb-timepicker [ngModel]="model" [seconds]="true"></ngb-timepicker>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: 10, minute: 20, second: false};
            fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '10:20:');
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => { expectToDisplayTime(fixture.nativeElement, '10:20:'); });
+           });
          });
        })));
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should render empty fields on null model', async(inject([TestComponentBuilder], (tcb) => {
          const html = `<ngb-timepicker [ngModel]="model" [seconds]="true"></ngb-timepicker>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = null;
            fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '::');
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => { expectToDisplayTime(fixture.nativeElement, '::'); });
+           });
          });
        })));
   });
@@ -127,281 +169,350 @@ describe('ngb-timepicker', () => {
 
   describe('model updates in response to increment / decrement button clicks', () => {
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should increment / decrement hours', async(inject([TestComponentBuilder], (tcb) => {
          const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
            fixture.detectChanges();
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
 
-           const buttons = getButtons(fixture.nativeElement);
+               const buttons = getButtons(fixture.nativeElement);
 
-           expectToDisplayTime(fixture.nativeElement, '10:30');
-           expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+               expectToDisplayTime(fixture.nativeElement, '10:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-           (<HTMLButtonElement>buttons[0]).click();  // H+
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '11:30');
-           expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[0]).click();  // H+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '11:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
 
 
-           (<HTMLButtonElement>buttons[2]).click();  // H-
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '10:30');
-           expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[2]).click();  // H-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+             });
+           });
          });
        })));
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should wrap hours', async(inject([TestComponentBuilder], (tcb) => {
          const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: 23, minute: 30, second: 0};
            fixture.detectChanges();
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
 
-           const buttons = getButtons(fixture.nativeElement);
+               const buttons = getButtons(fixture.nativeElement);
 
-           expectToDisplayTime(fixture.nativeElement, '23:30');
-           expect(fixture.componentInstance.model).toEqual({hour: 23, minute: 30, second: 0});
+               expectToDisplayTime(fixture.nativeElement, '23:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 23, minute: 30, second: 0});
 
-           (<HTMLButtonElement>buttons[0]).click();  // H+
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '00:30');
-           expect(fixture.componentInstance.model).toEqual({hour: 0, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[0]).click();  // H+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '00:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 0, minute: 30, second: 0});
 
-           (<HTMLButtonElement>buttons[2]).click();  // H-
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '23:30');
-           expect(fixture.componentInstance.model).toEqual({hour: 23, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[2]).click();  // H-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '23:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 23, minute: 30, second: 0});
+             });
+           });
          });
        })));
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should increment / decrement minutes', async(inject([TestComponentBuilder], (tcb) => {
          const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
            fixture.detectChanges();
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
 
-           const buttons = getButtons(fixture.nativeElement);
+               const buttons = getButtons(fixture.nativeElement);
 
-           expectToDisplayTime(fixture.nativeElement, '10:30');
-           expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+               expectToDisplayTime(fixture.nativeElement, '10:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-           (<HTMLButtonElement>buttons[1]).click();  // M+
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '10:31');
-           expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 0});
+               (<HTMLButtonElement>buttons[1]).click();  // M+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:31');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 0});
 
-           (<HTMLButtonElement>buttons[3]).click();  // M-
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '10:30');
-           expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[3]).click();  // M-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+             });
+           });
          });
        })));
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should wrap minutes', async(inject([TestComponentBuilder], (tcb) => {
          const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: 22, minute: 59, second: 0};
            fixture.detectChanges();
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
+               const buttons = getButtons(fixture.nativeElement);
 
-           const buttons = getButtons(fixture.nativeElement);
+               expectToDisplayTime(fixture.nativeElement, '22:59');
+               expect(fixture.componentInstance.model).toEqual({hour: 22, minute: 59, second: 0});
 
-           expectToDisplayTime(fixture.nativeElement, '22:59');
-           expect(fixture.componentInstance.model).toEqual({hour: 22, minute: 59, second: 0});
+               (<HTMLButtonElement>buttons[1]).click();  // M+
+               fixture.detectChanges();
+               expect(fixture.componentInstance.model).toEqual({hour: 23, minute: 0, second: 0});
 
-           (<HTMLButtonElement>buttons[1]).click();  // M+
-           fixture.detectChanges();
-           expect(fixture.componentInstance.model).toEqual({hour: 23, minute: 0, second: 0});
-
-           (<HTMLButtonElement>buttons[3]).click();  // M-
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '22:59');
-           expect(fixture.componentInstance.model).toEqual({hour: 22, minute: 59, second: 0});
+               (<HTMLButtonElement>buttons[3]).click();  // M-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '22:59');
+               expect(fixture.componentInstance.model).toEqual({hour: 22, minute: 59, second: 0});
+             });
+           });
          });
        })));
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should increment / decrement seconds', async(inject([TestComponentBuilder], (tcb) => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true"></ngb-timepicker>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
            fixture.detectChanges();
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
+               const buttons = getButtons(fixture.nativeElement);
 
-           const buttons = getButtons(fixture.nativeElement);
+               expectToDisplayTime(fixture.nativeElement, '10:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-           expectToDisplayTime(fixture.nativeElement, '10:30:00');
-           expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[2]).click();  // S+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:30:01');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 1});
 
-           (<HTMLButtonElement>buttons[2]).click();  // S+
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '10:30:01');
-           expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 1});
-
-           (<HTMLButtonElement>buttons[5]).click();  // S-
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '10:30:00');
-           expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[5]).click();  // S-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+             });
+           });
          });
        })));
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should wrap seconds', async(inject([TestComponentBuilder], (tcb) => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true"></ngb-timepicker>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: 10, minute: 30, second: 59};
            fixture.detectChanges();
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
 
-           const buttons = getButtons(fixture.nativeElement);
+               const buttons = getButtons(fixture.nativeElement);
 
-           expectToDisplayTime(fixture.nativeElement, '10:30:59');
-           expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 59});
+               expectToDisplayTime(fixture.nativeElement, '10:30:59');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 59});
 
-           (<HTMLButtonElement>buttons[2]).click();  // S+
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '10:31:00');
-           expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 0});
+               (<HTMLButtonElement>buttons[2]).click();  // S+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:31:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 0});
 
-           (<HTMLButtonElement>buttons[5]).click();  // S-
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '10:30:59');
-           expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 59});
+               (<HTMLButtonElement>buttons[5]).click();  // S-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:30:59');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 59});
+             });
+           });
          });
        })));
   });
 
   describe('model updates in response to input field changes', () => {
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should update hours', async(inject([TestComponentBuilder], (tcb) => {
          const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
            fixture.detectChanges();
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
 
-           const inputs = fixture.debugElement.queryAll(By.css('input'));
+               const inputs = fixture.debugElement.queryAll(By.css('input'));
 
-           expectToDisplayTime(fixture.nativeElement, '10:30');
-           expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+               expectToDisplayTime(fixture.nativeElement, '10:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-           inputs[0].triggerEventHandler('change', createChangeEvent('11'));
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '11:30');
-           expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
+               inputs[0].triggerEventHandler('change', createChangeEvent('11'));
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '11:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
 
-           inputs[0].triggerEventHandler('change', createChangeEvent(`${24 + 11}`));
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '11:30');
-           expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
+               inputs[0].triggerEventHandler('change', createChangeEvent(`${24 + 11}`));
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '11:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
 
-           inputs[0].triggerEventHandler('change', createChangeEvent('aa'));
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, ':30');
-           expect(fixture.componentInstance.model).toEqual(null);
+               inputs[0].triggerEventHandler('change', createChangeEvent('aa'));
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, ':30');
+               expect(fixture.componentInstance.model).toEqual(null);
+             });
+           });
          });
        })));
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should update minutes', async(inject([TestComponentBuilder], (tcb) => {
          const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
            fixture.detectChanges();
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
 
-           const inputs = fixture.debugElement.queryAll(By.css('input'));
+               const inputs = fixture.debugElement.queryAll(By.css('input'));
 
-           expectToDisplayTime(fixture.nativeElement, '10:30');
-           expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+               expectToDisplayTime(fixture.nativeElement, '10:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-           inputs[1].triggerEventHandler('change', createChangeEvent('40'));
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '10:40');
-           expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 40, second: 0});
+               inputs[1].triggerEventHandler('change', createChangeEvent('40'));
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:40');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 40, second: 0});
 
-           inputs[1].triggerEventHandler('change', createChangeEvent('70'));
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '11:10');
-           expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 10, second: 0});
+               inputs[1].triggerEventHandler('change', createChangeEvent('70'));
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '11:10');
+               expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 10, second: 0});
 
-           inputs[1].triggerEventHandler('change', createChangeEvent('aa'));
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '11:');
-           expect(fixture.componentInstance.model).toEqual(null);
+               inputs[1].triggerEventHandler('change', createChangeEvent('aa'));
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '11:');
+               expect(fixture.componentInstance.model).toEqual(null);
+             });
+           });
          });
        })));
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should update seconds', async(inject([TestComponentBuilder], (tcb) => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true"></ngb-timepicker>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
            fixture.detectChanges();
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
 
-           const inputs = fixture.debugElement.queryAll(By.css('input'));
+               const inputs = fixture.debugElement.queryAll(By.css('input'));
 
-           expectToDisplayTime(fixture.nativeElement, '10:30:00');
-           expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+               expectToDisplayTime(fixture.nativeElement, '10:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-           inputs[2].triggerEventHandler('change', createChangeEvent('40'));
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '10:30:40');
-           expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 40});
+               inputs[2].triggerEventHandler('change', createChangeEvent('40'));
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:30:40');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 40});
 
-           inputs[2].triggerEventHandler('change', createChangeEvent('70'));
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '10:31:10');
-           expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 10});
+               inputs[2].triggerEventHandler('change', createChangeEvent('70'));
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:31:10');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 10});
 
-           inputs[2].triggerEventHandler('change', createChangeEvent('aa'));
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '10:31:');
-           expect(fixture.componentInstance.model).toEqual(null);
+               inputs[2].triggerEventHandler('change', createChangeEvent('aa'));
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:31:');
+               expect(fixture.componentInstance.model).toEqual(null);
+             });
+           });
          });
        })));
   });
 
   describe('meridian', () => {
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should render meridian button with proper value', async(inject([TestComponentBuilder], (tcb) => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [meridian]="true"></ngb-timepicker>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: 13, minute: 30, second: 0};
            fixture.detectChanges();
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
 
-           const meridianButton = getMeridianButton(fixture.nativeElement);
+               const meridianButton = getMeridianButton(fixture.nativeElement);
 
-           expectToDisplayTime(fixture.nativeElement, '01:30:00');
-           expect(meridianButton.innerHTML).toBe('PM');
+               expectToDisplayTime(fixture.nativeElement, '01:30:00');
+               expect(meridianButton.innerHTML).toBe('PM');
 
-           fixture.componentInstance.model = {hour: 1, minute: 30, second: 0};
-           fixture.detectChanges();
-
-           expectToDisplayTime(fixture.nativeElement, '01:30:00');
-           expect(meridianButton.innerHTML).toBe('AM');
+               fixture.componentInstance.model = {hour: 1, minute: 30, second: 0};
+               fixture.detectChanges();
+               fixture.whenStable().then(() => {
+                 fixture.detectChanges();
+                 fixture.whenStable().then(() => {
+                   expectToDisplayTime(fixture.nativeElement, '01:30:00');
+                   expect(meridianButton.innerHTML).toBe('AM');
+                 });
+               });
+             });
+           });
          });
        })));
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should update model on meridian click', async(inject([TestComponentBuilder], (tcb) => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [meridian]="true"></ngb-timepicker>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: 13, minute: 30, second: 0};
            fixture.detectChanges();
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
 
-           const meridianButton = <HTMLButtonElement>getMeridianButton(fixture.nativeElement);
+               const meridianButton = <HTMLButtonElement>getMeridianButton(fixture.nativeElement);
 
-           expectToDisplayTime(fixture.nativeElement, '01:30:00');
-           expect(meridianButton.innerHTML).toBe('PM');
+               expectToDisplayTime(fixture.nativeElement, '01:30:00');
+               expect(meridianButton.innerHTML).toBe('PM');
 
-           meridianButton.click();
-           fixture.detectChanges();
-
-           expectToDisplayTime(fixture.nativeElement, '01:30:00');
-           expect(fixture.componentInstance.model).toEqual({hour: 1, minute: 30, second: 0});
-           expect(meridianButton.innerHTML).toBe('AM');
+               meridianButton.click();
+               fixture.detectChanges();
+               fixture.whenStable().then(() => {
+                 expectToDisplayTime(fixture.nativeElement, '01:30:00');
+                 expect(fixture.componentInstance.model).toEqual({hour: 1, minute: 30, second: 0});
+                 expect(meridianButton.innerHTML).toBe('AM');
+               });
+             });
+           });
          });
        })));
 
@@ -409,53 +520,66 @@ describe('ngb-timepicker', () => {
 
   describe('forms', () => {
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should work with template-driven form validation', async(inject([TestComponentBuilder], (tcb) => {
          const html = `
           <form>
-            <ngb-timepicker [(ngModel)]="model" required></ngb-timepicker>
+            <ngb-timepicker [(ngModel)]="model" name="control" required></ngb-timepicker>
           </form>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.detectChanges();
-           const compiled = fixture.nativeElement;
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
+               const compiled = fixture.nativeElement;
 
-           expect(getTimepicker(compiled)).toHaveCssClass('ng-invalid');
-           expect(getTimepicker(compiled)).not.toHaveCssClass('ng-valid');
+               expect(getTimepicker(compiled)).toHaveCssClass('ng-invalid');
+               expect(getTimepicker(compiled)).not.toHaveCssClass('ng-valid');
 
-           fixture.componentInstance.model = {hour: 12, minute: 0, second: 0};
-           fixture.detectChanges();
-           expect(getTimepicker(compiled)).toHaveCssClass('ng-valid');
-           expect(getTimepicker(compiled)).not.toHaveCssClass('ng-invalid');
+               fixture.componentInstance.model = {hour: 12, minute: 0, second: 0};
+               fixture.detectChanges();
+               fixture.whenStable().then(() => {
+                 fixture.detectChanges();
+                 fixture.whenStable().then(() => {
+                   expect(getTimepicker(compiled)).toHaveCssClass('ng-valid');
+                   expect(getTimepicker(compiled)).not.toHaveCssClass('ng-invalid');
+                 });
+               });
+             });
+           });
          });
        })));
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should work with model-driven form validation', async(inject([TestComponentBuilder], (tcb) => {
          const html = `
-          <form [ngFormModel]="form">
-            <ngb-timepicker ngControl="control" required></ngb-timepicker>
+          <form [formGroup]="form">
+            <ngb-timepicker formControlName="control" required></ngb-timepicker>
           </form>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.detectChanges();
-           const compiled = fixture.nativeElement;
-           const inputs = fixture.debugElement.queryAll(By.css('input'));
+           fixture.whenStable().then(() => {
+             const compiled = fixture.nativeElement;
+             const inputs = fixture.debugElement.queryAll(By.css('input'));
 
-           expect(getTimepicker(compiled)).toHaveCssClass('ng-invalid');
-           expect(getTimepicker(compiled)).not.toHaveCssClass('ng-valid');
+             expect(getTimepicker(compiled)).toHaveCssClass('ng-invalid');
+             expect(getTimepicker(compiled)).not.toHaveCssClass('ng-valid');
 
-           inputs[0].triggerEventHandler('change', createChangeEvent('12'));
-           inputs[1].triggerEventHandler('change', createChangeEvent('15'));
-           fixture.detectChanges();
-           expect(getTimepicker(compiled)).toHaveCssClass('ng-valid');
-           expect(getTimepicker(compiled)).not.toHaveCssClass('ng-invalid');
+             inputs[0].triggerEventHandler('change', createChangeEvent('12'));
+             inputs[1].triggerEventHandler('change', createChangeEvent('15'));
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
+               expect(getTimepicker(compiled)).toHaveCssClass('ng-valid');
+               expect(getTimepicker(compiled)).not.toHaveCssClass('ng-invalid');
+             });
+           });
          });
        })));
 
     it('should propagate model changes only if valid - no seconds', async(inject([TestComponentBuilder], (tcb) => {
-         const html = `
-          <form>
-            <ngb-timepicker [(ngModel)]="model"></ngb-timepicker>
-          </form>`;
+         const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: 12, minute: 0};
@@ -470,10 +594,7 @@ describe('ngb-timepicker', () => {
        })));
 
     it('should propagate model changes only if valid - with seconds', async(inject([TestComponentBuilder], (tcb) => {
-         const html = `
-          <form>
-            <ngb-timepicker [(ngModel)]="model" [seconds]="true"></ngb-timepicker>
-          </form>`;
+         const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true"></ngb-timepicker>`;
 
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: 12, minute: 0, second: 0};
@@ -490,6 +611,7 @@ describe('ngb-timepicker', () => {
 
   describe('disabled', () => {
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should not change the value on button click, when it is disabled',
        async(inject([TestComponentBuilder], (tcb) => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [disabled]="disabled"></ngb-timepicker>`;
@@ -497,42 +619,46 @@ describe('ngb-timepicker', () => {
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: 13, minute: 30, second: 0};
            fixture.detectChanges();
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
 
-           const buttons = getButtons(fixture.nativeElement);
+               const buttons = getButtons(fixture.nativeElement);
 
-           expectToDisplayTime(fixture.nativeElement, '13:30:00');
-           expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-           (<HTMLButtonElement>buttons[0]).click();  // H+
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '13:30:00');
-           expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[0]).click();  // H+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-           (<HTMLButtonElement>buttons[3]).click();  // H-
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '13:30:00');
-           expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[3]).click();  // H-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-           (<HTMLButtonElement>buttons[1]).click();  // M+
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '13:30:00');
-           expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[1]).click();  // M+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-           (<HTMLButtonElement>buttons[4]).click();  // M-
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '13:30:00');
-           expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[4]).click();  // M-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-           (<HTMLButtonElement>buttons[2]).click();  // S+
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '13:30:00');
-           expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[2]).click();  // S+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-           (<HTMLButtonElement>buttons[5]).click();  // S-
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '13:30:00');
-           expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
-
+               (<HTMLButtonElement>buttons[5]).click();  // S-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+             });
+           });
          });
        })));
 
@@ -557,6 +683,7 @@ describe('ngb-timepicker', () => {
 
   describe('readonly', () => {
 
+    // TODO: remove 'whenStable' once 'core/testing' is fixed
     it('should change the value on button click, when it is readonly', async(inject([TestComponentBuilder], (tcb) => {
          const html =
              `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [readonlyInputs]="readonly"></ngb-timepicker>`;
@@ -564,41 +691,46 @@ describe('ngb-timepicker', () => {
          tcb.overrideTemplate(TestComponent, html).createAsync(TestComponent).then((fixture) => {
            fixture.componentInstance.model = {hour: 13, minute: 30, second: 0};
            fixture.detectChanges();
+           fixture.whenStable().then(() => {
+             fixture.detectChanges();
+             fixture.whenStable().then(() => {
 
-           const buttons = getButtons(fixture.nativeElement);
+               const buttons = getButtons(fixture.nativeElement);
 
-           expectToDisplayTime(fixture.nativeElement, '13:30:00');
-           expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-           (<HTMLButtonElement>buttons[0]).click();  // H+
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '14:30:00');
-           expect(fixture.componentInstance.model).toEqual({hour: 14, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[0]).click();  // H+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '14:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 14, minute: 30, second: 0});
 
-           (<HTMLButtonElement>buttons[3]).click();  // H-
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '13:30:00');
-           expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[3]).click();  // H-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-           (<HTMLButtonElement>buttons[1]).click();  // M+
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '13:31:00');
-           expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 31, second: 0});
+               (<HTMLButtonElement>buttons[1]).click();  // M+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:31:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 31, second: 0});
 
-           (<HTMLButtonElement>buttons[4]).click();  // M-
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '13:30:00');
-           expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[4]).click();  // M-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-           (<HTMLButtonElement>buttons[2]).click();  // S+
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '13:30:01');
-           expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 1});
+               (<HTMLButtonElement>buttons[2]).click();  // S+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:01');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 1});
 
-           (<HTMLButtonElement>buttons[5]).click();  // S-
-           fixture.detectChanges();
-           expectToDisplayTime(fixture.nativeElement, '13:30:00');
-           expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[5]).click();  // S-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+             });
+           });
          });
        })));
 
@@ -610,16 +742,16 @@ describe('ngb-timepicker', () => {
            fixture.detectChanges();
 
            let inputs = getInputs(fixture.nativeElement);
-           expect(inputs[0].hasAttribute('readonly')).toBeTruthy;
-           expect(inputs[1].hasAttribute('readonly')).toBeTruthy;
-           expect(inputs[2].hasAttribute('readonly')).toBeTruthy;
+           expect(inputs[0].hasAttribute('readonly')).toBeTruthy();
+           expect(inputs[1].hasAttribute('readonly')).toBeTruthy();
+           expect(inputs[2].hasAttribute('readonly')).toBeTruthy();
 
            fixture.componentInstance.readonly = false;
            fixture.detectChanges();
            inputs = getInputs(fixture.nativeElement);
-           expect(inputs[0].hasAttribute('readonly')).toBeFalsy;
-           expect(inputs[1].hasAttribute('readonly')).toBeFalsy;
-           expect(inputs[2].hasAttribute('readonly')).toBeFalsy;
+           expect(inputs[0].hasAttribute('readonly')).toBeFalsy();
+           expect(inputs[1].hasAttribute('readonly')).toBeFalsy();
+           expect(inputs[2].hasAttribute('readonly')).toBeFalsy();
          });
        })));
   });
@@ -638,12 +770,10 @@ describe('ngb-timepicker', () => {
 });
 
 
-@Component({selector: 'test-cmp', directives: [NgbTimepicker], template: ''})
+@Component({selector: 'test-cmp', directives: [NgbTimepicker, REACTIVE_FORM_DIRECTIVES], template: ''})
 class TestComponent {
   model;
   disabled = true;
   readonly = true;
-  form = this._builder.group({control: new Control('', Validators.required)});
-
-  constructor(private _builder: FormBuilder) {}
+  form = new FormGroup({control: new FormControl('', Validators.required)});
 }

--- a/src/timepicker/timepicker.ts
+++ b/src/timepicker/timepicker.ts
@@ -1,5 +1,5 @@
 import {Component, Input, forwardRef} from '@angular/core';
-import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/common';
+import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 
 import {isNumber, padNumber, toInteger} from '../util/util';
 import {NgbTime} from './ngb-time';

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -17,7 +17,7 @@ import 'rxjs/add/operator/let';
 import {Positioning} from '../util/positioning';
 import {NgbTypeaheadWindow, ResultTplCtx} from './typeahead-window';
 import {PopupService} from '../util/popup';
-import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/common';
+import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {toString} from '../util/util';
 
 enum Key {


### PR DESCRIPTION
This is an experiment with migration to new forms 0.2.0. Everything works except for one thing:

Main issue is with tests now, as NgModel update became asynchronous → the recommended solution for now is to do the following until there is a solution in `core/testing`...

```javascript
fixture.detectChanges();
fixture.whenStable().then(() => {
    fixture.detectChanges();
    // expect here...
```

For now this makes tests absolutely ugly, especially for the `timepicker`