### PR TITLE
demo(typeahead): add error recovery to http demo

### DIFF
--- a/demo/src/app/components/typeahead/demos/http/typeahead-http.html
+++ b/demo/src/app/components/typeahead/demos/http/typeahead-http.html
@@ -1,12 +1,20 @@
 A typeahead example that gets values from the <code>WikipediaService</code>
 <ul>
-  <li>remote data retrieval</li>
   <li><code>debounceTime</code> operator</li>
-  <li><code>do</code> operator</li>
-  <li><code>distinctUntilChanged</code> operator</li>
-  <li><code>switchMap</code> operator</li>
+  <li>remote data retrieval</li>
+  <li>guaranteed ordering using <code>switchMap</code></li>
+  <li>error recovery after 2 retries</li>
 </ul>
 
-<input type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search" placeholder="Wikipedia search" /><span *ngIf="_searching"> searching...</span>
+<div class="form-group" [class.has-danger]="_error">
+  <input type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search" placeholder="Wikipedia search" />
+  <span class="form-control-feedback">
+    <span *ngIf="_searching"> searching...</span>
+    <span *ngIf="_error"> search failed</span>
+  </span>
+</div>
+<label>
+  <input type="checkbox" [(ngModel)]="_failRequests"> Fail requests
+</label>
 <hr>
 <pre>Model: {{ model | json }}</pre>

--- a/demo/src/app/components/typeahead/demos/http/typeahead-http.ts
+++ b/demo/src/app/components/typeahead/demos/http/typeahead-http.ts
@@ -1,26 +1,32 @@
-import {Component, Input} from '@angular/core';
+import {Component} from '@angular/core';
 import {HTTP_PROVIDERS, JSONP_PROVIDERS} from '@angular/http';
 import {NGB_TYPEAHEAD_DIRECTIVES, NGB_PRECOMPILE} from '@ng-bootstrap/ng-bootstrap';
 
 import {Injectable} from '@angular/core';
 import {Jsonp, URLSearchParams} from '@angular/http';
 import {Observable} from 'rxjs/Rx';
+import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/debounceTime';
 import 'rxjs/add/operator/distinctUntilChanged';
 import 'rxjs/add/operator/do';
+import 'rxjs/add/operator/retry';
 import 'rxjs/add/operator/switchMap';
 
 @Injectable()
 export class WikipediaService {
   constructor(private _jsonp: Jsonp) {}
 
-  search(term: string) {
+  search(term: string, failRequest: boolean) {
     let wikiUrl = 'https://en.wikipedia.org/w/api.php';
     let params = new URLSearchParams();
     params.set('search', term);
     params.set('action', 'opensearch');
     params.set('format', 'json');
     params.set('callback', 'JSONP_CALLBACK');
+
+    if (failRequest) {
+      wikiUrl = 'https://invalidurl';
+    }
 
     return this._jsonp
       .get(wikiUrl, {search: params})
@@ -38,6 +44,9 @@ export class WikipediaService {
 })
 export class NgbdTypeaheadHttp {
 
+  private _failRequests: boolean;
+
+  private _error: boolean;
   private _searching: boolean;
 
   constructor(private _service: WikipediaService) {}
@@ -46,7 +55,17 @@ export class NgbdTypeaheadHttp {
     text$
       .debounceTime(300)
       .distinctUntilChanged()
-      .do(term => { this._searching = term.length > 0; })
-      .switchMap(term => term === '' ? Observable.of([]) : this._service.search(term))
+      .do(term => {
+        this._searching = term.length > 0;
+        this._error = false;
+      })
+      .switchMap(term => term === '' ? Observable.of([]) :
+        this._service.search(term, this._failRequests)
+          .retry(2)
+          .catch(() => {
+            this._error = true;
+            return Observable.of([]);
+          })
+      )
       .do(() => { this._searching = false; });
 }


### PR DESCRIPTION
Add failed requests handling to wikipedia demo 

- in case it doesn't work 
- to explicitly demonstrate error recovery