### PR TITLE
refactor(test): make component creation common for tests

### DIFF
--- a/src/accordion/accordion.spec.ts
+++ b/src/accordion/accordion.spec.ts
@@ -1,8 +1,12 @@
 import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {createGenericTestComponent} from '../util/tests';
 
 import {Component} from '@angular/core';
 
 import {NgbAccordionModule} from './index';
+
+const createTestComponent = (html: string) =>
+    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
 function getPanels(element: HTMLElement): HTMLDivElement[] {
   return <HTMLDivElement[]>Array.from(element.querySelectorAll('div .card-header'));
@@ -22,13 +26,6 @@ function expectOpenPanels(nativeEl: HTMLElement, openPanelsDef: boolean[]) {
 
   const result = panels.map(panel => panel.classList.contains('active'));
   expect(result).toEqual(openPanelsDef);
-}
-
-function createTestComponent(html: string): ComponentFixture<TestComponent> {
-  TestBed.overrideComponent(TestComponent, {set: {template: html}});
-  const fixture = TestBed.createComponent(TestComponent);
-  fixture.detectChanges();
-  return fixture;
 }
 
 describe('ngb-accordion', () => {

--- a/src/alert/alert.spec.ts
+++ b/src/alert/alert.spec.ts
@@ -1,9 +1,13 @@
 import {fakeAsync, tick, TestBed, ComponentFixture} from '@angular/core/testing';
+import {createGenericTestComponent} from '../util/tests';
 
 import {Component} from '@angular/core';
 
 import {NgbAlertModule} from './index';
 import {NgbAlert, NgbDismissibleAlert} from './alert';
+
+const createTestComponent = (html: string) =>
+    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
 function getAlertElement(element: HTMLElement): HTMLDivElement {
   return <HTMLDivElement>element.querySelector('.alert');
@@ -11,13 +15,6 @@ function getAlertElement(element: HTMLElement): HTMLDivElement {
 
 function getCloseButton(element: HTMLElement): HTMLButtonElement {
   return <HTMLButtonElement>element.querySelector('button');
-}
-
-function createTestComponent(html: string): ComponentFixture<TestComponent> {
-  TestBed.overrideComponent(TestComponent, {set: {template: html}});
-  const fixture = TestBed.createComponent(TestComponent);
-  fixture.detectChanges();
-  return fixture;
 }
 
 describe('ngb-alert', () => {

--- a/src/buttons/radio.spec.ts
+++ b/src/buttons/radio.spec.ts
@@ -1,8 +1,13 @@
 import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {createGenericTestComponent} from '../util/tests';
+
 import {Component} from '@angular/core';
 import {Validators, FormControl, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
 
 import {NgbButtonsModule} from './index';
+
+const createTestComponent = (html: string) =>
+    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
 function expectRadios(element: HTMLElement, states: number[]) {
   const labels = element.querySelectorAll('label');
@@ -25,13 +30,6 @@ function getGroupElement(nativeEl: HTMLElement): HTMLDivElement {
 
 function getInput(nativeEl: HTMLElement, idx: number): HTMLInputElement {
   return <HTMLInputElement>nativeEl.querySelectorAll('input')[idx];
-}
-
-function createTestComponent(html: string): ComponentFixture<TestComponent> {
-  TestBed.overrideComponent(TestComponent, {set: {template: html}});
-  const fixture = TestBed.createComponent(TestComponent);
-  fixture.detectChanges();
-  return fixture;
 }
 
 describe('NgbActiveLabel', () => {

--- a/src/carousel/carousel.spec.ts
+++ b/src/carousel/carousel.spec.ts
@@ -1,10 +1,14 @@
 import {fakeAsync, discardPeriodicTasks, tick, TestBed, ComponentFixture} from '@angular/core/testing';
+import {createGenericTestComponent} from '../util/tests';
 
 import {By} from '@angular/platform-browser';
 import {Component} from '@angular/core';
 
 import {NgbCarouselModule} from './index';
 import {NgbCarousel} from './carousel';
+
+const createTestComponent = (html: string) =>
+    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
 function expectActiveSlides(nativeEl: HTMLDivElement, active: boolean[]) {
   const slideElms = nativeEl.querySelectorAll('.carousel-item');
@@ -22,13 +26,6 @@ function expectActiveSlides(nativeEl: HTMLDivElement, active: boolean[]) {
       expect(indicatorElms[i]).not.toHaveCssClass('active');
     }
   }
-}
-
-function createTestComponent(html: string): ComponentFixture<TestComponent> {
-  TestBed.overrideComponent(TestComponent, {set: {template: html}});
-  const fixture = TestBed.createComponent(TestComponent);
-  fixture.detectChanges();
-  return fixture;
 }
 
 describe('ngb-carousel', () => {

--- a/src/collapse/collapse.spec.ts
+++ b/src/collapse/collapse.spec.ts
@@ -1,17 +1,15 @@
-import {Component} from '@angular/core';
 import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {createGenericTestComponent} from '../util/tests';
+
+import {Component} from '@angular/core';
 
 import {NgbCollapseModule} from './index';
 
+const createTestComponent = (html: string) =>
+    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
+
 function getCollapsibleContent(element: HTMLElement): HTMLDivElement {
   return <HTMLDivElement>element.querySelector('.collapse');
-}
-
-function createTestComponent(html: string): ComponentFixture<TestComponent> {
-  TestBed.overrideComponent(TestComponent, {set: {template: html}});
-  const fixture = TestBed.createComponent(TestComponent);
-  fixture.detectChanges();
-  return fixture;
 }
 
 describe('ngb-collapse', () => {

--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -1,20 +1,17 @@
 import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {createGenericTestComponent} from '../util/tests';
 
 import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
 
 import {NgbDropdownModule} from './index';
-import {NgbDropdown, NgbDropdownToggle} from './dropdown';
+import {NgbDropdown} from './dropdown';
+
+const createTestComponent = (html: string) =>
+    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
 function getDropdownEl(tc) {
   return tc.querySelector(`[ngbDropdown]`);
-}
-
-function createTestComponent(html: string): ComponentFixture<TestComponent> {
-  TestBed.overrideComponent(TestComponent, {set: {template: html}});
-  const fixture = TestBed.createComponent(TestComponent);
-  fixture.detectChanges();
-  return fixture;
 }
 
 describe('ngb-dropdown', () => {

--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -1,8 +1,13 @@
-import {Component} from '@angular/core';
 import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {createGenericTestComponent} from '../util/tests';
+
+import {Component} from '@angular/core';
 
 import {NgbPaginationModule} from './index';
 import {NgbPagination} from './pagination';
+
+const createTestComponent = (html: string) =>
+    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
 function expectPages(nativeEl: HTMLElement, pagesDef: string[]): void {
   const pages = nativeEl.querySelectorAll('li');
@@ -39,13 +44,6 @@ function getList(nativeEl: HTMLElement) {
 
 function normalizeText(txt: string): string {
   return txt.trim().replace(/\s+/g, ' ');
-}
-
-function createTestComponent(html: string): ComponentFixture<TestComponent> {
-  TestBed.overrideComponent(TestComponent, {set: {template: html}});
-  const fixture = TestBed.createComponent(TestComponent);
-  fixture.detectChanges();
-  return fixture;
 }
 
 describe('ngb-pagination', () => {

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -1,4 +1,5 @@
 import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {createGenericTestComponent} from '../util/tests';
 
 import {By} from '@angular/platform-browser';
 import {Component} from '@angular/core';
@@ -6,12 +7,8 @@ import {Component} from '@angular/core';
 import {NgbPopoverModule} from './index';
 import {NgbPopoverWindow, NgbPopover} from './popover';
 
-function createTestComponent(html: string): ComponentFixture<TestComponent> {
-  TestBed.overrideComponent(TestComponent, {set: {template: html}});
-  const fixture = TestBed.createComponent(TestComponent);
-  fixture.detectChanges();
-  return fixture;
-}
+const createTestComponent = (html: string) =>
+    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
 describe('ngb-popover-window', () => {
   beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPopoverModule]}); });

--- a/src/progressbar/progressbar.spec.ts
+++ b/src/progressbar/progressbar.spec.ts
@@ -1,9 +1,13 @@
 import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {createGenericTestComponent} from '../util/tests';
 
 import {Component} from '@angular/core';
 
 import {NgbProgressbarModule} from './index';
 import {NgbProgressbar} from './progressbar';
+
+const createTestComponent = (html: string) =>
+    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
 function getBarWidth(nativeEl): string {
   return nativeEl.querySelector('.progress-bar').style.width;
@@ -11,13 +15,6 @@ function getBarWidth(nativeEl): string {
 
 function getProgressbar(nativeEl: Element): Element {
   return nativeEl.querySelector('progress');
-}
-
-function createTestComponent(html: string): ComponentFixture<TestComponent> {
-  TestBed.overrideComponent(TestComponent, {set: {template: html}});
-  const fixture = TestBed.createComponent(TestComponent);
-  fixture.detectChanges();
-  return fixture;
 }
 
 describe('ng-progressbar', () => {

--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -1,9 +1,13 @@
 import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {createGenericTestComponent} from '../util/tests';
 
 import {Component} from '@angular/core';
 
 import {NgbRatingModule} from './index';
 import {NgbRating} from './rating';
+
+const createTestComponent = (html: string) =>
+    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
 function getAriaState(compiled) {
   const stars = getStars(compiled, '.sr-only');
@@ -29,13 +33,6 @@ function getState(compiled) {
     state.push((stars[i].textContent === String.fromCharCode(9733)));
   }
   return state;
-}
-
-function createTestComponent(html: string): ComponentFixture<TestComponent> {
-  TestBed.overrideComponent(TestComponent, {set: {template: html}});
-  const fixture = TestBed.createComponent(TestComponent);
-  fixture.detectChanges();
-  return fixture;
 }
 
 describe('ngb-rating', () => {

--- a/src/tabset/tabset.spec.ts
+++ b/src/tabset/tabset.spec.ts
@@ -1,7 +1,12 @@
-import {Component} from '@angular/core';
 import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {createGenericTestComponent} from '../util/tests';
+
+import {Component} from '@angular/core';
 
 import {NgbTabsetModule} from './index';
+
+const createTestComponent = (html: string) =>
+    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
 function getTabTitles(nativeEl: HTMLElement) {
   return nativeEl.querySelectorAll('.nav-link');
@@ -42,13 +47,6 @@ function expectTabs(nativeEl: HTMLElement, active: boolean[], disabled?: boolean
 
 function getButton(nativeEl: HTMLElement) {
   return nativeEl.querySelectorAll('button');
-}
-
-function createTestComponent(html: string): ComponentFixture<TestComponent> {
-  TestBed.overrideComponent(TestComponent, {set: {template: html}});
-  const fixture = TestBed.createComponent(TestComponent);
-  fixture.detectChanges();
-  return fixture;
 }
 
 describe('ngb-tabset', () => {

--- a/src/timepicker/timepicker.spec.ts
+++ b/src/timepicker/timepicker.spec.ts
@@ -1,11 +1,14 @@
-import {Component} from '@angular/core';
-
 import {TestBed, ComponentFixture} from '@angular/core/testing';
-import {By} from '@angular/platform-browser';
+import {createGenericTestComponent} from '../util/tests';
 
+import {Component} from '@angular/core';
+import {By} from '@angular/platform-browser';
 import {Validators, FormControl, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
 
 import {NgbTimepickerModule} from './index';
+
+const createTestComponent = (html: string) =>
+    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
 function getTimepicker(el: HTMLElement) {
   return el.querySelector('ngb-timepicker');
@@ -43,13 +46,6 @@ function expectToDisplayTime(el: HTMLElement, time: string) {
   }
 
   expect(timeInInputs.join(':')).toBe(time);
-}
-
-function createTestComponent(html: string): ComponentFixture<TestComponent> {
-  TestBed.overrideComponent(TestComponent, {set: {template: html}});
-  const fixture = TestBed.createComponent(TestComponent);
-  fixture.detectChanges();
-  return fixture;
 }
 
 describe('ngb-timepicker', () => {

--- a/src/tooltip/tooltip.spec.ts
+++ b/src/tooltip/tooltip.spec.ts
@@ -1,16 +1,14 @@
 import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {createGenericTestComponent} from '../util/tests';
+
 import {By} from '@angular/platform-browser';
 import {Component} from '@angular/core';
 
 import {NgbTooltipModule} from './index';
 import {NgbTooltipWindow, NgbTooltip} from './tooltip';
 
-function createTestComponent(html: string): ComponentFixture<TestComponent> {
-  TestBed.overrideComponent(TestComponent, {set: {template: html}});
-  const fixture = TestBed.createComponent(TestComponent);
-  fixture.detectChanges();
-  return fixture;
-}
+const createTestComponent =
+    (html: string) => <ComponentFixture<TestComponent>>createGenericTestComponent(html, TestComponent);
 
 describe('ngb-tooltip-window', () => {
   beforeEach(() => { TestBed.configureTestingModule({imports: [NgbTooltipModule]}); });

--- a/src/typeahead/highlight.spec.ts
+++ b/src/typeahead/highlight.spec.ts
@@ -1,9 +1,13 @@
 import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {createGenericTestComponent} from '../util/tests';
 
 import {Component} from '@angular/core';
 
 import {NgbHighlight} from './highlight';
 import {NgbTypeaheadModule} from './index';
+
+const createTestComponent = (html: string) =>
+    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
 /**
  * Get generated innerHtml without HTML comments and Angular debug attributes
@@ -26,13 +30,6 @@ function highlightHtml(fixture) {
   }
 
   return result;
-}
-
-function createTestComponent(html: string): ComponentFixture<TestComponent> {
-  TestBed.overrideComponent(TestComponent, {set: {template: html}});
-  const fixture = TestBed.createComponent(TestComponent);
-  fixture.detectChanges();
-  return fixture;
 }
 
 describe('ngb-highlight', () => {

--- a/src/typeahead/typeahead-window.spec.ts
+++ b/src/typeahead/typeahead-window.spec.ts
@@ -1,4 +1,5 @@
 import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {createGenericTestComponent} from '../util/tests';
 
 import {Component} from '@angular/core';
 
@@ -6,12 +7,8 @@ import {NgbTypeaheadWindow} from './typeahead-window';
 import {expectResults, getWindowLinks} from './test-common';
 import {NgbTypeaheadModule} from './index';
 
-function createTestComponent(html: string): ComponentFixture<TestComponent> {
-  TestBed.overrideComponent(TestComponent, {set: {template: html}});
-  const fixture = TestBed.createComponent(TestComponent);
-  fixture.detectChanges();
-  return fixture;
-}
+const createTestComponent = (html: string) =>
+    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
 describe('ngb-typeahead-window', () => {
 

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -1,13 +1,18 @@
-import {Component, DebugElement} from '@angular/core';
 import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {createGenericTestComponent} from '../util/tests';
+import {expectResults, getWindowLinks} from './test-common';
+
+import {Component, DebugElement} from '@angular/core';
+import {Validators, FormControl, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {By} from '@angular/platform-browser';
+import {Observable} from 'rxjs/Rx';
+import 'rxjs/add/operator/map';
 
 import {NgbTypeahead} from './typeahead';
 import {NgbTypeaheadModule} from './index';
-import {Observable} from 'rxjs/Rx';
-import 'rxjs/add/operator/map';
-import {By} from '@angular/platform-browser';
-import {expectResults, getWindowLinks} from './test-common';
-import {Validators, FormControl, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
+
+const createTestComponent = (html: string) =>
+    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
 enum Key {
   Tab = 9,
@@ -51,13 +56,6 @@ function expectWindowResults(element, expectedResults: string[]) {
   const window = getWindow(element);
   expect(getWindow).not.toBeNull();
   expectResults(window, expectedResults);
-}
-
-function createTestComponent(html: string): ComponentFixture<TestComponent> {
-  TestBed.overrideComponent(TestComponent, {set: {template: html}});
-  const fixture = TestBed.createComponent(TestComponent);
-  fixture.detectChanges();
-  return fixture;
 }
 
 describe('ngb-typeahead', () => {

--- a/src/util/tests.ts
+++ b/src/util/tests.ts
@@ -1,0 +1,8 @@
+import {TestBed, ComponentFixture} from '@angular/core/testing';
+
+export function createGenericTestComponent<T>(html: string, type: {new (...args: any[]): T}): ComponentFixture<T> {
+  TestBed.overrideComponent(type, {set: {template: html}});
+  const fixture = TestBed.createComponent(type);
+  fixture.detectChanges();
+  return fixture as ComponentFixture<T>;
+}


### PR DESCRIPTION
Moving common component creation code into a generic function:

- new `util/tests.ts` for common test code (unless anybody suggests a better place)
- generic `createGenericTestComponent(html, componentType)` function
- input order harmonisation for tests
