### PR TITLE
test(all): standardizing spec files

### DIFF
--- a/src/accordion/accordion.spec.ts
+++ b/src/accordion/accordion.spec.ts
@@ -1,6 +1,4 @@
-import {async, TestBed} from '@angular/core/testing';
-
-import {TestComponentBuilder} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 
 import {Component} from '@angular/core';
 
@@ -26,6 +24,13 @@ function expectOpenPanels(nativeEl: HTMLElement, openPanelsDef: boolean[]) {
   expect(result).toEqual(openPanelsDef);
 }
 
+function createTestComponent(html: string): ComponentFixture<TestComponent> {
+  TestBed.overrideComponent(TestComponent, {set: {template: html}});
+  const fixture = TestBed.createComponent(TestComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
 describe('ngb-accordion', () => {
   let html = `
     <ngb-accordion #acc="ngbAccordion" [closeOthers]="closeOthers" [activeIds]="activeIds"
@@ -43,231 +48,230 @@ describe('ngb-accordion', () => {
     TestBed.overrideComponent(TestComponent, {set: {template: html}});
   });
 
-  it('should have no open panels', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
-       expectOpenPanels(fixture.nativeElement, [false, false, false]);
-     }));
+  it('should have no open panels', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expectOpenPanels(fixture.nativeElement, [false, false, false]);
+  });
 
-  it('should toggle panels based on "activeIds" values', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
-       const tc = fixture.componentInstance;
-       const el = fixture.nativeElement;
-       // as array
-       tc.activeIds = ['one', 'two'];
-       fixture.detectChanges();
-       expectOpenPanels(el, [true, true, false]);
+  it('should toggle panels based on "activeIds" values', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    const tc = fixture.componentInstance;
+    const el = fixture.nativeElement;
+    // as array
+    tc.activeIds = ['one', 'two'];
+    fixture.detectChanges();
+    expectOpenPanels(el, [true, true, false]);
 
-       tc.activeIds = ['two', 'three'];
-       fixture.detectChanges();
-       expectOpenPanels(el, [false, true, true]);
+    tc.activeIds = ['two', 'three'];
+    fixture.detectChanges();
+    expectOpenPanels(el, [false, true, true]);
 
-       tc.activeIds = [];
-       fixture.detectChanges();
-       expectOpenPanels(el, [false, false, false]);
+    tc.activeIds = [];
+    fixture.detectChanges();
+    expectOpenPanels(el, [false, false, false]);
 
-       tc.activeIds = ['wrong id', 'one'];
-       fixture.detectChanges();
-       expectOpenPanels(el, [true, false, false]);
+    tc.activeIds = ['wrong id', 'one'];
+    fixture.detectChanges();
+    expectOpenPanels(el, [true, false, false]);
 
-       // as string
-       tc.activeIds = 'one';
-       fixture.detectChanges();
-       expectOpenPanels(el, [true, false, false]);
+    // as string
+    tc.activeIds = 'one';
+    fixture.detectChanges();
+    expectOpenPanels(el, [true, false, false]);
 
-       tc.activeIds = 'two, three';
-       fixture.detectChanges();
-       expectOpenPanels(el, [false, true, true]);
+    tc.activeIds = 'two, three';
+    fixture.detectChanges();
+    expectOpenPanels(el, [false, true, true]);
 
-       tc.activeIds = '';
-       fixture.detectChanges();
-       expectOpenPanels(el, [false, false, false]);
+    tc.activeIds = '';
+    fixture.detectChanges();
+    expectOpenPanels(el, [false, false, false]);
 
-       tc.activeIds = 'wrong id,one';
-       fixture.detectChanges();
-       expectOpenPanels(el, [true, false, false]);
-     }));
-
-
-  it('should toggle panels independently', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
-
-       const el = fixture.nativeElement;
-
-       getButton(el, 1).click();
-       fixture.detectChanges();
-       expectOpenPanels(el, [false, true, false]);
-
-       getButton(el, 0).click();
-       fixture.detectChanges();
-       expectOpenPanels(el, [true, true, false]);
-
-       getButton(el, 1).click();
-       fixture.detectChanges();
-       expectOpenPanels(el, [true, false, false]);
-
-       getButton(el, 2).click();
-       fixture.detectChanges();
-
-       expectOpenPanels(el, [true, false, true]);
-
-       getButton(el, 0).click();
-       fixture.detectChanges();
-       expectOpenPanels(el, [false, false, true]);
-
-       getButton(el, 2).click();
-       fixture.detectChanges();
-       expectOpenPanels(el, [false, false, false]);
-     }));
-
-  it('should allow only one panel to be active with "closeOthers" flag', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
-
-       const tc = fixture.componentInstance;
-       const el = fixture.nativeElement;
-
-       tc.closeOthers = true;
-
-       getButton(el, 0).click();
-       fixture.detectChanges();
-       expectOpenPanels(el, [true, false, false]);
-
-       getButton(el, 1).click();
-       fixture.detectChanges();
-       expectOpenPanels(el, [false, true, false]);
-     }));
-
-  it('should have the appropriate heading', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
-
-       const compiled = fixture.nativeElement;
-
-       const titles = Array.from(compiled.querySelectorAll('.card-header a'));
-       expect(titles.length).not.toBe(0);
-
-       titles.forEach(
-           (title: HTMLElement, idx: number) => { expect(title.textContent.trim()).toBe(`Panel ${idx + 1}`); });
-     }));
-
-  it('should only open one at a time', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
-       const tc = fixture.componentInstance;
-       tc.closeOthers = true;
-       fixture.detectChanges();
-
-       const headingLinks = fixture.nativeElement.querySelectorAll('.card-header a');
-
-       headingLinks[0].click();
-       fixture.detectChanges();
-       expectOpenPanels(fixture.nativeElement, [true, false, false]);
-
-       headingLinks[2].click();
-       fixture.detectChanges();
-       expectOpenPanels(fixture.nativeElement, [false, false, true]);
-
-       headingLinks[2].click();
-       fixture.detectChanges();
-       expectOpenPanels(fixture.nativeElement, [false, false, false]);
-     }));
+    tc.activeIds = 'wrong id,one';
+    fixture.detectChanges();
+    expectOpenPanels(el, [true, false, false]);
+  });
 
 
+  it('should toggle panels independently', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
 
-  it('should have only one open panel even if binding says otherwise', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
-       const tc = fixture.componentInstance;
+    const el = fixture.nativeElement;
 
-       tc.activeIds = ['one', 'two'];
-       tc.closeOthers = true;
-       fixture.detectChanges();
+    getButton(el, 1).click();
+    fixture.detectChanges();
+    expectOpenPanels(el, [false, true, false]);
 
-       expectOpenPanels(fixture.nativeElement, [true, false, false]);
-     }));
+    getButton(el, 0).click();
+    fixture.detectChanges();
+    expectOpenPanels(el, [true, true, false]);
 
-  it('should not open disabled panels from click', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
-       const tc = fixture.componentInstance;
-       tc.panels[0].disabled = true;
-       fixture.detectChanges();
+    getButton(el, 1).click();
+    fixture.detectChanges();
+    expectOpenPanels(el, [true, false, false]);
 
-       const headingLinks = fixture.nativeElement.querySelectorAll('.card-header a');
+    getButton(el, 2).click();
+    fixture.detectChanges();
 
-       headingLinks[0].click();
-       fixture.detectChanges();
+    expectOpenPanels(el, [true, false, true]);
 
-       expectOpenPanels(fixture.nativeElement, [false, false, false]);
-     }));
+    getButton(el, 0).click();
+    fixture.detectChanges();
+    expectOpenPanels(el, [false, false, true]);
 
-  it('should open/collapse disabled panels', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
-       const tc = fixture.componentInstance;
+    getButton(el, 2).click();
+    fixture.detectChanges();
+    expectOpenPanels(el, [false, false, false]);
+  });
 
-       tc.activeIds = ['one'];
-       fixture.detectChanges();
-       expectOpenPanels(fixture.nativeElement, [true, false, false]);
+  it('should allow only one panel to be active with "closeOthers" flag', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
 
-       tc.panels[0].disabled = true;
-       fixture.detectChanges();
-       expectOpenPanels(fixture.nativeElement, [false, false, false]);
+    const tc = fixture.componentInstance;
+    const el = fixture.nativeElement;
 
-       tc.panels[0].disabled = false;
-       fixture.detectChanges();
-       expectOpenPanels(fixture.nativeElement, [true, false, false]);
-     }));
+    tc.closeOthers = true;
 
-  it('should remove collapsed panels content from DOM', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
-       expect(getPanelsContent(fixture.nativeElement).length).toBe(0);
+    getButton(el, 0).click();
+    fixture.detectChanges();
+    expectOpenPanels(el, [true, false, false]);
 
-       getButton(fixture.nativeElement, 0).click();
-       fixture.detectChanges();
-       expect(getPanelsContent(fixture.nativeElement).length).toBe(1);
-     }));
+    getButton(el, 1).click();
+    fixture.detectChanges();
+    expectOpenPanels(el, [false, true, false]);
+  });
 
-  it('should emit panel change event when toggling panels', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
+  it('should have the appropriate heading', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
 
-       fixture.componentInstance.changeCallback = () => {};
+    const compiled = fixture.nativeElement;
 
-       spyOn(fixture.componentInstance, 'changeCallback');
+    const titles = Array.from(compiled.querySelectorAll('.card-header a'));
+    expect(titles.length).not.toBe(0);
 
-       // Select the first tab -> change event
-       getButton(fixture.nativeElement, 0).click();
-       fixture.detectChanges();
-       expect(fixture.componentInstance.changeCallback)
-           .toHaveBeenCalledWith(jasmine.objectContaining({panelId: 'one', nextState: true}));
+    titles.forEach((title: HTMLElement, idx: number) => { expect(title.textContent.trim()).toBe(`Panel ${idx + 1}`); });
+  });
 
-       // Select the first tab again -> change event
-       getButton(fixture.nativeElement, 0).click();
-       fixture.detectChanges();
-       expect(fixture.componentInstance.changeCallback)
-           .toHaveBeenCalledWith(jasmine.objectContaining({panelId: 'one', nextState: false}));
-     }));
+  it('should only open one at a time', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    const tc = fixture.componentInstance;
+    tc.closeOthers = true;
+    fixture.detectChanges();
 
-  it('should cancel panel toggle when preventDefault() is called', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
+    const headingLinks = fixture.nativeElement.querySelectorAll('.card-header a');
 
-       let changeEvent = null;
-       fixture.componentInstance.changeCallback = event => {
-         changeEvent = event;
-         event.preventDefault();
-       };
+    headingLinks[0].click();
+    fixture.detectChanges();
+    expectOpenPanels(fixture.nativeElement, [true, false, false]);
 
-       // Select the first tab -> toggle will be canceled
-       getButton(fixture.nativeElement, 0).click();
-       fixture.detectChanges();
-       expect(changeEvent).toEqual(jasmine.objectContaining({panelId: 'one', nextState: true}));
-       expectOpenPanels(fixture.nativeElement, [false, false, false]);
-     }));
+    headingLinks[2].click();
+    fixture.detectChanges();
+    expectOpenPanels(fixture.nativeElement, [false, false, true]);
+
+    headingLinks[2].click();
+    fixture.detectChanges();
+    expectOpenPanels(fixture.nativeElement, [false, false, false]);
+  });
 
 
-  it('should have specified type of accordion ', async(() => {
-       const testHtml = `
+
+  it('should have only one open panel even if binding says otherwise', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    const tc = fixture.componentInstance;
+
+    tc.activeIds = ['one', 'two'];
+    tc.closeOthers = true;
+    fixture.detectChanges();
+
+    expectOpenPanels(fixture.nativeElement, [true, false, false]);
+  });
+
+  it('should not open disabled panels from click', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    const tc = fixture.componentInstance;
+    tc.panels[0].disabled = true;
+    fixture.detectChanges();
+
+    const headingLinks = fixture.nativeElement.querySelectorAll('.card-header a');
+
+    headingLinks[0].click();
+    fixture.detectChanges();
+
+    expectOpenPanels(fixture.nativeElement, [false, false, false]);
+  });
+
+  it('should open/collapse disabled panels', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    const tc = fixture.componentInstance;
+
+    tc.activeIds = ['one'];
+    fixture.detectChanges();
+    expectOpenPanels(fixture.nativeElement, [true, false, false]);
+
+    tc.panels[0].disabled = true;
+    fixture.detectChanges();
+    expectOpenPanels(fixture.nativeElement, [false, false, false]);
+
+    tc.panels[0].disabled = false;
+    fixture.detectChanges();
+    expectOpenPanels(fixture.nativeElement, [true, false, false]);
+  });
+
+  it('should remove collapsed panels content from DOM', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(getPanelsContent(fixture.nativeElement).length).toBe(0);
+
+    getButton(fixture.nativeElement, 0).click();
+    fixture.detectChanges();
+    expect(getPanelsContent(fixture.nativeElement).length).toBe(1);
+  });
+
+  it('should emit panel change event when toggling panels', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    fixture.componentInstance.changeCallback = () => {};
+
+    spyOn(fixture.componentInstance, 'changeCallback');
+
+    // Select the first tab -> change event
+    getButton(fixture.nativeElement, 0).click();
+    fixture.detectChanges();
+    expect(fixture.componentInstance.changeCallback)
+        .toHaveBeenCalledWith(jasmine.objectContaining({panelId: 'one', nextState: true}));
+
+    // Select the first tab again -> change event
+    getButton(fixture.nativeElement, 0).click();
+    fixture.detectChanges();
+    expect(fixture.componentInstance.changeCallback)
+        .toHaveBeenCalledWith(jasmine.objectContaining({panelId: 'one', nextState: false}));
+  });
+
+  it('should cancel panel toggle when preventDefault() is called', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    let changeEvent = null;
+    fixture.componentInstance.changeCallback = event => {
+      changeEvent = event;
+      event.preventDefault();
+    };
+
+    // Select the first tab -> toggle will be canceled
+    getButton(fixture.nativeElement, 0).click();
+    fixture.detectChanges();
+    expect(changeEvent).toEqual(jasmine.objectContaining({panelId: 'one', nextState: true}));
+    expectOpenPanels(fixture.nativeElement, [false, false, false]);
+  });
+
+
+  it('should have specified type of accordion ', () => {
+    const testHtml = `
     <ngb-accordion #acc="ngbAccordion" [closeOthers]="closeOthers" [type]="classType">
      <ngb-panel *ngFor="let panel of panels" [id]="panel.id" [disabled]="panel.disabled">
        <template ngbPanelTitle>{{panel.title}}</template>
@@ -276,34 +280,32 @@ describe('ngb-accordion', () => {
     </ngb-accordion>
     <button *ngFor="let panel of panels" (click)="acc.toggle(panel.id)">Toggle the panel {{ panel.id }}</button>
     `;
-       TestBed.overrideComponent(TestComponent, {set: {template: testHtml}});
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
+    const fixture = createTestComponent(testHtml);
 
-       fixture.componentInstance.classType = 'warning';
-       fixture.detectChanges();
+    fixture.componentInstance.classType = 'warning';
+    fixture.detectChanges();
 
-       let el = fixture.nativeElement.querySelectorAll('.card-header');
-       expect(el[0]).toHaveCssClass('card-warning');
-       expect(el[1]).toHaveCssClass('card-warning');
-       expect(el[2]).toHaveCssClass('card-warning');
-     }));
+    let el = fixture.nativeElement.querySelectorAll('.card-header');
+    expect(el[0]).toHaveCssClass('card-warning');
+    expect(el[1]).toHaveCssClass('card-warning');
+    expect(el[2]).toHaveCssClass('card-warning');
+  });
 
-  it('should override the type in accordion with type in panel', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
-       fixture.componentInstance.classType = 'warning';
+  it('should override the type in accordion with type in panel', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    fixture.componentInstance.classType = 'warning';
 
-       const tc = fixture.componentInstance;
-       tc.panels[0].type = 'success';
-       tc.panels[1].type = 'danger';
-       fixture.detectChanges();
+    const tc = fixture.componentInstance;
+    tc.panels[0].type = 'success';
+    tc.panels[1].type = 'danger';
+    fixture.detectChanges();
 
-       let el = fixture.nativeElement.querySelectorAll('.card-header');
-       expect(el[0]).toHaveCssClass('card-success');
-       expect(el[1]).toHaveCssClass('card-danger');
-       expect(el[2]).toHaveCssClass('card-warning');
-     }));
+    let el = fixture.nativeElement.querySelectorAll('.card-header');
+    expect(el[0]).toHaveCssClass('card-success');
+    expect(el[1]).toHaveCssClass('card-danger');
+    expect(el[2]).toHaveCssClass('card-warning');
+  });
 });
 
 @Component({selector: 'test-cmp', template: ''})

--- a/src/alert/alert.spec.ts
+++ b/src/alert/alert.spec.ts
@@ -1,4 +1,4 @@
-import {async, fakeAsync, tick, TestBed} from '@angular/core/testing';
+import {fakeAsync, tick, TestBed} from '@angular/core/testing';
 
 import {Component} from '@angular/core';
 
@@ -17,103 +17,102 @@ describe('ngb-alert', () => {
 
   beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAlertModule]}); });
 
-  it('should have type warning and by dismissible by default', async(() => {
-       TestBed.overrideComponent(TestComponent, {set: {template: '<ngb-alert>Watch out!</ngb-alert>'}})
-           .compileComponents()
-           .then(() => {
-             const fixture = TestBed.createComponent(TestComponent);
-             fixture.detectChanges();
+  it('should have type warning and by dismissible by default', () => {
+    TestBed.overrideComponent(TestComponent, {set: {template: '<ngb-alert>Watch out!</ngb-alert>'}})
+        .compileComponents()
+        .then(() => {
+          const fixture = TestBed.createComponent(TestComponent);
+          fixture.detectChanges();
 
-             const alertEl = getAlertElement(fixture.nativeElement);
+          const alertEl = getAlertElement(fixture.nativeElement);
 
-             expect(alertEl).toHaveCssClass('alert-warning');
-             expect(alertEl.getAttribute('role')).toEqual('alert');
-             expect(getCloseButton(alertEl)).toBeTruthy();
-           });
-     }));
+          expect(alertEl).toHaveCssClass('alert-warning');
+          expect(alertEl.getAttribute('role')).toEqual('alert');
+          expect(getCloseButton(alertEl)).toBeTruthy();
+        });
+  });
 
-  it('should allow specifying alert type', async(() => {
-       TestBed.overrideComponent(TestComponent, {set: {template: '<ngb-alert type="success">Cool!</ngb-alert>'}})
-           .compileComponents()
-           .then(() => {
-             const fixture = TestBed.createComponent(TestComponent);
-             fixture.detectChanges();
-             expect(getAlertElement(fixture.nativeElement)).toHaveCssClass('alert-success');
-           });
-     }));
+  it('should allow specifying alert type', () => {
+    TestBed.overrideComponent(TestComponent, {set: {template: '<ngb-alert type="success">Cool!</ngb-alert>'}})
+        .compileComponents()
+        .then(() => {
+          const fixture = TestBed.createComponent(TestComponent);
+          fixture.detectChanges();
+          expect(getAlertElement(fixture.nativeElement)).toHaveCssClass('alert-success');
+        });
+  });
 
-  it('should render close button only if dismissible', async(() => {
-       TestBed
-           .overrideComponent(
-               TestComponent, {set: {template: `<ngb-alert [dismissible]="false">Don't close!</ngb-alert>`}})
-           .compileComponents()
-           .then(() => {
-             const fixture = TestBed.createComponent(TestComponent);
-             fixture.detectChanges();
-             expect(getCloseButton(getAlertElement(fixture.nativeElement))).toBeFalsy();
-           });
-     }));
+  it('should render close button only if dismissible', () => {
+    TestBed
+        .overrideComponent(
+            TestComponent, {set: {template: `<ngb-alert [dismissible]="false">Don't close!</ngb-alert>`}})
+        .compileComponents()
+        .then(() => {
+          const fixture = TestBed.createComponent(TestComponent);
+          fixture.detectChanges();
+          expect(getCloseButton(getAlertElement(fixture.nativeElement))).toBeFalsy();
+        });
+  });
 });
 
 describe('NgbDismissibleAlert', () => {
 
   beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAlertModule]}); });
 
-  it('should open a dismissible alert with default type', async(() => {
-       TestBed.overrideComponent(TestComponent, {set: {template: '<template ngbAlert>Hello, {{name}}!</template>'}})
-           .compileComponents()
-           .then(() => {
-             const fixture = TestBed.createComponent(TestComponent);
-             fixture.detectChanges();
+  it('should open a dismissible alert with default type', () => {
+    TestBed.overrideComponent(TestComponent, {set: {template: '<template ngbAlert>Hello, {{name}}!</template>'}})
+        .compileComponents()
+        .then(() => {
+          const fixture = TestBed.createComponent(TestComponent);
+          fixture.detectChanges();
 
-             const alertEl = getAlertElement(fixture.nativeElement);
+          const alertEl = getAlertElement(fixture.nativeElement);
 
-             expect(alertEl).toHaveCssClass('alert-warning');
-             expect(alertEl.getAttribute('role')).toEqual('alert');
-             expect(getCloseButton(alertEl)).toBeTruthy();
+          expect(alertEl).toHaveCssClass('alert-warning');
+          expect(alertEl.getAttribute('role')).toEqual('alert');
+          expect(getCloseButton(alertEl)).toBeTruthy();
 
-             getCloseButton(alertEl).click();
-             fixture.detectChanges();
-             expect(getAlertElement(fixture.nativeElement)).toBeNull();
-           });
-     }));
+          getCloseButton(alertEl).click();
+          fixture.detectChanges();
+          expect(getAlertElement(fixture.nativeElement)).toBeNull();
+        });
+  });
 
-  it('should open a dismissible alert with a specified type', async(() => {
-       TestBed
-           .overrideComponent(
-               TestComponent, {set: {template: '<template ngbAlert type="success">Hello, {{name}}!</template>'}})
-           .compileComponents()
-           .then(() => {
-             const fixture = TestBed.createComponent(TestComponent);
-             fixture.detectChanges();
+  it('should open a dismissible alert with a specified type', () => {
+    TestBed
+        .overrideComponent(
+            TestComponent, {set: {template: '<template ngbAlert type="success">Hello, {{name}}!</template>'}})
+        .compileComponents()
+        .then(() => {
+          const fixture = TestBed.createComponent(TestComponent);
+          fixture.detectChanges();
 
-             const alertEl = getAlertElement(fixture.nativeElement);
+          const alertEl = getAlertElement(fixture.nativeElement);
 
-             expect(alertEl).toHaveCssClass('alert-success');
-             expect(getCloseButton(alertEl)).toBeTruthy();
-           });
-     }));
+          expect(alertEl).toHaveCssClass('alert-success');
+          expect(getCloseButton(alertEl)).toBeTruthy();
+        });
+  });
 
 
-  it('should dismiss alert and invoke close handler on close button click', async(() => {
-       TestBed
-           .overrideComponent(
-               TestComponent,
-               {set: {template: '<template ngbAlert (close)="closed = true">Hello, {{name}}!</template>'}})
-           .compileComponents()
-           .then(() => {
-             const fixture = TestBed.createComponent(TestComponent);
-             fixture.detectChanges();
+  it('should dismiss alert and invoke close handler on close button click', () => {
+    TestBed
+        .overrideComponent(
+            TestComponent, {set: {template: '<template ngbAlert (close)="closed = true">Hello, {{name}}!</template>'}})
+        .compileComponents()
+        .then(() => {
+          const fixture = TestBed.createComponent(TestComponent);
+          fixture.detectChanges();
 
-             const alertEl = getAlertElement(fixture.nativeElement);
+          const alertEl = getAlertElement(fixture.nativeElement);
 
-             getCloseButton(alertEl).click();
-             fixture.detectChanges();
+          getCloseButton(alertEl).click();
+          fixture.detectChanges();
 
-             expect(fixture.componentInstance.closed).toBeTruthy();
-             expect(getAlertElement(fixture.nativeElement)).toBeNull();
-           });
-     }));
+          expect(fixture.componentInstance.closed).toBeTruthy();
+          expect(getAlertElement(fixture.nativeElement)).toBeNull();
+        });
+  });
 
   it('should auto close on timeout specified', fakeAsync(() => {
        TestBed

--- a/src/buttons/radio.spec.ts
+++ b/src/buttons/radio.spec.ts
@@ -1,8 +1,8 @@
-import {async, TestBed} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {Component} from '@angular/core';
+import {Validators, FormControl, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
 
 import {NgbButtonsModule} from './index';
-import {Validators, FormControl, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
 
 function expectRadios(element: HTMLElement, states: number[]) {
   const labels = element.querySelectorAll('label');
@@ -27,18 +27,23 @@ function getInput(nativeEl: HTMLElement, idx: number): HTMLInputElement {
   return <HTMLInputElement>nativeEl.querySelectorAll('input')[idx];
 }
 
+function createTestComponent(html: string): ComponentFixture<TestComponent> {
+  TestBed.overrideComponent(TestComponent, {set: {template: html}});
+  const fixture = TestBed.createComponent(TestComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
 describe('NgbActiveLabel', () => {
-  beforeEach(async(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule(
         {declarations: [TestComponent], imports: [NgbButtonsModule, FormsModule, ReactiveFormsModule]});
-  }));
+  });
 
-  it('should not touch active class on labels not part of a group', async(() => {
-       TestBed.overrideComponent(TestComponent, {set: {template: '<label class="btn" [class.active]="true"></label>'}});
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
-       expect(fixture.nativeElement.children[0]).toHaveCssClass('active');
-     }));
+  it('should not touch active class on labels not part of a group', () => {
+    const fixture = createTestComponent('<label class="btn" [class.active]="true"></label>');
+    expect(fixture.nativeElement.children[0]).toHaveCssClass('active');
+  });
 });
 
 describe('ngbRadioGroup', () => {
@@ -51,165 +56,163 @@ describe('ngbRadioGroup', () => {
       </label>
     </div>`;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule(
         {declarations: [TestComponent], imports: [NgbButtonsModule, FormsModule, ReactiveFormsModule]});
     TestBed.overrideComponent(TestComponent, {set: {template: defaultHtml}});
-  }));
+  });
 
   // TODO: remove 'whenStable' once 'core/testing' is fixed
-  it('toggles radio inputs based on model changes', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
+  it('toggles radio inputs based on model changes', () => {
+    const fixture = TestBed.createComponent(TestComponent);
 
-       let values = fixture.componentInstance.values;
+    let values = fixture.componentInstance.values;
 
-       // checking initial values
-       fixture.detectChanges();
-       expectRadios(fixture.nativeElement, [0, 0]);
-       expect(getInput(fixture.nativeElement, 0).value).toEqual(values[0]);
-       expect(getInput(fixture.nativeElement, 1).value).toEqual(values[1]);
+    // checking initial values
+    fixture.detectChanges();
+    expectRadios(fixture.nativeElement, [0, 0]);
+    expect(getInput(fixture.nativeElement, 0).value).toEqual(values[0]);
+    expect(getInput(fixture.nativeElement, 1).value).toEqual(values[1]);
 
-       // checking null
-       fixture.componentInstance.model = null;
-       fixture.detectChanges();
-       fixture.whenStable().then(() => {
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0, 0]);
+    // checking null
+    fixture.componentInstance.model = null;
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expectRadios(fixture.nativeElement, [0, 0]);
 
-         // checking first radio
-         fixture.componentInstance.model = values[0];
-         fixture.detectChanges();
-         fixture.whenStable().then(() => {
-           fixture.detectChanges();
-           expectRadios(fixture.nativeElement, [1, 0]);
+      // checking first radio
+      fixture.componentInstance.model = values[0];
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        expectRadios(fixture.nativeElement, [1, 0]);
 
-           // checking second radio
-           fixture.componentInstance.model = values[1];
-           fixture.detectChanges();
-           fixture.whenStable().then(() => {
-             fixture.detectChanges();
-             expectRadios(fixture.nativeElement, [0, 1]);
+        // checking second radio
+        fixture.componentInstance.model = values[1];
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+          fixture.detectChanges();
+          expectRadios(fixture.nativeElement, [0, 1]);
 
-             // checking non-matching value
-             fixture.componentInstance.model = values[3];
-             fixture.detectChanges();
-             fixture.whenStable().then(() => {
-               fixture.detectChanges();
-               expectRadios(fixture.nativeElement, [0, 0]);
-             });
-           });
-         });
-       });
-     }));
+          // checking non-matching value
+          fixture.componentInstance.model = values[3];
+          fixture.detectChanges();
+          fixture.whenStable().then(() => {
+            fixture.detectChanges();
+            expectRadios(fixture.nativeElement, [0, 0]);
+          });
+        });
+      });
+    });
+  });
 
-  it('updates model based on radio input clicks', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
+  it('updates model based on radio input clicks', () => {
+    const fixture = TestBed.createComponent(TestComponent);
 
-       fixture.detectChanges();
-       expectRadios(fixture.nativeElement, [0, 0]);
+    fixture.detectChanges();
+    expectRadios(fixture.nativeElement, [0, 0]);
 
-       // clicking first radio
-       getInput(fixture.nativeElement, 0).click();
-       fixture.detectChanges();
-       expectRadios(fixture.nativeElement, [1, 0]);
-       expect(fixture.componentInstance.model).toBe('one');
+    // clicking first radio
+    getInput(fixture.nativeElement, 0).click();
+    fixture.detectChanges();
+    expectRadios(fixture.nativeElement, [1, 0]);
+    expect(fixture.componentInstance.model).toBe('one');
 
-       // clicking second radio
-       getInput(fixture.nativeElement, 1).click();
-       fixture.detectChanges();
-       expectRadios(fixture.nativeElement, [0, 1]);
-       expect(fixture.componentInstance.model).toBe('two');
-     }));
-
-  // TODO: remove 'whenStable' once 'core/testing' is fixed
-  it('can be used with objects as values', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
-
-       let [one, two] = [{one: 'one'}, {two: 'two'}];
-
-       fixture.componentInstance.values[0] = one;
-       fixture.componentInstance.values[1] = two;
-
-       // checking initial values
-       fixture.detectChanges();
-       expectRadios(fixture.nativeElement, [0, 0]);
-       expect(getInput(fixture.nativeElement, 0).value).toEqual({}.toString());
-       expect(getInput(fixture.nativeElement, 1).value).toEqual({}.toString());
-
-       // checking model -> radio input
-       fixture.componentInstance.model = one;
-       fixture.detectChanges();
-       fixture.whenStable().then(() => {
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [1, 0]);
-
-         // checking radio click -> model
-         getInput(fixture.nativeElement, 1).click();
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0, 1]);
-         expect(fixture.componentInstance.model).toBe(two);
-       });
-     }));
+    // clicking second radio
+    getInput(fixture.nativeElement, 1).click();
+    fixture.detectChanges();
+    expectRadios(fixture.nativeElement, [0, 1]);
+    expect(fixture.componentInstance.model).toBe('two');
+  });
 
   // TODO: remove 'whenStable' once 'core/testing' is fixed
-  it('updates radio input values dynamically', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
+  it('can be used with objects as values', () => {
+    const fixture = TestBed.createComponent(TestComponent);
 
-       let values = fixture.componentInstance.values;
+    let [one, two] = [{one: 'one'}, {two: 'two'}];
 
-       // checking first radio
-       fixture.componentInstance.model = values[0];
-       fixture.detectChanges();
-       fixture.whenStable().then(() => {
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [1, 0]);
-         expect(fixture.componentInstance.model).toEqual(values[0]);
+    fixture.componentInstance.values[0] = one;
+    fixture.componentInstance.values[1] = two;
 
-         // updating first radio value -> expecting none selected
-         let initialValue = values[0];
-         values[0] = 'ten';
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0, 0]);
-         expect(getInput(fixture.nativeElement, 0).value).toEqual('ten');
-         expect(fixture.componentInstance.model).toEqual(initialValue);
+    // checking initial values
+    fixture.detectChanges();
+    expectRadios(fixture.nativeElement, [0, 0]);
+    expect(getInput(fixture.nativeElement, 0).value).toEqual({}.toString());
+    expect(getInput(fixture.nativeElement, 1).value).toEqual({}.toString());
 
-         // updating values back -> expecting initial state
-         values[0] = initialValue;
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [1, 0]);
-         expect(getInput(fixture.nativeElement, 0).value).toEqual(values[0]);
-         expect(fixture.componentInstance.model).toEqual(values[0]);
-       });
-     }));
+    // checking model -> radio input
+    fixture.componentInstance.model = one;
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expectRadios(fixture.nativeElement, [1, 0]);
+
+      // checking radio click -> model
+      getInput(fixture.nativeElement, 1).click();
+      fixture.detectChanges();
+      expectRadios(fixture.nativeElement, [0, 1]);
+      expect(fixture.componentInstance.model).toBe(two);
+    });
+  });
 
   // TODO: remove 'whenStable' once 'core/testing' is fixed
-  it('can be used with ngFor', async(() => {
+  it('updates radio input values dynamically', () => {
+    const fixture = TestBed.createComponent(TestComponent);
 
-       const forHtml = `<div [(ngModel)]="model" ngbRadioGroup>
+    let values = fixture.componentInstance.values;
+
+    // checking first radio
+    fixture.componentInstance.model = values[0];
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expectRadios(fixture.nativeElement, [1, 0]);
+      expect(fixture.componentInstance.model).toEqual(values[0]);
+
+      // updating first radio value -> expecting none selected
+      let initialValue = values[0];
+      values[0] = 'ten';
+      fixture.detectChanges();
+      expectRadios(fixture.nativeElement, [0, 0]);
+      expect(getInput(fixture.nativeElement, 0).value).toEqual('ten');
+      expect(fixture.componentInstance.model).toEqual(initialValue);
+
+      // updating values back -> expecting initial state
+      values[0] = initialValue;
+      fixture.detectChanges();
+      expectRadios(fixture.nativeElement, [1, 0]);
+      expect(getInput(fixture.nativeElement, 0).value).toEqual(values[0]);
+      expect(fixture.componentInstance.model).toEqual(values[0]);
+    });
+  });
+
+  // TODO: remove 'whenStable' once 'core/testing' is fixed
+  it('can be used with ngFor', () => {
+
+    const forHtml = `<div [(ngModel)]="model" ngbRadioGroup>
           <label *ngFor="let v of values" class="btn">
             <input type="radio" name="radio" [value]="v"/> {{ v }}
           </label>
         </div>`;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: forHtml}});
-       const fixture = TestBed.createComponent(TestComponent);
-       let values = fixture.componentInstance.values;
+    const fixture = createTestComponent(forHtml);
+    let values = fixture.componentInstance.values;
 
-       fixture.detectChanges();
-       expectRadios(fixture.nativeElement, [0, 0, 0]);
+    expectRadios(fixture.nativeElement, [0, 0, 0]);
 
-       fixture.componentInstance.model = values[1];
-       fixture.detectChanges();
-       fixture.whenStable().then(() => {
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0, 1, 0]);
-       });
-     }));
+    fixture.componentInstance.model = values[1];
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expectRadios(fixture.nativeElement, [0, 1, 0]);
+    });
+  });
 
   // TODO: remove 'whenStable' once 'core/testing' is fixed
-  it('cleans up the model when radio inputs are added / removed', async(() => {
+  it('cleans up the model when radio inputs are added / removed', () => {
 
-       const ifHtml = `<div [(ngModel)]="model" ngbRadioGroup>
+    const ifHtml = `<div [(ngModel)]="model" ngbRadioGroup>
         <label class="btn">
           <input type="radio" name="radio" [value]="values[0]"/> {{ values[0] }}
         </label>
@@ -217,59 +220,56 @@ describe('ngbRadioGroup', () => {
           <input type="radio" name="radio" [value]="values[1]"/> {{ values[1] }}
         </label>
       </div>`;
-       TestBed.overrideComponent(TestComponent, {set: {template: ifHtml}});
-       const fixture = TestBed.createComponent(TestComponent);
+    const fixture = createTestComponent(ifHtml);
 
-       let values = fixture.componentInstance.values;
+    let values = fixture.componentInstance.values;
 
-       // hiding/showing non-selected radio -> expecting initial model value
-       fixture.detectChanges();
-       expectRadios(fixture.nativeElement, [0, 0]);
+    // hiding/showing non-selected radio -> expecting initial model value
+    expectRadios(fixture.nativeElement, [0, 0]);
 
-       fixture.componentInstance.shown = false;
-       fixture.detectChanges();
-       expectRadios(fixture.nativeElement, [0]);
-       expect(fixture.componentInstance.model).toBeUndefined();
+    fixture.componentInstance.shown = false;
+    fixture.detectChanges();
+    expectRadios(fixture.nativeElement, [0]);
+    expect(fixture.componentInstance.model).toBeUndefined();
 
-       fixture.componentInstance.shown = true;
-       fixture.detectChanges();
-       expectRadios(fixture.nativeElement, [0, 0]);
-       expect(fixture.componentInstance.model).toBeUndefined();
+    fixture.componentInstance.shown = true;
+    fixture.detectChanges();
+    expectRadios(fixture.nativeElement, [0, 0]);
+    expect(fixture.componentInstance.model).toBeUndefined();
 
-       // hiding/showing selected radio -> expecting model to unchange, but none selected
-       fixture.componentInstance.model = values[1];
-       fixture.detectChanges();
-       fixture.whenStable().then(() => {
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0, 1]);
+    // hiding/showing selected radio -> expecting model to unchange, but none selected
+    fixture.componentInstance.model = values[1];
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expectRadios(fixture.nativeElement, [0, 1]);
 
-         fixture.componentInstance.shown = false;
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0]);
-         expect(fixture.componentInstance.model).toEqual(values[1]);
+      fixture.componentInstance.shown = false;
+      fixture.detectChanges();
+      expectRadios(fixture.nativeElement, [0]);
+      expect(fixture.componentInstance.model).toEqual(values[1]);
 
-         fixture.componentInstance.shown = true;
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0, 1]);
-         expect(fixture.componentInstance.model).toEqual(values[1]);
-       });
+      fixture.componentInstance.shown = true;
+      fixture.detectChanges();
+      expectRadios(fixture.nativeElement, [0, 1]);
+      expect(fixture.componentInstance.model).toEqual(values[1]);
+    });
 
-     }));
+  });
 
-  it('should add data-toggle="buttons" and "btn-group" CSS class to button group', async(() => {
-       // Bootstrap for uses presence of data-toggle="buttons" to style radio buttons
-       const html = `<div class="foo" ngbRadioGroup></div>`;
+  it('should add data-toggle="buttons" and "btn-group" CSS class to button group', () => {
+    // Bootstrap for uses presence of data-toggle="buttons" to style radio buttons
+    const html = `<div class="foo" ngbRadioGroup></div>`;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       const fixture = TestBed.createComponent(TestComponent);
+    const fixture = createTestComponent(html);
 
-       expect(fixture.nativeElement.children[0].getAttribute('data-toggle')).toBe('buttons');
-       expect(fixture.nativeElement.children[0]).toHaveCssClass('btn-group');
-     }));
+    expect(fixture.nativeElement.children[0].getAttribute('data-toggle')).toBe('buttons');
+    expect(fixture.nativeElement.children[0]).toHaveCssClass('btn-group');
+  });
 
   // TODO: remove 'whenStable' once 'core/testing' is fixed
-  it('should work with template-driven form validation', async(() => {
-       const html = `
+  it('should work with template-driven form validation', () => {
+    const html = `
         <form>
           <div ngbRadioGroup [(ngModel)]="model" name="control" required>
             <label class="btn">
@@ -278,24 +278,22 @@ describe('ngbRadioGroup', () => {
           </div>
         </form>`;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       const fixture = TestBed.createComponent(TestComponent);
+    const fixture = createTestComponent(html);
 
-       fixture.detectChanges();
-       fixture.whenStable().then(() => {
-         fixture.detectChanges();
-         expect(getGroupElement(fixture.nativeElement)).toHaveCssClass('ng-invalid');
-         expect(getGroupElement(fixture.nativeElement)).not.toHaveCssClass('ng-valid');
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+      expect(getGroupElement(fixture.nativeElement)).toHaveCssClass('ng-invalid');
+      expect(getGroupElement(fixture.nativeElement)).not.toHaveCssClass('ng-valid');
 
-         getInput(fixture.nativeElement, 0).click();
-         fixture.detectChanges();
-         expect(getGroupElement(fixture.nativeElement)).toHaveCssClass('ng-valid');
-         expect(getGroupElement(fixture.nativeElement)).not.toHaveCssClass('ng-invalid');
-       });
-     }));
+      getInput(fixture.nativeElement, 0).click();
+      fixture.detectChanges();
+      expect(getGroupElement(fixture.nativeElement)).toHaveCssClass('ng-valid');
+      expect(getGroupElement(fixture.nativeElement)).not.toHaveCssClass('ng-invalid');
+    });
+  });
 
-  it('should work with model-driven form validation', async(() => {
-       const html = `
+  it('should work with model-driven form validation', () => {
+    const html = `
         <form [formGroup]="form">
           <div ngbRadioGroup formControlName="control">
             <label class="btn">
@@ -304,18 +302,16 @@ describe('ngbRadioGroup', () => {
           </div>
         </form>`;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       const fixture = TestBed.createComponent(TestComponent);
+    const fixture = createTestComponent(html);
 
-       fixture.detectChanges();
-       expect(getGroupElement(fixture.nativeElement)).toHaveCssClass('ng-invalid');
-       expect(getGroupElement(fixture.nativeElement)).not.toHaveCssClass('ng-valid');
+    expect(getGroupElement(fixture.nativeElement)).toHaveCssClass('ng-invalid');
+    expect(getGroupElement(fixture.nativeElement)).not.toHaveCssClass('ng-valid');
 
-       getInput(fixture.nativeElement, 0).click();
-       fixture.detectChanges();
-       expect(getGroupElement(fixture.nativeElement)).toHaveCssClass('ng-valid');
-       expect(getGroupElement(fixture.nativeElement)).not.toHaveCssClass('ng-invalid');
-     }));
+    getInput(fixture.nativeElement, 0).click();
+    fixture.detectChanges();
+    expect(getGroupElement(fixture.nativeElement)).toHaveCssClass('ng-valid');
+    expect(getGroupElement(fixture.nativeElement)).not.toHaveCssClass('ng-invalid');
+  });
 });
 
 @Component({selector: 'test-cmp', template: ''})

--- a/src/carousel/carousel.spec.ts
+++ b/src/carousel/carousel.spec.ts
@@ -1,4 +1,4 @@
-import {fakeAsync, discardPeriodicTasks, tick, TestBed} from '@angular/core/testing';
+import {fakeAsync, discardPeriodicTasks, tick, TestBed, ComponentFixture} from '@angular/core/testing';
 
 import {By} from '@angular/platform-browser';
 import {Component} from '@angular/core';
@@ -24,6 +24,13 @@ function expectActiveSlides(nativeEl: HTMLDivElement, active: boolean[]) {
   }
 }
 
+function createTestComponent(html: string): ComponentFixture<TestComponent> {
+  TestBed.overrideComponent(TestComponent, {set: {template: html}});
+  const fixture = TestBed.createComponent(TestComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
 describe('ngb-carousel', () => {
   beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbCarouselModule]}); });
 
@@ -34,9 +41,7 @@ describe('ngb-carousel', () => {
         <template ngbSlide>bar</template>
       </ngb-carousel>
     `;
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
+       const fixture = createTestComponent(html);
 
        const slideElms = fixture.nativeElement.querySelectorAll('.carousel-item');
        expect(slideElms.length).toBe(2);
@@ -57,9 +62,7 @@ describe('ngb-carousel', () => {
       </ngb-carousel>
     `;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
+       const fixture = createTestComponent(html);
        expectActiveSlides(fixture.nativeElement, [true, false]);
 
        discardPeriodicTasks();
@@ -74,8 +77,7 @@ describe('ngb-carousel', () => {
        </ngb-carousel>
      `;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       const fixture = TestBed.createComponent(TestComponent);
+       const fixture = createTestComponent(html);
 
        fixture.componentInstance.activeSlideId = 1;
        fixture.detectChanges();
@@ -92,9 +94,7 @@ describe('ngb-carousel', () => {
             </ngb-carousel>
           `;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
+       const fixture = createTestComponent(html);
        expectActiveSlides(fixture.nativeElement, [true, false]);
 
        discardPeriodicTasks();
@@ -109,9 +109,7 @@ describe('ngb-carousel', () => {
       </ngb-carousel>
     `;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
+       const fixture = createTestComponent(html);
        const indicatorElms = fixture.nativeElement.querySelectorAll('ol.carousel-indicators > li');
 
        expectActiveSlides(fixture.nativeElement, [true, false]);
@@ -132,9 +130,7 @@ describe('ngb-carousel', () => {
       </ngb-carousel>
     `;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
+       const fixture = createTestComponent(html);
 
        const controlElms = fixture.nativeElement.querySelectorAll('.carousel-control');
 
@@ -159,9 +155,7 @@ describe('ngb-carousel', () => {
       </ngb-carousel>
     `;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
+       const fixture = createTestComponent(html);
 
        expectActiveSlides(fixture.nativeElement, [true, false]);
 
@@ -180,9 +174,7 @@ describe('ngb-carousel', () => {
       </ngb-carousel>
     `;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
+       const fixture = createTestComponent(html);
 
        expectActiveSlides(fixture.nativeElement, [true, false]);
 
@@ -205,9 +197,7 @@ describe('ngb-carousel', () => {
       </ngb-carousel>
     `;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
+       const fixture = createTestComponent(html);
 
        const carouselDebugEl = fixture.debugElement.query(By.directive(NgbCarousel));
 
@@ -240,9 +230,7 @@ describe('ngb-carousel', () => {
       </ngb-carousel>
     `;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
+       const fixture = createTestComponent(html);
 
        const controlElms = fixture.nativeElement.querySelectorAll('.carousel-control');
 
@@ -271,9 +259,7 @@ describe('ngb-carousel', () => {
       </ngb-carousel>
     `;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
+       const fixture = createTestComponent(html);
 
        const controlElms = fixture.nativeElement.querySelectorAll('.carousel-control');
 
@@ -302,9 +288,7 @@ describe('ngb-carousel', () => {
             </ngb-carousel>
           `;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
+       const fixture = createTestComponent(html);
        expectActiveSlides(fixture.nativeElement, [true, false]);
 
        fixture.debugElement.query(By.directive(NgbCarousel)).triggerEventHandler('keyup.arrowRight', {});  // next()
@@ -334,9 +318,7 @@ describe('ngb-carousel', () => {
                </ngb-carousel>
              `;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
+       const fixture = createTestComponent(html);
        expectActiveSlides(fixture.nativeElement, [true, false]);
 
        fixture.componentInstance.keyboard = false;

--- a/src/collapse/collapse.spec.ts
+++ b/src/collapse/collapse.spec.ts
@@ -1,4 +1,4 @@
-import {async, TestBed} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 
 import {Component} from '@angular/core';
 
@@ -9,6 +9,13 @@ function getCollapsibleContent(element: HTMLElement): HTMLDivElement {
   return <HTMLDivElement>element.querySelector('.collapse');
 }
 
+function createTestComponent(html: string): ComponentFixture<TestComponent> {
+  TestBed.overrideComponent(TestComponent, {set: {template: html}});
+  const fixture = TestBed.createComponent(TestComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
 describe('ngb-collapse', () => {
   let html = `<div [ngbCollapse]="collapsed">Some content</div>`;
 
@@ -17,66 +24,64 @@ describe('ngb-collapse', () => {
     TestBed.overrideComponent(TestComponent, {set: {template: html}});
   });
 
-  it('should have content open and aria-expanded true', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
+  it('should have content open and aria-expanded true', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
 
-       const collapseEl = getCollapsibleContent(fixture.nativeElement);
+    const collapseEl = getCollapsibleContent(fixture.nativeElement);
 
-       expect(collapseEl).toHaveCssClass('in');
-       expect(collapseEl.getAttribute('aria-expanded')).toBe('true');
-     }));
+    expect(collapseEl).toHaveCssClass('in');
+    expect(collapseEl.getAttribute('aria-expanded')).toBe('true');
+  });
 
-  it('should have content closed and aria-expanded false', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
-       const tc = fixture.componentInstance;
-       tc.collapsed = true;
-       fixture.detectChanges();
+  it('should have content closed and aria-expanded false', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    const tc = fixture.componentInstance;
+    tc.collapsed = true;
+    fixture.detectChanges();
 
-       const collapseEl = getCollapsibleContent(fixture.nativeElement);
+    const collapseEl = getCollapsibleContent(fixture.nativeElement);
 
-       expect(collapseEl).not.toHaveCssClass('in');
-       expect(collapseEl.getAttribute('aria-expanded')).toBe('false');
-     }));
+    expect(collapseEl).not.toHaveCssClass('in');
+    expect(collapseEl.getAttribute('aria-expanded')).toBe('false');
+  });
 
-  it('should toggle collapsed content based on bound model change', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
+  it('should toggle collapsed content based on bound model change', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
 
-       const tc = fixture.componentInstance;
-       const collapseEl = getCollapsibleContent(fixture.nativeElement);
-       expect(collapseEl).toHaveCssClass('in');
+    const tc = fixture.componentInstance;
+    const collapseEl = getCollapsibleContent(fixture.nativeElement);
+    expect(collapseEl).toHaveCssClass('in');
 
-       tc.collapsed = true;
-       fixture.detectChanges();
-       expect(collapseEl).not.toHaveCssClass('in');
+    tc.collapsed = true;
+    fixture.detectChanges();
+    expect(collapseEl).not.toHaveCssClass('in');
 
-       tc.collapsed = false;
-       fixture.detectChanges();
-       expect(collapseEl).toHaveCssClass('in');
-     }));
+    tc.collapsed = false;
+    fixture.detectChanges();
+    expect(collapseEl).toHaveCssClass('in');
+  });
 
-  it('should allow toggling collapse from outside', async(() => {
-       html = `
+  it('should allow toggling collapse from outside', () => {
+    html = `
       <button (click)="collapse.collapsed = !collapse.collapsed">Collapse</button>
       <div [ngbCollapse] #collapse="ngbCollapse"></div>`;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
+    const fixture = createTestComponent(html);
 
-       const compiled = fixture.nativeElement;
-       const collapseEl = getCollapsibleContent(compiled);
-       const buttonEl = compiled.querySelector('button');
+    const compiled = fixture.nativeElement;
+    const collapseEl = getCollapsibleContent(compiled);
+    const buttonEl = compiled.querySelector('button');
 
-       buttonEl.click();
-       fixture.detectChanges();
-       expect(collapseEl).not.toHaveCssClass('in');
+    buttonEl.click();
+    fixture.detectChanges();
+    expect(collapseEl).not.toHaveCssClass('in');
 
-       buttonEl.click();
-       fixture.detectChanges();
-       expect(collapseEl).toHaveCssClass('in');
-     }));
+    buttonEl.click();
+    fixture.detectChanges();
+    expect(collapseEl).toHaveCssClass('in');
+  });
 });
 
 @Component({selector: 'test-cmp', template: ''})

--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -1,4 +1,4 @@
-import {async, TestBed} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 
 import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
@@ -10,225 +10,212 @@ function getDropdownEl(tc) {
   return tc.querySelector(`[ngbDropdown]`);
 }
 
+function createTestComponent(html: string): ComponentFixture<TestComponent> {
+  TestBed.overrideComponent(TestComponent, {set: {template: html}});
+  const fixture = TestBed.createComponent(TestComponent);
+  fixture.detectChanges();
+  return fixture;
+}
+
 describe('ngb-dropdown', () => {
   beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDropdownModule]}); });
 
-  it('should be closed by default', async(() => {
-       const html = `<div ngbDropdown></div>`;
+  it('should be closed by default', () => {
+    const html = `<div ngbDropdown></div>`;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
-       const compiled = fixture.nativeElement;
+    const fixture = createTestComponent(html);
+    const compiled = fixture.nativeElement;
 
-       expect(getDropdownEl(compiled)).toHaveCssClass('dropdown');
-       expect(getDropdownEl(compiled)).not.toHaveCssClass('open');
-     }));
+    expect(getDropdownEl(compiled)).toHaveCssClass('dropdown');
+    expect(getDropdownEl(compiled)).not.toHaveCssClass('open');
+  });
 
-  it('should be open initially if open expression is true', async(() => {
-       const html = `<div ngbDropdown [open]="true"></div>`;
+  it('should be open initially if open expression is true', () => {
+    const html = `<div ngbDropdown [open]="true"></div>`;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       const fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
-       const compiled = fixture.nativeElement;
+    const fixture = createTestComponent(html);
+    const compiled = fixture.nativeElement;
 
-       expect(getDropdownEl(compiled)).toHaveCssClass('dropdown');
-       expect(getDropdownEl(compiled)).toHaveCssClass('open');
-     }));
+    expect(getDropdownEl(compiled)).toHaveCssClass('dropdown');
+    expect(getDropdownEl(compiled)).toHaveCssClass('open');
+  });
 
-  it('should toggle open class', async(() => {
-       const html = `<div ngbDropdown [open]="isOpen"></div>`;
+  it('should toggle open class', () => {
+    const html = `<div ngbDropdown [open]="isOpen"></div>`;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       let fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
-       const compiled = fixture.nativeElement;
+    const fixture = createTestComponent(html);
+    const compiled = fixture.nativeElement;
 
-       let dropdownEl = getDropdownEl(compiled);
+    let dropdownEl = getDropdownEl(compiled);
 
-       expect(dropdownEl).not.toHaveCssClass('open');
+    expect(dropdownEl).not.toHaveCssClass('open');
 
-       fixture.componentInstance.isOpen = true;
-       fixture.detectChanges();
+    fixture.componentInstance.isOpen = true;
+    fixture.detectChanges();
 
-       expect(dropdownEl).toHaveCssClass('open');
+    expect(dropdownEl).toHaveCssClass('open');
 
-       fixture.componentInstance.isOpen = false;
-       fixture.detectChanges();
+    fixture.componentInstance.isOpen = false;
+    fixture.detectChanges();
 
-       expect(dropdownEl).not.toHaveCssClass('open');
-     }));
+    expect(dropdownEl).not.toHaveCssClass('open');
+  });
 
-  it('should allow toggling dropdown from outside', async(() => {
-       const html = `
+  it('should allow toggling dropdown from outside', () => {
+    const html = `
       <button (click)="drop.open(); $event.stopPropagation()">Open</button>
       <button (click)="drop.close(); $event.stopPropagation()">Close</button>
       <button (click)="drop.toggle(); $event.stopPropagation()">Toggle</button>
       <div ngbDropdown #drop="ngbDropdown"></div>`;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       let fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
-       const compiled = fixture.nativeElement;
-       let dropdownEl = getDropdownEl(compiled);
-       let buttonEls = compiled.querySelectorAll('button');
+    const fixture = createTestComponent(html);
+    const compiled = fixture.nativeElement;
+    let dropdownEl = getDropdownEl(compiled);
+    let buttonEls = compiled.querySelectorAll('button');
 
-       buttonEls[0].click();
-       fixture.detectChanges();
-       expect(dropdownEl).toHaveCssClass('open');
+    buttonEls[0].click();
+    fixture.detectChanges();
+    expect(dropdownEl).toHaveCssClass('open');
 
-       buttonEls[1].click();
-       fixture.detectChanges();
-       expect(dropdownEl).not.toHaveCssClass('open');
+    buttonEls[1].click();
+    fixture.detectChanges();
+    expect(dropdownEl).not.toHaveCssClass('open');
 
-       buttonEls[2].click();
-       fixture.detectChanges();
-       expect(dropdownEl).toHaveCssClass('open');
+    buttonEls[2].click();
+    fixture.detectChanges();
+    expect(dropdownEl).toHaveCssClass('open');
 
-       buttonEls[2].click();
-       fixture.detectChanges();
-       expect(dropdownEl).not.toHaveCssClass('open');
-     }));
+    buttonEls[2].click();
+    fixture.detectChanges();
+    expect(dropdownEl).not.toHaveCssClass('open');
+  });
 
-  it('should allow binding to open output', async(() => {
-       const html = `
+  it('should allow binding to open output', () => {
+    const html = `
       <button (click)="drop.toggle(); $event.stopPropagation()">Toggle</button>
       <div ngbDropdown [(open)]="isOpen" #drop="ngbDropdown"></div>`;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       let fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
-       const compiled = fixture.nativeElement;
-       let buttonEl = compiled.querySelector('button');
+    const fixture = createTestComponent(html);
+    const compiled = fixture.nativeElement;
+    let buttonEl = compiled.querySelector('button');
 
-       expect(fixture.componentInstance.isOpen).toBe(false);
+    expect(fixture.componentInstance.isOpen).toBe(false);
 
-       buttonEl.click();
-       fixture.detectChanges();
+    buttonEl.click();
+    fixture.detectChanges();
 
-       expect(fixture.componentInstance.isOpen).toBe(true);
+    expect(fixture.componentInstance.isOpen).toBe(true);
 
-       buttonEl.click();
-       fixture.detectChanges();
+    buttonEl.click();
+    fixture.detectChanges();
 
-       expect(fixture.componentInstance.isOpen).toBe(false);
-     }));
+    expect(fixture.componentInstance.isOpen).toBe(false);
+  });
 });
 
 describe('ngb-dropdown-toggle', () => {
   beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDropdownModule]}); });
 
-  it('should toggle dropdown on click', async(() => {
-       const html = `
+  it('should toggle dropdown on click', () => {
+    const html = `
       <div ngbDropdown>
           <button ngbDropdownToggle>Toggle dropdown</button>
       </div>`;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       let fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
-       const compiled = fixture.nativeElement;
-       let dropdownEl = getDropdownEl(compiled);
-       let buttonEl = compiled.querySelector('button');
+    const fixture = createTestComponent(html);
+    const compiled = fixture.nativeElement;
+    let dropdownEl = getDropdownEl(compiled);
+    let buttonEl = compiled.querySelector('button');
 
-       expect(dropdownEl).not.toHaveCssClass('open');
-       expect(buttonEl.getAttribute('aria-haspopup')).toBe('true');
-       expect(buttonEl.getAttribute('aria-expanded')).toBe('false');
+    expect(dropdownEl).not.toHaveCssClass('open');
+    expect(buttonEl.getAttribute('aria-haspopup')).toBe('true');
+    expect(buttonEl.getAttribute('aria-expanded')).toBe('false');
 
-       buttonEl.click();
-       fixture.detectChanges();
-       expect(dropdownEl).toHaveCssClass('open');
-       expect(buttonEl.getAttribute('aria-expanded')).toBe('true');
+    buttonEl.click();
+    fixture.detectChanges();
+    expect(dropdownEl).toHaveCssClass('open');
+    expect(buttonEl.getAttribute('aria-expanded')).toBe('true');
 
-       buttonEl.click();
-       fixture.detectChanges();
-       expect(dropdownEl).not.toHaveCssClass('open');
-       expect(buttonEl.getAttribute('aria-expanded')).toBe('false');
-     }));
+    buttonEl.click();
+    fixture.detectChanges();
+    expect(dropdownEl).not.toHaveCssClass('open');
+    expect(buttonEl.getAttribute('aria-expanded')).toBe('false');
+  });
 
-  it('should close on outside click', async(() => {
-       const html = `<button>Outside</button><div ngbDropdown [open]="true"></div>`;
+  it('should close on outside click', () => {
+    const html = `<button>Outside</button><div ngbDropdown [open]="true"></div>`;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       let fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
-       const compiled = fixture.nativeElement;
-       let dropdownEl = getDropdownEl(compiled);
-       let buttonEl = compiled.querySelector('button');
+    const fixture = createTestComponent(html);
+    const compiled = fixture.nativeElement;
+    let dropdownEl = getDropdownEl(compiled);
+    let buttonEl = compiled.querySelector('button');
 
-       fixture.detectChanges();
-       expect(dropdownEl).toHaveCssClass('open');
+    fixture.detectChanges();
+    expect(dropdownEl).toHaveCssClass('open');
 
-       buttonEl.click();
-       fixture.detectChanges();
-       expect(dropdownEl).not.toHaveCssClass('open');
-     }));
+    buttonEl.click();
+    fixture.detectChanges();
+    expect(dropdownEl).not.toHaveCssClass('open');
+  });
 
-  it('should not close on outside click if autoClose is set to false', async(() => {
-       const html = `<button>Outside</button><div ngbDropdown [open]="true" [autoClose]="false"></div>`;
+  it('should not close on outside click if autoClose is set to false', () => {
+    const html = `<button>Outside</button><div ngbDropdown [open]="true" [autoClose]="false"></div>`;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       let fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
-       const compiled = fixture.nativeElement;
-       let dropdownEl = getDropdownEl(compiled);
-       let buttonEl = compiled.querySelector('button');
+    const fixture = createTestComponent(html);
+    const compiled = fixture.nativeElement;
+    let dropdownEl = getDropdownEl(compiled);
+    let buttonEl = compiled.querySelector('button');
 
-       fixture.detectChanges();
-       expect(dropdownEl).toHaveCssClass('open');
+    fixture.detectChanges();
+    expect(dropdownEl).toHaveCssClass('open');
 
-       buttonEl.click();
-       fixture.detectChanges();
-       expect(dropdownEl).toHaveCssClass('open');
-     }));
+    buttonEl.click();
+    fixture.detectChanges();
+    expect(dropdownEl).toHaveCssClass('open');
+  });
 
-  it('should close on ESC', async(() => {
-       const html = `
+  it('should close on ESC', () => {
+    const html = `
       <div ngbDropdown>
           <button ngbDropdownToggle>Toggle dropdown</button>
       </div>`;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       let fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
-       const compiled = fixture.nativeElement;
-       let dropdownEl = getDropdownEl(compiled);
-       let buttonEl = compiled.querySelector('button');
+    const fixture = createTestComponent(html);
+    const compiled = fixture.nativeElement;
+    let dropdownEl = getDropdownEl(compiled);
+    let buttonEl = compiled.querySelector('button');
 
-       buttonEl.click();
-       fixture.detectChanges();
-       expect(dropdownEl).toHaveCssClass('open');
+    buttonEl.click();
+    fixture.detectChanges();
+    expect(dropdownEl).toHaveCssClass('open');
 
-       fixture.debugElement.query(By.directive(NgbDropdown)).triggerEventHandler('keyup.esc', {});
-       fixture.detectChanges();
-       expect(dropdownEl).not.toHaveCssClass('open');
-     }));
+    fixture.debugElement.query(By.directive(NgbDropdown)).triggerEventHandler('keyup.esc', {});
+    fixture.detectChanges();
+    expect(dropdownEl).not.toHaveCssClass('open');
+  });
 
-  it('should not close on ESC if autoClose is set to false', async(() => {
-       const html = `
+  it('should not close on ESC if autoClose is set to false', () => {
+    const html = `
       <div ngbDropdown [autoClose]="false">
           <button ngbDropdownToggle>Toggle dropdown</button>
       </div>`;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       let fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
-       const compiled = fixture.nativeElement;
-       let dropdownEl = getDropdownEl(compiled);
-       let buttonEl = compiled.querySelector('button');
+    const fixture = createTestComponent(html);
+    const compiled = fixture.nativeElement;
+    let dropdownEl = getDropdownEl(compiled);
+    let buttonEl = compiled.querySelector('button');
 
-       buttonEl.click();
-       fixture.detectChanges();
-       expect(dropdownEl).toHaveCssClass('open');
+    buttonEl.click();
+    fixture.detectChanges();
+    expect(dropdownEl).toHaveCssClass('open');
 
-       fixture.debugElement.query(By.directive(NgbDropdown)).triggerEventHandler('keyup.esc', {});
-       fixture.detectChanges();
-       expect(dropdownEl).toHaveCssClass('open');
-     }));
+    fixture.debugElement.query(By.directive(NgbDropdown)).triggerEventHandler('keyup.esc', {});
+    fixture.detectChanges();
+    expect(dropdownEl).toHaveCssClass('open');
+  });
 
-  it('should close on item click if autoClose is set to false', async(() => {
-       const html = `
+  it('should close on item click if autoClose is set to false', () => {
+    const html = `
       <div ngbDropdown [open]="true" [autoClose]="false">
           <button ngbDropdownToggle>Toggle dropdown</button>
           <div class="dropdown-menu" aria-labelledby="dropdownMenu1">
@@ -236,23 +223,21 @@ describe('ngb-dropdown-toggle', () => {
           </div>
       </div>`;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       let fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
-       const compiled = fixture.nativeElement;
-       let dropdownEl = getDropdownEl(compiled);
-       let linkEl = compiled.querySelector('a');
+    const fixture = createTestComponent(html);
+    const compiled = fixture.nativeElement;
+    let dropdownEl = getDropdownEl(compiled);
+    let linkEl = compiled.querySelector('a');
 
-       fixture.detectChanges();
-       expect(dropdownEl).toHaveCssClass('open');
+    fixture.detectChanges();
+    expect(dropdownEl).toHaveCssClass('open');
 
-       linkEl.click();
-       fixture.detectChanges();
-       expect(dropdownEl).toHaveCssClass('open');
-     }));
+    linkEl.click();
+    fixture.detectChanges();
+    expect(dropdownEl).toHaveCssClass('open');
+  });
 
-  it('should not close on item click', async(() => {
-       const html = `
+  it('should not close on item click', () => {
+    const html = `
       <div ngbDropdown [open]="true">
           <button ngbDropdownToggle>Toggle dropdown</button>
           <div class="dropdown-menu" aria-labelledby="dropdownMenu1">
@@ -260,25 +245,23 @@ describe('ngb-dropdown-toggle', () => {
           </div>
       </div>`;
 
-       TestBed.overrideComponent(TestComponent, {set: {template: html}});
-       let fixture = TestBed.createComponent(TestComponent);
-       fixture.detectChanges();
-       const compiled = fixture.nativeElement;
-       let dropdownEl = getDropdownEl(compiled);
-       let buttonEl = compiled.querySelector('button');
-       let linkEl = compiled.querySelector('a');
+    const fixture = createTestComponent(html);
+    const compiled = fixture.nativeElement;
+    let dropdownEl = getDropdownEl(compiled);
+    let buttonEl = compiled.querySelector('button');
+    let linkEl = compiled.querySelector('a');
 
-       fixture.detectChanges();
-       expect(dropdownEl).toHaveCssClass('open');
+    fixture.detectChanges();
+    expect(dropdownEl).toHaveCssClass('open');
 
-       linkEl.click();
-       fixture.detectChanges();
-       expect(dropdownEl).not.toHaveCssClass('open');
+    linkEl.click();
+    fixture.detectChanges();
+    expect(dropdownEl).not.toHaveCssClass('open');
 
-       buttonEl.click();
-       fixture.detectChanges();
-       expect(dropdownEl).toHaveCssClass('open');
-     }));
+    buttonEl.click();
+    fixture.detectChanges();
+    expect(dropdownEl).toHaveCssClass('open');
+  });
 });
 
 @Component({selector: 'test-cmp', template: ''})

--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -1,4 +1,4 @@
-import {async, TestBed} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 
 import {TestComponentBuilder} from '@angular/core/testing';
 
@@ -43,6 +43,13 @@ function getList(nativeEl: HTMLElement) {
 
 function normalizeText(txt: string): string {
   return txt.trim().replace(/\s+/g, ' ');
+}
+
+function createTestComponent(html: string): ComponentFixture<TestComponent> {
+  TestBed.overrideComponent(TestComponent, {set: {template: html}});
+  const fixture = TestBed.createComponent(TestComponent);
+  fixture.detectChanges();
+  return fixture;
 }
 
 describe('ngb-pagination', () => {
@@ -115,305 +122,291 @@ describe('ngb-pagination', () => {
     beforeEach(
         () => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPaginationModule]}); });
 
-    it('should render and respond to collectionSize change', async(() => {
-         const html = '<ngb-pagination [collectionSize]="collectionSize" [page]="1"></ngb-pagination>';
-         TestBed.overrideComponent(TestComponent, {set: {template: html}});
-         const fixture = TestBed.createComponent(TestComponent);
+    it('should render and respond to collectionSize change', () => {
+      const html = '<ngb-pagination [collectionSize]="collectionSize" [page]="1"></ngb-pagination>';
+      const fixture = createTestComponent(html);
 
-         fixture.componentInstance.collectionSize = 30;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
+      fixture.componentInstance.collectionSize = 30;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
 
-         fixture.componentInstance.collectionSize = 40;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '4', '» Next']);
-       }));
+      fixture.componentInstance.collectionSize = 40;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '4', '» Next']);
+    });
 
-    it('should render and respond to pageSize change', async(() => {
-         const html =
-             '<ngb-pagination [collectionSize]="collectionSize" [page]="1" [pageSize]="pageSize"></ngb-pagination>';
-         TestBed.overrideComponent(TestComponent, {set: {template: html}});
-         const fixture = TestBed.createComponent(TestComponent);
+    it('should render and respond to pageSize change', () => {
+      const html =
+          '<ngb-pagination [collectionSize]="collectionSize" [page]="1" [pageSize]="pageSize"></ngb-pagination>';
+      const fixture = createTestComponent(html);
 
-         fixture.componentInstance.collectionSize = 30;
-         fixture.componentInstance.pageSize = 5;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '4', '5', '6', '» Next']);
+      fixture.componentInstance.collectionSize = 30;
+      fixture.componentInstance.pageSize = 5;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '4', '5', '6', '» Next']);
 
-         fixture.componentInstance.pageSize = 10;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
-       }));
+      fixture.componentInstance.pageSize = 10;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
+    });
 
-    it('should render and respond to active page change', async(() => {
-         const html = '<ngb-pagination [collectionSize]="collectionSize" [page]="page"></ngb-pagination>';
-         TestBed.overrideComponent(TestComponent, {set: {template: html}});
-         const fixture = TestBed.createComponent(TestComponent);
+    it('should render and respond to active page change', () => {
+      const html = '<ngb-pagination [collectionSize]="collectionSize" [page]="page"></ngb-pagination>';
+      const fixture = createTestComponent(html);
 
-         fixture.componentInstance.collectionSize = 30;
-         fixture.componentInstance.page = 2;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '1', '+2', '3', '» Next']);
+      fixture.componentInstance.collectionSize = 30;
+      fixture.componentInstance.page = 2;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '1', '+2', '3', '» Next']);
 
-         fixture.componentInstance.page = 3;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '1', '2', '+3', '-» Next']);
-       }));
+      fixture.componentInstance.page = 3;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '1', '2', '+3', '-» Next']);
+    });
 
-    it('should update selected page model on page no click', async(() => {
-         const html = '<ngb-pagination [collectionSize]="collectionSize" [page]="page"></ngb-pagination>';
-         TestBed.overrideComponent(TestComponent, {set: {template: html}});
-         const fixture = TestBed.createComponent(TestComponent);
+    it('should update selected page model on page no click', () => {
+      const html = '<ngb-pagination [collectionSize]="collectionSize" [page]="page"></ngb-pagination>';
+      const fixture = createTestComponent(html);
 
-         fixture.componentInstance.collectionSize = 30;
-         fixture.componentInstance.page = 2;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '1', '+2', '3', '» Next']);
+      fixture.componentInstance.collectionSize = 30;
+      fixture.componentInstance.page = 2;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '1', '+2', '3', '» Next']);
 
-         getLink(fixture.nativeElement, 0).click();
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
+      getLink(fixture.nativeElement, 0).click();
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
 
 
-         getLink(fixture.nativeElement, 3).click();
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '1', '2', '+3', '-» Next']);
-       }));
+      getLink(fixture.nativeElement, 3).click();
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '1', '2', '+3', '-» Next']);
+    });
 
-    it('should update selected page model on prev / next click', async(() => {
-         const html =
-             '<ngb-pagination [collectionSize]="collectionSize" [page]="page" [directionLinks]="directionLinks"></ngb-pagination>';
-         TestBed.overrideComponent(TestComponent, {set: {template: html}});
-         const fixture = TestBed.createComponent(TestComponent);
+    it('should update selected page model on prev / next click', () => {
+      const html =
+          '<ngb-pagination [collectionSize]="collectionSize" [page]="page" [directionLinks]="directionLinks"></ngb-pagination>';
+      const fixture = createTestComponent(html);
 
-         fixture.componentInstance.collectionSize = 30;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['+1', '2', '3']);
+      fixture.componentInstance.collectionSize = 30;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['+1', '2', '3']);
 
-         fixture.componentInstance.directionLinks = true;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
+      fixture.componentInstance.directionLinks = true;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
 
-         getLink(fixture.nativeElement, 0).click();
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
+      getLink(fixture.nativeElement, 0).click();
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
 
-         getLink(fixture.nativeElement, 4).click();
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '1', '+2', '3', '» Next']);
+      getLink(fixture.nativeElement, 4).click();
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '1', '+2', '3', '» Next']);
 
-         getLink(fixture.nativeElement, 4).click();
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '1', '2', '+3', '-» Next']);
+      getLink(fixture.nativeElement, 4).click();
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '1', '2', '+3', '-» Next']);
 
-         getLink(fixture.nativeElement, 4).click();
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '1', '2', '+3', '-» Next']);
-       }));
+      getLink(fixture.nativeElement, 4).click();
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '1', '2', '+3', '-» Next']);
+    });
 
-    it('should update selected page model on first / last click', async(() => {
-         const html = `<ngb-pagination [collectionSize]="collectionSize" [page]="page" [maxSize]="maxSize"
+    it('should update selected page model on first / last click', () => {
+      const html = `<ngb-pagination [collectionSize]="collectionSize" [page]="page" [maxSize]="maxSize"
               [boundaryLinks]="boundaryLinks"></ngb-pagination>`;
-         TestBed.overrideComponent(TestComponent, {set: {template: html}});
-         const fixture = TestBed.createComponent(TestComponent);
+      const fixture = createTestComponent(html);
 
-         fixture.componentInstance.collectionSize = 30;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
+      fixture.componentInstance.collectionSize = 30;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
 
-         fixture.componentInstance.boundaryLinks = true;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['-«« First', '-« Previous', '+1', '2', '3', '» Next', '»» Last']);
+      fixture.componentInstance.boundaryLinks = true;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-«« First', '-« Previous', '+1', '2', '3', '» Next', '»» Last']);
 
-         getLink(fixture.nativeElement, 0).click();
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['-«« First', '-« Previous', '+1', '2', '3', '» Next', '»» Last']);
+      getLink(fixture.nativeElement, 0).click();
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-«« First', '-« Previous', '+1', '2', '3', '» Next', '»» Last']);
 
-         getLink(fixture.nativeElement, 6).click();
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['«« First', '« Previous', '1', '2', '+3', '-» Next', '-»» Last']);
+      getLink(fixture.nativeElement, 6).click();
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['«« First', '« Previous', '1', '2', '+3', '-» Next', '-»» Last']);
 
-         getLink(fixture.nativeElement, 3).click();
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['«« First', '« Previous', '1', '+2', '3', '» Next', '»» Last']);
+      getLink(fixture.nativeElement, 3).click();
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['«« First', '« Previous', '1', '+2', '3', '» Next', '»» Last']);
 
-         getLink(fixture.nativeElement, 0).click();
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['-«« First', '-« Previous', '+1', '2', '3', '» Next', '»» Last']);
+      getLink(fixture.nativeElement, 0).click();
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-«« First', '-« Previous', '+1', '2', '3', '» Next', '»» Last']);
 
-         // maxSize < number of pages
-         fixture.componentInstance.collectionSize = 70;
-         fixture.componentInstance.maxSize = 3;
-         fixture.detectChanges();
-         expectPages(
-             fixture.nativeElement, ['-«« First', '-« Previous', '+1', '2', '3', '-...', '7', '» Next', '»» Last']);
+      // maxSize < number of pages
+      fixture.componentInstance.collectionSize = 70;
+      fixture.componentInstance.maxSize = 3;
+      fixture.detectChanges();
+      expectPages(
+          fixture.nativeElement, ['-«« First', '-« Previous', '+1', '2', '3', '-...', '7', '» Next', '»» Last']);
 
-         getLink(fixture.nativeElement, 8).click();
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['«« First', '« Previous', '1', '-...', '+7', '-» Next', '-»» Last']);
+      getLink(fixture.nativeElement, 8).click();
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['«« First', '« Previous', '1', '-...', '+7', '-» Next', '-»» Last']);
 
-         getLink(fixture.nativeElement, 0).click();
-         fixture.detectChanges();
-         expectPages(
-             fixture.nativeElement, ['-«« First', '-« Previous', '+1', '2', '3', '-...', '7', '» Next', '»» Last']);
-       }));
+      getLink(fixture.nativeElement, 0).click();
+      fixture.detectChanges();
+      expectPages(
+          fixture.nativeElement, ['-«« First', '-« Previous', '+1', '2', '3', '-...', '7', '» Next', '»» Last']);
+    });
 
-    it('should render and respond to size change', async(() => {
-         const html = '<ngb-pagination [collectionSize]="20" [page]="1" [size]="size"></ngb-pagination>';
-         TestBed.overrideComponent(TestComponent, {set: {template: html}});
+    it('should render and respond to size change', () => {
+      const html = '<ngb-pagination [collectionSize]="20" [page]="1" [size]="size"></ngb-pagination>';
 
-         const fixture = TestBed.createComponent(TestComponent);
-         fixture.detectChanges();
-         const classList = getList(fixture.nativeElement).classList;
+      const fixture = createTestComponent(html);
+      const classList = getList(fixture.nativeElement).classList;
 
-         // default case
-         expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '» Next']);
-         expect(classList).toContain('pagination');
+      // default case
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '» Next']);
+      expect(classList).toContain('pagination');
 
-         // large size
-         fixture.componentInstance.size = 'lg';
-         fixture.detectChanges();
-         expect(classList).toContain('pagination');
-         expect(classList).toContain('pagination-lg');
+      // large size
+      fixture.componentInstance.size = 'lg';
+      fixture.detectChanges();
+      expect(classList).toContain('pagination');
+      expect(classList).toContain('pagination-lg');
 
-         // removing large size
-         fixture.componentInstance.size = '';
-         fixture.detectChanges();
-         expect(classList).toContain('pagination');
-         expect(classList).not.toContain('pagination-lg');
+      // removing large size
+      fixture.componentInstance.size = '';
+      fixture.detectChanges();
+      expect(classList).toContain('pagination');
+      expect(classList).not.toContain('pagination-lg');
 
-         // arbitrary string
-         fixture.componentInstance.size = '123';
-         fixture.detectChanges();
-         expect(classList).toContain('pagination');
-         expect(classList).toContain('pagination-123');
-       }));
+      // arbitrary string
+      fixture.componentInstance.size = '123';
+      fixture.detectChanges();
+      expect(classList).toContain('pagination');
+      expect(classList).toContain('pagination-123');
+    });
 
-    it('should render and respond to maxSize change correctly', async(() => {
-         const html =
-             '<ngb-pagination [collectionSize]="70" [page]="page" [maxSize]="maxSize" [ellipses]="ellipses"></ngb-pagination>';
-         TestBed.overrideComponent(TestComponent, {set: {template: html}});
-         const fixture = TestBed.createComponent(TestComponent);
+    it('should render and respond to maxSize change correctly', () => {
+      const html =
+          '<ngb-pagination [collectionSize]="70" [page]="page" [maxSize]="maxSize" [ellipses]="ellipses"></ngb-pagination>';
+      const fixture = createTestComponent(html);
 
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '4', '5', '6', '7', '» Next']);
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '4', '5', '6', '7', '» Next']);
 
-         // disabling ellipsis
-         fixture.componentInstance.ellipses = false;
+      // disabling ellipsis
+      fixture.componentInstance.ellipses = false;
 
-         // limiting to 3 page numbers
-         fixture.componentInstance.maxSize = 3;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
+      // limiting to 3 page numbers
+      fixture.componentInstance.maxSize = 3;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
 
-         fixture.componentInstance.page = 3;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '1', '2', '+3', '» Next']);
+      fixture.componentInstance.page = 3;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '1', '2', '+3', '» Next']);
 
-         fixture.componentInstance.page = 4;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '+4', '5', '6', '» Next']);
+      fixture.componentInstance.page = 4;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '+4', '5', '6', '» Next']);
 
-         fixture.componentInstance.page = 7;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '+7', '-» Next']);
+      fixture.componentInstance.page = 7;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '+7', '-» Next']);
 
-         // checking that maxSize > total pages works
-         fixture.componentInstance.maxSize = 100;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '1', '2', '3', '4', '5', '6', '+7', '-» Next']);
-       }));
+      // checking that maxSize > total pages works
+      fixture.componentInstance.maxSize = 100;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '1', '2', '3', '4', '5', '6', '+7', '-» Next']);
+    });
 
-    it('should render and rotate pages correctly', async(() => {
-         const html = `<ngb-pagination [collectionSize]="70" [page]="page" [maxSize]="maxSize" [rotate]="rotate"
+    it('should render and rotate pages correctly', () => {
+      const html = `<ngb-pagination [collectionSize]="70" [page]="page" [maxSize]="maxSize" [rotate]="rotate"
         [ellipses]="ellipses"></ngb-pagination>`;
-         TestBed.overrideComponent(TestComponent, {set: {template: html}});
-         const fixture = TestBed.createComponent(TestComponent);
+      const fixture = createTestComponent(html);
 
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '4', '5', '6', '7', '» Next']);
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '4', '5', '6', '7', '» Next']);
 
-         // disabling ellipsis
-         fixture.componentInstance.ellipses = false;
+      // disabling ellipsis
+      fixture.componentInstance.ellipses = false;
 
-         // limiting to 3 (odd) page numbers
-         fixture.componentInstance.maxSize = 3;
-         fixture.componentInstance.rotate = true;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
+      // limiting to 3 (odd) page numbers
+      fixture.componentInstance.maxSize = 3;
+      fixture.componentInstance.rotate = true;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
 
-         fixture.componentInstance.page = 2;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '1', '+2', '3', '» Next']);
+      fixture.componentInstance.page = 2;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '1', '+2', '3', '» Next']);
 
-         fixture.componentInstance.page = 3;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '2', '+3', '4', '» Next']);
+      fixture.componentInstance.page = 3;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '2', '+3', '4', '» Next']);
 
-         fixture.componentInstance.page = 7;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '5', '6', '+7', '-» Next']);
+      fixture.componentInstance.page = 7;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '5', '6', '+7', '-» Next']);
 
-         // limiting to 4 (even) page numbers
-         fixture.componentInstance.maxSize = 4;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '4', '5', '6', '+7', '-» Next']);
+      // limiting to 4 (even) page numbers
+      fixture.componentInstance.maxSize = 4;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '4', '5', '6', '+7', '-» Next']);
 
-         fixture.componentInstance.page = 5;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '3', '4', '+5', '6', '» Next']);
+      fixture.componentInstance.page = 5;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '3', '4', '+5', '6', '» Next']);
 
-         fixture.componentInstance.page = 3;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '1', '2', '+3', '4', '» Next']);
-       }));
+      fixture.componentInstance.page = 3;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '1', '2', '+3', '4', '» Next']);
+    });
 
-    it('should display ellipsis correctly', async(() => {
-         const html = `<ngb-pagination [collectionSize]="70" [page]="page"
+    it('should display ellipsis correctly', () => {
+      const html = `<ngb-pagination [collectionSize]="70" [page]="page"
         [maxSize]="maxSize" [rotate]="rotate" [ellipses]="ellipses"></ngb-pagination>`;
-         TestBed.overrideComponent(TestComponent, {set: {template: html}});
-         const fixture = TestBed.createComponent(TestComponent);
+      const fixture = createTestComponent(html);
 
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '4', '5', '6', '7', '» Next']);
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '4', '5', '6', '7', '» Next']);
 
-         // limiting to 3 page numbers
-         fixture.componentInstance.maxSize = 3;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '-...', '7', '» Next']);
+      // limiting to 3 page numbers
+      fixture.componentInstance.maxSize = 3;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '-...', '7', '» Next']);
 
-         fixture.componentInstance.page = 4;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '1', '-...', '+4', '5', '6', '-...', '7', '» Next']);
+      fixture.componentInstance.page = 4;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '1', '-...', '+4', '5', '6', '-...', '7', '» Next']);
 
-         fixture.componentInstance.page = 7;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '1', '-...', '+7', '-» Next']);
+      fixture.componentInstance.page = 7;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '1', '-...', '+7', '-» Next']);
 
-         // enabling rotation
-         fixture.componentInstance.rotate = true;
-         fixture.componentInstance.page = 1;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '-...', '7', '» Next']);
+      // enabling rotation
+      fixture.componentInstance.rotate = true;
+      fixture.componentInstance.page = 1;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '-...', '7', '» Next']);
 
-         fixture.componentInstance.page = 2;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '1', '+2', '3', '-...', '7', '» Next']);
+      fixture.componentInstance.page = 2;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '1', '+2', '3', '-...', '7', '» Next']);
 
-         fixture.componentInstance.page = 3;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '1', '-...', '2', '+3', '4', '-...', '7', '» Next']);
+      fixture.componentInstance.page = 3;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '1', '-...', '2', '+3', '4', '-...', '7', '» Next']);
 
-         fixture.componentInstance.page = 7;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '1', '-...', '5', '6', '+7', '-» Next']);
+      fixture.componentInstance.page = 7;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '1', '-...', '5', '6', '+7', '-» Next']);
 
-         // no ellipsis when maxPage > total pages
-         fixture.componentInstance.maxSize = 100;
-         fixture.componentInstance.page = 5;
-         fixture.detectChanges();
-         expectPages(fixture.nativeElement, ['« Previous', '1', '2', '3', '4', '+5', '6', '7', '» Next']);
-       }));
+      // no ellipsis when maxPage > total pages
+      fixture.componentInstance.maxSize = 100;
+      fixture.componentInstance.page = 5;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '1', '2', '3', '4', '+5', '6', '7', '» Next']);
+    });
   });
 
 });

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -6,11 +6,10 @@ import {Component} from '@angular/core';
 import {NgbPopoverModule} from './index';
 import {NgbPopoverWindow, NgbPopover} from './popover';
 
-function createTestComponent(html: string) {
+function createTestComponent(html: string): ComponentFixture<TestComponent> {
   TestBed.overrideComponent(TestComponent, {set: {template: html}});
   const fixture = TestBed.createComponent(TestComponent);
   fixture.detectChanges();
-
   return fixture;
 }
 
@@ -63,7 +62,9 @@ describe('ngb-popover', () => {
     });
 
     it('should open and close a popover - default settings and content from a template', () => {
-      const fixture = createTestComponent(`<template #t>Hello, {{name}}!</template><div [ngbPopover]="t" title="Title"></div>`);
+      const fixture = createTestComponent(`
+          <template #t>Hello, {{name}}!</template>
+          <div [ngbPopover]="t" title="Title"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
       directive.triggerEventHandler('click', {});

--- a/src/progressbar/progressbar.spec.ts
+++ b/src/progressbar/progressbar.spec.ts
@@ -1,4 +1,4 @@
-import {async, TestBed} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 
 import {Component} from '@angular/core';
 
@@ -11,6 +11,13 @@ function getBarWidth(nativeEl): string {
 
 function getProgressbar(nativeEl: Element): Element {
   return nativeEl.querySelector('progress');
+}
+
+function createTestComponent(html: string): ComponentFixture<TestComponent> {
+  TestBed.overrideComponent(TestComponent, {set: {template: html}});
+  const fixture = TestBed.createComponent(TestComponent);
+  fixture.detectChanges();
+  return fixture;
 }
 
 describe('ng-progressbar', () => {
@@ -71,99 +78,85 @@ describe('ng-progressbar', () => {
     beforeEach(
         () => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbProgressbarModule]}); });
 
-    it('accepts a value and respond to value changes', async(() => {
-         const html = '<ngb-progressbar [value]="value"></ngb-progressbar>';
-         TestBed.overrideComponent(TestComponent, {set: {template: html}});
-         const fixture = TestBed.createComponent(TestComponent);
-         fixture.detectChanges();
+    it('accepts a value and respond to value changes', () => {
+      const html = '<ngb-progressbar [value]="value"></ngb-progressbar>';
+      const fixture = createTestComponent(html);
 
-         expect(getBarWidth(fixture.nativeElement)).toBe('10%');
+      expect(getBarWidth(fixture.nativeElement)).toBe('10%');
 
-         // this might fail in IE11 if attribute binding order is not respected for the <progress> element:
-         // <progress [value]="" [max]=""> will fail with value = 1
-         // <progress [max]="" [value]=""> will work with value = 10
-         expect(getProgressbar(fixture.nativeElement).getAttribute('value')).toBe('10');
+      // this might fail in IE11 if attribute binding order is not respected for the <progress> element:
+      // <progress [value]="" [max]=""> will fail with value = 1
+      // <progress [max]="" [value]=""> will work with value = 10
+      expect(getProgressbar(fixture.nativeElement).getAttribute('value')).toBe('10');
 
-         fixture.componentInstance.value = 30;
-         fixture.detectChanges();
-         expect(getBarWidth(fixture.nativeElement)).toBe('30%');
-         expect(getProgressbar(fixture.nativeElement).getAttribute('value')).toBe('30');
-       }));
+      fixture.componentInstance.value = 30;
+      fixture.detectChanges();
+      expect(getBarWidth(fixture.nativeElement)).toBe('30%');
+      expect(getProgressbar(fixture.nativeElement).getAttribute('value')).toBe('30');
+    });
 
-    it('accepts a max value and respond to max changes', async(() => {
-         const html = '<ngb-progressbar [value]="value" [max]="max"></ngb-progressbar>';
-         TestBed.overrideComponent(TestComponent, {set: {template: html}});
-         const fixture = TestBed.createComponent(TestComponent);
-         fixture.detectChanges();
+    it('accepts a max value and respond to max changes', () => {
+      const html = '<ngb-progressbar [value]="value" [max]="max"></ngb-progressbar>';
+      const fixture = createTestComponent(html);
 
-         expect(getBarWidth(fixture.nativeElement)).toBe('20%');
+      expect(getBarWidth(fixture.nativeElement)).toBe('20%');
 
-         fixture.componentInstance.max = 200;
-         fixture.detectChanges();
-         expect(getBarWidth(fixture.nativeElement)).toBe('5%');
-       }));
+      fixture.componentInstance.max = 200;
+      fixture.detectChanges();
+      expect(getBarWidth(fixture.nativeElement)).toBe('5%');
+    });
 
 
-    it('accepts a value and max value above default values', async(() => {
-         const html = '<ngb-progressbar [value]="150" [max]="150"></ngb-progressbar>';
-         TestBed.overrideComponent(TestComponent, {set: {template: html}});
-         const fixture = TestBed.createComponent(TestComponent);
-         fixture.detectChanges();
+    it('accepts a value and max value above default values', () => {
+      const html = '<ngb-progressbar [value]="150" [max]="150"></ngb-progressbar>';
+      const fixture = createTestComponent(html);
 
-         expect(getBarWidth(fixture.nativeElement)).toBe('100%');
-       }));
+      expect(getBarWidth(fixture.nativeElement)).toBe('100%');
+    });
 
 
-    it('accepts a custom type', async(() => {
-         const html = '<ngb-progressbar [value]="value" [type]="type"></ngb-progressbar>';
-         TestBed.overrideComponent(TestComponent, {set: {template: html}});
-         const fixture = TestBed.createComponent(TestComponent);
+    it('accepts a custom type', () => {
+      const html = '<ngb-progressbar [value]="value" [type]="type"></ngb-progressbar>';
+      const fixture = createTestComponent(html);
 
-         fixture.detectChanges();
-         expect(getProgressbar(fixture.nativeElement)).toHaveCssClass('progress-warning');
+      expect(getProgressbar(fixture.nativeElement)).toHaveCssClass('progress-warning');
 
-         fixture.componentInstance.type = 'info';
-         fixture.detectChanges();
-         expect(getProgressbar(fixture.nativeElement)).toHaveCssClass('progress-info');
-       }));
+      fixture.componentInstance.type = 'info';
+      fixture.detectChanges();
+      expect(getProgressbar(fixture.nativeElement)).toHaveCssClass('progress-info');
+    });
 
-    it('accepts animated as normal attr', async(() => {
-         const html = '<ngb-progressbar [value]="value" [animated]="animated"></ngb-progressbar>';
-         TestBed.overrideComponent(TestComponent, {set: {template: html}});
-         const fixture = TestBed.createComponent(TestComponent);
-         fixture.detectChanges();
+    it('accepts animated as normal attr', () => {
+      const html = '<ngb-progressbar [value]="value" [animated]="animated"></ngb-progressbar>';
+      const fixture = createTestComponent(html);
 
-         expect(getProgressbar(fixture.nativeElement)).toHaveCssClass('progress-animated');
+      expect(getProgressbar(fixture.nativeElement)).toHaveCssClass('progress-animated');
 
-         fixture.componentInstance.animated = false;
-         fixture.detectChanges();
-         expect(getProgressbar(fixture.nativeElement)).not.toHaveCssClass('progress-animated');
-       }));
+      fixture.componentInstance.animated = false;
+      fixture.detectChanges();
+      expect(getProgressbar(fixture.nativeElement)).not.toHaveCssClass('progress-animated');
+    });
 
 
-    it('accepts striped as normal attr', async(() => {
-         const html = '<ngb-progressbar [value]="value" [striped]="striped"></ngb-progressbar>';
-         TestBed.overrideComponent(TestComponent, {set: {template: html}});
-         const fixture = TestBed.createComponent(TestComponent);
-         fixture.detectChanges();
+    it('accepts striped as normal attr', () => {
+      const html = '<ngb-progressbar [value]="value" [striped]="striped"></ngb-progressbar>';
+      const fixture = createTestComponent(html);
 
-         expect(getProgressbar(fixture.nativeElement)).toHaveCssClass('progress-striped');
+      expect(getProgressbar(fixture.nativeElement)).toHaveCssClass('progress-striped');
 
-         fixture.componentInstance.striped = false;
-         fixture.detectChanges();
-         expect(getProgressbar(fixture.nativeElement)).not.toHaveCssClass('progress-striped');
-       }));
+      fixture.componentInstance.striped = false;
+      fixture.detectChanges();
+      expect(getProgressbar(fixture.nativeElement)).not.toHaveCssClass('progress-striped');
+    });
 
 
-    it('should not add "false" CSS class', async(() => {
-         const html = '<ngb-progressbar [value]="value" [striped]="striped"></ngb-progressbar>';
-         TestBed.overrideComponent(TestComponent, {set: {template: html}});
-         const fixture = TestBed.createComponent(TestComponent);
-         fixture.detectChanges();
+    it('should not add "false" CSS class', () => {
+      const html = '<ngb-progressbar [value]="value" [striped]="striped"></ngb-progressbar>';
+      const fixture = createTestComponent(html);
 
-         expect(getProgressbar(fixture.nativeElement)).toHaveCssClass('progress-striped');
-         expect(getProgressbar(fixture.nativeElement)).not.toHaveCssClass('false');
-       }));
+      expect(getProgressbar(fixture.nativeElement)).toHaveCssClass('progress-striped');
+      expect(getProgressbar(fixture.nativeElement)).not.toHaveCssClass('false');
+    });
   });
 });
 

--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -1,4 +1,4 @@
-import {async, TestBed, ComponentFixture} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 
 import {Component} from '@angular/core';
 
@@ -31,7 +31,7 @@ function getState(compiled) {
   return state;
 }
 
-function createTestComponentFixture(html: string): ComponentFixture<TestComponent> {
+function createTestComponent(html: string): ComponentFixture<TestComponent> {
   TestBed.overrideComponent(TestComponent, {set: {template: html}});
   const fixture = TestBed.createComponent(TestComponent);
   fixture.detectChanges();
@@ -41,102 +41,102 @@ function createTestComponentFixture(html: string): ComponentFixture<TestComponen
 describe('ngb-rating', () => {
   beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbRatingModule]}); });
 
-  it('should show 10 stars by default', async(() => {
-       const fixture = TestBed.createComponent(NgbRating);
-       fixture.detectChanges();
+  it('should show 10 stars by default', () => {
+    const fixture = TestBed.createComponent(NgbRating);
+    fixture.detectChanges();
 
-       const compiled = fixture.nativeElement;
+    const compiled = fixture.nativeElement;
 
-       const stars = getStars(compiled);
-       expect(stars.length).toBe(10);
-     }));
+    const stars = getStars(compiled);
+    expect(stars.length).toBe(10);
+  });
 
-  it('should change the num of stars with `max`', async(() => {
-       const fixture = createTestComponentFixture('<ngb-rating max="3"></ngb-rating>');
+  it('should change the num of stars with `max`', () => {
+    const fixture = createTestComponent('<ngb-rating max="3"></ngb-rating>');
 
-       const compiled = fixture.nativeElement;
-       const stars = getStars(compiled);
-       expect(stars.length).toBe(3);
-     }));
+    const compiled = fixture.nativeElement;
+    const stars = getStars(compiled);
+    expect(stars.length).toBe(3);
+  });
 
-  it('initializes the default star icons as selected', async(() => {
-       const fixture = createTestComponentFixture('<ngb-rating rate="3" max="5"></ngb-rating>');
+  it('initializes the default star icons as selected', () => {
+    const fixture = createTestComponent('<ngb-rating rate="3" max="5"></ngb-rating>');
 
-       const compiled = fixture.nativeElement;
-       expect(getState(compiled)).toEqual([true, true, true, false, false]);
-     }));
+    const compiled = fixture.nativeElement;
+    expect(getState(compiled)).toEqual([true, true, true, false, false]);
+  });
 
-  it('handles correctly the click event', async(() => {
-       const fixture = createTestComponentFixture('<ngb-rating rate="3" max="5"></ngb-rating>');
+  it('handles correctly the click event', () => {
+    const fixture = createTestComponent('<ngb-rating rate="3" max="5"></ngb-rating>');
 
-       const compiled = fixture.nativeElement;
+    const compiled = fixture.nativeElement;
 
-       getStar(compiled, 2).click();
-       fixture.detectChanges();
-       expect(getState(compiled)).toEqual([true, true, false, false, false]);
-     }));
+    getStar(compiled, 2).click();
+    fixture.detectChanges();
+    expect(getState(compiled)).toEqual([true, true, false, false, false]);
+  });
 
-  it('should set pointer cursor on stars when not readonly', async(() => {
-       const fixture = TestBed.createComponent(NgbRating);
-       fixture.detectChanges();
+  it('should set pointer cursor on stars when not readonly', () => {
+    const fixture = TestBed.createComponent(NgbRating);
+    fixture.detectChanges();
 
-       const compiled = fixture.nativeElement;
+    const compiled = fixture.nativeElement;
 
-       expect(window.getComputedStyle(getStar(compiled, 1)).getPropertyValue('cursor')).toBe('pointer');
-     }));
+    expect(window.getComputedStyle(getStar(compiled, 1)).getPropertyValue('cursor')).toBe('pointer');
+  });
 
-  it('should set not allowed cursor on stars when readonly', async(() => {
-       const fixture = createTestComponentFixture('<ngb-rating [readonly]="true"></ngb-rating>');
+  it('should set not allowed cursor on stars when readonly', () => {
+    const fixture = createTestComponent('<ngb-rating [readonly]="true"></ngb-rating>');
 
-       const compiled = fixture.nativeElement;
+    const compiled = fixture.nativeElement;
 
-       expect(window.getComputedStyle(getStar(compiled, 1)).getPropertyValue('cursor')).toBe('not-allowed');
-     }));
+    expect(window.getComputedStyle(getStar(compiled, 1)).getPropertyValue('cursor')).toBe('not-allowed');
+  });
 
   describe('aria support', () => {
-    it('contains aria-valuemax with the number of stars', async(() => {
-         const fixture = createTestComponentFixture('<ngb-rating [max]="max"></ngb-rating>');
+    it('contains aria-valuemax with the number of stars', () => {
+      const fixture = createTestComponent('<ngb-rating [max]="max"></ngb-rating>');
 
-         const compiled = fixture.nativeElement;
+      const compiled = fixture.nativeElement;
 
-         expect(compiled.querySelector('span').getAttribute('aria-valuemax')).toBe('10');
-       }));
+      expect(compiled.querySelector('span').getAttribute('aria-valuemax')).toBe('10');
+    });
 
-    it('contains a hidden span for each star for screenreaders', async(() => {
-         const fixture = createTestComponentFixture('<ngb-rating max="5"></ngb-rating>');
+    it('contains a hidden span for each star for screenreaders', () => {
+      const fixture = createTestComponent('<ngb-rating max="5"></ngb-rating>');
 
-         const compiled = fixture.nativeElement;
-         const hiddenStars = getStars(compiled, '.sr-only');
+      const compiled = fixture.nativeElement;
+      const hiddenStars = getStars(compiled, '.sr-only');
 
-         expect(hiddenStars.length).toBe(5);
-       }));
+      expect(hiddenStars.length).toBe(5);
+    });
 
-    it('initializes populates the current rate for screenreaders', async(() => {
-         const fixture = createTestComponentFixture('<ngb-rating rate="3" max="5"></ngb-rating>');
+    it('initializes populates the current rate for screenreaders', () => {
+      const fixture = createTestComponent('<ngb-rating rate="3" max="5"></ngb-rating>');
 
-         const compiled = fixture.nativeElement;
+      const compiled = fixture.nativeElement;
 
-         expect(getAriaState(compiled)).toEqual([true, true, true, false, false]);
-       }));
+      expect(getAriaState(compiled)).toEqual([true, true, true, false, false]);
+    });
 
-    it('contains aria-valuenow with the current rate', async(() => {
-         const fixture = createTestComponentFixture('<ngb-rating [max]="max" rate="3"></ngb-rating>');
+    it('contains aria-valuenow with the current rate', () => {
+      const fixture = createTestComponent('<ngb-rating [max]="max" rate="3"></ngb-rating>');
 
-         const compiled = fixture.nativeElement;
+      const compiled = fixture.nativeElement;
 
-         expect(compiled.querySelector('span').getAttribute('aria-valuenow')).toBe('3');
-       }));
+      expect(compiled.querySelector('span').getAttribute('aria-valuenow')).toBe('3');
+    });
 
-    it('updates aria-valuenow when the rate changes', async(() => {
-         const fixture = createTestComponentFixture('<ngb-rating [max]="max" rate="3"></ngb-rating>');
+    it('updates aria-valuenow when the rate changes', () => {
+      const fixture = createTestComponent('<ngb-rating [max]="max" rate="3"></ngb-rating>');
 
-         const compiled = fixture.nativeElement;
+      const compiled = fixture.nativeElement;
 
-         getStar(compiled, 7).click();
-         fixture.detectChanges();
+      getStar(compiled, 7).click();
+      fixture.detectChanges();
 
-         expect(compiled.querySelector('span').getAttribute('aria-valuenow')).toBe('7');
-       }));
+      expect(compiled.querySelector('span').getAttribute('aria-valuenow')).toBe('7');
+    });
   });
 });
 

--- a/src/tabset/tabset.spec.ts
+++ b/src/tabset/tabset.spec.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 
 import {NgbTabsetModule} from './index';
 
@@ -44,11 +44,10 @@ function getButton(nativeEl: HTMLElement) {
   return nativeEl.querySelectorAll('button');
 }
 
-function createTestComponent(html: string) {
+function createTestComponent(html: string): ComponentFixture<TestComponent> {
   TestBed.overrideComponent(TestComponent, {set: {template: html}});
   const fixture = TestBed.createComponent(TestComponent);
   fixture.detectChanges();
-
   return fixture;
 }
 

--- a/src/timepicker/timepicker.spec.ts
+++ b/src/timepicker/timepicker.spec.ts
@@ -1,6 +1,6 @@
 import {Component} from '@angular/core';
 
-import {TestBed} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
 import {Validators, FormControl, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
@@ -45,11 +45,10 @@ function expectToDisplayTime(el: HTMLElement, time: string) {
   expect(timeInInputs.join(':')).toBe(time);
 }
 
-function createTestComponent(html: string) {
+function createTestComponent(html: string): ComponentFixture<TestComponent> {
   TestBed.overrideComponent(TestComponent, {set: {template: html}});
   const fixture = TestBed.createComponent(TestComponent);
   fixture.detectChanges();
-
   return fixture;
 }
 

--- a/src/tooltip/tooltip.spec.ts
+++ b/src/tooltip/tooltip.spec.ts
@@ -1,11 +1,11 @@
-import {async, TestBed, ComponentFixture} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {Component} from '@angular/core';
 
 import {NgbTooltipModule} from './index';
 import {NgbTooltipWindow, NgbTooltip} from './tooltip';
 
-function createTestComponentFixture(html: string): ComponentFixture<TestComponent> {
+function createTestComponent(html: string): ComponentFixture<TestComponent> {
   TestBed.overrideComponent(TestComponent, {set: {template: html}});
   const fixture = TestBed.createComponent(TestComponent);
   fixture.detectChanges();
@@ -15,21 +15,21 @@ function createTestComponentFixture(html: string): ComponentFixture<TestComponen
 describe('ngb-tooltip-window', () => {
   beforeEach(() => { TestBed.configureTestingModule({imports: [NgbTooltipModule]}); });
 
-  it('should render tooltip on top by default', async(() => {
-       const fixture = TestBed.createComponent(NgbTooltipWindow);
-       fixture.detectChanges();
+  it('should render tooltip on top by default', () => {
+    const fixture = TestBed.createComponent(NgbTooltipWindow);
+    fixture.detectChanges();
 
-       expect(fixture.nativeElement).toHaveCssClass('tooltip');
-       expect(fixture.nativeElement).toHaveCssClass('tooltip-top');
-       expect(fixture.nativeElement.getAttribute('role')).toBe('tooltip');
-     }));
+    expect(fixture.nativeElement).toHaveCssClass('tooltip');
+    expect(fixture.nativeElement).toHaveCssClass('tooltip-top');
+    expect(fixture.nativeElement.getAttribute('role')).toBe('tooltip');
+  });
 
-  it('should position tooltips as requested', async(() => {
-       const fixture = TestBed.createComponent(NgbTooltipWindow);
-       fixture.componentInstance.placement = 'left';
-       fixture.detectChanges();
-       expect(fixture.nativeElement).toHaveCssClass('tooltip-left');
-     }));
+  it('should position tooltips as requested', () => {
+    const fixture = TestBed.createComponent(NgbTooltipWindow);
+    fixture.componentInstance.placement = 'left';
+    fixture.detectChanges();
+    expect(fixture.nativeElement).toHaveCssClass('tooltip-left');
+  });
 });
 
 describe('ngb-tooltip', () => {
@@ -40,214 +40,213 @@ describe('ngb-tooltip', () => {
 
   describe('basic functionality', () => {
 
-    it('should open and close a tooltip - default settings and content as string', async(() => {
-         const fixture = createTestComponentFixture(`<div ngbTooltip="Great tip!"></div>`);
-         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+    it('should open and close a tooltip - default settings and content as string', () => {
+      const fixture = createTestComponent(`<div ngbTooltip="Great tip!"></div>`);
+      const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-         directive.triggerEventHandler('mouseenter', {});
-         fixture.detectChanges();
-         const windowEl = getWindow(fixture);
+      directive.triggerEventHandler('mouseenter', {});
+      fixture.detectChanges();
+      const windowEl = getWindow(fixture);
 
-         expect(windowEl).toHaveCssClass('tooltip');
-         expect(windowEl).toHaveCssClass('tooltip-top');
-         expect(windowEl.textContent.trim()).toBe('Great tip!');
-         expect(windowEl.getAttribute('role')).toBe('tooltip');
+      expect(windowEl).toHaveCssClass('tooltip');
+      expect(windowEl).toHaveCssClass('tooltip-top');
+      expect(windowEl.textContent.trim()).toBe('Great tip!');
+      expect(windowEl.getAttribute('role')).toBe('tooltip');
 
-         directive.triggerEventHandler('mouseleave', {});
-         fixture.detectChanges();
-         expect(getWindow(fixture)).toBeNull();
-       }));
+      directive.triggerEventHandler('mouseleave', {});
+      fixture.detectChanges();
+      expect(getWindow(fixture)).toBeNull();
+    });
 
-    it('should open and close a tooltip - default settings and content from a template', async(() => {
-         const fixture = createTestComponentFixture(`<template #t>Hello, {{name}}!</template><div [ngbTooltip]="t"></div>`);
-         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+    it('should open and close a tooltip - default settings and content from a template', () => {
+      const fixture = createTestComponent(`<template #t>Hello, {{name}}!</template><div [ngbTooltip]="t"></div>`);
+      const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-         directive.triggerEventHandler('mouseenter', {});
-         fixture.detectChanges();
-         const windowEl = getWindow(fixture);
+      directive.triggerEventHandler('mouseenter', {});
+      fixture.detectChanges();
+      const windowEl = getWindow(fixture);
 
-         expect(windowEl).toHaveCssClass('tooltip');
-         expect(windowEl).toHaveCssClass('tooltip-top');
-         expect(windowEl.textContent.trim()).toBe('Hello, World!');
-         expect(windowEl.getAttribute('role')).toBe('tooltip');
+      expect(windowEl).toHaveCssClass('tooltip');
+      expect(windowEl).toHaveCssClass('tooltip-top');
+      expect(windowEl.textContent.trim()).toBe('Hello, World!');
+      expect(windowEl.getAttribute('role')).toBe('tooltip');
 
-         directive.triggerEventHandler('mouseleave', {});
-         fixture.detectChanges();
-         expect(getWindow(fixture)).toBeNull();
-       }));
+      directive.triggerEventHandler('mouseleave', {});
+      fixture.detectChanges();
+      expect(getWindow(fixture)).toBeNull();
+    });
 
-    it('should allow re-opening previously closed tooltips', async(() => {
-         const fixture = createTestComponentFixture(`<div ngbTooltip="Great tip!"></div>`);
-         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+    it('should allow re-opening previously closed tooltips', () => {
+      const fixture = createTestComponent(`<div ngbTooltip="Great tip!"></div>`);
+      const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-         directive.triggerEventHandler('mouseenter', {});
-         fixture.detectChanges();
-         expect(getWindow(fixture)).not.toBeNull();
+      directive.triggerEventHandler('mouseenter', {});
+      fixture.detectChanges();
+      expect(getWindow(fixture)).not.toBeNull();
 
-         directive.triggerEventHandler('mouseleave', {});
-         fixture.detectChanges();
-         expect(getWindow(fixture)).toBeNull();
+      directive.triggerEventHandler('mouseleave', {});
+      fixture.detectChanges();
+      expect(getWindow(fixture)).toBeNull();
 
-         directive.triggerEventHandler('mouseenter', {});
-         fixture.detectChanges();
-         expect(getWindow(fixture)).not.toBeNull();
-       }));
+      directive.triggerEventHandler('mouseenter', {});
+      fixture.detectChanges();
+      expect(getWindow(fixture)).not.toBeNull();
+    });
 
-    it('should not leave dangling tooltips in the DOM', async(() => {
-         const fixture = createTestComponentFixture(`<template [ngIf]="show"><div ngbTooltip="Great tip!"></div></template>`);
-         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+    it('should not leave dangling tooltips in the DOM', () => {
+      const fixture = createTestComponent(`<template [ngIf]="show"><div ngbTooltip="Great tip!"></div></template>`);
+      const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-         directive.triggerEventHandler('mouseenter', {});
-         fixture.detectChanges();
-         expect(getWindow(fixture)).not.toBeNull();
+      directive.triggerEventHandler('mouseenter', {});
+      fixture.detectChanges();
+      expect(getWindow(fixture)).not.toBeNull();
 
-         fixture.componentInstance.show = false;
-         fixture.detectChanges();
-         expect(getWindow(fixture)).toBeNull();
-       }));
+      fixture.componentInstance.show = false;
+      fixture.detectChanges();
+      expect(getWindow(fixture)).toBeNull();
+    });
 
-    it('should properly cleanup tooltips with manual triggers', async(() => {
-         const fixture = createTestComponentFixture(`
+    it('should properly cleanup tooltips with manual triggers', () => {
+      const fixture = createTestComponent(`
             <template [ngIf]="show">
               <div ngbTooltip="Great tip!" triggers="manual" #t="ngbTooltip" (mouseenter)="t.open()"></div>
             </template>`);
-         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+      const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-         directive.triggerEventHandler('mouseenter', {});
-         fixture.detectChanges();
-         expect(getWindow(fixture)).not.toBeNull();
+      directive.triggerEventHandler('mouseenter', {});
+      fixture.detectChanges();
+      expect(getWindow(fixture)).not.toBeNull();
 
-         fixture.componentInstance.show = false;
-         fixture.detectChanges();
-         expect(getWindow(fixture)).toBeNull();
-       }));
+      fixture.componentInstance.show = false;
+      fixture.detectChanges();
+      expect(getWindow(fixture)).toBeNull();
+    });
 
     describe('positioning', () => {
 
-      it('should use requested position', async(() => {
-           const fixture = createTestComponentFixture(`<div ngbTooltip="Great tip!" placement="left"></div>`);
-           const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+      it('should use requested position', () => {
+        const fixture = createTestComponent(`<div ngbTooltip="Great tip!" placement="left"></div>`);
+        const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-           directive.triggerEventHandler('mouseenter', {});
-           fixture.detectChanges();
-           const windowEl = getWindow(fixture);
+        directive.triggerEventHandler('mouseenter', {});
+        fixture.detectChanges();
+        const windowEl = getWindow(fixture);
 
-           expect(windowEl).toHaveCssClass('tooltip');
-           expect(windowEl).toHaveCssClass('tooltip-left');
-           expect(windowEl.textContent.trim()).toBe('Great tip!');
-         }));
+        expect(windowEl).toHaveCssClass('tooltip');
+        expect(windowEl).toHaveCssClass('tooltip-left');
+        expect(windowEl.textContent.trim()).toBe('Great tip!');
+      });
     });
 
     describe('triggers', () => {
 
-      it('should support toggle triggers', async(() => {
-           const fixture = createTestComponentFixture(`<div ngbTooltip="Great tip!" triggers="click"></div>`);
-           const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+      it('should support toggle triggers', () => {
+        const fixture = createTestComponent(`<div ngbTooltip="Great tip!" triggers="click"></div>`);
+        const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-           directive.triggerEventHandler('click', {});
-           fixture.detectChanges();
-           expect(getWindow(fixture)).not.toBeNull();
+        directive.triggerEventHandler('click', {});
+        fixture.detectChanges();
+        expect(getWindow(fixture)).not.toBeNull();
 
-           directive.triggerEventHandler('click', {});
-           fixture.detectChanges();
-           expect(getWindow(fixture)).toBeNull();
-         }));
+        directive.triggerEventHandler('click', {});
+        fixture.detectChanges();
+        expect(getWindow(fixture)).toBeNull();
+      });
 
-      it('should non-default toggle triggers', async(() => {
-           const fixture =
-               createTestComponentFixture(`<div ngbTooltip="Great tip!" triggers="mouseenter:click"></div>`);
-           const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+      it('should non-default toggle triggers', () => {
+        const fixture = createTestComponent(`<div ngbTooltip="Great tip!" triggers="mouseenter:click"></div>`);
+        const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-           directive.triggerEventHandler('mouseenter', {});
-           fixture.detectChanges();
-           expect(getWindow(fixture)).not.toBeNull();
+        directive.triggerEventHandler('mouseenter', {});
+        fixture.detectChanges();
+        expect(getWindow(fixture)).not.toBeNull();
 
-           directive.triggerEventHandler('click', {});
-           fixture.detectChanges();
-           expect(getWindow(fixture)).toBeNull();
-         }));
+        directive.triggerEventHandler('click', {});
+        fixture.detectChanges();
+        expect(getWindow(fixture)).toBeNull();
+      });
 
-      it('should support multiple triggers', async(() => {
-           const fixture =
-               createTestComponentFixture(`<div ngbTooltip="Great tip!" triggers="mouseenter:mouseleave click"></div>`);
-           const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+      it('should support multiple triggers', () => {
+        const fixture =
+            createTestComponent(`<div ngbTooltip="Great tip!" triggers="mouseenter:mouseleave click"></div>`);
+        const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-           directive.triggerEventHandler('mouseenter', {});
-           fixture.detectChanges();
-           expect(getWindow(fixture)).not.toBeNull();
+        directive.triggerEventHandler('mouseenter', {});
+        fixture.detectChanges();
+        expect(getWindow(fixture)).not.toBeNull();
 
-           directive.triggerEventHandler('click', {});
-           fixture.detectChanges();
-           expect(getWindow(fixture)).toBeNull();
-         }));
+        directive.triggerEventHandler('click', {});
+        fixture.detectChanges();
+        expect(getWindow(fixture)).toBeNull();
+      });
 
-      it('should not use default for manual triggers', async(() => {
-           const fixture = createTestComponentFixture(`<div ngbTooltip="Great tip!" triggers="manual"></div>`);
-           const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+      it('should not use default for manual triggers', () => {
+        const fixture = createTestComponent(`<div ngbTooltip="Great tip!" triggers="manual"></div>`);
+        const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-           directive.triggerEventHandler('mouseenter', {});
-           fixture.detectChanges();
-           expect(getWindow(fixture)).toBeNull();
-         }));
+        directive.triggerEventHandler('mouseenter', {});
+        fixture.detectChanges();
+        expect(getWindow(fixture)).toBeNull();
+      });
 
-      it('should allow toggling for manual triggers', async(() => {
-           const fixture = createTestComponentFixture(`
+      it('should allow toggling for manual triggers', () => {
+        const fixture = createTestComponent(`
                 <div ngbTooltip="Great tip!" triggers="manual" #t="ngbTooltip"></div>
                 <button (click)="t.toggle()">T</button>`);
-           const button = fixture.nativeElement.querySelector('button');
+        const button = fixture.nativeElement.querySelector('button');
 
-           button.click();
-           fixture.detectChanges();
-           expect(getWindow(fixture)).not.toBeNull();
+        button.click();
+        fixture.detectChanges();
+        expect(getWindow(fixture)).not.toBeNull();
 
-           button.click();
-           fixture.detectChanges();
-           expect(getWindow(fixture)).toBeNull();
-         }));
+        button.click();
+        fixture.detectChanges();
+        expect(getWindow(fixture)).toBeNull();
+      });
 
-      it('should allow open / close for manual triggers', async(() => {
-           const fixture = createTestComponentFixture(`
+      it('should allow open / close for manual triggers', () => {
+        const fixture = createTestComponent(`
                 <div ngbTooltip="Great tip!" triggers="manual" #t="ngbTooltip"></div>
                 <button (click)="t.open()">O</button>
                 <button (click)="t.close()">C</button>`);
 
-           const buttons = fixture.nativeElement.querySelectorAll('button');
+        const buttons = fixture.nativeElement.querySelectorAll('button');
 
-           buttons[0].click();  // open
-           fixture.detectChanges();
-           expect(getWindow(fixture)).not.toBeNull();
+        buttons[0].click();  // open
+        fixture.detectChanges();
+        expect(getWindow(fixture)).not.toBeNull();
 
-           buttons[1].click();  // close
-           fixture.detectChanges();
-           expect(getWindow(fixture)).toBeNull();
-         }));
+        buttons[1].click();  // close
+        fixture.detectChanges();
+        expect(getWindow(fixture)).toBeNull();
+      });
 
-      it('should not throw when open called for manual triggers and open tooltip', async(() => {
-           const fixture = createTestComponentFixture(`
+      it('should not throw when open called for manual triggers and open tooltip', () => {
+        const fixture = createTestComponent(`
                 <div ngbTooltip="Great tip!" triggers="manual" #t="ngbTooltip"></div>
                 <button (click)="t.open()">O</button>`);
-           const button = fixture.nativeElement.querySelector('button');
+        const button = fixture.nativeElement.querySelector('button');
 
-           button.click();  // open
-           fixture.detectChanges();
-           expect(getWindow(fixture)).not.toBeNull();
+        button.click();  // open
+        fixture.detectChanges();
+        expect(getWindow(fixture)).not.toBeNull();
 
-           button.click();  // open
-           fixture.detectChanges();
-           expect(getWindow(fixture)).not.toBeNull();
-         }));
+        button.click();  // open
+        fixture.detectChanges();
+        expect(getWindow(fixture)).not.toBeNull();
+      });
 
-      it('should not throw when closed called for manual triggers and closed tooltip', async(() => {
-           const fixture = createTestComponentFixture(`
+      it('should not throw when closed called for manual triggers and closed tooltip', () => {
+        const fixture = createTestComponent(`
                 <div ngbTooltip="Great tip!" triggers="manual" #t="ngbTooltip"></div>
                 <button (click)="t.close()">C</button>`);
 
-           const button = fixture.nativeElement.querySelector('button');
+        const button = fixture.nativeElement.querySelector('button');
 
-           button.click();  // close
-           fixture.detectChanges();
-           expect(getWindow(fixture)).toBeNull();
-         }));
+        button.click();  // close
+        fixture.detectChanges();
+        expect(getWindow(fixture)).toBeNull();
+      });
     });
   });
 });

--- a/src/typeahead/highlight.spec.ts
+++ b/src/typeahead/highlight.spec.ts
@@ -1,10 +1,9 @@
-import {async, TestBed, ComponentFixture} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 
 import {Component} from '@angular/core';
 
 import {NgbHighlight} from './highlight';
 import {NgbTypeaheadModule} from './index';
-
 
 /**
  * Get generated innerHtml without HTML comments and Angular debug attributes
@@ -29,7 +28,7 @@ function highlightHtml(fixture) {
   return result;
 }
 
-function createTestComponentFixture(html: string): ComponentFixture<TestComponent> {
+function createTestComponent(html: string): ComponentFixture<TestComponent> {
   TestBed.overrideComponent(TestComponent, {set: {template: html}});
   const fixture = TestBed.createComponent(TestComponent);
   fixture.detectChanges();
@@ -43,92 +42,90 @@ describe('ngb-highlight', () => {
     TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTypeaheadModule]});
   });
 
-  it('should render highlighted text when there is one match', async(() => {
-       const fixture = createTestComponentFixture('<ngb-highlight result="foo bar baz" term="bar"></ngb-highlight>');
+  it('should render highlighted text when there is one match', () => {
+    const fixture = createTestComponent('<ngb-highlight result="foo bar baz" term="bar"></ngb-highlight>');
 
-       expect(highlightHtml(fixture)).toBe('foo <span class="ngb-highlight">bar</span> baz');
-     }));
+    expect(highlightHtml(fixture)).toBe('foo <span class="ngb-highlight">bar</span> baz');
+  });
 
-  it('should render highlighted text when there are multiple matches', async(() => {
-       const fixture =
-           createTestComponentFixture('<ngb-highlight result="foo bar baz bar foo" term="bar"></ngb-highlight>');
+  it('should render highlighted text when there are multiple matches', () => {
+    const fixture = createTestComponent('<ngb-highlight result="foo bar baz bar foo" term="bar"></ngb-highlight>');
 
-       expect(highlightHtml(fixture))
-           .toBe('foo <span class="ngb-highlight">bar</span> baz <span class="ngb-highlight">bar</span> foo');
-     }));
+    expect(highlightHtml(fixture))
+        .toBe('foo <span class="ngb-highlight">bar</span> baz <span class="ngb-highlight">bar</span> foo');
+  });
 
-  it('should render highlighted text when there is a match at the beginning', async(() => {
-       const fixture = createTestComponentFixture('<ngb-highlight result="bar baz" term="bar"></ngb-highlight>');
+  it('should render highlighted text when there is a match at the beginning', () => {
+    const fixture = createTestComponent('<ngb-highlight result="bar baz" term="bar"></ngb-highlight>');
 
-       expect(highlightHtml(fixture)).toBe('<span class="ngb-highlight">bar</span> baz');
-     }));
+    expect(highlightHtml(fixture)).toBe('<span class="ngb-highlight">bar</span> baz');
+  });
 
-  it('should render highlighted text when there is a match at the end', async(() => {
-       const fixture = createTestComponentFixture('<ngb-highlight result="bar baz" term="baz"></ngb-highlight>');
+  it('should render highlighted text when there is a match at the end', () => {
+    const fixture = createTestComponent('<ngb-highlight result="bar baz" term="baz"></ngb-highlight>');
 
-       expect(highlightHtml(fixture)).toBe('bar <span class="ngb-highlight">baz</span>');
-     }));
+    expect(highlightHtml(fixture)).toBe('bar <span class="ngb-highlight">baz</span>');
+  });
 
-  it('should render highlighted text when there is a case-insensitive match', async(() => {
-       const fixture = createTestComponentFixture('<ngb-highlight result="foo bAR baz" term="bar"></ngb-highlight>');
+  it('should render highlighted text when there is a case-insensitive match', () => {
+    const fixture = createTestComponent('<ngb-highlight result="foo bAR baz" term="bar"></ngb-highlight>');
 
-       expect(highlightHtml(fixture)).toBe('foo <span class="ngb-highlight">bAR</span> baz');
-     }));
+    expect(highlightHtml(fixture)).toBe('foo <span class="ngb-highlight">bAR</span> baz');
+  });
 
-  it('should render highlighted text with special characters', async(() => {
-       const fixture = createTestComponentFixture('<ngb-highlight result="foo (bAR baz" term="(BAR"></ngb-highlight>');
+  it('should render highlighted text with special characters', () => {
+    const fixture = createTestComponent('<ngb-highlight result="foo (bAR baz" term="(BAR"></ngb-highlight>');
 
-       expect(highlightHtml(fixture)).toBe('foo <span class="ngb-highlight">(bAR</span> baz');
-     }));
+    expect(highlightHtml(fixture)).toBe('foo <span class="ngb-highlight">(bAR</span> baz');
+  });
 
-  it('should render highlighted text for stringified non-string args', async(() => {
-       const fixture = createTestComponentFixture('<ngb-highlight [result]="123" term="2"></ngb-highlight>');
-       fixture.detectChanges();
-       expect(highlightHtml(fixture)).toBe('1<span class="ngb-highlight">2</span>3');
-     }));
+  it('should render highlighted text for stringified non-string args', () => {
+    const fixture = createTestComponent('<ngb-highlight [result]="123" term="2"></ngb-highlight>');
+    fixture.detectChanges();
+    expect(highlightHtml(fixture)).toBe('1<span class="ngb-highlight">2</span>3');
+  });
 
-  it('should behave reasonably for blank result', async(() => {
-       const fixture = createTestComponentFixture('<ngb-highlight [result]="null" term="2"></ngb-highlight>');
+  it('should behave reasonably for blank result', () => {
+    const fixture = createTestComponent('<ngb-highlight [result]="null" term="2"></ngb-highlight>');
 
-       expect(highlightHtml(fixture)).toBe('');
-     }));
+    expect(highlightHtml(fixture)).toBe('');
+  });
 
-  it('should not convert null result to string', async(() => {
-       const fixture = createTestComponentFixture('<ngb-highlight [result]="null" term="null"></ngb-highlight>');
+  it('should not convert null result to string', () => {
+    const fixture = createTestComponent('<ngb-highlight [result]="null" term="null"></ngb-highlight>');
 
-       expect(highlightHtml(fixture)).toBe('');
-     }));
+    expect(highlightHtml(fixture)).toBe('');
+  });
 
-  it('should properly detect matches in 0 result', async(() => {
-       const fixture = createTestComponentFixture('<ngb-highlight [result]="0" term="0"></ngb-highlight>');
+  it('should properly detect matches in 0 result', () => {
+    const fixture = createTestComponent('<ngb-highlight [result]="0" term="0"></ngb-highlight>');
 
-       expect(highlightHtml(fixture)).toBe(`<span class="ngb-highlight">0</span>`);
-     }));
+    expect(highlightHtml(fixture)).toBe(`<span class="ngb-highlight">0</span>`);
+  });
 
-  it('should not higlight anything for blank term', async(() => {
-       const fixture = createTestComponentFixture('<ngb-highlight result="1null23" [term]="null"></ngb-highlight>');
+  it('should not higlight anything for blank term', () => {
+    const fixture = createTestComponent('<ngb-highlight result="1null23" [term]="null"></ngb-highlight>');
 
-       expect(highlightHtml(fixture)).toBe('1null23');
-     }));
+    expect(highlightHtml(fixture)).toBe('1null23');
+  });
 
-  it('should not higlight anything for blank term', async(() => {
-       const fixture = createTestComponentFixture(`<ngb-highlight result="123" [term]="''"></ngb-highlight>`);
+  it('should not higlight anything for blank term', () => {
+    const fixture = createTestComponent(`<ngb-highlight result="123" [term]="''"></ngb-highlight>`);
 
-       expect(highlightHtml(fixture)).toBe('123');
-     }));
+    expect(highlightHtml(fixture)).toBe('123');
+  });
 
-  it('should properly higlight zeros', async(() => {
-       const fixture = createTestComponentFixture(`<ngb-highlight result="0123" [term]="0"></ngb-highlight>`);
+  it('should properly higlight zeros', () => {
+    const fixture = createTestComponent(`<ngb-highlight result="0123" [term]="0"></ngb-highlight>`);
 
-       expect(highlightHtml(fixture)).toBe('<span class="ngb-highlight">0</span>123');
-     }));
+    expect(highlightHtml(fixture)).toBe('<span class="ngb-highlight">0</span>123');
+  });
 
-  it('should support custom highlight class', async(() => {
-       const fixture =
-           createTestComponentFixture('<ngb-highlight result="123" [term]="2" highlightClass="my"></ngb-highlight>');
+  it('should support custom highlight class', () => {
+    const fixture = createTestComponent('<ngb-highlight result="123" [term]="2" highlightClass="my"></ngb-highlight>');
 
-       expect(highlightHtml(fixture)).toBe('1<span class="my">2</span>3');
-     }));
+    expect(highlightHtml(fixture)).toBe('1<span class="my">2</span>3');
+  });
 });
 
 

--- a/src/typeahead/typeahead-window.spec.ts
+++ b/src/typeahead/typeahead-window.spec.ts
@@ -1,4 +1,4 @@
-import {async, TestBed, ComponentFixture} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 
 import {Component} from '@angular/core';
 
@@ -6,7 +6,7 @@ import {NgbTypeaheadWindow} from './typeahead-window';
 import {expectResults, getWindowLinks} from './test-common';
 import {NgbTypeaheadModule} from './index';
 
-function createTestComponentFixture(html: string): ComponentFixture<TestComponent> {
+function createTestComponent(html: string): ComponentFixture<TestComponent> {
   TestBed.overrideComponent(TestComponent, {set: {template: html}});
   const fixture = TestBed.createComponent(TestComponent);
   fixture.detectChanges();
@@ -22,116 +22,116 @@ describe('ngb-typeahead-window', () => {
 
   describe('display', () => {
 
-    it('should display results with the first row active', async(() => {
-         const fixture = createTestComponentFixture(
-             '<ngb-typeahead-window [results]="results" [term]="term"></ngb-typeahead-window>');
+    it('should display results with the first row active', () => {
+      const fixture =
+          createTestComponent('<ngb-typeahead-window [results]="results" [term]="term"></ngb-typeahead-window>');
 
-         expectResults(fixture.nativeElement, ['+bar', 'baz']);
-       }));
+      expectResults(fixture.nativeElement, ['+bar', 'baz']);
+    });
 
-    it('should use a formatting function to display results', async(() => {
-         const fixture = createTestComponentFixture(
-             '<ngb-typeahead-window [results]="results" [term]="term" [formatter]="formatterFn"></ngb-typeahead-window>');
+    it('should use a formatting function to display results', () => {
+      const fixture = createTestComponent(
+          '<ngb-typeahead-window [results]="results" [term]="term" [formatter]="formatterFn"></ngb-typeahead-window>');
 
-         expectResults(fixture.nativeElement, ['+BAR', 'BAZ']);
-       }));
+      expectResults(fixture.nativeElement, ['+BAR', 'BAZ']);
+    });
 
-    it('should use a custom template if provided', async(() => {
-         const fixture = createTestComponentFixture(`
+    it('should use a custom template if provided', () => {
+      const fixture = createTestComponent(`
            <template #rt let-r="result" let-t="term">{{r.toUpperCase()}}-{{t}}</template>
            <ngb-typeahead-window [results]="results" [term]="term" [resultTemplate]="rt"></ngb-typeahead-window>`);
 
-         expectResults(fixture.nativeElement, ['+BAR-ba', 'BAZ-ba']);
-       }));
+      expectResults(fixture.nativeElement, ['+BAR-ba', 'BAZ-ba']);
+    });
   });
 
   describe('active row', () => {
 
-    it('should change active row on prev / next method call', async(() => {
-         const html = `
+    it('should change active row on prev / next method call', () => {
+      const html = `
            <button (click)="w.next()">+</button>
            <button (click)="w.prev()">-</button>
            <ngb-typeahead-window [results]="results" [term]="term" #w="ngbTypeaheadWindow"></ngb-typeahead-window>`;
-         const fixture = createTestComponentFixture(html);
-         const buttons = fixture.nativeElement.querySelectorAll('button');
+      const fixture = createTestComponent(html);
+      const buttons = fixture.nativeElement.querySelectorAll('button');
 
-         expectResults(fixture.nativeElement, ['+bar', 'baz']);
+      expectResults(fixture.nativeElement, ['+bar', 'baz']);
 
-         buttons[0].click();
-         fixture.detectChanges();
-         expectResults(fixture.nativeElement, ['bar', '+baz']);
+      buttons[0].click();
+      fixture.detectChanges();
+      expectResults(fixture.nativeElement, ['bar', '+baz']);
 
-         buttons[1].click();
-         fixture.detectChanges();
-         expectResults(fixture.nativeElement, ['+bar', 'baz']);
-       }));
+      buttons[1].click();
+      fixture.detectChanges();
+      expectResults(fixture.nativeElement, ['+bar', 'baz']);
+    });
 
-    it('should wrap active row on prev / next method call', async(() => {
-         const html = `
+    it('should wrap active row on prev / next method call', () => {
+      const html = `
            <button (click)="w.next()">+</button>
            <button (click)="w.prev()">-</button>
            <ngb-typeahead-window [results]="results" [term]="term" #w="ngbTypeaheadWindow"></ngb-typeahead-window>`;
-         const fixture = createTestComponentFixture(html);
-         const buttons = fixture.nativeElement.querySelectorAll('button');
+      const fixture = createTestComponent(html);
+      const buttons = fixture.nativeElement.querySelectorAll('button');
 
-         expectResults(fixture.nativeElement, ['+bar', 'baz']);
+      expectResults(fixture.nativeElement, ['+bar', 'baz']);
 
-         buttons[1].click();
-         fixture.detectChanges();
-         expectResults(fixture.nativeElement, ['bar', '+baz']);
+      buttons[1].click();
+      fixture.detectChanges();
+      expectResults(fixture.nativeElement, ['bar', '+baz']);
 
-         buttons[0].click();
-         fixture.detectChanges();
-         expectResults(fixture.nativeElement, ['+bar', 'baz']);
-       }));
+      buttons[0].click();
+      fixture.detectChanges();
+      expectResults(fixture.nativeElement, ['+bar', 'baz']);
+    });
 
-    it('should change active row on mouseenter', async(() => {
-         const fixture = createTestComponentFixture(
-             `<ngb-typeahead-window [results]="results" [term]="term"></ngb-typeahead-window>`);
-         const links = getWindowLinks(fixture.debugElement);
+    it('should change active row on mouseenter', () => {
+      const fixture =
+          createTestComponent(`<ngb-typeahead-window [results]="results" [term]="term"></ngb-typeahead-window>`);
+      const links = getWindowLinks(fixture.debugElement);
 
-         expectResults(fixture.nativeElement, ['+bar', 'baz']);
+      expectResults(fixture.nativeElement, ['+bar', 'baz']);
 
-         links[1].triggerEventHandler('mouseenter', {});
-         fixture.detectChanges();
-         expectResults(fixture.nativeElement, ['bar', '+baz']);
-       }));
+      links[1].triggerEventHandler('mouseenter', {});
+      fixture.detectChanges();
+      expectResults(fixture.nativeElement, ['bar', '+baz']);
+    });
   });
 
   describe('result selection', () => {
-    it('should select a given row on click', async(() => {
-         const fixture = createTestComponentFixture(
-             '<ngb-typeahead-window [results]="results" [term]="term" (select)="selected = $event"></ngb-typeahead-window>');
-         const links = getWindowLinks(fixture.debugElement);
+    it('should select a given row on click', () => {
+      const fixture = createTestComponent(
+          '<ngb-typeahead-window [results]="results" [term]="term" (select)="selected = $event"></ngb-typeahead-window>');
+      const links = getWindowLinks(fixture.debugElement);
 
-         expectResults(fixture.nativeElement, ['+bar', 'baz']);
+      expectResults(fixture.nativeElement, ['+bar', 'baz']);
 
-         links[1].triggerEventHandler('click', {});
-         fixture.detectChanges();
-         expect(fixture.componentInstance.selected).toBe('baz');
-       }));
+      links[1].triggerEventHandler('click', {});
+      fixture.detectChanges();
+      expect(fixture.componentInstance.selected).toBe('baz');
+    });
 
-    it('should return selected row via getActive()', async(() => {
-         const html = `
+    it('should return selected row via getActive()', () => {
+      const html = `
            <button (click)="active = w.getActive()">getActive</button>
            <button (click)="w.next()">+</button>
            <ngb-typeahead-window [results]="results" [term]="term" #w="ngbTypeaheadWindow"></ngb-typeahead-window>`;
-         const fixture = createTestComponentFixture(html);
+      const fixture = createTestComponent(html);
 
-         const buttons = fixture.nativeElement.querySelectorAll('button');
-         const activeBtn = buttons[0];
-         const nextBtn = buttons[1];
+      const buttons = fixture.nativeElement.querySelectorAll('button');
+      const activeBtn = buttons[0];
+      const nextBtn = buttons[1];
 
-         activeBtn.click();
-         expectResults(fixture.nativeElement, ['+bar', 'baz']);
-         expect(fixture.componentInstance.active).toBe('bar');
+      activeBtn.click();
+      expectResults(fixture.nativeElement, ['+bar', 'baz']);
+      expect(fixture.componentInstance.active).toBe('bar');
 
-         nextBtn.click();
-         activeBtn.click();
-         fixture.detectChanges();
-         expectResults(fixture.nativeElement, ['bar', '+baz']);
-         expect(fixture.componentInstance.active).toBe('baz');
-       }));
+      nextBtn.click();
+      activeBtn.click();
+      fixture.detectChanges();
+      expectResults(fixture.nativeElement, ['bar', '+baz']);
+      expect(fixture.componentInstance.active).toBe('baz');
+    });
   });
 
 });

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -1,5 +1,5 @@
 import {Component, DebugElement} from '@angular/core';
-import {async, TestBed, ComponentFixture} from '@angular/core/testing';
+import {TestBed, ComponentFixture} from '@angular/core/testing';
 
 import {NgbTypeahead} from './typeahead';
 import {NgbTypeaheadModule} from './index';
@@ -51,7 +51,7 @@ function expectWindowResults(element, expectedResults: string[]) {
   expectResults(window, expectedResults);
 }
 
-function createTestComponentFixture(html: string): ComponentFixture<TestComponent> {
+function createTestComponent(html: string): ComponentFixture<TestComponent> {
   TestBed.overrideComponent(TestComponent, {set: {template: html}});
   const fixture = TestBed.createComponent(TestComponent);
   fixture.detectChanges();
@@ -68,312 +68,311 @@ describe('ngb-typeahead', () => {
   describe('valueaccessor', () => {
 
     // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should format values when no formatter provided', async(() => {
-         const fixture = createTestComponentFixture('<input [(ngModel)]="model" [ngbTypeahead]="findNothing" />');
+    it('should format values when no formatter provided', () => {
+      const fixture = createTestComponent('<input [(ngModel)]="model" [ngbTypeahead]="findNothing" />');
 
-         const el = fixture.nativeElement;
-         const comp = fixture.componentInstance;
-         expectInputValue(el, '');
+      const el = fixture.nativeElement;
+      const comp = fixture.componentInstance;
+      expectInputValue(el, '');
 
-         comp.model = 'text';
-         fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               expectInputValue(el, 'text');
+      comp.model = 'text';
+      fixture.detectChanges();
+      fixture.whenStable()
+          .then(() => {
+            expectInputValue(el, 'text');
 
-               comp.model = null;
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expectInputValue(el, '');
+            comp.model = null;
+            fixture.detectChanges();
+            return fixture.whenStable();
+          })
+          .then(() => {
+            expectInputValue(el, '');
 
-               comp.model = {};
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => { expectInputValue(el, '[object Object]'); });
-       }));
+            comp.model = {};
+            fixture.detectChanges();
+            return fixture.whenStable();
+          })
+          .then(() => { expectInputValue(el, '[object Object]'); });
+    });
 
     // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should format values with custom formatter provided', async(() => {
-         const html =
-             '<input [(ngModel)]="model" [ngbTypeahead]="findNothing" [inputFormatter]="uppercaseObjFormatter"/>';
-         const fixture = createTestComponentFixture(html);
-         const el = fixture.nativeElement;
-         const comp = fixture.componentInstance;
-         expectInputValue(el, '');
+    it('should format values with custom formatter provided', () => {
+      const html = '<input [(ngModel)]="model" [ngbTypeahead]="findNothing" [inputFormatter]="uppercaseObjFormatter"/>';
+      const fixture = createTestComponent(html);
+      const el = fixture.nativeElement;
+      const comp = fixture.componentInstance;
+      expectInputValue(el, '');
 
-         comp.model = null;
-         fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               expectInputValue(el, '');
+      comp.model = null;
+      fixture.detectChanges();
+      fixture.whenStable()
+          .then(() => {
+            expectInputValue(el, '');
 
-               comp.model = {value: 'text'};
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => { expectInputValue(el, 'TEXT'); });
-       }));
+            comp.model = {value: 'text'};
+            fixture.detectChanges();
+            return fixture.whenStable();
+          })
+          .then(() => { expectInputValue(el, 'TEXT'); });
+    });
   });
 
   describe('window', () => {
 
-    it('should be closed by default', async(() => {
-         const fixture = createTestComponentFixture(`<input type="text" [ngbTypeahead]="find"/>`);
-         const compiled = fixture.nativeElement;
-         expect(getWindow(compiled)).toBeNull();
-       }));
+    it('should be closed by default', () => {
+      const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="find"/>`);
+      const compiled = fixture.nativeElement;
+      expect(getWindow(compiled)).toBeNull();
+    });
 
     // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should not be opened when the model changes', async(() => {
-         const fixture = createTestComponentFixture(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
-         const compiled = fixture.nativeElement;
+    it('should not be opened when the model changes', () => {
+      const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
+      const compiled = fixture.nativeElement;
 
-         fixture.componentInstance.model = 'one';
-         fixture.detectChanges();
-         fixture.whenStable().then(() => { expect(getWindow(compiled)).toBeNull(); });
-       }));
+      fixture.componentInstance.model = 'one';
+      fixture.detectChanges();
+      fixture.whenStable().then(() => { expect(getWindow(compiled)).toBeNull(); });
+    });
 
-    it('should be opened when there are results', async(() => {
-         const fixture = createTestComponentFixture(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
-         const compiled = fixture.nativeElement;
+    it('should be opened when there are results', () => {
+      const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
+      const compiled = fixture.nativeElement;
 
-         changeInput(compiled, 'one');
-         fixture.detectChanges();
-         expectWindowResults(compiled, ['+one', 'one more']);
-         expect(fixture.componentInstance.model).toBe('one');
-       }));
+      changeInput(compiled, 'one');
+      fixture.detectChanges();
+      expectWindowResults(compiled, ['+one', 'one more']);
+      expect(fixture.componentInstance.model).toBe('one');
+    });
 
-    it('should be closed when there no results', async(() => {
-         const fixture = createTestComponentFixture(`<input type="text" [ngbTypeahead]="findNothing"/>`);
-         const compiled = fixture.nativeElement;
+    it('should be closed when there no results', () => {
+      const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="findNothing"/>`);
+      const compiled = fixture.nativeElement;
 
-         expect(getWindow(compiled)).toBeNull();
-       }));
+      expect(getWindow(compiled)).toBeNull();
+    });
 
-    it('should be closed on document click', async(() => {
-         const fixture = createTestComponentFixture(`<input type="text" [ngbTypeahead]="find"/>`);
-         const compiled = fixture.nativeElement;
+    it('should be closed on document click', () => {
+      const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="find"/>`);
+      const compiled = fixture.nativeElement;
 
-         changeInput(compiled, 'one');
-         fixture.detectChanges();
-         expect(getWindow(compiled)).not.toBeNull();
+      changeInput(compiled, 'one');
+      fixture.detectChanges();
+      expect(getWindow(compiled)).not.toBeNull();
 
-         fixture.nativeElement.click();
-         expect(getWindow(compiled)).toBeNull();
-       }));
+      fixture.nativeElement.click();
+      expect(getWindow(compiled)).toBeNull();
+    });
 
-    it('should be closed when ESC is pressed', async(() => {
-         const fixture = createTestComponentFixture(`<input type="text" [ngbTypeahead]="find"/>`);
-         const compiled = fixture.nativeElement;
+    it('should be closed when ESC is pressed', () => {
+      const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="find"/>`);
+      const compiled = fixture.nativeElement;
 
-         changeInput(compiled, 'one');
-         fixture.detectChanges();
-         expect(getWindow(compiled)).not.toBeNull();
+      changeInput(compiled, 'one');
+      fixture.detectChanges();
+      expect(getWindow(compiled)).not.toBeNull();
 
-         const event = createKeyDownEvent(Key.Escape);
-         getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-         fixture.detectChanges();
-         expect(getWindow(compiled)).toBeNull();
-         expect(event.preventDefault).toHaveBeenCalled();
-       }));
+      const event = createKeyDownEvent(Key.Escape);
+      getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+      fixture.detectChanges();
+      expect(getWindow(compiled)).toBeNull();
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
 
-    it('should select the result on click, close window and fill the input', async(() => {
-         const fixture = createTestComponentFixture(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
-         const compiled = fixture.nativeElement;
+    it('should select the result on click, close window and fill the input', () => {
+      const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
+      const compiled = fixture.nativeElement;
 
-         // clicking selected
-         changeInput(compiled, 'o');
-         fixture.detectChanges();
-         expectWindowResults(compiled, ['+one', 'one more']);
+      // clicking selected
+      changeInput(compiled, 'o');
+      fixture.detectChanges();
+      expectWindowResults(compiled, ['+one', 'one more']);
 
-         getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
-         fixture.detectChanges();
-         expect(getWindow(compiled)).toBeNull();
-         expectInputValue(compiled, 'one');
-         expect(fixture.componentInstance.model).toBe('one');
+      getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
+      fixture.detectChanges();
+      expect(getWindow(compiled)).toBeNull();
+      expectInputValue(compiled, 'one');
+      expect(fixture.componentInstance.model).toBe('one');
 
-         // clicking not selected
-         changeInput(compiled, 'o');
-         fixture.detectChanges();
-         expectWindowResults(compiled, ['+one', 'one more']);
-         expectInputValue(compiled, 'o');
+      // clicking not selected
+      changeInput(compiled, 'o');
+      fixture.detectChanges();
+      expectWindowResults(compiled, ['+one', 'one more']);
+      expectInputValue(compiled, 'o');
 
-         getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
-         fixture.detectChanges();
-         expect(getWindow(compiled)).toBeNull();
-         expectInputValue(compiled, 'one');
-       }));
+      getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
+      fixture.detectChanges();
+      expect(getWindow(compiled)).toBeNull();
+      expectInputValue(compiled, 'one');
+    });
 
-    it('should select the result on ENTER, close window and fill the input', async(() => {
-         const fixture = createTestComponentFixture(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
-         const compiled = fixture.nativeElement;
+    it('should select the result on ENTER, close window and fill the input', () => {
+      const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
+      const compiled = fixture.nativeElement;
 
-         changeInput(compiled, 'o');
-         fixture.detectChanges();
-         expectWindowResults(compiled, ['+one', 'one more']);
+      changeInput(compiled, 'o');
+      fixture.detectChanges();
+      expectWindowResults(compiled, ['+one', 'one more']);
 
-         const event = createKeyDownEvent(Key.Enter);
-         getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-         fixture.detectChanges();
-         expect(getWindow(compiled)).toBeNull();
-         expectInputValue(compiled, 'one');
-         expect(fixture.componentInstance.model).toBe('one');
-         expect(event.preventDefault).toHaveBeenCalled();
-       }));
+      const event = createKeyDownEvent(Key.Enter);
+      getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+      fixture.detectChanges();
+      expect(getWindow(compiled)).toBeNull();
+      expectInputValue(compiled, 'one');
+      expect(fixture.componentInstance.model).toBe('one');
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
 
-    it('should select the result on TAB, close window and fill the input', async(() => {
-         const fixture = createTestComponentFixture(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
-         const compiled = fixture.nativeElement;
+    it('should select the result on TAB, close window and fill the input', () => {
+      const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
+      const compiled = fixture.nativeElement;
 
-         changeInput(compiled, 'o');
-         fixture.detectChanges();
-         expect(getWindow(compiled)).not.toBeNull();
+      changeInput(compiled, 'o');
+      fixture.detectChanges();
+      expect(getWindow(compiled)).not.toBeNull();
 
-         const event = createKeyDownEvent(Key.Tab);
-         getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-         fixture.detectChanges();
-         expect(getWindow(compiled)).toBeNull();
-         expectInputValue(compiled, 'one');
-         expect(fixture.componentInstance.model).toBe('one');
-         expect(event.preventDefault).toHaveBeenCalled();
-       }));
+      const event = createKeyDownEvent(Key.Tab);
+      getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+      fixture.detectChanges();
+      expect(getWindow(compiled)).toBeNull();
+      expectInputValue(compiled, 'one');
+      expect(fixture.componentInstance.model).toBe('one');
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
 
-    it('should make previous/next results active with up/down arrow keys', async(() => {
-         const fixture = createTestComponentFixture(`<input type="text" [ngbTypeahead]="find"/>`);
-         const compiled = fixture.nativeElement;
+    it('should make previous/next results active with up/down arrow keys', () => {
+      const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="find"/>`);
+      const compiled = fixture.nativeElement;
 
-         changeInput(compiled, 'o');
-         fixture.detectChanges();
-         expectWindowResults(compiled, ['+one', 'one more']);
+      changeInput(compiled, 'o');
+      fixture.detectChanges();
+      expectWindowResults(compiled, ['+one', 'one more']);
 
-         // down
-         let event = createKeyDownEvent(Key.ArrowDown);
-         getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-         fixture.detectChanges();
-         expectWindowResults(compiled, ['one', '+one more']);
-         expect(event.preventDefault).toHaveBeenCalled();
+      // down
+      let event = createKeyDownEvent(Key.ArrowDown);
+      getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+      fixture.detectChanges();
+      expectWindowResults(compiled, ['one', '+one more']);
+      expect(event.preventDefault).toHaveBeenCalled();
 
-         event = createKeyDownEvent(Key.ArrowDown);
-         getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-         fixture.detectChanges();
-         expectWindowResults(compiled, ['+one', 'one more']);
-         expect(event.preventDefault).toHaveBeenCalled();
+      event = createKeyDownEvent(Key.ArrowDown);
+      getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+      fixture.detectChanges();
+      expectWindowResults(compiled, ['+one', 'one more']);
+      expect(event.preventDefault).toHaveBeenCalled();
 
-         // up
-         event = createKeyDownEvent(Key.ArrowUp);
-         getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-         fixture.detectChanges();
-         expectWindowResults(compiled, ['one', '+one more']);
-         expect(event.preventDefault).toHaveBeenCalled();
+      // up
+      event = createKeyDownEvent(Key.ArrowUp);
+      getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+      fixture.detectChanges();
+      expectWindowResults(compiled, ['one', '+one more']);
+      expect(event.preventDefault).toHaveBeenCalled();
 
-         event = createKeyDownEvent(Key.ArrowUp);
-         getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-         fixture.detectChanges();
-         expectWindowResults(compiled, ['+one', 'one more']);
-         expect(event.preventDefault).toHaveBeenCalled();
-       }));
+      event = createKeyDownEvent(Key.ArrowUp);
+      getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+      fixture.detectChanges();
+      expectWindowResults(compiled, ['+one', 'one more']);
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
 
-    it('should use provided result formatter function', async(() => {
-         const fixture = createTestComponentFixture(
-             `<input type="text" [ngbTypeahead]="find" [resultFormatter]="uppercaseFormatter"/>`);
-         const compiled = fixture.nativeElement;
+    it('should use provided result formatter function', () => {
+      const fixture =
+          createTestComponent(`<input type="text" [ngbTypeahead]="find" [resultFormatter]="uppercaseFormatter"/>`);
+      const compiled = fixture.nativeElement;
 
-         changeInput(compiled, 'o');
-         fixture.detectChanges();
-         expectWindowResults(compiled, ['+ONE', 'ONE MORE']);
-       }));
+      changeInput(compiled, 'o');
+      fixture.detectChanges();
+      expectWindowResults(compiled, ['+ONE', 'ONE MORE']);
+    });
 
   });
 
   describe('objects', () => {
 
-    it('should work with custom objects as values', async(() => {
-         const fixture = createTestComponentFixture(`
+    it('should work with custom objects as values', () => {
+      const fixture = createTestComponent(`
              <input type="text" [(ngModel)]="model" [ngbTypeahead]="findObjects"
                     [inputFormatter]="formatter" [resultFormatter]="uppercaseObjFormatter"/>`);
-         const compiled = fixture.nativeElement;
+      const compiled = fixture.nativeElement;
 
-         changeInput(compiled, 'o');
-         fixture.detectChanges();
-         expectWindowResults(compiled, ['+ONE', 'ONE MORE']);
+      changeInput(compiled, 'o');
+      fixture.detectChanges();
+      expectWindowResults(compiled, ['+ONE', 'ONE MORE']);
 
-         const event = createKeyDownEvent(Key.Enter);
-         getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-         fixture.detectChanges();
-         expect(getWindow(compiled)).toBeNull();
-         expect(getNativeInput(compiled).value).toBe('1 one');
-         expect(fixture.componentInstance.model).toEqual({id: 1, value: 'one'});
-       }));
+      const event = createKeyDownEvent(Key.Enter);
+      getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+      fixture.detectChanges();
+      expect(getWindow(compiled)).toBeNull();
+      expect(getNativeInput(compiled).value).toBe('1 one');
+      expect(fixture.componentInstance.model).toEqual({id: 1, value: 'one'});
+    });
 
     // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should allow to assign ngModel custom objects', async(() => {
-         const fixture = createTestComponentFixture(`
+    it('should allow to assign ngModel custom objects', () => {
+      const fixture = createTestComponent(`
              <input type="text" [(ngModel)]="model" [ngbTypeahead]="findObjects"
                     [inputFormatter]="formatter" [resultFormatter]="uppercaseObjFormatter"/>`);
-         const compiled = fixture.nativeElement;
+      const compiled = fixture.nativeElement;
 
-         fixture.componentInstance.model = {id: 1, value: 'one'};
-         fixture.detectChanges();
-         fixture.whenStable().then(() => {
-           expect(getWindow(compiled)).toBeNull();
-           expect(getNativeInput(compiled).value).toBe('1 one');
-         });
-       }));
+      fixture.componentInstance.model = {id: 1, value: 'one'};
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        expect(getWindow(compiled)).toBeNull();
+        expect(getNativeInput(compiled).value).toBe('1 one');
+      });
+    });
   });
 
   describe('forms', () => {
 
     // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should work with template-driven form validation', async(() => {
-         const html = `
+    it('should work with template-driven form validation', () => {
+      const html = `
             <form>
               <input type="text" [(ngModel)]="model" name="control" required [ngbTypeahead]="findObjects" />
             </form>`;
-         const fixture = createTestComponentFixture(html);
-         fixture.whenStable().then(() => {
-           fixture.detectChanges();
-           const compiled = fixture.nativeElement;
-           expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
-           expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
+      const fixture = createTestComponent(html);
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        const compiled = fixture.nativeElement;
+        expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
+        expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
 
-           changeInput(compiled, 'o');
-           fixture.detectChanges();
-           expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
-           expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
-         });
-       }));
+        changeInput(compiled, 'o');
+        fixture.detectChanges();
+        expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
+        expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
+      });
+    });
 
-    it('should work with model-driven form validation', async(() => {
-         const html = `
+    it('should work with model-driven form validation', () => {
+      const html = `
            <form [formGroup]="form">
              <input type="text" formControlName="control" required [ngbTypeahead]="findObjects" />
            </form>`;
-         const fixture = createTestComponentFixture(html);
-         const compiled = fixture.nativeElement;
+      const fixture = createTestComponent(html);
+      const compiled = fixture.nativeElement;
 
-         expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
-         expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
+      expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
+      expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
 
-         changeInput(compiled, 'o');
-         fixture.detectChanges();
-         expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
-         expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
-       }));
+      changeInput(compiled, 'o');
+      fixture.detectChanges();
+      expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
+      expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
+    });
   });
 
   describe('auto attributes', () => {
 
-    it('should have autocomplete, autocapitalize and autocorrect attributes set to off', async(() => {
-         const fixture = createTestComponentFixture('<input type="text" [ngbTypeahead]="findObjects" />');
-         const input = getNativeInput(fixture.nativeElement);
+    it('should have autocomplete, autocapitalize and autocorrect attributes set to off', () => {
+      const fixture = createTestComponent('<input type="text" [ngbTypeahead]="findObjects" />');
+      const input = getNativeInput(fixture.nativeElement);
 
-         expect(input.getAttribute('autocomplete')).toBe('off');
-         expect(input.getAttribute('autocapitalize')).toBe('off');
-         expect(input.getAttribute('autocorrect')).toBe('off');
-       }));
+      expect(input.getAttribute('autocomplete')).toBe('off');
+      expect(input.getAttribute('autocapitalize')).toBe('off');
+      expect(input.getAttribute('autocorrect')).toBe('off');
+    });
   });
 
 });


### PR DESCRIPTION
currently `createTestComponent` gets two args.

They will be helpful when we move this function to `testUtils`