### PR TITLE
test: prepare for angular rc6

### DIFF
--- a/karma-test-shim.js
+++ b/karma-test-shim.js
@@ -23,14 +23,12 @@ System.config({
   }
 });
 
-Promise.all([System.import('@angular/core/testing'), System.import('@angular/platform-browser-dynamic/testing')])
-    .then(function(providers) {
-      var testing = providers[0];
-      var testingBrowser = providers[1];
-
-      testing.setBaseTestProviders(
-          testingBrowser.TEST_BROWSER_DYNAMIC_PLATFORM_PROVIDERS,
-          testingBrowser.TEST_BROWSER_DYNAMIC_APPLICATION_PROVIDERS);
+System.import('@angular/core/testing')
+    .then(function(coreTesting) {
+      return System.import('@angular/platform-browser-dynamic/testing').then(function(browserTesting) {
+        coreTesting.TestBed.initTestEnvironment(
+            browserTesting.BrowserDynamicTestingModule, browserTesting.platformBrowserDynamicTesting());
+      });
     })
     .then(function() { return Promise.all(customMatchers()); })
     .then(function() { return Promise.all(resolveTestFiles()); })

--- a/src/util/triggers.spec.ts
+++ b/src/util/triggers.spec.ts
@@ -1,5 +1,3 @@
-import {inject, addProviders} from '@angular/core/testing';
-
 import {parseTriggers} from './triggers';
 
 describe('triggers', () => {


### PR DESCRIPTION
This PR removes last bits of deprecated API usage and prepares us for the rc6 compatibility.