### PR TITLE
chore: extract methods that a part of the public API

### DIFF
--- a/demo/src/app/components/shared/api-docs/api-docs.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs.component.html
@@ -53,5 +53,22 @@
       </table>
     </section>
   </template>
+
+  <template [ngIf]="apiDocs.exportAs && apiDocs.methods.length">
+    <section>
+      <h3 id="methods">Methods</h3>
+      <table class="table table-sm table-hover">
+        <tbody>
+        <tr *ngFor="let method of apiDocs.methods">
+          <td class="col-md-3"><code>{{method.name}}</code></td>
+          <td class="col-md-9">
+            <div><i>Signature: </i><code>{{ _methodSignature(method) }}</code></div>
+            <div style="margin: 10px 0">{{ method.description }}</div>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </section>
+  </template>
 </div>
 <hr/>

--- a/demo/src/app/components/shared/api-docs/api-docs.component.ts
+++ b/demo/src/app/components/shared/api-docs/api-docs.component.ts
@@ -13,4 +13,9 @@ export class NgbdApiDocs {
   @Input() set directive(directiveName) {
     this.apiDocs = docs[directiveName];
   };
+
+  private _methodSignature(method) {
+    const args = method.args.map(arg => `${arg.name}: ${arg.type}`).join(', ');
+    return `${method.name}(${args})`;
+  }
 }

--- a/misc/api-doc-test-cases/component-with-internal-methods.ts
+++ b/misc/api-doc-test-cases/component-with-internal-methods.ts
@@ -1,0 +1,31 @@
+import {Component, Input, OnInit} from '@angular/core';
+
+/**
+ * Foo doc
+ */
+@Component({
+  selector: '[foo]',
+  template: '<button (click)="forTemplateOnly()">{{buttonTxt}}</button>',
+  exportAs: 'foo'
+})
+export class Foo implements OnInit {
+  @Input() buttonTxt;
+
+  constructor() {
+  }
+
+  /**
+   * Only used in a template
+   *
+   * @internal
+   */
+  forTemplateOnly() {
+    console.log('I was clicked!');
+  }
+
+  ngOnInit() {
+  }
+  
+  private _dontSerialize() {
+  }
+}

--- a/misc/api-doc-test-cases/directives-with-methods.ts
+++ b/misc/api-doc-test-cases/directives-with-methods.ts
@@ -1,0 +1,27 @@
+import {Directive, Input, OnInit} from '@angular/core';
+
+/**
+ * Foo doc
+ */
+@Directive({
+  selector: '[foo]',
+  exportAs: 'foo'
+})
+export class Foo implements OnInit {
+  @Input() notMethod;
+
+  constructor() {
+  }
+
+  /**
+   * Use this one to produce foo!
+   */
+  fooMethod(arg1: string, arg2, arg3 = 1) {
+  }
+
+  ngOnInit() {
+  }
+
+  private _dontSerialize() {
+  }
+}

--- a/misc/api-doc.spec.js
+++ b/misc/api-doc.spec.js
@@ -88,7 +88,25 @@ describe('APIDocVisitor', function() {
     expect(outDocs[1].name).toBe('myMappedEvent');
   });
 
-});
+  it('should extract public methods info', function() {
+    var methodDocs = apiDoc(['./misc/api-doc-test-cases/directives-with-methods.ts']).Foo.methods;
 
-// TODO: extract types for setters
-// TODO: other members (we are only interested in public, non-lifecycle members)
+    expect(methodDocs.length).toBe(1);
+    expect(methodDocs[0].name).toBe('fooMethod');
+    expect(methodDocs[0].description).toBe('Use this one to produce foo!');
+    expect(methodDocs[0].args.length).toBe(3);
+    expect(methodDocs[0].args[0].name).toBe('arg1');
+    expect(methodDocs[0].args[0].type).toBe('string');
+    expect(methodDocs[0].args[1].name).toBe('arg2');
+    expect(methodDocs[0].args[1].type).toBe('any');
+    expect(methodDocs[0].args[2].name).toBe('arg3');
+    expect(methodDocs[0].args[2].type).toBe('number');
+  });
+
+  it('should not extract public methods info when annotated with @internal', function() {
+    var methodDocs = apiDoc(['./misc/api-doc-test-cases/component-with-internal-methods.ts']).Foo.methods;
+
+    expect(methodDocs.length).toBe(0);
+  });
+
+});

--- a/src/accordion/accordion.ts
+++ b/src/accordion/accordion.ts
@@ -129,20 +129,9 @@ export class NgbAccordion implements AfterContentChecked {
    */
   private _panelRefs: Map<string, NgbPanel> = new Map<string, NgbPanel>();
 
-  ngAfterContentChecked() {
-    // active id updates
-    if (isString(this.activeIds)) {
-      this.activeIds = (this.activeIds as string).split(/\s*,\s*/);
-    }
-    this._updateStates();
-
-    // closeOthers updates
-    if (this.activeIds.length > 1 && this.closeOtherPanels) {
-      this._closeOthers(this.activeIds[0]);
-      this._updateActiveIds();
-    }
-  }
-
+  /**
+   * Programmatically toggle a panel with a given id.
+   */
   toggle(panelId: string) {
     const panel = this._panelRefs.get(panelId);
 
@@ -160,6 +149,20 @@ export class NgbAccordion implements AfterContentChecked {
         }
         this._updateActiveIds();
       }
+    }
+  }
+
+  ngAfterContentChecked() {
+    // active id updates
+    if (isString(this.activeIds)) {
+      this.activeIds = (this.activeIds as string).split(/\s*,\s*/);
+    }
+    this._updateStates();
+
+    // closeOthers updates
+    if (this.activeIds.length > 1 && this.closeOtherPanels) {
+      this._closeOthers(this.activeIds[0]);
+      this._updateActiveIds();
     }
   }
 

--- a/src/carousel/carousel.ts
+++ b/src/carousel/carousel.ts
@@ -93,23 +93,38 @@ export class NgbCarousel implements AfterContentChecked,
 
   ngOnDestroy() { clearInterval(this._slideChangeInterval); }
 
+  /**
+   * Navigate to a slide with a specified identifier.
+   */
   select(slideIdx: string) {
     this._cycleToSelected(slideIdx);
     this._restartTimer();
   }
 
+  /**
+   * Navigate to the next slide.
+   */
   prev() {
     this._cycleToPrev();
     this._restartTimer();
   }
 
+  /**
+   * Navigate to the next slide.
+   */
   next() {
     this._cycleToNext();
     this._restartTimer();
   }
 
+  /**
+   * Stops the carousel from cycling through items.
+   */
   pause() { this._stopTimer(); }
 
+  /**
+   * Restarts cycling through the carousel slides from left to right.
+   */
   cycle() { this._startTimer(); }
 
   private _keyPrev() {

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -30,15 +30,31 @@ export class NgbDropdown {
    */
   @Output() openChange = new EventEmitter();
 
+
+  /**
+   * Checks if the dropdown menu is open or not.
+   */
   isOpen() { return this._open; }
+
+  /**
+   * Opens the dropdown menu of a given navbar or tabbed navigation.
+   */
   open() {
     this._open = true;
     this.openChange.emit(true);
   }
+
+  /**
+   * Closes the dropdown menu of a given navbar or tabbed navigation.
+   */
   close() {
     this._open = false;
     this.openChange.emit(false);
   }
+
+  /**
+   * Toggles the dropdown menu of a given navbar or tabbed navigation.
+   */
   toggle() {
     if (this.isOpen()) {
       this.close();

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -67,6 +67,10 @@ export class NgbPopover implements OnInit, AfterViewChecked, OnDestroy {
         NgbPopoverWindow, injector, viewContainerRef, _renderer, componentFactoryResolver);
   }
 
+
+  /**
+   * Opens an element’s popover. This is considered a “manual” triggering of the popover.
+   */
   open() {
     if (!this._windowRef) {
       this._windowRef = this._popupService.open(this.ngbPopover);
@@ -75,11 +79,17 @@ export class NgbPopover implements OnInit, AfterViewChecked, OnDestroy {
     }
   }
 
+  /**
+   * Closes an element’s popover. This is considered a “manual” triggering of the popover.
+   */
   close(): void {
     this._popupService.close();
     this._windowRef = null;
   }
 
+  /**
+   * Toggles an element’s popover. This is considered a “manual” triggering of the popover.
+   */
   toggle(): void {
     if (this._windowRef) {
       this.close();

--- a/src/tabset/tabset.ts
+++ b/src/tabset/tabset.ts
@@ -104,6 +104,10 @@ export class NgbTabset implements AfterContentChecked {
    */
   @Output() change = new EventEmitter<NgbTabChangeEvent>();
 
+  /**
+   * Selects the given tab and shows its associated pane.
+   * Any other tab that was previously selected becomes unselected and its associated pane is hidden.
+   */
   select(tabIdx: string) {
     let selectedTab = this._getTabById(tabIdx);
     if (selectedTab && !selectedTab.disabled && this.activeId !== selectedTab.id) {

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -62,6 +62,9 @@ export class NgbTooltip implements OnInit, AfterViewChecked, OnDestroy {
         NgbTooltipWindow, injector, viewContainerRef, _renderer, componentFactoryResolver);
   }
 
+  /**
+   * Opens an element’s tooltip. This is considered a “manual” triggering of the tooltip.
+   */
   open() {
     if (!this._windowRef) {
       this._windowRef = this._popupService.open(this.ngbTooltip);
@@ -69,11 +72,17 @@ export class NgbTooltip implements OnInit, AfterViewChecked, OnDestroy {
     }
   }
 
+  /**
+   * Closes an element’s tooltip. This is considered a “manual” triggering of the tooltip.
+   */
   close(): void {
     this._popupService.close();
     this._windowRef = null;
   }
 
+  /**
+   * Toggles an element’s tooltip. This is considered a “manual” triggering of the tooltip.
+   */
   toggle(): void {
     if (this._windowRef) {
       this.close();


### PR DESCRIPTION
PR adds extraction of methods that can be called on exported directive instances. I've added a sample doc to accordion to see how it displays. Will add more docs if this approach is validated.

@icfantv could you please have a look at it from the l&f points of view? What worries me that now a user needs to scroll really a lot to see samples. Maybe we should re-organize the page in the way that demos are displayed first? Or display one flashy demo first (with a link to more demos), then API and then more demos? 

Part of #222.