### PR TITLE
feat(progressbar): add config service to provide default values

### DIFF
--- a/demo/src/app/components/progressbar/demos/config/progressbar-config.html
+++ b/demo/src/app/components/progressbar/demos/config/progressbar-config.html
@@ -1,0 +1,5 @@
+<p>This progress bar uses the customized default values.</p>
+<ngb-progressbar value="250"></ngb-progressbar>
+
+<p>This progress bar uses the customized default values, but changes the type using an input.</p>
+<ngb-progressbar value="500" type="info"></ngb-progressbar>

--- a/demo/src/app/components/progressbar/demos/config/progressbar-config.ts
+++ b/demo/src/app/components/progressbar/demos/config/progressbar-config.ts
@@ -1,0 +1,17 @@
+import {Component} from '@angular/core';
+import {NgbProgressbarConfig} from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+  selector: 'ngbd-progressbar-config',
+  templateUrl: './progressbar-config.html',
+  providers: [NgbProgressbarConfig] // add the NgbProgressbarConfig to the component providers
+})
+export class NgbdProgressbarConfig {
+  constructor(config: NgbProgressbarConfig) {
+    // customize default values of progress bars used by this component tree
+    config.max = 1000;
+    config.striped = true;
+    config.animated = true;
+    config.type = 'success';
+  }
+}

--- a/demo/src/app/components/progressbar/demos/index.ts
+++ b/demo/src/app/components/progressbar/demos/index.ts
@@ -1,7 +1,8 @@
 import {NgbdProgressbarBasic} from './basic/progressbar-basic';
 import {NgbdProgressbarStriped} from './striped/progressbar-striped';
+import {NgbdProgressbarConfig} from './config/progressbar-config';
 
-export const DEMO_DIRECTIVES = [NgbdProgressbarBasic, NgbdProgressbarStriped];
+export const DEMO_DIRECTIVES = [NgbdProgressbarBasic, NgbdProgressbarStriped, NgbdProgressbarConfig];
 
 export const DEMO_SNIPPETS = {
   basic: {
@@ -9,5 +10,8 @@ export const DEMO_SNIPPETS = {
     markup: require('!!prismjs?lang=markup!./basic/progressbar-basic.html')},
   striped: {
     code: require('!!prismjs?lang=typescript!./striped/progressbar-striped'),
-    markup: require('!!prismjs?lang=markup!./striped/progressbar-striped.html')}
+    markup: require('!!prismjs?lang=markup!./striped/progressbar-striped.html')},
+  config: {
+    code: require('!!prismjs?lang=typescript!./config/progressbar-config'),
+    markup: require('!!prismjs?lang=markup!./config/progressbar-config.html')}
 };

--- a/demo/src/app/components/progressbar/progressbar.component.ts
+++ b/demo/src/app/components/progressbar/progressbar.component.ts
@@ -6,7 +6,8 @@ import {DEMO_SNIPPETS} from './demos';
   template: `
     <ngbd-content-wrapper component="Progressbar">
       <ngbd-api-docs directive="NgbProgressbar"></ngbd-api-docs>
-       <ngbd-example-box demoTitle="Contextual progress bars" [htmlSnippet]="snippets.basic.markup" [tsSnippet]="snippets.basic.code">
+      <ngbd-api-docs-config type="NgbProgressbarConfig"></ngbd-api-docs-config>
+      <ngbd-example-box demoTitle="Contextual progress bars" [htmlSnippet]="snippets.basic.markup" [tsSnippet]="snippets.basic.code">
         <ngbd-progressbar-basic></ngbd-progressbar-basic>
       </ngbd-example-box>
       <ngbd-example-box demoTitle="Striped progress bars" [htmlSnippet]="snippets.striped.markup" [tsSnippet]="snippets.striped.code">

--- a/demo/src/app/components/progressbar/progressbar.component.ts
+++ b/demo/src/app/components/progressbar/progressbar.component.ts
@@ -12,6 +12,11 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Striped progress bars" [htmlSnippet]="snippets.striped.markup" [tsSnippet]="snippets.striped.code">
         <ngbd-progressbar-striped></ngbd-progressbar-striped>
       </ngbd-example-box>
+      <ngbd-example-box demoTitle="Global configuration of progress bars" 
+                        [htmlSnippet]="snippets.config.markup" 
+                        [tsSnippet]="snippets.config.code">
+        <ngbd-progressbar-config></ngbd-progressbar-config>      
+      </ngbd-example-box>
     </ngbd-content-wrapper>
   `
 })

--- a/demo/src/app/components/shared/api-docs/api-docs-class.component.ts
+++ b/demo/src/app/components/shared/api-docs/api-docs-class.component.ts
@@ -1,6 +1,11 @@
 import {Component, ChangeDetectionStrategy, Input} from '@angular/core';
 import docs from '../../../../api-docs';
 
+/**
+ * Displays the API docs of a class, which is not a directive.
+ *
+ * For Config services, use NgbdApiDocsConfig instead.
+ */
 @Component({
   selector: 'ngbd-api-docs-class',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -8,11 +13,11 @@ import docs from '../../../../api-docs';
 })
 export class NgbdApiDocsClass {
   apiDocs;
-  @Input() set type(directiveName) {
-    this.apiDocs = docs[directiveName];
+  @Input() set type(typeName) {
+    this.apiDocs = docs[typeName];
   };
 
-  private methodSignature(method) {
+  methodSignature(method) {
     const args = method.args.map(arg => `${arg.name}: ${arg.type}`).join(', ');
     return `${method.name}(${args}): ${method.returnType}`;
   }

--- a/demo/src/app/components/shared/api-docs/api-docs-config.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs-config.component.html
@@ -1,0 +1,23 @@
+<div class="api-doc-component">
+  <h2>
+    <a href="https://github.com/ng-bootstrap/ng-bootstrap/tree/master/{{apiDocs.fileName}}"
+       target="_blank"
+       angulartics2On="click"
+       angularticsEvent="Demo HTML Content"
+       angularticsCategory="{{ demoTitle }}">{{apiDocs.className}}</a>
+  </h2>
+  <p>{{apiDocs.description}}</p>
+
+  <template [ngIf]="apiDocs.properties && apiDocs.properties.length">
+    <section>
+      <h3 id="inputs">Properties</h3>
+      <p>
+        <template ngFor let-property [ngForOf]="apiDocs.properties">
+          <code>{{ property.name }}</code>
+        </template>
+        <i>&mdash; Documentation available in {{ directiveName }}</i>
+      </p>
+    </section>
+  </template>
+</div>
+<hr/>

--- a/demo/src/app/components/shared/api-docs/api-docs-config.component.ts
+++ b/demo/src/app/components/shared/api-docs/api-docs-config.component.ts
@@ -1,0 +1,26 @@
+import {Component, ChangeDetectionStrategy, Input} from '@angular/core';
+import docs from '../../../../api-docs';
+
+const CONFIG_SUFFIX_LENGTH = 'Config'.length;
+
+/**
+ * Displays the API docs of a Config service. A Config service for a component Foo is named, by convention,
+ * FooConfig, and only has properties, whose name matches with an input of the directive.
+ * In order to avoid cluttering the demo pages, the only things displayed by this component
+ * is the description of the Config service and the list of its properties, whose documentation and
+ * default value is documented in the directive itself.
+ */
+@Component({
+  selector: 'ngbd-api-docs-config',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './api-docs-config.component.html'
+})
+export class NgbdApiDocsConfig {
+  apiDocs;
+  directiveName;
+
+  @Input() set type(typeName) {
+    this.apiDocs = docs[typeName];
+    this.directiveName = typeName.slice(0, -CONFIG_SUFFIX_LENGTH);
+  };
+}

--- a/demo/src/app/components/shared/api-docs/api-docs.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs.component.html
@@ -7,11 +7,9 @@
        angularticsCategory="{{ demoTitle }}">{{apiDocs.className}}</a>
   </h2>
   <p>{{apiDocs.description}}</p>
-
-  <template [ngIf]="isDirective">
     <table class="table table-sm table-hover">
       <tbody>
-        <tr *ngIf="apiDocs.selector">
+        <tr>
           <td class="col-md-3">Selector</td>
           <td class="col-md-9"><code>{{apiDocs.selector}}</code></td>
         </tr>
@@ -21,9 +19,8 @@
         </tr>
       </tbody>
     </table>
-  </template>
 
-  <template [ngIf]="isDirective && apiDocs.inputs.length">
+  <template [ngIf]="apiDocs.inputs.length">
     <section>
       <h3 id="inputs">Inputs</h3>
       <table class="table table-sm table-hover">
@@ -32,8 +29,11 @@
           <td class="col-md-3"><code>{{input.name}}</code></td>
           <td class="col-md-9">
             <div><i>Type: </i><code>{{ input.type }}</code></div>
-            <template [ngIf]="input.defaultValue">
-            <div><i>Default value: </i><code>{{input.defaultValue || '-'}}</code></div>
+            <template [ngIf]="defaultInputValue(input) || hasConfigProperty(input)">
+              <div>
+                <span><i>Default value: </i><code>{{ defaultInputValue(input) || '-' }}</code></span>
+                <span *ngIf="hasConfigProperty(input)">&mdash; initialized from {{ configServiceName }} service</span>
+              </div>
             </template>
             <div style="margin: 10px 0">{{ input.description }}</div>
           </td>
@@ -43,7 +43,7 @@
     </section>
   </template>
 
-  <template [ngIf]="isDirective && apiDocs.outputs.length">
+  <template [ngIf]="apiDocs.outputs.length">
     <section>
       <h3 id="outputs">Outputs</h3>
       <table class="table table-sm table-hover">
@@ -57,7 +57,7 @@
     </section>
   </template>
 
-  <template [ngIf]="isDirective ? apiDocs.methods.length && apiDocs.exportAs : apiDocs.methods.length">
+  <template [ngIf]="apiDocs.methods.length && apiDocs.exportAs">
     <section>
       <h3 id="methods">Methods</h3>
       <table class="table table-sm table-hover">
@@ -65,7 +65,7 @@
         <tr *ngFor="let method of apiDocs.methods">
           <td class="col-md-3"><code>{{method.name}}</code></td>
           <td class="col-md-9">
-            <div><i>Signature: </i><code>{{ _methodSignature(method) }}</code></div>
+            <div><i>Signature: </i><code>{{ methodSignature(method) }}</code></div>
             <div style="margin: 10px 0">{{ method.description }}</div>
           </td>
         </tr>

--- a/demo/src/app/components/shared/api-docs/api-docs.component.ts
+++ b/demo/src/app/components/shared/api-docs/api-docs.component.ts
@@ -1,22 +1,67 @@
 import {Component, ChangeDetectionStrategy, Input} from '@angular/core';
 import docs from '../../../../api-docs';
 
+/**
+ * Displays the API docs of a directive.
+ *
+ * The default values of its inputs are looked for in the directive api doc itself, or in the matching property
+ * of associated Config service, if any.
+ *
+ * The config service of a directive NgbFoo is, by convention, named NgbFooConfig.
+ */
 @Component({
   selector: 'ngbd-api-docs',
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './api-docs.component.html'
 })
 export class NgbdApiDocs {
-  isDirective;
+
+  /**
+   * Object which contains, for each input name of the directive, the corresponding property of the associated config
+   * service (if any)
+   */
+  private _configProperties;
 
   apiDocs;
+  configServiceName;
+
   @Input() set directive(directiveName) {
     this.apiDocs = docs[directiveName];
-    this.isDirective = this.apiDocs.selector;
+    this.configServiceName = `${directiveName}Config`;
+    const configApiDocs = docs[this.configServiceName];
+    this._configProperties = {};
+    if (configApiDocs) {
+      this.apiDocs.inputs.forEach(
+        input => this._configProperties[input.name] = this._findInputConfigProperty(configApiDocs, input));
+    }
   };
 
-  private _methodSignature(method) {
+  /**
+   * Returns the default value of the given directive input. If falsy, returns the default value of the matching
+   * config service property
+   */
+  defaultInputValue(input) {
+    if (input.defaultValue !== undefined) {
+      return input.defaultValue;
+    }
+
+    const configProperty = this._configProperties[input.name];
+    return (configProperty && configProperty.defaultValue);
+  }
+
+  /**
+   * Returns true if there is a config service property matching with the given directive input
+   */
+  hasConfigProperty(input) {
+    return !!this._configProperties[input.name];
+  }
+
+  methodSignature(method) {
     const args = method.args.map(arg => `${arg.name}: ${arg.type}`).join(', ');
     return `${method.name}(${args})`;
+  }
+
+  private _findInputConfigProperty(configApiDocs, input) {
+    return configApiDocs.properties.filter(prop => prop.name === input.name)[0];
   }
 }

--- a/demo/src/app/components/shared/api-docs/index.ts
+++ b/demo/src/app/components/shared/api-docs/index.ts
@@ -1,2 +1,3 @@
 export * from './api-docs.component';
 export * from './api-docs-class.component';
+export * from './api-docs-config.component';

--- a/demo/src/app/components/shared/index.ts
+++ b/demo/src/app/components/shared/index.ts
@@ -4,10 +4,11 @@ import {NgbdSharedModule} from '../../shared';
 import {ExampleBoxComponent} from './example-box/example-box.component';
 import {NgbdApiDocs} from './api-docs/api-docs.component';
 import {NgbdApiDocsClass} from './api-docs/api-docs-class.component';
+import {NgbdApiDocsConfig} from './api-docs/api-docs-config.component';
 
 @NgModule({
   imports: [NgbdSharedModule],
-  declarations: [ExampleBoxComponent, NgbdApiDocs, NgbdApiDocsClass],
-  exports: [ExampleBoxComponent, NgbdApiDocs, NgbdApiDocsClass]
+  declarations: [ExampleBoxComponent, NgbdApiDocs, NgbdApiDocsClass, NgbdApiDocsConfig],
+  exports: [ExampleBoxComponent, NgbdApiDocs, NgbdApiDocsClass, NgbdApiDocsConfig]
 })
 export class NgbdComponentsSharedModule {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import {NgbTypeaheadModule} from './typeahead/typeahead.module';
 export {NgbPanelChangeEvent} from './accordion/accordion.module';
 export {NgbModal, NgbModalOptions, NgbModalRef, ModalDismissReasons} from './modal/modal.module';
 export {NgbTabChangeEvent} from './tabset/tabset.module';
+export {NgbProgressbarConfig} from './progressbar/progressbar.module';
 
 @NgModule({
   exports: [

--- a/src/progressbar/progressbar-config.spec.ts
+++ b/src/progressbar/progressbar-config.spec.ts
@@ -1,0 +1,12 @@
+import {NgbProgressbarConfig} from './progressbar-config';
+
+describe('ngb-progressbar-config', () => {
+  it('should have sensible default values', () => {
+    const config = new NgbProgressbarConfig();
+
+    expect(config.max).toBe(100);
+    expect(config.striped).toBe(false);
+    expect(config.animated).toBe(false);
+    expect(config.type).toBeUndefined();
+  });
+});

--- a/src/progressbar/progressbar-config.ts
+++ b/src/progressbar/progressbar-config.ts
@@ -1,0 +1,30 @@
+import {Injectable} from '@angular/core';
+
+/**
+ * Configuration service for the NgbProgressbar component.
+ * You can inject this service, typically in your root component, and customize the values of its properties in
+ * order to provide default values for all the progress bars used in the application.
+ */
+@Injectable()
+export class NgbProgressbarConfig {
+  /**
+   * Maximal value to be displayed in the progressbar.
+   */
+  max = 100;
+
+  /**
+   * A flag indicating if the stripes of the progress bar should be animated. Takes effect only for browsers
+   * supporting CSS3 animations, and if striped is true.
+   */
+  animated: boolean = false;
+
+  /**
+   * A flag indicating if a progress bar should be displayed as striped.
+   */
+  striped: boolean = false;
+
+  /**
+   * Type of progress bar, can be one of "success", "info", "warning" or "danger".
+   */
+  type: string;
+}

--- a/src/progressbar/progressbar-config.ts
+++ b/src/progressbar/progressbar-config.ts
@@ -7,24 +7,8 @@ import {Injectable} from '@angular/core';
  */
 @Injectable()
 export class NgbProgressbarConfig {
-  /**
-   * Maximal value to be displayed in the progressbar.
-   */
   max = 100;
-
-  /**
-   * A flag indicating if the stripes of the progress bar should be animated. Takes effect only for browsers
-   * supporting CSS3 animations, and if striped is true.
-   */
-  animated: boolean = false;
-
-  /**
-   * A flag indicating if a progress bar should be displayed as striped.
-   */
-  striped: boolean = false;
-
-  /**
-   * Type of progress bar, can be one of "success", "info", "warning" or "danger".
-   */
+  animated = false;
+  striped = false;
   type: string;
 }

--- a/src/progressbar/progressbar.module.ts
+++ b/src/progressbar/progressbar.module.ts
@@ -1,6 +1,10 @@
 import {NgModule} from '@angular/core';
 import {NGB_PROGRESSBAR_DIRECTIVES} from './progressbar';
+import {NgbProgressbarConfig} from './progressbar-config';
 
-@NgModule({declarations: NGB_PROGRESSBAR_DIRECTIVES, exports: NGB_PROGRESSBAR_DIRECTIVES})
+export {NgbProgressbarConfig} from './progressbar-config';
+
+@NgModule(
+    {declarations: NGB_PROGRESSBAR_DIRECTIVES, exports: NGB_PROGRESSBAR_DIRECTIVES, providers: [NgbProgressbarConfig]})
 export class NgbProgressbarModule {
 }

--- a/src/progressbar/progressbar.spec.ts
+++ b/src/progressbar/progressbar.spec.ts
@@ -1,10 +1,11 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
 import {createGenericTestComponent} from '../util/tests';
 
 import {Component} from '@angular/core';
 
 import {NgbProgressbarModule} from './progressbar.module';
 import {NgbProgressbar} from './progressbar';
+import {NgbProgressbarConfig} from './progressbar-config';
 
 const createTestComponent = (html: string) =>
     createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
@@ -17,11 +18,19 @@ function getProgressbar(nativeEl: Element): Element {
   return nativeEl.querySelector('progress');
 }
 
-describe('ng-progressbar', () => {
+describe('ngb-progressbar', () => {
   describe('business logic', () => {
     let progressCmp: NgbProgressbar;
 
-    beforeEach(() => { progressCmp = new NgbProgressbar(); });
+    beforeEach(() => { progressCmp = new NgbProgressbar(new NgbProgressbarConfig()); });
+
+    it('should initialize inputs with default values', () => {
+      const defaultConfig = new NgbProgressbarConfig();
+      expect(progressCmp.max).toBe(defaultConfig.max);
+      expect(progressCmp.animated).toBe(defaultConfig.animated);
+      expect(progressCmp.striped).toBe(defaultConfig.striped);
+      expect(progressCmp.type).toBe(defaultConfig.type);
+    });
 
     it('should calculate the percentage (default max size)', () => {
       progressCmp.value = 50;
@@ -153,6 +162,31 @@ describe('ng-progressbar', () => {
 
       expect(getProgressbar(fixture.nativeElement)).toHaveCssClass('progress-striped');
       expect(getProgressbar(fixture.nativeElement)).not.toHaveCssClass('false');
+    });
+  });
+
+  describe('Custom config', () => {
+    let config: NgbProgressbarConfig;
+
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbProgressbarModule]}); });
+
+    beforeEach(inject([NgbProgressbarConfig], (c: NgbProgressbarConfig) => {
+      config = c;
+      config.max = 1000;
+      config.striped = true;
+      config.animated = true;
+      config.type = 'success';
+    }));
+
+    it('should initialize inputs with provided config', () => {
+      const fixture = TestBed.createComponent(NgbProgressbar);
+      fixture.detectChanges();
+
+      let progressbar = fixture.componentInstance;
+      expect(progressbar.max).toBe(config.max);
+      expect(progressbar.striped).toBe(config.striped);
+      expect(progressbar.animated).toBe(config.animated);
+      expect(progressbar.type).toBe(config.type);
     });
   });
 });

--- a/src/progressbar/progressbar.spec.ts
+++ b/src/progressbar/progressbar.spec.ts
@@ -189,6 +189,30 @@ describe('ngb-progressbar', () => {
       expect(progressbar.type).toBe(config.type);
     });
   });
+
+  describe('Custom config as provider', () => {
+    let config = new NgbProgressbarConfig();
+    config.max = 1000;
+    config.striped = true;
+    config.animated = true;
+    config.type = 'success';
+
+    beforeEach(() => {
+      TestBed.configureTestingModule(
+          {imports: [NgbProgressbarModule], providers: [{provide: NgbProgressbarConfig, useValue: config}]});
+    });
+
+    it('should initialize inputs with provided config as provider', () => {
+      const fixture = TestBed.createComponent(NgbProgressbar);
+      fixture.detectChanges();
+
+      let progressbar = fixture.componentInstance;
+      expect(progressbar.max).toBe(config.max);
+      expect(progressbar.striped).toBe(config.striped);
+      expect(progressbar.animated).toBe(config.animated);
+      expect(progressbar.type).toBe(config.type);
+    });
+  });
 });
 
 @Component({selector: 'test-cmp', template: ''})

--- a/src/progressbar/progressbar.ts
+++ b/src/progressbar/progressbar.ts
@@ -1,5 +1,6 @@
-import {Component, Input, ChangeDetectionStrategy} from '@angular/core';
+import {Component, Input, ChangeDetectionStrategy, Optional} from '@angular/core';
 import {getValueInRange} from '../util/util';
+import {NgbProgressbarConfig} from './progressbar-config';
 
 /**
  * Directive that can be used to provide feedback on the progress of a workflow or an action.
@@ -25,8 +26,8 @@ export class NgbProgressbar {
   @Input() max = 100;
 
   /**
-   * A flag indicating if a progress bar should be animated when the value changes. Takes effect only for browsers
-   * supporting CSS3 animations.
+   * A flag indicating if the stripes of the progress bar should be animated. Takes effect only for browsers
+   * supporting CSS3 animations, and if striped is true.
    */
   @Input() animated = false;
 
@@ -44,6 +45,13 @@ export class NgbProgressbar {
    * Current value to be displayed in the progressbar. Should be smaller or equal to "max" value.
    */
   @Input() value = 0;
+
+  constructor(config: NgbProgressbarConfig) {
+    this.max = config.max;
+    this.animated = config.animated;
+    this.striped = config.striped;
+    this.type = config.type;
+  }
 
   getValue() { return getValueInRange(this.value, this.max); }
 


### PR DESCRIPTION
refs #518

The first commit keeps the initialization of the inputs in the component as is. 
Also note that I changed the documentation of the animated input in order to indicate what it *will* do once the bootstrap bug is fixed, according to bootstrap's documentation.

The second commit changes the infrastructure code to
 - generate documentation for public properties of services in addition to methods
 - add a component to display the api docs of services in the demo
 - get the default value and description of inputs from the matching config service property if not specified in the directive itself
 - indicate which properties are initialized with properties of the config service
 - use all this in the documentation of NgbProgressbar
