### PR TITLE
refactor(timepicker): use disabled state from a control

### DIFF
--- a/src/timepicker/timepicker.spec.ts
+++ b/src/timepicker/timepicker.spec.ts
@@ -728,8 +728,16 @@ describe('ngb-timepicker', () => {
       fixture.detectChanges();
       fieldset = getFieldsetElement(fixture.nativeElement);
       expect(fieldset.hasAttribute('disabled')).toBeFalsy;
-
     });
+
+    it('should have disabled class, when it is disabled using reactive forms', async(() => {
+         const html = `<form [formGroup]="disabledForm"><ngb-timepicker formControlName="control"></ngb-timepicker></form>`;
+
+         const fixture = createTestComponent(html);
+         fixture.detectChanges();
+         let fieldset = getFieldsetElement(fixture.nativeElement);
+         expect(fieldset.hasAttribute('disabled')).toBeTruthy();
+       }));
   });
 
   describe('readonly', () => {
@@ -862,6 +870,7 @@ class TestComponent {
   disabled = true;
   readonly = true;
   form = new FormGroup({control: new FormControl('', Validators.required)});
+  disabledForm = new FormGroup({control: new FormControl({value: '', disabled: true})});
   submitted = false;
 
   onSubmit() { this.submitted = true; }

--- a/src/timepicker/timepicker.ts
+++ b/src/timepicker/timepicker.ts
@@ -135,6 +135,7 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
   providers: [NGB_TIMEPICKER_VALUE_ACCESSOR]
 })
 export class NgbTimepicker implements ControlValueAccessor {
+  disabled: boolean;
   model: NgbTime;
 
   /**
@@ -168,11 +169,6 @@ export class NgbTimepicker implements ControlValueAccessor {
   @Input() secondStep: number;
 
   /**
-   * To disable timepicker
-   */
-  @Input() disabled: boolean;
-
-  /**
    * To make timepicker readonly
    */
   @Input() readonlyInputs: boolean;
@@ -196,6 +192,8 @@ export class NgbTimepicker implements ControlValueAccessor {
   registerOnChange(fn: (value: any) => any): void { this.onChange = fn; }
 
   registerOnTouched(fn: () => any): void { this.onTouched = fn; }
+
+  setDisabledState(isDisabled: boolean) { this.disabled = isDisabled; }
 
   /**
    * @internal


### PR DESCRIPTION
New forms have an additional callback (`setDisabledState`) on the `ControlValueAccessor` - let's use this hook to properly support disabled controls (both template-driven and reactive).
