### PR TITLE
chore: add types to the api-docs components

### DIFF
--- a/demo/src/app/components/shared/api-docs/api-docs-class.component.ts
+++ b/demo/src/app/components/shared/api-docs/api-docs-class.component.ts
@@ -1,5 +1,6 @@
 import {Component, ChangeDetectionStrategy, Input} from '@angular/core';
 import docs from '../../../../api-docs';
+import {ClassDesc, MethodDesc, signature} from './api-docs.model';
 
 /**
  * Displays the API docs of a class, which is not a directive.
@@ -12,13 +13,10 @@ import docs from '../../../../api-docs';
   templateUrl: './api-docs-class.component.html'
 })
 export class NgbdApiDocsClass {
-  apiDocs;
-  @Input() set type(typeName) {
+  apiDocs: ClassDesc;
+  @Input() set type(typeName: string) {
     this.apiDocs = docs[typeName];
   };
 
-  methodSignature(method) {
-    const args = method.args.map(arg => `${arg.name}: ${arg.type}`).join(', ');
-    return `${method.name}(${args}): ${method.returnType}`;
-  }
+  methodSignature(method: MethodDesc): string { return signature(method); }
 }

--- a/demo/src/app/components/shared/api-docs/api-docs-config.component.ts
+++ b/demo/src/app/components/shared/api-docs/api-docs-config.component.ts
@@ -1,5 +1,6 @@
 import {Component, ChangeDetectionStrategy, Input} from '@angular/core';
 import docs from '../../../../api-docs';
+import {ClassDesc} from './api-docs.model';
 
 const CONFIG_SUFFIX_LENGTH = 'Config'.length;
 
@@ -16,10 +17,10 @@ const CONFIG_SUFFIX_LENGTH = 'Config'.length;
   templateUrl: './api-docs-config.component.html'
 })
 export class NgbdApiDocsConfig {
-  apiDocs;
-  directiveName;
+  apiDocs: ClassDesc;
+  directiveName: string;
 
-  @Input() set type(typeName) {
+  @Input() set type(typeName: string) {
     this.apiDocs = docs[typeName];
     this.directiveName = typeName.slice(0, -CONFIG_SUFFIX_LENGTH);
   };

--- a/demo/src/app/components/shared/api-docs/api-docs.component.ts
+++ b/demo/src/app/components/shared/api-docs/api-docs.component.ts
@@ -1,5 +1,6 @@
 import {Component, ChangeDetectionStrategy, Input} from '@angular/core';
 import docs from '../../../../api-docs';
+import {PropertyDesc, DirectiveDesc, InputDesc, MethodDesc, ClassDesc, signature} from './api-docs.model';
 
 /**
  * Displays the API docs of a directive.
@@ -20,12 +21,12 @@ export class NgbdApiDocs {
    * Object which contains, for each input name of the directive, the corresponding property of the associated config
    * service (if any)
    */
-  private _configProperties;
+  private _configProperties: {[propertyName: string]: PropertyDesc};
 
-  apiDocs;
-  configServiceName;
+  apiDocs: DirectiveDesc;
+  configServiceName: string;
 
-  @Input() set directive(directiveName) {
+  @Input() set directive(directiveName: string) {
     this.apiDocs = docs[directiveName];
     this.configServiceName = `${directiveName}Config`;
     const configApiDocs = docs[this.configServiceName];
@@ -40,7 +41,7 @@ export class NgbdApiDocs {
    * Returns the default value of the given directive input. If falsy, returns the default value of the matching
    * config service property
    */
-  defaultInputValue(input) {
+  defaultInputValue(input: InputDesc): string {
     if (input.defaultValue !== undefined) {
       return input.defaultValue;
     }
@@ -52,16 +53,13 @@ export class NgbdApiDocs {
   /**
    * Returns true if there is a config service property matching with the given directive input
    */
-  hasConfigProperty(input) {
+  hasConfigProperty(input: InputDesc): boolean {
     return !!this._configProperties[input.name];
   }
 
-  methodSignature(method) {
-    const args = method.args.map(arg => `${arg.name}: ${arg.type}`).join(', ');
-    return `${method.name}(${args})`;
-  }
+  methodSignature(method: MethodDesc): string { return signature(method); }
 
-  private _findInputConfigProperty(configApiDocs, input) {
+  private _findInputConfigProperty(configApiDocs: ClassDesc, input: InputDesc): PropertyDesc {
     return configApiDocs.properties.filter(prop => prop.name === input.name)[0];
   }
 }

--- a/demo/src/app/components/shared/api-docs/api-docs.model.ts
+++ b/demo/src/app/components/shared/api-docs/api-docs.model.ts
@@ -1,0 +1,42 @@
+export interface ClassDesc {
+  fileName: string;
+  className: string;
+  description: string;
+  properties: PropertyDesc[];
+  methods: MethodDesc[];
+}
+
+export interface DirectiveDesc extends ClassDesc {
+  selector: string;
+  exportAs?: string;
+  inputs: InputDesc[];
+  outputs: OutputDesc[];
+}
+
+export interface PropertyDesc {
+  name: string;
+  type: string;
+  description: string;
+  defaultValue?: string;
+}
+
+export interface MethodDesc {
+  name: string;
+  description: string;
+  args: ArgumentDesc[];
+  returnType: string;
+}
+
+export interface ArgumentDesc {
+  name: string;
+  type: string;
+}
+
+export interface InputDesc extends PropertyDesc {}
+
+export interface OutputDesc extends PropertyDesc {}
+
+export function signature(method: MethodDesc): string {
+  const args = method.args.map(arg => `${arg.name}: ${arg.type}`).join(', ');
+  return `${method.name}(${args})`;
+}

--- a/misc/api-doc.js
+++ b/misc/api-doc.js
@@ -81,6 +81,7 @@ class APIDocVisitor {
             exportAs: directiveInfo.exportAs,
             inputs: members.inputs,
             outputs: members.outputs,
+            properties: members.properties,
             methods: members.methods
           }];
         } else if (this.isServiceDecorator(classDeclaration.decorators[i])) {


### PR DESCRIPTION
The doc components are getting more complex. Adding types makes the code easier to understand and maintain.