### PR TITLE
test: ability to exclude certain tests for certain browsers

### DIFF
--- a/src/util/tests.spec.ts
+++ b/src/util/tests.spec.ts
@@ -1,0 +1,52 @@
+import {getBrowser, isBrowser} from './tests';
+
+const sampleAgents = {
+  ie9: 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 7.1; Trident/5.0)',
+  ie10: 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)',
+  ie11: 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko',
+  edge:
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246',
+  chrome: 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36',
+  safari:
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A',
+  unknown: 'Something that wont match at all'
+};
+
+describe('test-tools', () => {
+
+  describe('getBrowser()', () => {
+
+    it('should detect browsers', () => {
+      expect(getBrowser(sampleAgents.ie11)).toBe('ie11');
+      expect(getBrowser(sampleAgents.ie10)).toBe('ie10');
+      expect(getBrowser(sampleAgents.ie9)).toBe('ie9');
+      expect(getBrowser(sampleAgents.edge)).toBe('edge');
+      expect(getBrowser(sampleAgents.chrome)).toBe('chrome');
+      expect(getBrowser(sampleAgents.safari)).toBe('safari');
+    });
+
+    it('should crash for an unknown browser', () => { expect(() => { getBrowser(sampleAgents.unknown); }).toThrow(); });
+  });
+
+  describe('isBrowser()', () => {
+
+    it('should match browser to the current one', () => {
+      expect(isBrowser('ie9', sampleAgents.ie9)).toBeTruthy();
+      expect(isBrowser('ie9', sampleAgents.ie10)).toBeFalsy();
+    });
+
+    it('should match an array of browsers to the current one', () => {
+      expect(isBrowser(['ie10', 'ie11'], sampleAgents.ie9)).toBeFalsy();
+      expect(isBrowser(['ie9', 'ie11'], sampleAgents.ie9)).toBeTruthy();
+    });
+
+    it('should match all ie browsers as one', () => {
+      expect(isBrowser('ie', sampleAgents.ie9)).toBeTruthy();
+      expect(isBrowser(['ie'], sampleAgents.ie10)).toBeTruthy();
+      expect(isBrowser(['ie', 'edge'], sampleAgents.ie11)).toBeTruthy();
+      expect(isBrowser('edge', sampleAgents.ie11)).toBeFalsy();
+    });
+  });
+
+
+});

--- a/src/util/tests.ts
+++ b/src/util/tests.ts
@@ -6,3 +6,53 @@ export function createGenericTestComponent<T>(html: string, type: {new (...args:
   fixture.detectChanges();
   return fixture as ComponentFixture<T>;
 }
+
+type Browser = 'ie9' | 'ie10' | 'ie11' | 'ie' | 'edge' | 'chrome' | 'safari';
+
+export function getBrowser(ua = window.navigator.userAgent) {
+  let browser = 'unknown';
+
+  // IE < 11
+  const msie = ua.indexOf('MSIE ');
+  if (msie > 0) {
+    return 'ie' + parseInt(ua.substring(msie + 5, ua.indexOf('.', msie)), 10);
+  }
+
+  // IE 11
+  if (ua.indexOf('Trident/') > 0) {
+    let rv = ua.indexOf('rv:');
+    return 'ie' + parseInt(ua.substring(rv + 3, ua.indexOf('.', rv)), 10);
+  }
+
+  // Edge
+  if (ua.indexOf('Edge/') > 0) {
+    return 'edge';
+  }
+
+  // Chrome
+  if (ua.indexOf('Chrome/') > 0) {
+    return 'chrome';
+  }
+
+  // Safari
+  if (ua.indexOf('Safari/') > 0) {
+    return 'safari';
+  }
+
+  if (browser === 'unknown') {
+    throw new Error('Browser detection failed for test exclusion');
+  }
+
+  return browser;
+}
+
+export function isBrowser(browsers: Browser | Browser[], ua = window.navigator.userAgent) {
+  let browsersStr = Array.isArray(browsers) ? (browsers as Browser[]).map(x => x.toString()) : [browsers.toString()];
+  let browser = getBrowser(ua);
+
+  if (browsersStr.indexOf('ie') > -1 && browser.startsWith('ie')) {
+    return true;
+  } else {
+    return browsersStr.indexOf(browser) > -1;
+  }
+}


### PR DESCRIPTION
Ability to exclude certain tests from execution in certain browsers needed by #618 and #640 

```javascript
it_disableFor(['ie9', 'ie10'], 'test description' () => {
  // ...
});

xit_disableFor(...)

fit_disableFor(...)
```
Simplest version, might be enhanced to support async, timeouts, later, etc