### PR TITLE
feat(alert): self-closing alerts are non-dismissible by default

### DIFF
--- a/demo/src/app/components/alert/alert.component.ts
+++ b/demo/src/app/components/alert/alert.component.ts
@@ -6,9 +6,9 @@ import {DEMO_SNIPPETS} from './demos';
   template: `
     <ngbd-content-wrapper component="Alert">
       <ngbd-api-docs directive="NgbAlert"></ngbd-api-docs>
-      <ngbd-api-docs directive="NgbDismissibleAlert"></ngbd-api-docs>
+      <ngbd-api-docs directive="NgbSelfClosingAlert"></ngbd-api-docs>
       <ngbd-api-docs-config type="NgbAlertConfig"></ngbd-api-docs-config>
-      <ngbd-api-docs-config type="NgbDismissibleAlertConfig"></ngbd-api-docs-config>
+      <ngbd-api-docs-config type="NgbSelfClosingAlertConfig"></ngbd-api-docs-config>
       <ngbd-example-box demoTitle="Basic Alert" [htmlSnippet]="snippets.basic.markup" [tsSnippet]="snippets.basic.code">
         <ngbd-alert-basic></ngbd-alert-basic>
       </ngbd-example-box>

--- a/demo/src/app/components/alert/demos/config/alert-config.ts
+++ b/demo/src/app/components/alert/demos/config/alert-config.ts
@@ -1,21 +1,22 @@
 import {Component, Input} from '@angular/core';
-import {NgbAlertConfig, NgbDismissibleAlertConfig} from '@ng-bootstrap/ng-bootstrap';
+import {NgbAlertConfig, NgbSelfClosingAlertConfig} from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
   selector: 'ngbd-alert-config',
   templateUrl: './alert-config.html',
-  // add NgbProgressbarConfig and NgbDismissibleAlertConfig to the component providers
-  providers: [NgbAlertConfig, NgbDismissibleAlertConfig]
+  // add NgbProgressbarConfig and NgbSelfClosingAlertConfig to the component providers
+  providers: [NgbAlertConfig, NgbSelfClosingAlertConfig]
 })
 export class NgbdAlertConfig {
   @Input() public alerts: Array<string> = [];
 
-  constructor(alertConfig: NgbAlertConfig, dismissibleAlertConfig: NgbDismissibleAlertConfig) {
+  constructor(alertConfig: NgbAlertConfig, selfClosingAlertConfig: NgbSelfClosingAlertConfig) {
     // customize default values of alerts used by this component tree
     alertConfig.type = 'success';
     alertConfig.dismissible = false;
-    dismissibleAlertConfig.dismissOnTimeout = 5000;
-    dismissibleAlertConfig.type = 'danger';
+    selfClosingAlertConfig.dismissible = true;
+    selfClosingAlertConfig.dismissOnTimeout = 5000;
+    selfClosingAlertConfig.type = 'danger';
   }
 
   public addAlert() {

--- a/src/alert/alert-config.spec.ts
+++ b/src/alert/alert-config.spec.ts
@@ -1,4 +1,4 @@
-import {NgbAlertConfig, NgbDismissibleAlertConfig} from './alert-config';
+import {NgbAlertConfig, NgbSelfClosingAlertConfig} from './alert-config';
 
 describe('ngb-alert-config', () => {
   it('should have sensible default values', () => {
@@ -9,10 +9,11 @@ describe('ngb-alert-config', () => {
   });
 });
 
-describe('ngb-dismissible-alert-config', () => {
+describe('ngb-self-closing-alert-config', () => {
   it('should have sensible default values', () => {
-    const config = new NgbDismissibleAlertConfig();
+    const config = new NgbSelfClosingAlertConfig();
 
+    expect(config.dismissible).toBe(false);
     expect(config.type).toBe('warning');
     expect(config.dismissOnTimeout).toBeUndefined();
   });

--- a/src/alert/alert-config.ts
+++ b/src/alert/alert-config.ts
@@ -12,12 +12,13 @@ export class NgbAlertConfig {
 }
 
 /**
- * Configuration service for the NgbDismissibleAlert component.
+ * Configuration service for the NgbSelfClosingAlert component.
  * You can inject this service, typically in your root component, and customize the values of its properties in
- * order to provide default values for all the dismissible alerts used in the application.
+ * order to provide default values for all the self-closing alerts used in the application.
  */
 @Injectable()
-export class NgbDismissibleAlertConfig {
+export class NgbSelfClosingAlertConfig {
+  dismissible = false;
   type = 'warning';
   dismissOnTimeout: number;
 }

--- a/src/alert/alert.module.ts
+++ b/src/alert/alert.module.ts
@@ -2,16 +2,16 @@ import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NGB_ALERT_DIRECTIVES, NgbAlert} from './alert';
-import {NgbAlertConfig, NgbDismissibleAlertConfig} from './alert-config';
+import {NgbAlertConfig, NgbSelfClosingAlertConfig} from './alert-config';
 
-export {NgbAlertConfig, NgbDismissibleAlertConfig} from './alert-config';
+export {NgbAlertConfig, NgbSelfClosingAlertConfig} from './alert-config';
 
 @NgModule({
   declarations: NGB_ALERT_DIRECTIVES,
   exports: NGB_ALERT_DIRECTIVES,
   imports: [CommonModule],
   entryComponents: [NgbAlert],
-  providers: [NgbAlertConfig, NgbDismissibleAlertConfig]
+  providers: [NgbAlertConfig, NgbSelfClosingAlertConfig]
 })
 export class NgbAlertModule {
 }

--- a/src/alert/alert.spec.ts
+++ b/src/alert/alert.spec.ts
@@ -4,8 +4,8 @@ import {createGenericTestComponent} from '../util/tests';
 import {Component} from '@angular/core';
 
 import {NgbAlertModule} from './alert.module';
-import {NgbAlert, NgbDismissibleAlert} from './alert';
-import {NgbAlertConfig, NgbDismissibleAlertConfig} from './alert-config';
+import {NgbAlert, NgbSelfClosingAlert} from './alert';
+import {NgbAlertConfig, NgbSelfClosingAlertConfig} from './alert-config';
 
 const createTestComponent = (html: string) =>
     createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
@@ -91,35 +91,31 @@ describe('ngb-alert', () => {
   });
 });
 
-describe('NgbDismissibleAlert', () => {
+describe('NgbSelfClosingAlert', () => {
 
   describe('UI logic', () => {
     beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAlertModule]}); });
 
-    it('should open a dismissible alert with default type', () => {
-      const defaultConfig = new NgbDismissibleAlertConfig();
+    it('should open a self-closing alert with default type and no close button', () => {
+      const defaultConfig = new NgbSelfClosingAlertConfig();
       const fixture = createTestComponent(`<template ngbAlert>Hello, {{name}}!</template>`);
       const alertEl = getAlertElement(fixture.nativeElement);
 
       expect(alertEl).toHaveCssClass(`alert-${defaultConfig.type}`);
       expect(alertEl.getAttribute('role')).toEqual('alert');
-      expect(getCloseButton(alertEl)).toBeTruthy();
-
-      getCloseButton(alertEl).click();
-      fixture.detectChanges();
-      expect(getAlertElement(fixture.nativeElement)).toBeNull();
+      expect(getCloseButton(alertEl)).toBeFalsy();
     });
 
-    it('should open a dismissible alert with a specified type', () => {
+    it('should open a self-closing alert with a specified type', () => {
       const fixture = createTestComponent(`<template ngbAlert type="success">Hello, {{name}}!</template>`);
       const alertEl = getAlertElement(fixture.nativeElement);
 
       expect(alertEl).toHaveCssClass('alert-success');
-      expect(getCloseButton(alertEl)).toBeTruthy();
     });
 
     it('should dismiss alert and invoke close handler on close button click', () => {
-      const fixture = createTestComponent(`<template ngbAlert (close)="closed = true">Hello, {{name}}!</template>`);
+      const fixture = createTestComponent(
+          `<template ngbAlert (close)="closed = true" [dismissible]="true">Hello, {{name}}!</template>`);
       const alertEl = getAlertElement(fixture.nativeElement);
 
       getCloseButton(alertEl).click();
@@ -134,13 +130,9 @@ describe('NgbDismissibleAlert', () => {
              createTestComponent(`<template ngbAlert [dismissOnTimeout]="1000">Hello, {{name}}!</template>`);
          const alertEl = getAlertElement(fixture.nativeElement);
 
-         expect(alertEl.getAttribute('role')).toEqual('alert');
-         expect(getCloseButton(alertEl)).toBeTruthy();
-
          tick(800);
          fixture.detectChanges();
          expect(alertEl.getAttribute('role')).toEqual('alert');
-         expect(getCloseButton(alertEl)).toBeTruthy();
 
          tick(1200);
          fixture.detectChanges();
@@ -150,21 +142,29 @@ describe('NgbDismissibleAlert', () => {
 
   describe('Custom config', () => {
 
-    beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAlertModule]}); });
+    let config: NgbSelfClosingAlertConfig;
 
-    it('should initialize inputs with provided config', () => {
-      let config: NgbDismissibleAlertConfig;
-      const fixture = createTestComponent(`<template ngbAlert>Hello, {{name}}!</template>`);
-      inject([NgbDismissibleAlertConfig], (c: NgbDismissibleAlertConfig) => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAlertModule]});
+      TestBed.overrideComponent(TestComponent, {set: {template: '<template ngbAlert>Hello, {{name}}!</template>'}});
+      inject([NgbSelfClosingAlertConfig], (c: NgbSelfClosingAlertConfig) => {
         config = c;
+        config.dismissible = true;
         config.dismissOnTimeout = 2000;
         config.type = 'success';
       });
+    });
+
+    it('should initialize inputs with provided config', () => {
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
 
       fakeAsync(() => {
         const alertEl = getAlertElement(fixture.nativeElement);
 
         expect(alertEl).toHaveCssClass(`alert-${config.type}`);
+        expect(getCloseButton(alertEl)).toBeTruthy();
+
         tick(config.dismissOnTimeout);
         fixture.detectChanges();
         expect(getAlertElement(fixture.nativeElement)).toBeNull();
@@ -173,7 +173,8 @@ describe('NgbDismissibleAlert', () => {
   });
 
   describe('Custom config as provider', () => {
-    const config = new NgbDismissibleAlertConfig();
+    const config = new NgbSelfClosingAlertConfig();
+    config.dismissible = true;
     config.dismissOnTimeout = 2000;
     config.type = 'success';
 
@@ -181,7 +182,7 @@ describe('NgbDismissibleAlert', () => {
       TestBed.configureTestingModule({
         declarations: [TestComponent],
         imports: [NgbAlertModule],
-        providers: [{provide: NgbDismissibleAlertConfig, useValue: config}]
+        providers: [{provide: NgbSelfClosingAlertConfig, useValue: config}]
       });
     });
 
@@ -190,6 +191,8 @@ describe('NgbDismissibleAlert', () => {
          const alertEl = getAlertElement(fixture.nativeElement);
 
          expect(alertEl).toHaveCssClass(`alert-${config.type}`);
+         expect(getCloseButton(alertEl)).toBeTruthy();
+
          tick(config.dismissOnTimeout);
          fixture.detectChanges();
          expect(getAlertElement(fixture.nativeElement)).toBeNull();

--- a/src/alert/alert.ts
+++ b/src/alert/alert.ts
@@ -16,7 +16,7 @@ import {
 } from '@angular/core';
 
 import {PopupService} from '../util/popup';
-import {NgbAlertConfig, NgbDismissibleAlertConfig} from './alert-config';
+import {NgbAlertConfig, NgbSelfClosingAlertConfig} from './alert-config';
 
 /**
  * Alerts can be used to provide feedback messages.
@@ -36,7 +36,7 @@ import {NgbAlertConfig, NgbDismissibleAlertConfig} from './alert-config';
 export class NgbAlert {
   /**
    * A flag indicating if a given alert can be dismissed (closed) by a user. If this flag is set, a close button (in a
-   * form of a cross) will be displayed.
+   * form of an ×) will be displayed.
    */
   @Input() dismissible: boolean;
   /**
@@ -60,10 +60,15 @@ export class NgbAlert {
  * Alerts that can be dismissed without any additional code.
  */
 @Directive({selector: 'template[ngbAlert]'})
-export class NgbDismissibleAlert implements OnInit, OnDestroy {
+export class NgbSelfClosingAlert implements OnInit, OnDestroy {
   private _popupService: PopupService<NgbAlert>;
   private _timeout;
 
+  /**
+   * A flag indicating if the alert can be dismissed (closed) by a user. If this flag is set, a close button (in a
+   * form of an ×) will be displayed.
+   */
+  @Input() dismissible: boolean;
   /**
    * Alert type (CSS class). Bootstrap 4 recognizes the following types: "success", "info", "warning" and "danger".
    */
@@ -79,9 +84,10 @@ export class NgbDismissibleAlert implements OnInit, OnDestroy {
 
   constructor(
       private _templateRef: TemplateRef<Object>, viewContainerRef: ViewContainerRef, injector: Injector,
-      componentFactoryResolver: ComponentFactoryResolver, renderer: Renderer, config: NgbDismissibleAlertConfig) {
+      componentFactoryResolver: ComponentFactoryResolver, renderer: Renderer, config: NgbSelfClosingAlertConfig) {
     this._popupService =
         new PopupService<NgbAlert>(NgbAlert, injector, viewContainerRef, renderer, componentFactoryResolver);
+    this.dismissible = config.dismissible;
     this.type = config.type;
     this.dismissOnTimeout = config.dismissOnTimeout;
   }
@@ -91,6 +97,7 @@ export class NgbDismissibleAlert implements OnInit, OnDestroy {
   ngOnInit() {
     const windowRef = this._popupService.open(this._templateRef);
     windowRef.instance.type = this.type;
+    windowRef.instance.dismissible = this.dismissible;
     windowRef.instance.close.subscribe(($event) => {
       this.closeEvent.emit($event);
       this.close();
@@ -103,4 +110,4 @@ export class NgbDismissibleAlert implements OnInit, OnDestroy {
   ngOnDestroy() { clearTimeout(this._timeout); }
 }
 
-export const NGB_ALERT_DIRECTIVES = [NgbAlert, NgbDismissibleAlert];
+export const NGB_ALERT_DIRECTIVES = [NgbAlert, NgbSelfClosingAlert];

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import {NgbTypeaheadModule} from './typeahead/typeahead.module';
 export {NgbPanelChangeEvent, NgbAccordionConfig} from './accordion/accordion.module';
 export {NgbModal, NgbModalOptions, NgbModalRef, ModalDismissReasons} from './modal/modal.module';
 export {NgbTabChangeEvent} from './tabset/tabset.module';
-export {NgbAlertConfig, NgbDismissibleAlertConfig} from './alert/alert.module';
+export {NgbAlertConfig, NgbSelfClosingAlertConfig} from './alert/alert.module';
 export {NgbCarouselConfig} from './carousel/carousel.module';
 export {NgbPaginationConfig} from './pagination/pagination.module';
 export {NgbProgressbarConfig} from './progressbar/progressbar.module';


### PR DESCRIPTION
- refactor NgbDismissibleAlert to NgbSelfClosingAlert
- make it possible to hide the close button on self-closing alerts
- make the self-closing alert tests a bit less convoluted

fix #660