### PR TITLE
fix(typeahead): don't use 'select' as an output name

### DIFF
--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -368,7 +368,7 @@ describe('ngb-typeahead', () => {
   describe('select event', () => {
 
     it('should raise select event when a result is selected', () => {
-      const fixture = createTestComponent('<input type="text" [ngbTypeahead]="find" (select)="onSelect($event)"/>');
+      const fixture = createTestComponent('<input type="text" [ngbTypeahead]="find" (selectItem)="onSelect($event)"/>');
       const input = getNativeInput(fixture.nativeElement);
 
       // clicking selected

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -85,7 +85,7 @@ export class NgbTypeahead implements OnInit,
   /**
    * An event emitted when a match is selected. Event payload is equal to the selected item.
    */
-  @Output() select = new EventEmitter();
+  @Output() selectItem = new EventEmitter();
 
   onChange = (value) => {
     this._onChangeNoEmit(value);
@@ -193,7 +193,7 @@ export class NgbTypeahead implements OnInit,
   private _selectResult(result: any) {
     this.writeValue(result);
     this._onChangeNoEmit(result);
-    this.select.emit(result);
+    this.selectItem.emit(result);
     this.closePopup();
   }
 }


### PR DESCRIPTION
Fixes #606