### PR TITLE
fix(demo): clarify typeahead demo variable name

### DIFF
--- a/demo/src/app/components/typeahead/demos/http/typeahead-http.ts
+++ b/demo/src/app/components/typeahead/demos/http/typeahead-http.ts
@@ -24,7 +24,7 @@ export class WikipediaService {
 
     return this._jsonp
       .get(wikiUrl, {search: params})
-      .map(request => <string[]> request.json()[1]);
+      .map(response => <string[]> response.json()[1]);
   }
 }
 


### PR DESCRIPTION
The demo specified `request` while the parameter was actually the `response`