### PR TITLE
docs: add missing docs on event payloads and template contexts

### DIFF
--- a/demo/src/app/components/accordion/accordion.component.ts
+++ b/demo/src/app/components/accordion/accordion.component.ts
@@ -9,6 +9,7 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-api-docs directive="NgbPanel"></ngbd-api-docs>
       <ngbd-api-docs directive="NgbPanelTitle"></ngbd-api-docs>
       <ngbd-api-docs directive="NgbPanelContent"></ngbd-api-docs>
+      <ngbd-api-docs-class type="NgbPanelChangeEvent"></ngbd-api-docs-class>
       <ngbd-example-box demoTitle="Accordion" [htmlSnippet]="snippets.basic.markup" [tsSnippet]="snippets.basic.code">
         <ngbd-accordion-basic></ngbd-accordion-basic>
       </ngbd-example-box>

--- a/demo/src/app/components/tabset/tabset.component.ts
+++ b/demo/src/app/components/tabset/tabset.component.ts
@@ -9,6 +9,7 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-api-docs directive="NgbTab"></ngbd-api-docs>
       <ngbd-api-docs directive="NgbTabTitle"></ngbd-api-docs>
       <ngbd-api-docs directive="NgbTabContent"></ngbd-api-docs>
+      <ngbd-api-docs-class type="NgbTabChangeEvent"></ngbd-api-docs-class>
       <ngbd-example-box demoTitle="Tabset" [htmlSnippet]="snippets.basic.markup" [tsSnippet]="snippets.basic.code">
         <ngbd-tabset-basic></ngbd-tabset-basic>
       </ngbd-example-box>

--- a/demo/src/app/components/typeahead/typeahead.component.ts
+++ b/demo/src/app/components/typeahead/typeahead.component.ts
@@ -6,6 +6,7 @@ import {DEMO_SNIPPETS} from './demos';
   template: `
     <ngbd-content-wrapper component="Typeahead">
       <ngbd-api-docs directive="NgbTypeahead"></ngbd-api-docs>
+      <ngbd-api-docs-class type="ResultTemplateContext"></ngbd-api-docs-class>
       <ngbd-example-box demoTitle="Simple Typeahead" [htmlSnippet]="snippets.basic.markup" [tsSnippet]="snippets.basic.code">
         <ngbd-typeahead-basic></ngbd-typeahead-basic>
       </ngbd-example-box>

--- a/src/accordion/accordion.ts
+++ b/src/accordion/accordion.ts
@@ -63,12 +63,23 @@ export class NgbPanel {
 }
 
 /**
- * The payload of the panel change event
+ * The payload of the change event fired right before toggling an accordion panel
  */
 export interface NgbPanelChangeEvent {
+  /**
+   * Id of the accordion panel that is toggled
+   */
   panelId: string;
+
+  /**
+   * Whether the panel will be opened (true) or closed (false)
+   */
   nextState: boolean;
-  preventDefault();
+
+  /**
+   * Function that will prevent panel toggling if called
+   */
+  preventDefault: () => void;
 }
 
 /**
@@ -113,9 +124,7 @@ export class NgbAccordion implements AfterContentChecked {
 
 
   /**
-   * A panel change event fired right before the panel toggle happens. The event object has three properties:
-   * 'panelId', the id of panel that id toggled, 'nextState' whether panel will be opened (true) or closed (false),
-   * and a function, 'preventDefault()' which, when executed, will prevent the panel toggle from occurring.
+   * A panel change event fired right before the panel toggle happens. See NgbPanelChangeEvent for payload details
    */
   @Output() change = new EventEmitter<NgbPanelChangeEvent>();
 

--- a/src/tabset/tabset.ts
+++ b/src/tabset/tabset.ts
@@ -52,12 +52,23 @@ export class NgbTab {
 }
 
 /**
- * The payload of the tab change event
+ * The payload of the change event fired right before the tab change
  */
 export interface NgbTabChangeEvent {
+  /**
+   * Id of the currently active tab
+   */
   activeId: string;
+
+  /**
+   * Id of the newly selected tab
+   */
   nextId: string;
-  preventDefault();
+
+  /**
+   * Function that will prevent tab switch if called
+   */
+  preventDefault: () => void;
 }
 
 /**
@@ -98,9 +109,7 @@ export class NgbTabset implements AfterContentChecked {
   @Input() type = 'tabs';
 
   /**
-   * A tab change event fired right before the tab selection happens.  The event object has three properties:
-   * 'activeId', the id of the currently active tab, 'nextId' the id of the newly selected tab, and a function,
-   * 'preventDefault()' which, when executed, will prevent the tab change from occurring.
+   * A tab change event fired right before the tab selection happens. See NgbTabChangeEvent for payload details
    */
   @Output() change = new EventEmitter<NgbTabChangeEvent>();
 

--- a/src/typeahead/typeahead-window.ts
+++ b/src/typeahead/typeahead-window.ts
@@ -2,11 +2,20 @@ import {Component, Input, Output, EventEmitter, TemplateRef} from '@angular/core
 
 import {toString} from '../util/util';
 
-export type ResultTplCtx = {
-  result: any,
-  term: string,
-  formatter: (_: string) => string
-};
+/**
+ * Context for the typeahead result template in case you want to override the default one
+ */
+export interface ResultTemplateContext {
+  /**
+   * Your typeahead result data model
+   */
+  result: any;
+
+  /**
+   * Search term from the input used to get current result
+   */
+  term: string;
+}
 
 @Component({
   selector: 'ngb-typeahead-window',
@@ -41,17 +50,17 @@ export class NgbTypeaheadWindow {
 
   /**
    * A function used to format a given result before display. This function should return a formatted string without any
-   * HTML markup.
+   * HTML markup
    */
   @Input() formatter = toString;
 
   /**
-   * A template to display a matching result.
+   * A template to override a matching result default display
    */
-  @Input() resultTemplate: TemplateRef<ResultTplCtx>;
+  @Input() resultTemplate: TemplateRef<ResultTemplateContext>;
 
   /**
-   * Event raised when users selects a particular result row.
+   * Event raised when user selects a particular result row
    */
   @Output('select') selectEvent = new EventEmitter();
 

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -19,7 +19,7 @@ import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {Observable, Subject, Subscription} from 'rxjs/Rx';
 import 'rxjs/add/operator/let';
 import {Positioning} from '../util/positioning';
-import {NgbTypeaheadWindow, ResultTplCtx} from './typeahead-window';
+import {NgbTypeaheadWindow, ResultTemplateContext} from './typeahead-window';
 import {PopupService} from '../util/popup';
 import {toString} from '../util/util';
 
@@ -75,17 +75,17 @@ export class NgbTypeahead implements OnInit,
 
   /**
    * A function to format a given result before display. This function should return a formatted string without any
-   * HTML markup.
+   * HTML markup
    */
   @Input() resultFormatter: (value: any) => string;
 
   /**
-   * A template to display a matching result.
+   * A template to override a matching result default display
    */
-  @Input() resultTemplate: TemplateRef<ResultTplCtx>;
+  @Input() resultTemplate: TemplateRef<ResultTemplateContext>;
 
   /**
-   * An event emitted when a match is selected. Event payload is equal to the selected item.
+   * An event emitted when a match is selected. Event payload is equal to the selected item
    */
   @Output() selectItem = new EventEmitter();
 


### PR DESCRIPTION
Adding previously missing docs:

- accordion: `NgbPanelChangeEvent`
- tabset: `NgbTabChangeEvent`
- typeahead: `ResultTemplateContext`
