### PR TITLE
docs(tabset): make the doc of `select()` clearer

### DIFF
--- a/src/tabset/tabset.spec.ts
+++ b/src/tabset/tabset.spec.ts
@@ -115,7 +115,7 @@ describe('ngb-tabset', () => {
   });
 
 
-  it('should auto-correct requested active tab index', () => {
+  it('should auto-correct requested active tab id', () => {
     const fixture = createTestComponent(`
       <ngb-tabset activeId="doesntExist">
         <ngb-tab title="foo"><template ngbTabContent>Foo</template></ngb-tab>
@@ -127,7 +127,7 @@ describe('ngb-tabset', () => {
   });
 
 
-  it('should auto-correct requested active tab index for undefined indexes', () => {
+  it('should auto-correct requested active tab id for undefined ids', () => {
     const fixture = createTestComponent(`
       <ngb-tabset [activeId]="activeTabId">
         <ngb-tab title="foo"><template ngbTabContent>Foo</template></ngb-tab>

--- a/src/tabset/tabset.ts
+++ b/src/tabset/tabset.ts
@@ -105,11 +105,11 @@ export class NgbTabset implements AfterContentChecked {
   @Output() change = new EventEmitter<NgbTabChangeEvent>();
 
   /**
-   * Selects the given tab and shows its associated pane.
+   * Selects the tab with the given id and shows its associated pane.
    * Any other tab that was previously selected becomes unselected and its associated pane is hidden.
    */
-  select(tabIdx: string) {
-    let selectedTab = this._getTabById(tabIdx);
+  select(tabId: string) {
+    let selectedTab = this._getTabById(tabId);
     if (selectedTab && !selectedTab.disabled && this.activeId !== selectedTab.id) {
       let defaultPrevented = false;
 


### PR DESCRIPTION
The name of the argument, `tabIdx`, lead the reader to think that what must be passed is the index of the tab, instead of its unique id. Renaming to `tabId` and indicating that the id of the tab is what is expected by the method makes it clearer.

The same confusion is also fixed in the tests.