### PR TITLE
fix(datepicker): remove useless .row from demo

### DIFF
--- a/demo/src/app/components/datepicker/demos/i18n/datepicker-i18n.html
+++ b/demo/src/app/components/datepicker/demos/i18n/datepicker-i18n.html
@@ -1,12 +1,11 @@
-<div class="row">
-  <div [(ngModel)]="language" ngbRadioGroup>
-    <label class="btn btn-primary">
-      <input type="radio" value="en"> English
-    </label>
-    <label class="btn btn-primary">
-      <input type="radio" value="fr"> Français
-    </label>
-  </div>
-  <hr>
-  <ngb-datepicker [(ngModel)]="model"></ngb-datepicker>
+<div [(ngModel)]="language" ngbRadioGroup>
+  <label class="btn btn-primary">
+    <input type="radio" value="en"> English
+  </label>
+  <label class="btn btn-primary">
+    <input type="radio" value="fr"> Français
+  </label>
 </div>
+<hr>
+<ngb-datepicker [(ngModel)]="model"></ngb-datepicker>
+


### PR DESCRIPTION
The .row is useless, and causes the content to be moved to the left