### PR TITLE
chore: use ViewChild to make some tests simpler

### DIFF
--- a/src/alert/alert.spec.ts
+++ b/src/alert/alert.spec.ts
@@ -1,7 +1,7 @@
 import {fakeAsync, tick, TestBed, ComponentFixture, inject} from '@angular/core/testing';
 import {createGenericTestComponent} from '../test/common';
 
-import {Component} from '@angular/core';
+import {Component, ViewChild} from '@angular/core';
 
 import {NgbAlertModule} from './alert.module';
 import {NgbAlert, NgbSelfClosingAlert} from './alert';
@@ -147,28 +147,24 @@ describe('NgbSelfClosingAlert', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAlertModule]});
       TestBed.overrideComponent(TestComponent, {set: {template: '<template ngbAlert>Hello, {{name}}!</template>'}});
-      inject([NgbSelfClosingAlertConfig], (c: NgbSelfClosingAlertConfig) => {
-        config = c;
-        config.dismissible = true;
-        config.dismissOnTimeout = 2000;
-        config.type = 'success';
-      });
     });
+
+    beforeEach(inject([NgbSelfClosingAlertConfig], (c: NgbSelfClosingAlertConfig) => {
+      config = c;
+      config.dismissible = true;
+      config.dismissOnTimeout = 2000;
+      config.type = 'success';
+    }));
 
     it('should initialize inputs with provided config', () => {
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
 
-      fakeAsync(() => {
-        const alertEl = getAlertElement(fixture.nativeElement);
+      const alert = fixture.componentInstance.selfClosingAlert;
 
-        expect(alertEl).toHaveCssClass(`alert-${config.type}`);
-        expect(getCloseButton(alertEl)).toBeTruthy();
-
-        tick(config.dismissOnTimeout);
-        fixture.detectChanges();
-        expect(getAlertElement(fixture.nativeElement)).toBeNull();
-      });
+      expect(alert.type).toBe(config.type);
+      expect(alert.dismissible).toBe(config.dismissible);
+      expect(alert.dismissOnTimeout).toBe(config.dismissOnTimeout);
     });
   });
 
@@ -186,17 +182,14 @@ describe('NgbSelfClosingAlert', () => {
       });
     });
 
-    it('should initialize inputs with provided config as provider', fakeAsync(() => {
-         const fixture = createTestComponent(`<template ngbAlert>Hello, {{name}}!</template>`);
-         const alertEl = getAlertElement(fixture.nativeElement);
+    it('should initialize inputs with provided config as provider', () => {
+      const fixture = createTestComponent(`<template ngbAlert>Hello, {{name}}!</template>`);
+      const alert = fixture.componentInstance.selfClosingAlert;
 
-         expect(alertEl).toHaveCssClass(`alert-${config.type}`);
-         expect(getCloseButton(alertEl)).toBeTruthy();
-
-         tick(config.dismissOnTimeout);
-         fixture.detectChanges();
-         expect(getAlertElement(fixture.nativeElement)).toBeNull();
-       }));
+      expect(alert.type).toBe(config.type);
+      expect(alert.dismissible).toBe(config.dismissible);
+      expect(alert.dismissOnTimeout).toBe(config.dismissOnTimeout);
+    });
   });
 });
 
@@ -204,4 +197,6 @@ describe('NgbSelfClosingAlert', () => {
 class TestComponent {
   name = 'World';
   closed = false;
+
+  @ViewChild(NgbSelfClosingAlert) selfClosingAlert: NgbSelfClosingAlert;
 }

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -2,7 +2,7 @@ import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
 import {createGenericTestComponent} from '../test/common';
 
 import {By} from '@angular/platform-browser';
-import {Component} from '@angular/core';
+import {Component, ViewChild} from '@angular/core';
 
 import {NgbPopoverModule} from './popover.module';
 import {NgbPopoverWindow, NgbPopover} from './popover';
@@ -269,13 +269,11 @@ describe('ngb-popover', () => {
     it('should initialize inputs with provided config', () => {
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
-      const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('mouseenter', {});
-      fixture.detectChanges();
-      const windowEl = getWindow(fixture);
+      const popover = fixture.componentInstance.popover;
 
-      expect(windowEl).toHaveCssClass('popover-bottom');
+      expect(popover.placement).toBe(config.placement);
+      expect(popover.triggers).toBe(config.triggers);
     });
   });
 
@@ -291,13 +289,10 @@ describe('ngb-popover', () => {
 
     it('should initialize inputs with provided config as provider', () => {
       const fixture = createTestComponent(`<div ngbPopover="Great tip!"></div>`);
-      const directive = fixture.debugElement.query(By.directive(NgbPopover));
+      const popover = fixture.componentInstance.popover;
 
-      directive.triggerEventHandler('mouseenter', {});
-      fixture.detectChanges();
-      const windowEl = getWindow(fixture);
-
-      expect(windowEl).toHaveCssClass('popover-bottom');
+      expect(popover.placement).toBe(config.placement);
+      expect(popover.triggers).toBe(config.triggers);
     });
   });
 });
@@ -308,4 +303,6 @@ export class TestComponent {
   show = true;
   title: string;
   placement: string;
+
+  @ViewChild(NgbPopover) popover: NgbPopover;
 }

--- a/src/tooltip/tooltip.spec.ts
+++ b/src/tooltip/tooltip.spec.ts
@@ -2,7 +2,7 @@ import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
 import {createGenericTestComponent} from '../test/common';
 
 import {By} from '@angular/platform-browser';
-import {Component} from '@angular/core';
+import {Component, ViewChild} from '@angular/core';
 
 import {NgbTooltipModule} from './tooltip.module';
 import {NgbTooltipWindow, NgbTooltip} from './tooltip';
@@ -267,13 +267,10 @@ describe('ngb-tooltip', () => {
     it('should initialize inputs with provided config', () => {
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
-      const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+      const tooltip = fixture.componentInstance.tooltip;
 
-      directive.triggerEventHandler('click', {});
-      fixture.detectChanges();
-      const windowEl = getWindow(fixture);
-
-      expect(windowEl).toHaveCssClass('tooltip-bottom');
+      expect(tooltip.placement).toBe(config.placement);
+      expect(tooltip.triggers).toBe(config.triggers);
     });
   });
 
@@ -289,13 +286,10 @@ describe('ngb-tooltip', () => {
 
     it('should initialize inputs with provided config as provider', () => {
       const fixture = createTestComponent(`<div ngbTooltip="Great tip!"></div>`);
-      const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+      const tooltip = fixture.componentInstance.tooltip;
 
-      directive.triggerEventHandler('click', {});
-      fixture.detectChanges();
-      const windowEl = getWindow(fixture);
-
-      expect(windowEl).toHaveCssClass('tooltip-bottom');
+      expect(tooltip.placement).toBe(config.placement);
+      expect(tooltip.triggers).toBe(config.triggers);
     });
   });
 });
@@ -304,4 +298,6 @@ describe('ngb-tooltip', () => {
 export class TestComponent {
   name = 'World';
   show = true;
+
+  @ViewChild(NgbTooltip) tooltip: NgbTooltip;
 }

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -2,7 +2,7 @@ import {TestBed, ComponentFixture, async, inject} from '@angular/core/testing';
 import {createGenericTestComponent, isBrowser} from '../test/common';
 import {expectResults, getWindowLinks} from '../test/typeahead/common';
 
-import {Component, DebugElement} from '@angular/core';
+import {Component, DebugElement, ViewChild} from '@angular/core';
 import {Validators, FormControl, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 import {Observable} from 'rxjs/Rx';
@@ -514,21 +514,13 @@ describe('ngb-typeahead', () => {
 
       beforeEach(inject([NgbTypeaheadConfig], (c: NgbTypeaheadConfig) => { c.showHint = true; }));
 
-      it('should initialize inputs with provided config', async(() => {
-           const fixture = TestBed.createComponent(TestComponent);
-           fixture.detectChanges();
-           const compiled = fixture.nativeElement;
-           const inputEl = getNativeInput(compiled);
+      it('should initialize inputs with provided config', () => {
+        const fixture = TestBed.createComponent(TestComponent);
+        fixture.detectChanges();
 
-           fixture.whenStable().then(() => {
-             changeInput(compiled, 'on');
-             fixture.detectChanges();
-             expectWindowResults(compiled, ['+one', 'one more']);
-             expect(inputEl.value).toBe('one');
-             expect(inputEl.selectionStart).toBe(2);
-             expect(inputEl.selectionEnd).toBe(3);
-           });
-         }));
+        const typeahead = fixture.componentInstance.typeahead;
+        expect(typeahead.showHint).toBe(true);
+      });
     });
 
     describe('Custom config as provider', () => {
@@ -541,21 +533,12 @@ describe('ngb-typeahead', () => {
             TestComponent, {set: {template: '<input type="text" [(ngModel)]="model" [ngbTypeahead]="findAnywhere"/>'}});
       });
 
-      it('should initialize inputs with provided config as provider', async(() => {
-           const fixture = TestBed.createComponent(TestComponent);
-           fixture.detectChanges();
-           const compiled = fixture.nativeElement;
-           const inputEl = getNativeInput(compiled);
-
-           fixture.whenStable().then(() => {
-             changeInput(compiled, 'on');
-             fixture.detectChanges();
-             expectWindowResults(compiled, ['+one', 'one more']);
-             expect(inputEl.value).toBe('one');
-             expect(inputEl.selectionStart).toBe(2);
-             expect(inputEl.selectionEnd).toBe(3);
-           });
-         }));
+      it('should initialize inputs with provided config as provider', () => {
+        const fixture = TestBed.createComponent(TestComponent);
+        fixture.detectChanges();
+        const typeahead = fixture.componentInstance.typeahead;
+        expect(typeahead.showHint).toBe(true);
+      });
     });
   }
 });
@@ -570,6 +553,8 @@ class TestComponent {
   selectEventValue: any;
 
   form = new FormGroup({control: new FormControl('', Validators.required)});
+
+  @ViewChild(NgbTypeahead) typeahead: NgbTypeahead;
 
   find = (text$: Observable<string>) => { return text$.map(text => this._strings.filter(v => v.startsWith(text))); };
 
@@ -586,6 +571,7 @@ class TestComponent {
   uppercaseFormatter = s => s.toUpperCase();
 
   uppercaseObjFormatter = (obj: {value: string}) => { return obj.value.toUpperCase(); };
+
 
   onSelect($event) { this.selectEventValue = $event; }
 }


### PR DESCRIPTION
Just discovered that ViewChild allowed getting a reference to the actual component under test, which thus allows to check its state without going through DOM manipulation to check that it has the expected state.