### PR TITLE
chore: don't extract API docs for private properties

### DIFF
--- a/misc/api-doc-test-cases/services-with-properties.ts
+++ b/misc/api-doc-test-cases/services-with-properties.ts
@@ -14,5 +14,12 @@ export class ProgressbarConfig {
   /**
    * Voluntarily left without a default value.
    */
-  foo: string
+  foo: string;
+
+  private _dontExtract;
+
+  /**
+   * @internal
+   */
+  notForDocumentation;
 }

--- a/misc/api-doc.js
+++ b/misc/api-doc.js
@@ -131,14 +131,14 @@ class APIDocVisitor {
       } else if (outDecorator) {
         outputs.push(this.visitOutput(members[i], outDecorator));
 
-      } else if (
-          members[i].kind === ts.SyntaxKind.MethodDeclaration && !isPrivateOrInternal(members[i]) &&
-          !isAngularLifecycleHook(members[i].name.text)) {
-        methods.push(this.visitMethodDeclaration(members[i]));
-      } else if (
-          members[i].kind === ts.SyntaxKind.PropertyDeclaration ||
-          members[i].kind === ts.SyntaxKind.PropertySignature) {
-        properties.push(this.visitProperty(members[i]));
+      } else if (!isPrivateOrInternal(members[i])) {
+        if (members[i].kind === ts.SyntaxKind.MethodDeclaration && !isAngularLifecycleHook(members[i].name.text)) {
+          methods.push(this.visitMethodDeclaration(members[i]));
+        } else if (
+            members[i].kind === ts.SyntaxKind.PropertyDeclaration ||
+            members[i].kind === ts.SyntaxKind.PropertySignature) {
+          properties.push(this.visitProperty(members[i]));
+        }
       }
     }
 


### PR DESCRIPTION
This is needed to properly document modal options / value returned from the `open(...)` method call.