### PR TITLE
chore(build): publish ES modules with metadata

### DIFF
--- a/karma-test-shim.js
+++ b/karma-test-shim.js
@@ -73,8 +73,8 @@ function customMatchers() {
   return System.import('/base/temp/test/matchers.js');
 }
 
-function onlyAppFiles(filePath) {
-  return /\/base\/temp\/(?!.*\.spec\.js$).*\.js$/.test(filePath);
+function onlyBuiltFiles(filePath) {
+  return /^\/base\/temp\//.test(filePath);
 }
 
 function onlySpecFiles(path) {
@@ -84,6 +84,7 @@ function onlySpecFiles(path) {
 function resolveTestFiles() {
   return Object
       .keys(window.__karma__.files)  // All files served by Karma.
+      .filter(onlyBuiltFiles)
       .filter(onlySpecFiles)
       .map(function(moduleName) {
         // loads all spec files via their global module names (e.g.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@angular/compiler": "2.0.0-rc.6",
+    "@angular/compiler-cli": "0.6.0",
     "@angular/http": "2.0.0-rc.6",
     "@angular/platform-browser": "2.0.0-rc.6",
     "@angular/platform-browser-dynamic": "2.0.0-rc.6",

--- a/tsconfig-es2015.json
+++ b/tsconfig-es2015.json
@@ -1,11 +1,25 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es5",
     "module": "es2015",
     "moduleResolution": "node",
     "declaration": true,
-    "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "noEmitOnError": true
+    "baseUrl": ".",
+    "stripInternal": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "sourceMap": true,
+    "inlineSources": true,
+    "skipLibCheck": true
+  },
+  "files": [
+    "src/index.ts",
+    "typings/index.d.ts"
+  ],
+  "angularCompilerOptions": {
+    "strictMetadataEmit": true,
+    "genDir": "./dist/waste"
   }
 }
+


### PR DESCRIPTION
Aligns what is published with Angular 2, this is needed for AoT compilation.

BREAKING CHANGE:

npm package: code in ESM (ES6 Modules) format is now published at the default location in the npm package with `package.json`'s `main` entry pointint to an UMD bundle (primarily for node and webpack 1 users).

If you are using SystemJS, you should adjust your configuration to point to the UMD bundle.