### PR TITLE
feat(alert): add config service to provide default values

### DIFF
--- a/demo/src/app/components/alert/alert.component.ts
+++ b/demo/src/app/components/alert/alert.component.ts
@@ -7,6 +7,8 @@ import {DEMO_SNIPPETS} from './demos';
     <ngbd-content-wrapper component="Alert">
       <ngbd-api-docs directive="NgbAlert"></ngbd-api-docs>
       <ngbd-api-docs directive="NgbDismissibleAlert"></ngbd-api-docs>
+      <ngbd-api-docs-config type="NgbAlertConfig"></ngbd-api-docs-config>
+      <ngbd-api-docs-config type="NgbDismissibleAlertConfig"></ngbd-api-docs-config>
       <ngbd-example-box demoTitle="Basic Alert" [htmlSnippet]="snippets.basic.markup" [tsSnippet]="snippets.basic.code">
         <ngbd-alert-basic></ngbd-alert-basic>
       </ngbd-example-box>
@@ -18,6 +20,11 @@ import {DEMO_SNIPPETS} from './demos';
       </ngbd-example-box>
       <ngbd-example-box demoTitle="Custom Alert" [htmlSnippet]="snippets.custom.markup" [tsSnippet]="snippets.custom.code">
         <ngbd-alert-custom></ngbd-alert-custom>
+      </ngbd-example-box>
+      <ngbd-example-box demoTitle="Global configuration of alerts" 
+                        [htmlSnippet]="snippets.config.markup" 
+                        [tsSnippet]="snippets.config.code">
+        <ngbd-alert-config></ngbd-alert-config>
       </ngbd-example-box>
     </ngbd-content-wrapper>
   `

--- a/demo/src/app/components/alert/demos/config/alert-config.html
+++ b/demo/src/app/components/alert/demos/config/alert-config.html
@@ -1,0 +1,11 @@
+<p>
+  <ngb-alert>
+    This alert's type is success and it's not dismissible because the config has been customized
+  </ngb-alert>
+</p>
+<p *ngFor="let alert of alerts">
+  <template ngbAlert>{{ alert }}</template>
+</p>
+<p>
+  <button class="btn btn-primary" (click)="addAlert()">Add self-closing alert</button>
+</p>

--- a/demo/src/app/components/alert/demos/config/alert-config.ts
+++ b/demo/src/app/components/alert/demos/config/alert-config.ts
@@ -1,0 +1,24 @@
+import {Component, Input} from '@angular/core';
+import {NgbAlertConfig, NgbDismissibleAlertConfig} from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+  selector: 'ngbd-alert-config',
+  templateUrl: './alert-config.html',
+  // add NgbProgressbarConfig and NgbDismissibleAlertConfig to the component providers
+  providers: [NgbAlertConfig, NgbDismissibleAlertConfig]
+})
+export class NgbdAlertConfig {
+  @Input() public alerts: Array<string> = [];
+
+  constructor(alertConfig: NgbAlertConfig, dismissibleAlertConfig: NgbDismissibleAlertConfig) {
+    // customize default values of alerts used by this component tree
+    alertConfig.type = 'success';
+    alertConfig.dismissible = false;
+    dismissibleAlertConfig.dismissOnTimeout = 5000;
+    dismissibleAlertConfig.type = 'danger';
+  }
+
+  public addAlert() {
+    this.alerts.push('This alert has type danger and will close automatically after 5 seconds thanks to the custom config');
+  }
+}

--- a/demo/src/app/components/alert/demos/index.ts
+++ b/demo/src/app/components/alert/demos/index.ts
@@ -2,20 +2,30 @@ import {NgbdAlertBasic} from './basic/alert-basic';
 import {NgbdAlertCloseable} from './closeable/alert-closeable';
 import {NgbdAlertCustom} from './custom/alert-custom';
 import {NgbdAlertSelfclosing} from './selfclosing/alert-selfclosing';
+import {NgbdAlertConfig} from './config/alert-config';
 
-export const DEMO_DIRECTIVES = [NgbdAlertBasic, NgbdAlertCloseable, NgbdAlertCustom, NgbdAlertSelfclosing];
+export const DEMO_DIRECTIVES =
+    [NgbdAlertBasic, NgbdAlertCloseable, NgbdAlertCustom, NgbdAlertSelfclosing, NgbdAlertConfig];
 
 export const DEMO_SNIPPETS = {
   basic: {
     code: require('!!prismjs?lang=typescript!./basic/alert-basic'),
-    markup: require('!!prismjs?lang=markup!./basic/alert-basic.html')},
+    markup: require('!!prismjs?lang=markup!./basic/alert-basic.html')
+  },
   closeable: {
     code: require('!!prismjs?lang=typescript!./closeable/alert-closeable'),
-    markup: require('!!prismjs?lang=markup!./closeable/alert-closeable.html')},
+    markup: require('!!prismjs?lang=markup!./closeable/alert-closeable.html')
+  },
   custom: {
     code: require('!!prismjs?lang=typescript!./custom/alert-custom'),
-    markup: require('!!prismjs?lang=markup!./custom/alert-custom.html')},
+    markup: require('!!prismjs?lang=markup!./custom/alert-custom.html')
+  },
   selfClosing: {
     code: require('!!prismjs?lang=typescript!./selfclosing/alert-selfclosing'),
-    markup: require('!!prismjs?lang=markup!./selfclosing/alert-selfclosing.html')}
+    markup: require('!!prismjs?lang=markup!./selfclosing/alert-selfclosing.html')
+  },
+  config: {
+    code: require('!!prismjs?lang=typescript!./config/alert-config'),
+    markup: require('!!prismjs?lang=markup!./config/alert-config.html')
+  }
 };

--- a/src/alert/alert-config.spec.ts
+++ b/src/alert/alert-config.spec.ts
@@ -1,0 +1,19 @@
+import {NgbAlertConfig, NgbDismissibleAlertConfig} from './alert-config';
+
+describe('ngb-alert-config', () => {
+  it('should have sensible default values', () => {
+    const config = new NgbAlertConfig();
+
+    expect(config.dismissible).toBe(true);
+    expect(config.type).toBe('warning');
+  });
+});
+
+describe('ngb-dismissible-alert-config', () => {
+  it('should have sensible default values', () => {
+    const config = new NgbDismissibleAlertConfig();
+
+    expect(config.type).toBe('warning');
+    expect(config.dismissOnTimeout).toBeUndefined();
+  });
+});

--- a/src/alert/alert-config.ts
+++ b/src/alert/alert-config.ts
@@ -1,0 +1,23 @@
+import {Injectable} from '@angular/core';
+
+/**
+ * Configuration service for the NgbAlert component.
+ * You can inject this service, typically in your root component, and customize the values of its properties in
+ * order to provide default values for all the alerts used in the application.
+ */
+@Injectable()
+export class NgbAlertConfig {
+  dismissible = true;
+  type = 'warning';
+}
+
+/**
+ * Configuration service for the NgbDismissibleAlert component.
+ * You can inject this service, typically in your root component, and customize the values of its properties in
+ * order to provide default values for all the dismissible alerts used in the application.
+ */
+@Injectable()
+export class NgbDismissibleAlertConfig {
+  type = 'warning';
+  dismissOnTimeout: number;
+}

--- a/src/alert/alert.module.ts
+++ b/src/alert/alert.module.ts
@@ -2,12 +2,16 @@ import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NGB_ALERT_DIRECTIVES, NgbAlert} from './alert';
+import {NgbAlertConfig, NgbDismissibleAlertConfig} from './alert-config';
+
+export {NgbAlertConfig, NgbDismissibleAlertConfig} from './alert-config';
 
 @NgModule({
   declarations: NGB_ALERT_DIRECTIVES,
   exports: NGB_ALERT_DIRECTIVES,
   imports: [CommonModule],
-  entryComponents: [NgbAlert]
+  entryComponents: [NgbAlert],
+  providers: [NgbAlertConfig, NgbDismissibleAlertConfig]
 })
 export class NgbAlertModule {
 }

--- a/src/alert/alert.spec.ts
+++ b/src/alert/alert.spec.ts
@@ -1,10 +1,11 @@
-import {fakeAsync, tick, TestBed, ComponentFixture} from '@angular/core/testing';
+import {fakeAsync, tick, TestBed, ComponentFixture, inject} from '@angular/core/testing';
 import {createGenericTestComponent} from '../util/tests';
 
 import {Component} from '@angular/core';
 
 import {NgbAlertModule} from './alert.module';
 import {NgbAlert, NgbDismissibleAlert} from './alert';
+import {NgbAlertConfig, NgbDismissibleAlertConfig} from './alert-config';
 
 const createTestComponent = (html: string) =>
     createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
@@ -21,79 +22,179 @@ describe('ngb-alert', () => {
 
   beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAlertModule]}); });
 
-  it('should have type warning and by dismissible by default', () => {
-    const fixture = createTestComponent('<ngb-alert>Watch out!</ngb-alert>');
-    const alertEl = getAlertElement(fixture.nativeElement);
+  it('should initialize inputs with default values', () => {
+    const defaultConfig = new NgbAlertConfig();
+    const alertCmp = new NgbAlert(new NgbAlertConfig());
 
-    expect(alertEl).toHaveCssClass('alert-warning');
-    expect(alertEl.getAttribute('role')).toEqual('alert');
-    expect(getCloseButton(alertEl)).toBeTruthy();
+    expect(alertCmp.dismissible).toBe(defaultConfig.dismissible);
+    expect(alertCmp.type).toBe(defaultConfig.type);
   });
 
   it('should allow specifying alert type', () => {
     const fixture = createTestComponent('<ngb-alert type="success">Cool!</ngb-alert>');
-    expect(getAlertElement(fixture.nativeElement)).toHaveCssClass('alert-success');
+    const alertEl = getAlertElement(fixture.nativeElement);
+
+    expect(alertEl.getAttribute('role')).toEqual('alert');
+    expect(alertEl).toHaveCssClass('alert-success');
+  });
+
+  it('should render close button when dismissible', () => {
+    const fixture = createTestComponent('<ngb-alert [dismissible]="true">Watch out!</ngb-alert>');
+
+    expect(getCloseButton(getAlertElement(fixture.nativeElement))).toBeTruthy();
   });
 
   it('should render close button only if dismissible', () => {
     const fixture = createTestComponent(`<ngb-alert [dismissible]="false">Don't close!</ngb-alert>`);
     expect(getCloseButton(getAlertElement(fixture.nativeElement))).toBeFalsy();
   });
+
+  describe('Custom config', () => {
+    let config: NgbAlertConfig;
+
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbAlertModule]}); });
+
+    beforeEach(inject([NgbAlertConfig], (c: NgbAlertConfig) => {
+      config = c;
+      config.dismissible = false;
+      config.type = 'success';
+    }));
+
+    it('should initialize inputs with provided config', () => {
+      const fixture = TestBed.createComponent(NgbAlert);
+      fixture.detectChanges();
+
+      const alert = fixture.componentInstance;
+      expect(alert.dismissible).toBe(config.dismissible);
+      expect(alert.type).toBe(config.type);
+    });
+  });
+
+  describe('Custom config as provider', () => {
+    let config = new NgbAlertConfig();
+    config.dismissible = false;
+    config.type = 'success';
+
+    beforeEach(() => {
+      TestBed.configureTestingModule(
+          {imports: [NgbAlertModule], providers: [{provide: NgbAlertConfig, useValue: config}]});
+    });
+
+    it('should initialize inputs with provided config as provider', () => {
+      const fixture = TestBed.createComponent(NgbAlert);
+      fixture.detectChanges();
+
+      const alert = fixture.componentInstance;
+      expect(alert.dismissible).toBe(config.dismissible);
+      expect(alert.type).toBe(config.type);
+    });
+  });
 });
 
 describe('NgbDismissibleAlert', () => {
 
-  beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAlertModule]}); });
+  describe('UI logic', () => {
+    beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAlertModule]}); });
 
-  it('should open a dismissible alert with default type', () => {
-    const fixture = createTestComponent(`<template ngbAlert>Hello, {{name}}!</template>`);
-    const alertEl = getAlertElement(fixture.nativeElement);
+    it('should open a dismissible alert with default type', () => {
+      const defaultConfig = new NgbDismissibleAlertConfig();
+      const fixture = createTestComponent(`<template ngbAlert>Hello, {{name}}!</template>`);
+      const alertEl = getAlertElement(fixture.nativeElement);
 
-    expect(alertEl).toHaveCssClass('alert-warning');
-    expect(alertEl.getAttribute('role')).toEqual('alert');
-    expect(getCloseButton(alertEl)).toBeTruthy();
+      expect(alertEl).toHaveCssClass(`alert-${defaultConfig.type}`);
+      expect(alertEl.getAttribute('role')).toEqual('alert');
+      expect(getCloseButton(alertEl)).toBeTruthy();
 
-    getCloseButton(alertEl).click();
-    fixture.detectChanges();
-    expect(getAlertElement(fixture.nativeElement)).toBeNull();
+      getCloseButton(alertEl).click();
+      fixture.detectChanges();
+      expect(getAlertElement(fixture.nativeElement)).toBeNull();
+    });
+
+    it('should open a dismissible alert with a specified type', () => {
+      const fixture = createTestComponent(`<template ngbAlert type="success">Hello, {{name}}!</template>`);
+      const alertEl = getAlertElement(fixture.nativeElement);
+
+      expect(alertEl).toHaveCssClass('alert-success');
+      expect(getCloseButton(alertEl)).toBeTruthy();
+    });
+
+    it('should dismiss alert and invoke close handler on close button click', () => {
+      const fixture = createTestComponent(`<template ngbAlert (close)="closed = true">Hello, {{name}}!</template>`);
+      const alertEl = getAlertElement(fixture.nativeElement);
+
+      getCloseButton(alertEl).click();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.closed).toBeTruthy();
+      expect(getAlertElement(fixture.nativeElement)).toBeNull();
+    });
+
+    it('should auto close on timeout specified', fakeAsync(() => {
+         const fixture =
+             createTestComponent(`<template ngbAlert [dismissOnTimeout]="1000">Hello, {{name}}!</template>`);
+         const alertEl = getAlertElement(fixture.nativeElement);
+
+         expect(alertEl.getAttribute('role')).toEqual('alert');
+         expect(getCloseButton(alertEl)).toBeTruthy();
+
+         tick(800);
+         fixture.detectChanges();
+         expect(alertEl.getAttribute('role')).toEqual('alert');
+         expect(getCloseButton(alertEl)).toBeTruthy();
+
+         tick(1200);
+         fixture.detectChanges();
+         expect(getAlertElement(fixture.nativeElement)).toBeNull();
+       }));
   });
 
-  it('should open a dismissible alert with a specified type', () => {
-    const fixture = createTestComponent(`<template ngbAlert type="success">Hello, {{name}}!</template>`);
-    const alertEl = getAlertElement(fixture.nativeElement);
+  describe('Custom config', () => {
 
-    expect(alertEl).toHaveCssClass('alert-success');
-    expect(getCloseButton(alertEl)).toBeTruthy();
+    beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAlertModule]}); });
+
+    it('should initialize inputs with provided config', () => {
+      let config: NgbDismissibleAlertConfig;
+      const fixture = createTestComponent(`<template ngbAlert>Hello, {{name}}!</template>`);
+      inject([NgbDismissibleAlertConfig], (c: NgbDismissibleAlertConfig) => {
+        config = c;
+        config.dismissOnTimeout = 2000;
+        config.type = 'success';
+      });
+
+      fakeAsync(() => {
+        const alertEl = getAlertElement(fixture.nativeElement);
+
+        expect(alertEl).toHaveCssClass(`alert-${config.type}`);
+        tick(config.dismissOnTimeout);
+        fixture.detectChanges();
+        expect(getAlertElement(fixture.nativeElement)).toBeNull();
+      });
+    });
   });
 
+  describe('Custom config as provider', () => {
+    const config = new NgbDismissibleAlertConfig();
+    config.dismissOnTimeout = 2000;
+    config.type = 'success';
 
-  it('should dismiss alert and invoke close handler on close button click', () => {
-    const fixture = createTestComponent(`<template ngbAlert (close)="closed = true">Hello, {{name}}!</template>`);
-    const alertEl = getAlertElement(fixture.nativeElement);
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        declarations: [TestComponent],
+        imports: [NgbAlertModule],
+        providers: [{provide: NgbDismissibleAlertConfig, useValue: config}]
+      });
+    });
 
-    getCloseButton(alertEl).click();
-    fixture.detectChanges();
+    it('should initialize inputs with provided config as provider', fakeAsync(() => {
+         const fixture = createTestComponent(`<template ngbAlert>Hello, {{name}}!</template>`);
+         const alertEl = getAlertElement(fixture.nativeElement);
 
-    expect(fixture.componentInstance.closed).toBeTruthy();
-    expect(getAlertElement(fixture.nativeElement)).toBeNull();
+         expect(alertEl).toHaveCssClass(`alert-${config.type}`);
+         tick(config.dismissOnTimeout);
+         fixture.detectChanges();
+         expect(getAlertElement(fixture.nativeElement)).toBeNull();
+       }));
   });
-
-  it('should auto close on timeout specified', fakeAsync(() => {
-       const fixture = createTestComponent(`<template ngbAlert [dismissOnTimeout]="1000">Hello, {{name}}!</template>`);
-       const alertEl = getAlertElement(fixture.nativeElement);
-
-       expect(alertEl.getAttribute('role')).toEqual('alert');
-       expect(getCloseButton(alertEl)).toBeTruthy();
-
-       tick(800);
-       fixture.detectChanges();
-       expect(alertEl.getAttribute('role')).toEqual('alert');
-       expect(getCloseButton(alertEl)).toBeTruthy();
-
-       tick(1200);
-       fixture.detectChanges();
-       expect(getAlertElement(fixture.nativeElement)).toBeNull();
-     }));
 });
 
 @Component({selector: 'test-cmp', template: '', entryComponents: [NgbAlert]})

--- a/src/alert/alert.ts
+++ b/src/alert/alert.ts
@@ -16,6 +16,7 @@ import {
 } from '@angular/core';
 
 import {PopupService} from '../util/popup';
+import {NgbAlertConfig, NgbDismissibleAlertConfig} from './alert-config';
 
 /**
  * Alerts can be used to provide feedback messages.
@@ -37,15 +38,20 @@ export class NgbAlert {
    * A flag indicating if a given alert can be dismissed (closed) by a user. If this flag is set, a close button (in a
    * form of a cross) will be displayed.
    */
-  @Input() dismissible = true;
+  @Input() dismissible: boolean;
   /**
    * Alert type (CSS class). Bootstrap 4 recognizes the following types: "success", "info", "warning" and "danger".
    */
-  @Input() type = 'warning';
+  @Input() type: string;
   /**
    * An event emitted when the close button is clicked. This event has no payload. Only relevant for dismissible alerts.
    */
   @Output() close = new EventEmitter();
+
+  constructor(config: NgbAlertConfig) {
+    this.dismissible = config.dismissible;
+    this.type = config.type;
+  }
 
   closeHandler() { this.close.emit(null); }
 }
@@ -56,13 +62,12 @@ export class NgbAlert {
 @Directive({selector: 'template[ngbAlert]'})
 export class NgbDismissibleAlert implements OnInit, OnDestroy {
   private _popupService: PopupService<NgbAlert>;
-  private _windowRef: ComponentRef<NgbAlert>;
   private _timeout;
 
   /**
    * Alert type (CSS class). Bootstrap 4 recognizes the following types: "success", "info", "warning" and "danger".
    */
-  @Input() type = 'warning';
+  @Input() type: string;
   /**
    * An event emitted when the close button is clicked.
    */
@@ -74,17 +79,19 @@ export class NgbDismissibleAlert implements OnInit, OnDestroy {
 
   constructor(
       private _templateRef: TemplateRef<Object>, viewContainerRef: ViewContainerRef, injector: Injector,
-      componentFactoryResolver: ComponentFactoryResolver, renderer: Renderer) {
+      componentFactoryResolver: ComponentFactoryResolver, renderer: Renderer, config: NgbDismissibleAlertConfig) {
     this._popupService =
         new PopupService<NgbAlert>(NgbAlert, injector, viewContainerRef, renderer, componentFactoryResolver);
+    this.type = config.type;
+    this.dismissOnTimeout = config.dismissOnTimeout;
   }
 
   close(): void { this._popupService.close(); }
 
   ngOnInit() {
-    this._windowRef = this._popupService.open(this._templateRef);
-    this._windowRef.instance.type = this.type;
-    this._windowRef.instance.close.subscribe(($event) => {
+    const windowRef = this._popupService.open(this._templateRef);
+    windowRef.instance.type = this.type;
+    windowRef.instance.close.subscribe(($event) => {
       this.closeEvent.emit($event);
       this.close();
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,9 +19,10 @@ import {NgbTypeaheadModule} from './typeahead/typeahead.module';
 export {NgbPanelChangeEvent, NgbAccordionConfig} from './accordion/accordion.module';
 export {NgbModal, NgbModalOptions, NgbModalRef, ModalDismissReasons} from './modal/modal.module';
 export {NgbTabChangeEvent} from './tabset/tabset.module';
-export {NgbProgressbarConfig} from './progressbar/progressbar.module';
+export {NgbAlertConfig, NgbDismissibleAlertConfig} from './alert/alert.module';
 export {NgbCarouselConfig} from './carousel/carousel.module';
 export {NgbPaginationConfig} from './pagination/pagination.module';
+export {NgbProgressbarConfig} from './progressbar/progressbar.module';
 
 @NgModule({
   exports: [


### PR DESCRIPTION
refs #518

I suffered with the tests of NgbDismissibleAlert because creating an instance of this component using new or with the TestBed is harder than with other components: it has many dependencies thatare used in the constructor. Instead of trying to mock them all or to change the code of the component just to ease that test, I thus used a slightly different test strategy than for the other components. 