### PR TITLE
fix(typeahead): properly support disabled inputs

### DIFF
--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -366,6 +366,19 @@ describe('ngb-typeahead', () => {
       expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
       expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
     });
+
+    it('should support disabled state', async(() => {
+         const html = `
+            <form>
+              <input type="text" [(ngModel)]="model" name="control" [disabled]="true" [ngbTypeahead]="findObjects" />
+            </form>`;
+         const fixture = createTestComponent(html);
+         fixture.whenStable().then(() => {
+           fixture.detectChanges();
+           const compiled = fixture.nativeElement;
+           expect(getNativeInput(compiled).disabled).toBeTruthy();
+         });
+       }));
   });
 
   describe('select event', () => {

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -152,6 +152,10 @@ export class NgbTypeahead implements OnInit,
 
   writeValue(value) { this._writeInputValue(this._formatItemForInput(value)); }
 
+  setDisabledState(isDisabled: boolean): void {
+    this._renderer.setElementProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
+  }
+
   /**
    * @internal
    */


### PR DESCRIPTION
Since `ngModel` was taking over `disabled` binding before this change it was impossible to disable an input containing the typeahead control.