### PR TITLE
API docs: extract info from properties and interfaces

### DIFF
--- a/misc/api-doc-test-cases/interface-with-properties.ts
+++ b/misc/api-doc-test-cases/interface-with-properties.ts
@@ -1,0 +1,20 @@
+/**
+ * Represent options available when opening new modal windows.
+ */
+export interface NgbModalOptions {
+  /**
+   * Weather a backdrop element should be created for a given modal (true by default).
+   * Alternatively, specify 'static' for a backdrop which doesn't close the modal on click.
+   */
+  backdrop?: boolean | 'static';
+
+  /**
+   * Weather to close the modal when escape key is pressed (true by default).
+   */
+  keyboard?: boolean;
+
+  /**
+   * Size of a new modal window.
+   */
+  size?: 'sm' | 'lg';
+}

--- a/misc/api-doc-test-cases/services-with-properties.ts
+++ b/misc/api-doc-test-cases/services-with-properties.ts
@@ -1,0 +1,18 @@
+import {Injectable, TemplateRef} from '@angular/core';
+
+/**
+ * Service defining default values for progress bars
+ */
+@Injectable()
+export class ProgressbarConfig {
+
+  /**
+   * Maximal value to be displayed in the progressbar.
+   */
+  max = 100;
+
+  /**
+   * Voluntarily left without a default value.
+   */
+  foo: string
+}

--- a/misc/api-doc.spec.js
+++ b/misc/api-doc.spec.js
@@ -123,4 +123,19 @@ describe('APIDocVisitor', function() {
     expect(serviceDocs.methods[0].returnType).toBe('boolean');
   });
 
+  it('should extract documentation of properties from services', function() {
+    var serviceDocs = apiDoc(['./misc/api-doc-test-cases/services-with-properties.ts']).ProgressbarConfig;
+
+    expect(serviceDocs.properties.length).toBe(2);
+    expect(serviceDocs.properties[0].name).toBe('foo');
+    expect(serviceDocs.properties[0].description).toBe('Voluntarily left without a default value.');
+    expect(serviceDocs.properties[0].type).toBe('string');
+    expect(serviceDocs.properties[0].defaultValue).toBeUndefined();
+
+    expect(serviceDocs.properties[1].name).toBe('max');
+    expect(serviceDocs.properties[1].description).toBe('Maximal value to be displayed in the progressbar.');
+    expect(serviceDocs.properties[1].type).toBe('number');
+    expect(serviceDocs.properties[1].defaultValue).toBe('100');
+  });
+
 });

--- a/misc/api-doc.spec.js
+++ b/misc/api-doc.spec.js
@@ -138,4 +138,31 @@ describe('APIDocVisitor', function() {
     expect(serviceDocs.properties[1].defaultValue).toBe('100');
   });
 
+  it('should extract documentation from interfaces', function() {
+    var interfaceDocs = apiDoc(['./misc/api-doc-test-cases/interface-with-properties.ts']).NgbModalOptions;
+
+    expect(interfaceDocs.className).toBe('NgbModalOptions');
+    expect(interfaceDocs.description).toBe('Represent options available when opening new modal windows.');
+    expect(interfaceDocs.properties.length).toBe(3);
+
+    expect(interfaceDocs.properties[0].name).toBe('backdrop');
+    expect(interfaceDocs.properties[0].description)
+        .toContain('Weather a backdrop element should be created for a given modal (true by default)');
+    expect(interfaceDocs.properties[0].description)
+        .toContain("Alternatively, specify 'static' for a backdrop which doesn't close the modal on click.");
+    expect(interfaceDocs.properties[0].type).toBe('boolean | "static"');
+    expect(interfaceDocs.properties[0].defaultValue).toBeUndefined();
+
+    expect(interfaceDocs.properties[1].name).toBe('keyboard');
+    expect(interfaceDocs.properties[1].description)
+        .toBe('Weather to close the modal when escape key is pressed (true by default).');
+    expect(interfaceDocs.properties[1].type).toBe('boolean');
+    expect(interfaceDocs.properties[1].defaultValue).toBeUndefined();
+
+    expect(interfaceDocs.properties[2].name).toBe('size');
+    expect(interfaceDocs.properties[2].description).toBe('Size of a new modal window.');
+    expect(interfaceDocs.properties[2].type).toBe('"sm" | "lg"');
+    expect(interfaceDocs.properties[2].defaultValue).toBeUndefined();
+  });
+
 });


### PR DESCRIPTION
This PR builds on @jnizet work and adds extraction of API docs from interfaces. We need this new capabilities to properly document classes / interfaces for the modal window. 