### PR TITLE
chore: fix build

### DIFF
--- a/src/util/tests.ts
+++ b/src/util/tests.ts
@@ -7,7 +7,7 @@ export function createGenericTestComponent<T>(html: string, type: {new (...args:
   return fixture as ComponentFixture<T>;
 }
 
-type Browser = 'ie9' | 'ie10' | 'ie11' | 'ie' | 'edge' | 'chrome' | 'safari' | 'firefox';
+export type Browser = 'ie9' | 'ie10' | 'ie11' | 'ie' | 'edge' | 'chrome' | 'safari' | 'firefox';
 
 export function getBrowser(ua = window.navigator.userAgent) {
   let browser = 'unknown';


### PR DESCRIPTION
Without this fix, the build fails with `error TS4078: Parameter 'browsers' of exported function has or is using private name 'Browser'`.