### PR TITLE
chore: document interface methods and commented classes

### DIFF
--- a/misc/api-doc-test-cases/class-with-doc.ts
+++ b/misc/api-doc-test-cases/class-with-doc.ts
@@ -1,0 +1,16 @@
+//a class with doc to extract
+
+/**
+ * This is a documented foo
+ */
+class DocumentedFoo {
+  /**
+   * the bar
+   */
+  bar: string;
+
+  /**
+   * some method
+   */
+  someMethod(): void {}
+}

--- a/misc/api-doc-test-cases/interface-with-methods.ts
+++ b/misc/api-doc-test-cases/interface-with-methods.ts
@@ -1,0 +1,9 @@
+/**
+ * Some interface
+ */
+export interface SomeInterface {
+  /**
+   * does something
+   */
+  foo(): void;
+}

--- a/misc/api-doc.js
+++ b/misc/api-doc.js
@@ -32,7 +32,6 @@ class APIDocVisitor {
     this.typeChecker = this.program.getTypeChecker(true);
   }
 
-
   visitSourceFile(fileName) {
     var sourceFile = this.program.getSourceFile(fileName);
 
@@ -90,6 +89,10 @@ class APIDocVisitor {
           return [{fileName, className, description, methods: members.methods, properties: members.properties}];
         }
       }
+    } else if (description) {
+      members = this.visitMembers(classDeclaration.members);
+
+      return [{fileName, className, description, methods: members.methods, properties: members.properties}];
     }
 
     // a class that is not a directive or a service, not documented for now
@@ -133,7 +136,9 @@ class APIDocVisitor {
         outputs.push(this.visitOutput(members[i], outDecorator));
 
       } else if (!isPrivateOrInternal(members[i])) {
-        if (members[i].kind === ts.SyntaxKind.MethodDeclaration && !isAngularLifecycleHook(members[i].name.text)) {
+        if ((members[i].kind === ts.SyntaxKind.MethodDeclaration ||
+             members[i].kind === ts.SyntaxKind.MethodSignature) &&
+            !isAngularLifecycleHook(members[i].name.text)) {
           methods.push(this.visitMethodDeclaration(members[i]));
         } else if (
             members[i].kind === ts.SyntaxKind.PropertyDeclaration ||

--- a/misc/api-doc.spec.js
+++ b/misc/api-doc.spec.js
@@ -171,4 +171,33 @@ describe('APIDocVisitor', function() {
     expect(interfaceDocs.properties[2].defaultValue).toBeUndefined();
   });
 
+  it('should extract method documentation from interfaces', function() {
+    var interfaceDocs = apiDoc(['./misc/api-doc-test-cases/interface-with-methods.ts']).SomeInterface;
+
+    expect(interfaceDocs.className).toBe('SomeInterface');
+    expect(interfaceDocs.description).toBe('Some interface');
+    expect(interfaceDocs.methods.length).toBe(1);
+
+    expect(interfaceDocs.methods[0].name).toBe('foo');
+    expect(interfaceDocs.methods[0].description).toContain('does something');
+    expect(interfaceDocs.methods[0].returnType).toBe('void');
+  });
+
+  it('should extract documentation from documented classes', function() {
+    var classDocs = apiDoc(['./misc/api-doc-test-cases/class-with-doc.ts']).DocumentedFoo;
+
+    expect(classDocs.className).toBe('DocumentedFoo');
+    expect(classDocs.description).toBe('This is a documented foo');
+
+    expect(classDocs.properties[0].name).toBe('bar');
+    expect(classDocs.properties[0].description).toContain('the bar');
+    expect(classDocs.properties[0].type).toBe('string');
+
+    expect(classDocs.methods.length).toBe(1);
+
+    expect(classDocs.methods[0].name).toBe('someMethod');
+    expect(classDocs.methods[0].description).toContain('some method');
+    expect(classDocs.methods[0].returnType).toBe('void');
+  });
+
 });


### PR DESCRIPTION
Documenting methods in interfaces is not needed yet but will probably be in the future.
Documenting classes which don't have any decorator is useful for context classes, that could be used later, in accordion for example