### PR TITLE
fix(typeahead): specify any type for formatters argument

### DIFF
--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -62,7 +62,7 @@ export class NgbTypeahead implements OnInit,
   /**
    * A function to convert a given value into string to display in the input field
    */
-  @Input() inputFormatter: (value) => string;
+  @Input() inputFormatter: (value: any) => string;
 
   /**
    * A function to transform the provided observable text into the array of results
@@ -73,7 +73,7 @@ export class NgbTypeahead implements OnInit,
    * A function to format a given result before display. This function should return a formatted string without any
    * HTML markup.
    */
-  @Input() resultFormatter: (value) => string;
+  @Input() resultFormatter: (value: any) => string;
 
   /**
    * A template to display a matching result.


### PR DESCRIPTION
The generated .d.ts file doesn't specify `any` as the type of the formatter argument (`value`) when it is defined as

    inputFormatter: (value) => string;

Declaring it with an explicit `any` type fixes the issue:

    inputFormatter: (value: any) => string;

That is quite strange, because for the attributes of `NgbTypeaheadWindow` which don't have a explicit type declared, like for example

    @Input() results;

The corresponding attribute in the generated .d.ts file does have an explicit `any` type declared:

    results: any;

So this looks like a bug or limitation of the typescript compiler. 