### PR TITLE
fix(progressbar): reorder 'value' and 'max' attribute bindings for IE

### DIFF
--- a/src/progressbar/progressbar.spec.ts
+++ b/src/progressbar/progressbar.spec.ts
@@ -76,9 +76,15 @@ describe('ng-progressbar', () => {
 
            expect(getBarWidth(fixture.nativeElement)).toBe('10%');
 
+           // this might fail in IE11 if attribute binding order is not respected for the <progress> element:
+           // <progress [value]="" [max]=""> will fail with value = 1
+           // <progress [max]="" [value]=""> will work with value = 10
+           expect(getProgressbar(fixture.nativeElement).getAttribute('value')).toBe('10');
+
            fixture.componentInstance.value = 30;
            fixture.detectChanges();
            expect(getBarWidth(fixture.nativeElement)).toBe('30%');
+           expect(getProgressbar(fixture.nativeElement).getAttribute('value')).toBe('30');
          });
        })));
 

--- a/src/progressbar/progressbar.ts
+++ b/src/progressbar/progressbar.ts
@@ -11,7 +11,7 @@ import {getValueInRange, toBoolean} from '../util/util';
     <progress class="progress {{type ? 'progress-' + type : ''}}" 
       [class.progress-animated]="isAnimated()" 
       [class.progress-striped]="isStriped()"
-      [value]="getValue()" [max]="max">
+      [max]="max" [value]="getValue()">
       <div class="progress">
         <span class="progress-bar" [style.width.%]="getPercentValue()"><ng-content></ng-content></span>
       </div>


### PR DESCRIPTION
See the explanation in the issue in question.
Changing attribute binding order seems to fix progressbar display in IE

Closes #543