### PR TITLE
fix(demo): fix the error emited by TS due to missing generic type

### DIFF
--- a/misc/api-doc-test-cases/services-with-methods.ts
+++ b/misc/api-doc-test-cases/services-with-methods.ts
@@ -9,7 +9,7 @@ export class ModalService {
   /**
    * A method to open a modal
    */
-  open(content: string | TemplateRef, options = {}): boolean {
+  open(content: string | TemplateRef<any>, options = {}): boolean {
     return true;
   }
 }


### PR DESCRIPTION
`gulp demo-server` was emitting the following error:

```
ERROR in /Users/jb/projects/ng-bootstrap/misc/api-doc-test-cases/services-with-methods.ts
(12,26): error TS2314: Generic type 'TemplateRef<C>' requires 1 type argument(s).
```
