### PR TITLE
feat(tabset): add two-way binding with activeId

### DIFF
--- a/demo/src/app/components/tabset/demos/selectbyid/tabset-selectbyid.html
+++ b/demo/src/app/components/tabset/demos/selectbyid/tabset-selectbyid.html
@@ -1,4 +1,4 @@
-<ngb-tabset [activeId]="selectedId">
+<ngb-tabset [(activeId)]="selectedId">
   <ngb-tab title="Simple" id="foo">
     <template ngbTabContent>
       <p>Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth

--- a/src/tabset/tabset.spec.ts
+++ b/src/tabset/tabset.spec.ts
@@ -158,6 +158,84 @@ describe('ngb-tabset', () => {
     expectTabs(fixture.nativeElement, [true, false]);
   });
 
+  it('should set the active tab to bound variable', () => {
+    const fixture = createTestComponent(`
+        <ngb-tabset [activeId]="activeTabId">
+          <ngb-tab title="foo" id="1"><template ngbTabContent>Foo</template></ngb-tab>
+          <ngb-tab title="bar" id="2"><template ngbTabContent>Bar</template></ngb-tab>
+        </ngb-tabset>
+    `);
+
+    fixture.componentInstance.activeTabId = '2';
+
+    fixture.detectChanges();
+    expectTabs(fixture.nativeElement, [false, true]);
+  });
+
+  it('should change the active tab when bound variable changes', () => {
+    const fixture = createTestComponent(`
+        <ngb-tabset [activeId]="activeTabId">
+          <ngb-tab title="foo" id="1"><template ngbTabContent>Foo</template></ngb-tab>
+          <ngb-tab title="bar" id="2"><template ngbTabContent>Bar</template></ngb-tab>
+        </ngb-tabset>
+    `);
+
+    fixture.componentInstance.activeTabId = '2';
+
+    fixture.detectChanges();
+    expectTabs(fixture.nativeElement, [false, true]);
+
+    fixture.componentInstance.activeTabId = '1';
+
+    fixture.detectChanges();
+    expectTabs(fixture.nativeElement, [true, false]);
+  });
+
+  it('should emit active ID change event when switching tabs', () => {
+    const fixture = createTestComponent(`
+        <ngb-tabset activeId="1" (activeIdChange)="changeCallback($event)">
+          <ngb-tab title="foo" id="1"><template ngbTabContent>Foo</template></ngb-tab>
+          <ngb-tab title="bar" id="2"><template ngbTabContent>Bar</template></ngb-tab>
+        </ngb-tabset>
+    `);
+
+    fixture.componentInstance.changeCallback = () => {};
+
+    spyOn(fixture.componentInstance, 'changeCallback');
+
+    fixture.detectChanges();
+
+    expectTabs(fixture.nativeElement, [true, false]);
+
+    (<HTMLAnchorElement>getTabTitles(fixture.nativeElement)[1]).click();
+
+    fixture.detectChanges();
+    expectTabs(fixture.nativeElement, [false, true]);
+
+    expect(fixture.componentInstance.changeCallback).toHaveBeenCalledWith('2');
+  });
+
+  it('should update bound activeId when tab changes on click', () => {
+    const fixture = createTestComponent(`
+        <ngb-tabset [(activeId)]="activeTabId">
+          <ngb-tab title="foo" id="1"><template ngbTabContent>Foo</template></ngb-tab>
+          <ngb-tab title="bar" id="2"><template ngbTabContent>Bar</template></ngb-tab>
+        </ngb-tabset>
+    `);
+
+    fixture.componentInstance.activeTabId = '1';
+
+    fixture.detectChanges();
+
+    expectTabs(fixture.nativeElement, [true, false]);
+
+    (<HTMLAnchorElement>getTabTitles(fixture.nativeElement)[1]).click();
+
+    fixture.detectChanges();
+    expectTabs(fixture.nativeElement, [false, true]);
+
+    expect(fixture.componentInstance.activeTabId).toBe('2');
+  });
 
   it('should support disabled tabs', () => {
     const fixture = createTestComponent(`

--- a/src/tabset/tabset.ts
+++ b/src/tabset/tabset.ts
@@ -98,6 +98,12 @@ export class NgbTabset implements AfterContentChecked {
   @Input() type = 'tabs';
 
   /**
+   *  An event fired when selected tab is changed.
+   *  Event's payload equals the active tab's identifier.
+   */
+  @Output() activeIdChange = new EventEmitter<string>();
+
+  /**
    * A tab change event fired right before the tab selection happens.  The event object has three properties:
    * 'activeId', the id of the currently active tab, 'nextId' the id of the newly selected tab, and a function,
    * 'preventDefault()' which, when executed, will prevent the tab change from occurring.
@@ -118,6 +124,7 @@ export class NgbTabset implements AfterContentChecked {
 
       if (!defaultPrevented) {
         this.activeId = selectedTab.id;
+        this.activeIdChange.emit(this.activeId);
       }
     }
   }


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.

This also fixes the demo 'Select an active tab by id' where the bound id would not be in-sync if the user clicked on the tab.