### PR TITLE
fix(typeahead): fix excessive rendering and revert click events

### DIFF
--- a/src/typeahead/typeahead-window.spec.ts
+++ b/src/typeahead/typeahead-window.spec.ts
@@ -114,7 +114,7 @@ describe('ngb-typeahead-window', () => {
 
            expectResults(fixture.nativeElement, ['+bar', 'baz']);
 
-           links[1].triggerEventHandler('mousedown', {});
+           links[1].triggerEventHandler('click', {});
            fixture.detectChanges();
            expect(fixture.componentInstance.selected).toBe('baz');
          });

--- a/src/typeahead/typeahead-window.ts
+++ b/src/typeahead/typeahead-window.ts
@@ -3,9 +3,11 @@ import {NgbHighlight} from './highlight';
 
 import {toString} from '../util/util';
 
-export class ResultTplCtx {
-  constructor(public result, public term: string, public formatter: (result) => string) {}
-}
+export type ResultTplCtx = {
+  result: string,
+  term: string,
+  formatter: (_: string) => string
+};
 
 @Component({
   selector: 'ngb-typeahead-window',
@@ -19,7 +21,8 @@ export class ResultTplCtx {
       <button class="dropdown-item" [class.active]="idx === _activeIdx" 
         (mouseenter)="markActive(idx)" 
         (mousedown)="select(result)">
-          <template [ngTemplateOutlet]="resultTemplate || rt" [ngOutletContext]="_prepareTplCtx(result)"></template>
+          <template [ngTemplateOutlet]="resultTemplate || rt" 
+          [ngOutletContext]="{result: result, term: term, formatter: formatter}"></template>
       </button>
     </template>
   `,
@@ -68,6 +71,4 @@ export class NgbTypeaheadWindow {
   prev() { this._activeIdx = (this._activeIdx === 0 ? this.results.length - 1 : this._activeIdx - 1); }
 
   select(item) { this.selectEvent.emit(item); }
-
-  private _prepareTplCtx(result: any) { return new ResultTplCtx(result, this.term, this.formatter); }
 }

--- a/src/typeahead/typeahead-window.ts
+++ b/src/typeahead/typeahead-window.ts
@@ -20,7 +20,7 @@ export type ResultTplCtx = {
     <template ngFor [ngForOf]="results" let-result let-idx="index">
       <button class="dropdown-item" [class.active]="idx === _activeIdx" 
         (mouseenter)="markActive(idx)" 
-        (mousedown)="select(result)">
+        (click)="select(result)">
           <template [ngTemplateOutlet]="resultTemplate || rt" 
           [ngOutletContext]="{result: result, term: term, formatter: formatter}"></template>
       </button>

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -201,7 +201,7 @@ describe('ngb-typeahead', () => {
          });
        })));
 
-    it('should select the result on mousedown, close window and fill the input',
+    it('should select the result on click, close window and fill the input',
        async(inject([TestComponentBuilder], (tcb) => {
          const html = `<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`;
 
@@ -214,7 +214,7 @@ describe('ngb-typeahead', () => {
            fixture.detectChanges();
            expectWindowResults(compiled, ['+one', 'one more']);
 
-           getWindowLinks(fixture.debugElement)[0].triggerEventHandler('mousedown', {});
+           getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
            fixture.detectChanges();
            expect(getWindow(compiled)).toBeNull();
            expectInputValue(compiled, 'one');
@@ -226,7 +226,7 @@ describe('ngb-typeahead', () => {
            expectWindowResults(compiled, ['+one', 'one more']);
            expectInputValue(compiled, 'o');
 
-           getWindowLinks(fixture.debugElement)[0].triggerEventHandler('mousedown', {});
+           getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
            fixture.detectChanges();
            expect(getWindow(compiled)).toBeNull();
            expectInputValue(compiled, 'one');


### PR DESCRIPTION
This 
- fixes typeahead window items excessive rendering
- reverts `(mousedown)` to `(click)` for a more standard behaviour

Closes #526 