### PR TITLE
refactor(timepicker): introduce a NgbTimeStruct interface

### DIFF
--- a/demo/src/app/components/timepicker/demos/config/timepicker-config.ts
+++ b/demo/src/app/components/timepicker/demos/config/timepicker-config.ts
@@ -1,5 +1,6 @@
 import {Component} from '@angular/core';
 import {NgbTimepickerConfig} from '@ng-bootstrap/ng-bootstrap';
+import {NgbTimeStruct} from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
   selector: 'ngbd-timepicker-config',
@@ -7,7 +8,7 @@ import {NgbTimepickerConfig} from '@ng-bootstrap/ng-bootstrap';
   providers: [NgbTimepickerConfig] // add NgbTimepickerConfig to the component providers
 })
 export class NgbdTimepickerConfig {
-  time = {hour: 13, minute: 30, second: 0};
+  time: NgbTimeStruct = {hour: 13, minute: 30, second: 0};
 
   constructor(config: NgbTimepickerConfig) {
     // customize default values of ratings used by this component tree

--- a/demo/src/app/components/timepicker/demos/seconds/timepicker-seconds.ts
+++ b/demo/src/app/components/timepicker/demos/seconds/timepicker-seconds.ts
@@ -1,11 +1,12 @@
 import {Component} from '@angular/core';
+import {NgbTimeStruct} from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
   selector: 'ngbd-timepicker-seconds',
   templateUrl: './timepicker-seconds.html'
 })
 export class NgbdTimepickerSeconds {
-  time = {hour: 13, minute: 30, second: 30};
+  time: NgbTimeStruct = {hour: 13, minute: 30, second: 30};
   seconds = true;
 
   toggleSeconds() {

--- a/demo/src/app/components/timepicker/demos/steps/timepicker-steps.ts
+++ b/demo/src/app/components/timepicker/demos/steps/timepicker-steps.ts
@@ -1,11 +1,12 @@
 import {Component} from '@angular/core';
+import {NgbTimeStruct} from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
   selector: 'ngbd-timepicker-steps',
   templateUrl: './timepicker-steps.html'
 })
 export class NgbdTimepickerSteps {
-  time = {hour: 13, minute: 30, second: 0};
+  time: NgbTimeStruct = {hour: 13, minute: 30, second: 0};
   hourStep = 1;
   minuteStep = 15;
   secondStep = 30;

--- a/demo/src/app/components/timepicker/timepicker.component.ts
+++ b/demo/src/app/components/timepicker/timepicker.component.ts
@@ -6,6 +6,7 @@ import {DEMO_SNIPPETS} from './demos';
   template: `
     <ngbd-content-wrapper component="Timepicker">
       <ngbd-api-docs directive="NgbTimepicker"></ngbd-api-docs>
+      <ngbd-api-docs-class type="NgbTimeStruct"></ngbd-api-docs-class>
       <ngbd-api-docs-config type="NgbTimepickerConfig"></ngbd-api-docs-config>
       <ngbd-example-box demoTitle="Timepicker" [htmlSnippet]="snippets.basic.markup" [tsSnippet]="snippets.basic.code">
         <ngbd-timepicker-basic></ngbd-timepicker-basic>

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ export {NgbPopoverModule, NgbPopoverConfig} from './popover/popover.module';
 export {NgbProgressbarModule, NgbProgressbarConfig} from './progressbar/progressbar.module';
 export {NgbRatingModule, NgbRatingConfig} from './rating/rating.module';
 export {NgbTabsetModule, NgbTabChangeEvent, NgbTabsetConfig} from './tabset/tabset.module';
-export {NgbTimepickerModule, NgbTimepickerConfig} from './timepicker/timepicker.module';
+export {NgbTimepickerModule, NgbTimepickerConfig, NgbTimeStruct} from './timepicker/timepicker.module';
 export {NgbTooltipModule, NgbTooltipConfig} from './tooltip/tooltip.module';
 export {NgbTypeaheadModule, NgbTypeaheadConfig, NgbTypeaheadSelectItemEvent} from './typeahead/typeahead.module';
 

--- a/src/timepicker/ngb-time-struct.ts
+++ b/src/timepicker/ngb-time-struct.ts
@@ -1,0 +1,19 @@
+/**
+ * Interface of the model of the NgbTimepicker directive
+ */
+export interface NgbTimeStruct {
+  /**
+   * The hour, going from 0 to 23
+   */
+  hour: number;
+
+  /**
+   * The minute, going from 0 to 59
+   */
+  minute: number;
+
+  /**
+   * The second, going from 0 to 59
+   */
+  second: number;
+}

--- a/src/timepicker/timepicker.module.ts
+++ b/src/timepicker/timepicker.module.ts
@@ -5,6 +5,7 @@ import {NGB_TIMEPICKER_DIRECTIVES} from './timepicker';
 import {NgbTimepickerConfig} from './timepicker-config';
 
 export {NgbTimepickerConfig} from './timepicker-config';
+export {NgbTimeStruct} from './ngb-time-struct';
 
 @NgModule({
   declarations: NGB_TIMEPICKER_DIRECTIVES,


### PR DESCRIPTION
note: I chose to use `second`, and not `second?`, because the timepicker always sets the second to a non-null value, and I think being stricter can only lead to safer code.

refs #731