### PR TITLE
test: mark async tests as async

### DIFF
--- a/src/buttons/radio.spec.ts
+++ b/src/buttons/radio.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {TestBed, ComponentFixture, async} from '@angular/core/testing';
 import {createGenericTestComponent} from '../util/tests';
 
 import {Component} from '@angular/core';
@@ -60,166 +60,161 @@ describe('ngbRadioGroup', () => {
     TestBed.overrideComponent(TestComponent, {set: {template: defaultHtml}});
   });
 
-  // TODO: remove 'whenStable' once 'core/testing' is fixed
-  it('toggles radio inputs based on model changes', () => {
-    const fixture = TestBed.createComponent(TestComponent);
+  it('toggles radio inputs based on model changes', async(() => {
+       const fixture = TestBed.createComponent(TestComponent);
 
-    let values = fixture.componentInstance.values;
+       let values = fixture.componentInstance.values;
 
-    // checking initial values
-    fixture.detectChanges();
-    expectRadios(fixture.nativeElement, [0, 0]);
-    expect(getInput(fixture.nativeElement, 0).value).toEqual(values[0]);
-    expect(getInput(fixture.nativeElement, 1).value).toEqual(values[1]);
+       // checking initial values
+       fixture.detectChanges();
+       expectRadios(fixture.nativeElement, [0, 0]);
+       expect(getInput(fixture.nativeElement, 0).value).toEqual(values[0]);
+       expect(getInput(fixture.nativeElement, 1).value).toEqual(values[1]);
 
-    // checking null
-    fixture.componentInstance.model = null;
-    fixture.detectChanges();
-    fixture.whenStable()
-        .then(() => {
-          fixture.detectChanges();
-          expectRadios(fixture.nativeElement, [0, 0]);
+       // checking null
+       fixture.componentInstance.model = null;
+       fixture.detectChanges();
+       fixture.whenStable()
+           .then(() => {
+             fixture.detectChanges();
+             expectRadios(fixture.nativeElement, [0, 0]);
 
-          // checking first radio
-          fixture.componentInstance.model = values[0];
-          fixture.detectChanges();
-          return fixture.whenStable();
-        })
-        .then(() => {
-          fixture.detectChanges();
-          expectRadios(fixture.nativeElement, [1, 0]);
+             // checking first radio
+             fixture.componentInstance.model = values[0];
+             fixture.detectChanges();
+             return fixture.whenStable();
+           })
+           .then(() => {
+             fixture.detectChanges();
+             expectRadios(fixture.nativeElement, [1, 0]);
 
-          // checking second radio
-          fixture.componentInstance.model = values[1];
-          fixture.detectChanges();
-          return fixture.whenStable();
-        })
-        .then(() => {
-          fixture.detectChanges();
-          expectRadios(fixture.nativeElement, [0, 1]);
+             // checking second radio
+             fixture.componentInstance.model = values[1];
+             fixture.detectChanges();
+             return fixture.whenStable();
+           })
+           .then(() => {
+             fixture.detectChanges();
+             expectRadios(fixture.nativeElement, [0, 1]);
 
-          // checking non-matching value
-          fixture.componentInstance.model = values[3];
-          fixture.detectChanges();
-          return fixture.whenStable();
-        })
-        .then(() => {
-          fixture.detectChanges();
-          expectRadios(fixture.nativeElement, [0, 0]);
-        });
-  });
+             // checking non-matching value
+             fixture.componentInstance.model = values[3];
+             fixture.detectChanges();
+             return fixture.whenStable();
+           })
+           .then(() => {
+             fixture.detectChanges();
+             expectRadios(fixture.nativeElement, [0, 0]);
+           });
+     }));
 
-  it('updates model based on radio input clicks', () => {
-    const fixture = TestBed.createComponent(TestComponent);
+  it('updates model based on radio input clicks', async(() => {
+       const fixture = TestBed.createComponent(TestComponent);
 
-    fixture.detectChanges();
-    expectRadios(fixture.nativeElement, [0, 0]);
+       fixture.detectChanges();
+       expectRadios(fixture.nativeElement, [0, 0]);
 
-    fixture.whenStable()
-        .then(() => {
-          // clicking first radio
-          getInput(fixture.nativeElement, 0).click();
-          fixture.detectChanges();
-          expectRadios(fixture.nativeElement, [1, 0]);
-          expect(fixture.componentInstance.model).toBe('one');
-          return fixture.whenStable();
-        })
-        .then(() => {
-          // clicking second radio
-          getInput(fixture.nativeElement, 1).click();
-          fixture.detectChanges();
-          expectRadios(fixture.nativeElement, [0, 1]);
-          expect(fixture.componentInstance.model).toBe('two');
-        });
-  });
+       fixture.whenStable()
+           .then(() => {
+             // clicking first radio
+             getInput(fixture.nativeElement, 0).click();
+             fixture.detectChanges();
+             expectRadios(fixture.nativeElement, [1, 0]);
+             expect(fixture.componentInstance.model).toBe('one');
+             return fixture.whenStable();
+           })
+           .then(() => {
+             // clicking second radio
+             getInput(fixture.nativeElement, 1).click();
+             fixture.detectChanges();
+             expectRadios(fixture.nativeElement, [0, 1]);
+             expect(fixture.componentInstance.model).toBe('two');
+           });
+     }));
 
-  // TODO: remove 'whenStable' once 'core/testing' is fixed
-  it('can be used with objects as values', () => {
-    const fixture = TestBed.createComponent(TestComponent);
+  it('can be used with objects as values', async(() => {
+       const fixture = TestBed.createComponent(TestComponent);
 
-    let [one, two] = [{one: 'one'}, {two: 'two'}];
+       let [one, two] = [{one: 'one'}, {two: 'two'}];
 
-    fixture.componentInstance.values[0] = one;
-    fixture.componentInstance.values[1] = two;
+       fixture.componentInstance.values[0] = one;
+       fixture.componentInstance.values[1] = two;
 
-    // checking initial values
-    fixture.detectChanges();
-    expectRadios(fixture.nativeElement, [0, 0]);
-    expect(getInput(fixture.nativeElement, 0).value).toEqual({}.toString());
-    expect(getInput(fixture.nativeElement, 1).value).toEqual({}.toString());
+       // checking initial values
+       fixture.detectChanges();
+       expectRadios(fixture.nativeElement, [0, 0]);
+       expect(getInput(fixture.nativeElement, 0).value).toEqual({}.toString());
+       expect(getInput(fixture.nativeElement, 1).value).toEqual({}.toString());
 
-    // checking model -> radio input
-    fixture.componentInstance.model = one;
-    fixture.detectChanges();
-    fixture.whenStable().then(() => {
-      fixture.detectChanges();
-      expectRadios(fixture.nativeElement, [1, 0]);
+       // checking model -> radio input
+       fixture.componentInstance.model = one;
+       fixture.detectChanges();
+       fixture.whenStable().then(() => {
+         fixture.detectChanges();
+         expectRadios(fixture.nativeElement, [1, 0]);
 
-      // checking radio click -> model
-      getInput(fixture.nativeElement, 1).click();
-      fixture.detectChanges();
-      expectRadios(fixture.nativeElement, [0, 1]);
-      expect(fixture.componentInstance.model).toBe(two);
-    });
-  });
+         // checking radio click -> model
+         getInput(fixture.nativeElement, 1).click();
+         fixture.detectChanges();
+         expectRadios(fixture.nativeElement, [0, 1]);
+         expect(fixture.componentInstance.model).toBe(two);
+       });
+     }));
 
-  // TODO: remove 'whenStable' once 'core/testing' is fixed
-  it('updates radio input values dynamically', () => {
-    const fixture = TestBed.createComponent(TestComponent);
+  it('updates radio input values dynamically', async(() => {
+       const fixture = TestBed.createComponent(TestComponent);
 
-    let values = fixture.componentInstance.values;
+       let values = fixture.componentInstance.values;
 
-    // checking first radio
-    fixture.componentInstance.model = values[0];
-    fixture.detectChanges();
-    fixture.whenStable().then(() => {
-      fixture.detectChanges();
-      expectRadios(fixture.nativeElement, [1, 0]);
-      expect(fixture.componentInstance.model).toEqual(values[0]);
+       // checking first radio
+       fixture.componentInstance.model = values[0];
+       fixture.detectChanges();
+       fixture.whenStable().then(() => {
+         fixture.detectChanges();
+         expectRadios(fixture.nativeElement, [1, 0]);
+         expect(fixture.componentInstance.model).toEqual(values[0]);
 
-      // updating first radio value -> expecting none selected
-      let initialValue = values[0];
-      values[0] = 'ten';
-      fixture.detectChanges();
-      expectRadios(fixture.nativeElement, [0, 0]);
-      expect(getInput(fixture.nativeElement, 0).value).toEqual('ten');
-      expect(fixture.componentInstance.model).toEqual(initialValue);
+         // updating first radio value -> expecting none selected
+         let initialValue = values[0];
+         values[0] = 'ten';
+         fixture.detectChanges();
+         expectRadios(fixture.nativeElement, [0, 0]);
+         expect(getInput(fixture.nativeElement, 0).value).toEqual('ten');
+         expect(fixture.componentInstance.model).toEqual(initialValue);
 
-      // updating values back -> expecting initial state
-      values[0] = initialValue;
-      fixture.detectChanges();
-      expectRadios(fixture.nativeElement, [1, 0]);
-      expect(getInput(fixture.nativeElement, 0).value).toEqual(values[0]);
-      expect(fixture.componentInstance.model).toEqual(values[0]);
-    });
-  });
+         // updating values back -> expecting initial state
+         values[0] = initialValue;
+         fixture.detectChanges();
+         expectRadios(fixture.nativeElement, [1, 0]);
+         expect(getInput(fixture.nativeElement, 0).value).toEqual(values[0]);
+         expect(fixture.componentInstance.model).toEqual(values[0]);
+       });
+     }));
 
-  // TODO: remove 'whenStable' once 'core/testing' is fixed
-  it('can be used with ngFor', () => {
+  it('can be used with ngFor', async(() => {
 
-    const forHtml = `<div [(ngModel)]="model" ngbRadioGroup>
+       const forHtml = `<div [(ngModel)]="model" ngbRadioGroup>
           <label *ngFor="let v of values" class="btn">
             <input type="radio" name="radio" [value]="v"/> {{ v }}
           </label>
         </div>`;
 
-    const fixture = createTestComponent(forHtml);
-    let values = fixture.componentInstance.values;
+       const fixture = createTestComponent(forHtml);
+       let values = fixture.componentInstance.values;
 
-    expectRadios(fixture.nativeElement, [0, 0, 0]);
+       expectRadios(fixture.nativeElement, [0, 0, 0]);
 
-    fixture.componentInstance.model = values[1];
-    fixture.detectChanges();
-    fixture.whenStable().then(() => {
-      fixture.detectChanges();
-      expectRadios(fixture.nativeElement, [0, 1, 0]);
-    });
-  });
+       fixture.componentInstance.model = values[1];
+       fixture.detectChanges();
+       fixture.whenStable().then(() => {
+         fixture.detectChanges();
+         expectRadios(fixture.nativeElement, [0, 1, 0]);
+       });
+     }));
 
-  // TODO: remove 'whenStable' once 'core/testing' is fixed
-  it('cleans up the model when radio inputs are added / removed', () => {
+  it('cleans up the model when radio inputs are added / removed', async(() => {
 
-    const ifHtml = `<div [(ngModel)]="model" ngbRadioGroup>
+       const ifHtml = `<div [(ngModel)]="model" ngbRadioGroup>
         <label class="btn">
           <input type="radio" name="radio" [value]="values[0]"/> {{ values[0] }}
         </label>
@@ -227,42 +222,41 @@ describe('ngbRadioGroup', () => {
           <input type="radio" name="radio" [value]="values[1]"/> {{ values[1] }}
         </label>
       </div>`;
-    const fixture = createTestComponent(ifHtml);
+       const fixture = createTestComponent(ifHtml);
 
-    let values = fixture.componentInstance.values;
+       let values = fixture.componentInstance.values;
 
-    // hiding/showing non-selected radio -> expecting initial model value
-    expectRadios(fixture.nativeElement, [0, 0]);
+       // hiding/showing non-selected radio -> expecting initial model value
+       expectRadios(fixture.nativeElement, [0, 0]);
 
-    fixture.componentInstance.shown = false;
-    fixture.detectChanges();
-    expectRadios(fixture.nativeElement, [0]);
-    expect(fixture.componentInstance.model).toBeUndefined();
+       fixture.componentInstance.shown = false;
+       fixture.detectChanges();
+       expectRadios(fixture.nativeElement, [0]);
+       expect(fixture.componentInstance.model).toBeUndefined();
 
-    fixture.componentInstance.shown = true;
-    fixture.detectChanges();
-    expectRadios(fixture.nativeElement, [0, 0]);
-    expect(fixture.componentInstance.model).toBeUndefined();
+       fixture.componentInstance.shown = true;
+       fixture.detectChanges();
+       expectRadios(fixture.nativeElement, [0, 0]);
+       expect(fixture.componentInstance.model).toBeUndefined();
 
-    // hiding/showing selected radio -> expecting model to unchange, but none selected
-    fixture.componentInstance.model = values[1];
-    fixture.detectChanges();
-    fixture.whenStable().then(() => {
-      fixture.detectChanges();
-      expectRadios(fixture.nativeElement, [0, 1]);
+       // hiding/showing selected radio -> expecting model to unchange, but none selected
+       fixture.componentInstance.model = values[1];
+       fixture.detectChanges();
+       fixture.whenStable().then(() => {
+         fixture.detectChanges();
+         expectRadios(fixture.nativeElement, [0, 1]);
 
-      fixture.componentInstance.shown = false;
-      fixture.detectChanges();
-      expectRadios(fixture.nativeElement, [0]);
-      expect(fixture.componentInstance.model).toEqual(values[1]);
+         fixture.componentInstance.shown = false;
+         fixture.detectChanges();
+         expectRadios(fixture.nativeElement, [0]);
+         expect(fixture.componentInstance.model).toEqual(values[1]);
 
-      fixture.componentInstance.shown = true;
-      fixture.detectChanges();
-      expectRadios(fixture.nativeElement, [0, 1]);
-      expect(fixture.componentInstance.model).toEqual(values[1]);
-    });
-
-  });
+         fixture.componentInstance.shown = true;
+         fixture.detectChanges();
+         expectRadios(fixture.nativeElement, [0, 1]);
+         expect(fixture.componentInstance.model).toEqual(values[1]);
+       });
+     }));
 
   it('should add data-toggle="buttons" and "btn-group" CSS class to button group', () => {
     // Bootstrap for uses presence of data-toggle="buttons" to style radio buttons
@@ -274,9 +268,8 @@ describe('ngbRadioGroup', () => {
     expect(fixture.nativeElement.children[0]).toHaveCssClass('btn-group');
   });
 
-  // TODO: remove 'whenStable' once 'core/testing' is fixed
-  it('should work with template-driven form validation', () => {
-    const html = `
+  it('should work with template-driven form validation', async(() => {
+       const html = `
         <form>
           <div ngbRadioGroup [(ngModel)]="model" name="control" required>
             <label class="btn">
@@ -285,19 +278,19 @@ describe('ngbRadioGroup', () => {
           </div>
         </form>`;
 
-    const fixture = createTestComponent(html);
+       const fixture = createTestComponent(html);
 
-    fixture.whenStable().then(() => {
-      fixture.detectChanges();
-      expect(getGroupElement(fixture.nativeElement)).toHaveCssClass('ng-invalid');
-      expect(getGroupElement(fixture.nativeElement)).not.toHaveCssClass('ng-valid');
+       fixture.whenStable().then(() => {
+         fixture.detectChanges();
+         expect(getGroupElement(fixture.nativeElement)).toHaveCssClass('ng-invalid');
+         expect(getGroupElement(fixture.nativeElement)).not.toHaveCssClass('ng-valid');
 
-      getInput(fixture.nativeElement, 0).click();
-      fixture.detectChanges();
-      expect(getGroupElement(fixture.nativeElement)).toHaveCssClass('ng-valid');
-      expect(getGroupElement(fixture.nativeElement)).not.toHaveCssClass('ng-invalid');
-    });
-  });
+         getInput(fixture.nativeElement, 0).click();
+         fixture.detectChanges();
+         expect(getGroupElement(fixture.nativeElement)).toHaveCssClass('ng-valid');
+         expect(getGroupElement(fixture.nativeElement)).not.toHaveCssClass('ng-invalid');
+       });
+     }));
 
   it('should work with model-driven form validation', () => {
     const html = `

--- a/src/timepicker/timepicker.spec.ts
+++ b/src/timepicker/timepicker.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {TestBed, ComponentFixture, async} from '@angular/core/testing';
 import {createGenericTestComponent} from '../util/tests';
 
 import {Component} from '@angular/core';
@@ -57,546 +57,526 @@ describe('ngb-timepicker', () => {
 
   describe('rendering based on model', () => {
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should render hour and minute inputs', () => {
-      const html = `<ngb-timepicker [ngModel]="model"></ngb-timepicker>`;
+    it('should render hour and minute inputs', async(() => {
+         const html = `<ngb-timepicker [ngModel]="model"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = {hour: 13, minute: 30};
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => { expectToDisplayTime(fixture.nativeElement, '13:30'); });
-    });
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 13, minute: 30};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => { expectToDisplayTime(fixture.nativeElement, '13:30'); });
+       }));
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should update inputs value on model change', () => {
-      const html = `<ngb-timepicker [ngModel]="model"></ngb-timepicker>`;
+    it('should update inputs value on model change', async(() => {
+         const html = `<ngb-timepicker [ngModel]="model"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = {hour: 13, minute: 30};
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
-            expectToDisplayTime(fixture.nativeElement, '13:30');
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 13, minute: 30};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+               expectToDisplayTime(fixture.nativeElement, '13:30');
 
-            fixture.componentInstance.model = {hour: 14, minute: 40};
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => { expectToDisplayTime(fixture.nativeElement, '14:40'); });
-    });
+               fixture.componentInstance.model = {hour: 14, minute: 40};
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => { expectToDisplayTime(fixture.nativeElement, '14:40'); });
+       }));
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should render hour and minute inputs with padding', () => {
-      const html = `<ngb-timepicker [ngModel]="model"></ngb-timepicker>`;
+    it('should render hour and minute inputs with padding', async(() => {
+         const html = `<ngb-timepicker [ngModel]="model"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = {hour: 1, minute: 3};
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => { expectToDisplayTime(fixture.nativeElement, '01:03'); });
-    });
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 1, minute: 3};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => { expectToDisplayTime(fixture.nativeElement, '01:03'); });
+       }));
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should render hour, minute and seconds inputs with padding', () => {
-      const html = `<ngb-timepicker [ngModel]="model" [seconds]="true"></ngb-timepicker>`;
+    it('should render hour, minute and seconds inputs with padding', async(() => {
+         const html = `<ngb-timepicker [ngModel]="model" [seconds]="true"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = {hour: 10, minute: 3, second: 4};
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => { expectToDisplayTime(fixture.nativeElement, '10:03:04'); });
-    });
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 10, minute: 3, second: 4};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => { expectToDisplayTime(fixture.nativeElement, '10:03:04'); });
+       }));
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should render invalid or empty hour and minute as blank string', () => {
-      const html = `<ngb-timepicker [ngModel]="model"></ngb-timepicker>`;
+    it('should render invalid or empty hour and minute as blank string', async(() => {
+         const html = `<ngb-timepicker [ngModel]="model"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = {hour: undefined, minute: 'aaa'};
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => { expectToDisplayTime(fixture.nativeElement, ':'); });
-    });
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: undefined, minute: 'aaa'};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => { expectToDisplayTime(fixture.nativeElement, ':'); });
+       }));
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should render invalid or empty second as blank string', () => {
-      const html = `<ngb-timepicker [ngModel]="model" [seconds]="true"></ngb-timepicker>`;
+    it('should render invalid or empty second as blank string', async(() => {
+         const html = `<ngb-timepicker [ngModel]="model" [seconds]="true"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = {hour: 10, minute: 20, second: false};
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => { expectToDisplayTime(fixture.nativeElement, '10:20:'); });
-    });
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 10, minute: 20, second: false};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => { expectToDisplayTime(fixture.nativeElement, '10:20:'); });
+       }));
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should render empty fields on null model', () => {
-      const html = `<ngb-timepicker [ngModel]="model" [seconds]="true"></ngb-timepicker>`;
+    it('should render empty fields on null model', async(() => {
+         const html = `<ngb-timepicker [ngModel]="model" [seconds]="true"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = null;
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => { expectToDisplayTime(fixture.nativeElement, '::'); });
-    });
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = null;
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => { expectToDisplayTime(fixture.nativeElement, '::'); });
+       }));
   });
 
 
   describe('model updates in response to increment / decrement button clicks', () => {
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should increment / decrement hours', () => {
-      const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
+    it('should increment / decrement hours', async(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
 
-            const buttons = getButtons(fixture.nativeElement);
+               const buttons = getButtons(fixture.nativeElement);
 
-            expectToDisplayTime(fixture.nativeElement, '10:30');
-            expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+               expectToDisplayTime(fixture.nativeElement, '10:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-            (<HTMLButtonElement>buttons[0]).click();  // H+
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '11:30');
-            expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[0]).click();  // H+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '11:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
 
 
-            (<HTMLButtonElement>buttons[2]).click();  // H-
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '10:30');
-            expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
-          });
-    });
+               (<HTMLButtonElement>buttons[2]).click();  // H-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+             });
+       }));
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should wrap hours', () => {
-      const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
+    it('should wrap hours', async(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = {hour: 23, minute: 30, second: 0};
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 23, minute: 30, second: 0};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
 
-            const buttons = getButtons(fixture.nativeElement);
+               const buttons = getButtons(fixture.nativeElement);
 
-            expectToDisplayTime(fixture.nativeElement, '23:30');
-            expect(fixture.componentInstance.model).toEqual({hour: 23, minute: 30, second: 0});
+               expectToDisplayTime(fixture.nativeElement, '23:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 23, minute: 30, second: 0});
 
-            (<HTMLButtonElement>buttons[0]).click();  // H+
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '00:30');
-            expect(fixture.componentInstance.model).toEqual({hour: 0, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[0]).click();  // H+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '00:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 0, minute: 30, second: 0});
 
-            (<HTMLButtonElement>buttons[2]).click();  // H-
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '23:30');
-            expect(fixture.componentInstance.model).toEqual({hour: 23, minute: 30, second: 0});
-          });
-    });
+               (<HTMLButtonElement>buttons[2]).click();  // H-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '23:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 23, minute: 30, second: 0});
+             });
+       }));
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should increment / decrement minutes', () => {
-      const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
+    it('should increment / decrement minutes', async(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
 
-            const buttons = getButtons(fixture.nativeElement);
+               const buttons = getButtons(fixture.nativeElement);
 
-            expectToDisplayTime(fixture.nativeElement, '10:30');
-            expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+               expectToDisplayTime(fixture.nativeElement, '10:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-            (<HTMLButtonElement>buttons[1]).click();  // M+
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '10:31');
-            expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 0});
+               (<HTMLButtonElement>buttons[1]).click();  // M+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:31');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 0});
 
-            (<HTMLButtonElement>buttons[3]).click();  // M-
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '10:30');
-            expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
-          });
-    });
+               (<HTMLButtonElement>buttons[3]).click();  // M-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+             });
+       }));
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should wrap minutes', () => {
-      const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
+    it('should wrap minutes', async(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = {hour: 22, minute: 59, second: 0};
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
-            const buttons = getButtons(fixture.nativeElement);
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 22, minute: 59, second: 0};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+               const buttons = getButtons(fixture.nativeElement);
 
-            expectToDisplayTime(fixture.nativeElement, '22:59');
-            expect(fixture.componentInstance.model).toEqual({hour: 22, minute: 59, second: 0});
+               expectToDisplayTime(fixture.nativeElement, '22:59');
+               expect(fixture.componentInstance.model).toEqual({hour: 22, minute: 59, second: 0});
 
-            (<HTMLButtonElement>buttons[1]).click();  // M+
-            fixture.detectChanges();
-            expect(fixture.componentInstance.model).toEqual({hour: 23, minute: 0, second: 0});
+               (<HTMLButtonElement>buttons[1]).click();  // M+
+               fixture.detectChanges();
+               expect(fixture.componentInstance.model).toEqual({hour: 23, minute: 0, second: 0});
 
-            (<HTMLButtonElement>buttons[3]).click();  // M-
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '22:59');
-            expect(fixture.componentInstance.model).toEqual({hour: 22, minute: 59, second: 0});
-          });
-    });
+               (<HTMLButtonElement>buttons[3]).click();  // M-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '22:59');
+               expect(fixture.componentInstance.model).toEqual({hour: 22, minute: 59, second: 0});
+             });
+       }));
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should increment / decrement seconds', () => {
-      const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true"></ngb-timepicker>`;
+    it('should increment / decrement seconds', async(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
-            const buttons = getButtons(fixture.nativeElement);
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+               const buttons = getButtons(fixture.nativeElement);
 
-            expectToDisplayTime(fixture.nativeElement, '10:30:00');
-            expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+               expectToDisplayTime(fixture.nativeElement, '10:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-            (<HTMLButtonElement>buttons[2]).click();  // S+
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '10:30:01');
-            expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 1});
+               (<HTMLButtonElement>buttons[2]).click();  // S+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:30:01');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 1});
 
-            (<HTMLButtonElement>buttons[5]).click();  // S-
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '10:30:00');
-            expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
-          });
-    });
+               (<HTMLButtonElement>buttons[5]).click();  // S-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+             });
+       }));
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should wrap seconds', () => {
-      const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true"></ngb-timepicker>`;
+    it('should wrap seconds', async(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = {hour: 10, minute: 30, second: 59};
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 10, minute: 30, second: 59};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
 
-            const buttons = getButtons(fixture.nativeElement);
+               const buttons = getButtons(fixture.nativeElement);
 
-            expectToDisplayTime(fixture.nativeElement, '10:30:59');
-            expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 59});
+               expectToDisplayTime(fixture.nativeElement, '10:30:59');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 59});
 
-            (<HTMLButtonElement>buttons[2]).click();  // S+
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '10:31:00');
-            expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 0});
+               (<HTMLButtonElement>buttons[2]).click();  // S+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:31:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 0});
 
-            (<HTMLButtonElement>buttons[5]).click();  // S-
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '10:30:59');
-            expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 59});
-          });
-    });
+               (<HTMLButtonElement>buttons[5]).click();  // S-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:30:59');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 59});
+             });
+       }));
   });
 
   describe('model updates in response to input field changes', () => {
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should update hours', () => {
-      const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
+    it('should update hours', async(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
 
-            const inputs = fixture.debugElement.queryAll(By.css('input'));
+               const inputs = fixture.debugElement.queryAll(By.css('input'));
 
-            expectToDisplayTime(fixture.nativeElement, '10:30');
-            expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+               expectToDisplayTime(fixture.nativeElement, '10:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-            inputs[0].triggerEventHandler('change', createChangeEvent('11'));
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '11:30');
-            expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
+               inputs[0].triggerEventHandler('change', createChangeEvent('11'));
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '11:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
 
-            inputs[0].triggerEventHandler('change', createChangeEvent(`${24 + 11}`));
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '11:30');
-            expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
+               inputs[0].triggerEventHandler('change', createChangeEvent(`${24 + 11}`));
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '11:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
 
-            inputs[0].triggerEventHandler('change', createChangeEvent('aa'));
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, ':30');
-            expect(fixture.componentInstance.model).toEqual(null);
-          });
-    });
+               inputs[0].triggerEventHandler('change', createChangeEvent('aa'));
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, ':30');
+               expect(fixture.componentInstance.model).toEqual(null);
+             });
+       }));
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should update minutes', () => {
-      const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
+    it('should update minutes', async(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
 
-            const inputs = fixture.debugElement.queryAll(By.css('input'));
+               const inputs = fixture.debugElement.queryAll(By.css('input'));
 
-            expectToDisplayTime(fixture.nativeElement, '10:30');
-            expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+               expectToDisplayTime(fixture.nativeElement, '10:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-            inputs[1].triggerEventHandler('change', createChangeEvent('40'));
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '10:40');
-            expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 40, second: 0});
+               inputs[1].triggerEventHandler('change', createChangeEvent('40'));
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:40');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 40, second: 0});
 
-            inputs[1].triggerEventHandler('change', createChangeEvent('70'));
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '11:10');
-            expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 10, second: 0});
+               inputs[1].triggerEventHandler('change', createChangeEvent('70'));
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '11:10');
+               expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 10, second: 0});
 
-            inputs[1].triggerEventHandler('change', createChangeEvent('aa'));
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '11:');
-            expect(fixture.componentInstance.model).toEqual(null);
-          });
-    });
+               inputs[1].triggerEventHandler('change', createChangeEvent('aa'));
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '11:');
+               expect(fixture.componentInstance.model).toEqual(null);
+             });
+       }));
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should update seconds', () => {
-      const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true"></ngb-timepicker>`;
+    it('should update seconds', async(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
 
-            const inputs = fixture.debugElement.queryAll(By.css('input'));
+               const inputs = fixture.debugElement.queryAll(By.css('input'));
 
-            expectToDisplayTime(fixture.nativeElement, '10:30:00');
-            expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+               expectToDisplayTime(fixture.nativeElement, '10:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-            inputs[2].triggerEventHandler('change', createChangeEvent('40'));
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '10:30:40');
-            expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 40});
+               inputs[2].triggerEventHandler('change', createChangeEvent('40'));
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:30:40');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 40});
 
-            inputs[2].triggerEventHandler('change', createChangeEvent('70'));
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '10:31:10');
-            expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 10});
+               inputs[2].triggerEventHandler('change', createChangeEvent('70'));
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:31:10');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 10});
 
-            inputs[2].triggerEventHandler('change', createChangeEvent('aa'));
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '10:31:');
-            expect(fixture.componentInstance.model).toEqual(null);
-          });
-    });
+               inputs[2].triggerEventHandler('change', createChangeEvent('aa'));
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:31:');
+               expect(fixture.componentInstance.model).toEqual(null);
+             });
+       }));
   });
 
   describe('meridian', () => {
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should render meridian button with proper value', () => {
-      const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [meridian]="true"></ngb-timepicker>`;
+    it('should render meridian button with proper value', async(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [meridian]="true"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = {hour: 13, minute: 30, second: 0};
-      const meridianButton = getMeridianButton(fixture.nativeElement);
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
-            expectToDisplayTime(fixture.nativeElement, '01:30:00');
-            expect(meridianButton.innerHTML).toBe('PM');
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 13, minute: 30, second: 0};
+         const meridianButton = getMeridianButton(fixture.nativeElement);
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+               expectToDisplayTime(fixture.nativeElement, '01:30:00');
+               expect(meridianButton.innerHTML).toBe('PM');
 
-            fixture.componentInstance.model = {hour: 1, minute: 30, second: 0};
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
-            expectToDisplayTime(fixture.nativeElement, '01:30:00');
-            expect(meridianButton.innerHTML).toBe('AM');
-          });
-    });
+               fixture.componentInstance.model = {hour: 1, minute: 30, second: 0};
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+               expectToDisplayTime(fixture.nativeElement, '01:30:00');
+               expect(meridianButton.innerHTML).toBe('AM');
+             });
+       }));
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should update model on meridian click', () => {
-      const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [meridian]="true"></ngb-timepicker>`;
+    it('should update model on meridian click', async(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [meridian]="true"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = {hour: 13, minute: 30, second: 0};
-      const meridianButton = <HTMLButtonElement>getMeridianButton(fixture.nativeElement);
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
-            expectToDisplayTime(fixture.nativeElement, '01:30:00');
-            expect(meridianButton.innerHTML).toBe('PM');
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 13, minute: 30, second: 0};
+         const meridianButton = <HTMLButtonElement>getMeridianButton(fixture.nativeElement);
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+               expectToDisplayTime(fixture.nativeElement, '01:30:00');
+               expect(meridianButton.innerHTML).toBe('PM');
 
-            meridianButton.click();
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
-            expectToDisplayTime(fixture.nativeElement, '01:30:00');
-            expect(fixture.componentInstance.model).toEqual({hour: 1, minute: 30, second: 0});
-            expect(meridianButton.innerHTML).toBe('AM');
-          });
-    });
+               meridianButton.click();
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+               expectToDisplayTime(fixture.nativeElement, '01:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 1, minute: 30, second: 0});
+               expect(meridianButton.innerHTML).toBe('AM');
+             });
+       }));
   });
 
   describe('forms', () => {
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should work with template-driven form validation', () => {
-      const html = `
+    it('should work with template-driven form validation', async(() => {
+         const html = `
           <form>
             <ngb-timepicker [(ngModel)]="model" name="control" required></ngb-timepicker>
           </form>`;
 
-      const fixture = createTestComponent(html);
-      const compiled = fixture.nativeElement;
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
-            expect(getTimepicker(compiled)).toHaveCssClass('ng-invalid');
-            expect(getTimepicker(compiled)).not.toHaveCssClass('ng-valid');
+         const fixture = createTestComponent(html);
+         const compiled = fixture.nativeElement;
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+               expect(getTimepicker(compiled)).toHaveCssClass('ng-invalid');
+               expect(getTimepicker(compiled)).not.toHaveCssClass('ng-valid');
 
-            fixture.componentInstance.model = {hour: 12, minute: 0, second: 0};
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
-            expect(getTimepicker(compiled)).toHaveCssClass('ng-valid');
-            expect(getTimepicker(compiled)).not.toHaveCssClass('ng-invalid');
-          });
-    });
+               fixture.componentInstance.model = {hour: 12, minute: 0, second: 0};
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+               expect(getTimepicker(compiled)).toHaveCssClass('ng-valid');
+               expect(getTimepicker(compiled)).not.toHaveCssClass('ng-invalid');
+             });
+       }));
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should work with model-driven form validation', () => {
-      const html = `
+    it('should work with model-driven form validation', async(() => {
+         const html = `
           <form [formGroup]="form">
             <ngb-timepicker formControlName="control" required></ngb-timepicker>
           </form>`;
 
-      const fixture = createTestComponent(html);
-      const compiled = fixture.nativeElement;
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            const inputs = fixture.debugElement.queryAll(By.css('input'));
+         const fixture = createTestComponent(html);
+         const compiled = fixture.nativeElement;
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               const inputs = fixture.debugElement.queryAll(By.css('input'));
 
-            expect(getTimepicker(compiled)).toHaveCssClass('ng-invalid');
-            expect(getTimepicker(compiled)).not.toHaveCssClass('ng-valid');
+               expect(getTimepicker(compiled)).toHaveCssClass('ng-invalid');
+               expect(getTimepicker(compiled)).not.toHaveCssClass('ng-valid');
 
-            inputs[0].triggerEventHandler('change', createChangeEvent('12'));
-            inputs[1].triggerEventHandler('change', createChangeEvent('15'));
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
-            expect(getTimepicker(compiled)).toHaveCssClass('ng-valid');
-            expect(getTimepicker(compiled)).not.toHaveCssClass('ng-invalid');
-          });
-    });
+               inputs[0].triggerEventHandler('change', createChangeEvent('12'));
+               inputs[1].triggerEventHandler('change', createChangeEvent('15'));
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+               expect(getTimepicker(compiled)).toHaveCssClass('ng-valid');
+               expect(getTimepicker(compiled)).not.toHaveCssClass('ng-invalid');
+             });
+       }));
 
     it('should propagate model changes only if valid - no seconds', () => {
       const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
@@ -629,56 +609,55 @@ describe('ngb-timepicker', () => {
 
   describe('disabled', () => {
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should not change the value on button click, when it is disabled', () => {
-      const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [disabled]="disabled"></ngb-timepicker>`;
+    it('should not change the value on button click, when it is disabled', async(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [disabled]="disabled"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = {hour: 13, minute: 30, second: 0};
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 13, minute: 30, second: 0};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
 
-            const buttons = getButtons(fixture.nativeElement);
+               const buttons = getButtons(fixture.nativeElement);
 
-            expectToDisplayTime(fixture.nativeElement, '13:30:00');
-            expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-            (<HTMLButtonElement>buttons[0]).click();  // H+
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '13:30:00');
-            expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[0]).click();  // H+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-            (<HTMLButtonElement>buttons[3]).click();  // H-
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '13:30:00');
-            expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[3]).click();  // H-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-            (<HTMLButtonElement>buttons[1]).click();  // M+
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '13:30:00');
-            expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[1]).click();  // M+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-            (<HTMLButtonElement>buttons[4]).click();  // M-
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '13:30:00');
-            expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[4]).click();  // M-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-            (<HTMLButtonElement>buttons[2]).click();  // S+
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '13:30:00');
-            expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[2]).click();  // S+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-            (<HTMLButtonElement>buttons[5]).click();  // S-
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '13:30:00');
-            expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
-          });
-    });
+               (<HTMLButtonElement>buttons[5]).click();  // S-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+             });
+       }));
 
     it('should have disabled class, when it is disabled', () => {
       const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [disabled]="disabled"></ngb-timepicker>`;
@@ -699,56 +678,56 @@ describe('ngb-timepicker', () => {
 
   describe('readonly', () => {
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should change the value on button click, when it is readonly', () => {
-      const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [readonlyInputs]="readonly"></ngb-timepicker>`;
+    it('should change the value on button click, when it is readonly', async(() => {
+         const html =
+             `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [readonlyInputs]="readonly"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = {hour: 13, minute: 30, second: 0};
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 13, minute: 30, second: 0};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
 
-            const buttons = getButtons(fixture.nativeElement);
+               const buttons = getButtons(fixture.nativeElement);
 
-            expectToDisplayTime(fixture.nativeElement, '13:30:00');
-            expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-            (<HTMLButtonElement>buttons[0]).click();  // H+
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '14:30:00');
-            expect(fixture.componentInstance.model).toEqual({hour: 14, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[0]).click();  // H+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '14:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 14, minute: 30, second: 0});
 
-            (<HTMLButtonElement>buttons[3]).click();  // H-
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '13:30:00');
-            expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[3]).click();  // H-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-            (<HTMLButtonElement>buttons[1]).click();  // M+
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '13:31:00');
-            expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 31, second: 0});
+               (<HTMLButtonElement>buttons[1]).click();  // M+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:31:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 31, second: 0});
 
-            (<HTMLButtonElement>buttons[4]).click();  // M-
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '13:30:00');
-            expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+               (<HTMLButtonElement>buttons[4]).click();  // M-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-            (<HTMLButtonElement>buttons[2]).click();  // S+
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '13:30:01');
-            expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 1});
+               (<HTMLButtonElement>buttons[2]).click();  // S+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:01');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 1});
 
-            (<HTMLButtonElement>buttons[5]).click();  // S-
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '13:30:00');
-            expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
-          });
-    });
+               (<HTMLButtonElement>buttons[5]).click();  // S-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+             });
+       }));
 
     it('should not change value on input change, when it is readonly', () => {
       const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [readonlyInputs]="readonly"></ngb-timepicker>`;

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {TestBed, ComponentFixture, async} from '@angular/core/testing';
 import {createGenericTestComponent} from '../util/tests';
 import {expectResults, getWindowLinks} from './test-common';
 
@@ -67,54 +67,53 @@ describe('ngb-typeahead', () => {
 
   describe('valueaccessor', () => {
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should format values when no formatter provided', () => {
-      const fixture = createTestComponent('<input [(ngModel)]="model" [ngbTypeahead]="findNothing" />');
+    it('should format values when no formatter provided', async(() => {
+         const fixture = createTestComponent('<input [(ngModel)]="model" [ngbTypeahead]="findNothing" />');
 
-      const el = fixture.nativeElement;
-      const comp = fixture.componentInstance;
-      expectInputValue(el, '');
+         const el = fixture.nativeElement;
+         const comp = fixture.componentInstance;
+         expectInputValue(el, '');
 
-      comp.model = 'text';
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            expectInputValue(el, 'text');
+         comp.model = 'text';
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               expectInputValue(el, 'text');
 
-            comp.model = null;
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
-            expectInputValue(el, '');
+               comp.model = null;
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+               expectInputValue(el, '');
 
-            comp.model = {};
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => { expectInputValue(el, '[object Object]'); });
-    });
+               comp.model = {};
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => { expectInputValue(el, '[object Object]'); });
+       }));
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should format values with custom formatter provided', () => {
-      const html = '<input [(ngModel)]="model" [ngbTypeahead]="findNothing" [inputFormatter]="uppercaseObjFormatter"/>';
-      const fixture = createTestComponent(html);
-      const el = fixture.nativeElement;
-      const comp = fixture.componentInstance;
-      expectInputValue(el, '');
+    it('should format values with custom formatter provided', async(() => {
+         const html =
+             '<input [(ngModel)]="model" [ngbTypeahead]="findNothing" [inputFormatter]="uppercaseObjFormatter"/>';
+         const fixture = createTestComponent(html);
+         const el = fixture.nativeElement;
+         const comp = fixture.componentInstance;
+         expectInputValue(el, '');
 
-      comp.model = null;
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            expectInputValue(el, '');
+         comp.model = null;
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               expectInputValue(el, '');
 
-            comp.model = {value: 'text'};
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => { expectInputValue(el, 'TEXT'); });
-    });
+               comp.model = {value: 'text'};
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => { expectInputValue(el, 'TEXT'); });
+       }));
   });
 
   describe('window', () => {
@@ -125,27 +124,26 @@ describe('ngb-typeahead', () => {
       expect(getWindow(compiled)).toBeNull();
     });
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should not be opened when the model changes', () => {
-      const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
-      const compiled = fixture.nativeElement;
+    it('should not be opened when the model changes', async(() => {
+         const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
+         const compiled = fixture.nativeElement;
 
-      fixture.componentInstance.model = 'one';
-      fixture.detectChanges();
-      fixture.whenStable().then(() => { expect(getWindow(compiled)).toBeNull(); });
-    });
+         fixture.componentInstance.model = 'one';
+         fixture.detectChanges();
+         fixture.whenStable().then(() => { expect(getWindow(compiled)).toBeNull(); });
+       }));
 
-    it('should be opened when there are results', () => {
-      const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
-      const compiled = fixture.nativeElement;
+    it('should be opened when there are results', async(() => {
+         const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
+         const compiled = fixture.nativeElement;
 
-      fixture.whenStable().then(() => {
-        changeInput(compiled, 'one');
-        fixture.detectChanges();
-        expectWindowResults(compiled, ['+one', 'one more']);
-        expect(fixture.componentInstance.model).toBe('one');
-      });
-    });
+         fixture.whenStable().then(() => {
+           changeInput(compiled, 'one');
+           fixture.detectChanges();
+           expectWindowResults(compiled, ['+one', 'one more']);
+           expect(fixture.componentInstance.model).toBe('one');
+         });
+       }));
 
     it('should be closed when there no results', () => {
       const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="findNothing"/>`);
@@ -181,53 +179,53 @@ describe('ngb-typeahead', () => {
       expect(event.preventDefault).toHaveBeenCalled();
     });
 
-    it('should select the result on click, close window and fill the input', () => {
-      const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
-      const compiled = fixture.nativeElement;
+    it('should select the result on click, close window and fill the input', async(() => {
+         const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
+         const compiled = fixture.nativeElement;
 
-      fixture.whenStable().then(() => {
-        // clicking selected
-        changeInput(compiled, 'o');
-        fixture.detectChanges();
-        expectWindowResults(compiled, ['+one', 'one more']);
+         fixture.whenStable().then(() => {
+           // clicking selected
+           changeInput(compiled, 'o');
+           fixture.detectChanges();
+           expectWindowResults(compiled, ['+one', 'one more']);
 
-        getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
-        fixture.detectChanges();
-        expect(getWindow(compiled)).toBeNull();
-        expectInputValue(compiled, 'one');
-        expect(fixture.componentInstance.model).toBe('one');
+           getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
+           fixture.detectChanges();
+           expect(getWindow(compiled)).toBeNull();
+           expectInputValue(compiled, 'one');
+           expect(fixture.componentInstance.model).toBe('one');
 
-        // clicking not selected
-        changeInput(compiled, 'o');
-        fixture.detectChanges();
-        expectWindowResults(compiled, ['+one', 'one more']);
-        expectInputValue(compiled, 'o');
+           // clicking not selected
+           changeInput(compiled, 'o');
+           fixture.detectChanges();
+           expectWindowResults(compiled, ['+one', 'one more']);
+           expectInputValue(compiled, 'o');
 
-        getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
-        fixture.detectChanges();
-        expect(getWindow(compiled)).toBeNull();
-        expectInputValue(compiled, 'one');
-      });
-    });
+           getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
+           fixture.detectChanges();
+           expect(getWindow(compiled)).toBeNull();
+           expectInputValue(compiled, 'one');
+         });
+       }));
 
-    it('should select the result on ENTER, close window and fill the input', () => {
-      const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
-      const compiled = fixture.nativeElement;
+    it('should select the result on ENTER, close window and fill the input', async(() => {
+         const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
+         const compiled = fixture.nativeElement;
 
-      fixture.whenStable().then(() => {
-        changeInput(compiled, 'o');
-        fixture.detectChanges();
-        expectWindowResults(compiled, ['+one', 'one more']);
+         fixture.whenStable().then(() => {
+           changeInput(compiled, 'o');
+           fixture.detectChanges();
+           expectWindowResults(compiled, ['+one', 'one more']);
 
-        const event = createKeyDownEvent(Key.Enter);
-        getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-        fixture.detectChanges();
-        expect(getWindow(compiled)).toBeNull();
-        expectInputValue(compiled, 'one');
-        expect(fixture.componentInstance.model).toBe('one');
-        expect(event.preventDefault).toHaveBeenCalled();
-      });
-    });
+           const event = createKeyDownEvent(Key.Enter);
+           getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+           fixture.detectChanges();
+           expect(getWindow(compiled)).toBeNull();
+           expectInputValue(compiled, 'one');
+           expect(fixture.componentInstance.model).toBe('one');
+           expect(event.preventDefault).toHaveBeenCalled();
+         });
+       }));
 
     it('should select the result on TAB, close window and fill the input', () => {
       const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
@@ -295,63 +293,61 @@ describe('ngb-typeahead', () => {
 
   describe('objects', () => {
 
-    it('should work with custom objects as values', () => {
-      const fixture = createTestComponent(`
+    it('should work with custom objects as values', async(() => {
+         const fixture = createTestComponent(`
              <input type="text" [(ngModel)]="model" [ngbTypeahead]="findObjects"
                     [inputFormatter]="formatter" [resultFormatter]="uppercaseObjFormatter"/>`);
-      const compiled = fixture.nativeElement;
+         const compiled = fixture.nativeElement;
 
-      fixture.whenStable().then(() => {
-        changeInput(compiled, 'o');
-        fixture.detectChanges();
-        expectWindowResults(compiled, ['+ONE', 'ONE MORE']);
+         fixture.whenStable().then(() => {
+           changeInput(compiled, 'o');
+           fixture.detectChanges();
+           expectWindowResults(compiled, ['+ONE', 'ONE MORE']);
 
-        const event = createKeyDownEvent(Key.Enter);
-        getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-        fixture.detectChanges();
-        expect(getWindow(compiled)).toBeNull();
-        expect(getNativeInput(compiled).value).toBe('1 one');
-        expect(fixture.componentInstance.model).toEqual({id: 1, value: 'one'});
-      });
-    });
+           const event = createKeyDownEvent(Key.Enter);
+           getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+           fixture.detectChanges();
+           expect(getWindow(compiled)).toBeNull();
+           expect(getNativeInput(compiled).value).toBe('1 one');
+           expect(fixture.componentInstance.model).toEqual({id: 1, value: 'one'});
+         });
+       }));
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should allow to assign ngModel custom objects', () => {
-      const fixture = createTestComponent(`
+    it('should allow to assign ngModel custom objects', async(() => {
+         const fixture = createTestComponent(`
              <input type="text" [(ngModel)]="model" [ngbTypeahead]="findObjects"
                     [inputFormatter]="formatter" [resultFormatter]="uppercaseObjFormatter"/>`);
-      const compiled = fixture.nativeElement;
+         const compiled = fixture.nativeElement;
 
-      fixture.componentInstance.model = {id: 1, value: 'one'};
-      fixture.detectChanges();
-      fixture.whenStable().then(() => {
-        expect(getWindow(compiled)).toBeNull();
-        expect(getNativeInput(compiled).value).toBe('1 one');
-      });
-    });
+         fixture.componentInstance.model = {id: 1, value: 'one'};
+         fixture.detectChanges();
+         fixture.whenStable().then(() => {
+           expect(getWindow(compiled)).toBeNull();
+           expect(getNativeInput(compiled).value).toBe('1 one');
+         });
+       }));
   });
 
   describe('forms', () => {
 
-    // TODO: remove 'whenStable' once 'core/testing' is fixed
-    it('should work with template-driven form validation', () => {
-      const html = `
+    it('should work with template-driven form validation', async(() => {
+         const html = `
             <form>
               <input type="text" [(ngModel)]="model" name="control" required [ngbTypeahead]="findObjects" />
             </form>`;
-      const fixture = createTestComponent(html);
-      fixture.whenStable().then(() => {
-        fixture.detectChanges();
-        const compiled = fixture.nativeElement;
-        expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
-        expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
+         const fixture = createTestComponent(html);
+         fixture.whenStable().then(() => {
+           fixture.detectChanges();
+           const compiled = fixture.nativeElement;
+           expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
+           expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
 
-        changeInput(compiled, 'o');
-        fixture.detectChanges();
-        expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
-        expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
-      });
-    });
+           changeInput(compiled, 'o');
+           fixture.detectChanges();
+           expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
+           expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
+         });
+       }));
 
     it('should work with model-driven form validation', () => {
       const html = `


### PR DESCRIPTION
We need to mark asynchronous tests with `async(...)` otherwise things fail miserably in RC6.