### PR TITLE
fix(popover): avoid shadowing of the native title property

### DIFF
--- a/demo/src/app/components/popover/demos/basic/popover-basic.html
+++ b/demo/src/app/components/popover/demos/basic/popover-basic.html
@@ -1,19 +1,19 @@
 <button type="button" class="btn btn-secondary" placement="top"
-        ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." title="Popover on top">
+        ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on top">
   Popover on top
 </button>
 
 <button type="button" class="btn btn-secondary" placement="right"
-        ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." title="Popover on right">
+        ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on right">
   Popover on right
 </button>
 
 <button type="button" class="btn btn-secondary" placement="bottom"
-        ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." title="Popover on bottom">
+        ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on bottom">
   Popover on bottom
 </button>
 
 <button type="button" class="btn btn-secondary" placement="left"
-        ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." title="Popover on left">
+        ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on left">
   Popover on left
 </button>

--- a/demo/src/app/components/popover/demos/config/popover-config.html
+++ b/demo/src/app/components/popover/demos/config/popover-config.html
@@ -1,4 +1,4 @@
 <button type="button" class="btn btn-secondary"
-        ngbPopover="This popover gets its inputs from the customized configuration" title="Customized popover">
+        ngbPopover="This popover gets its inputs from the customized configuration" popoverTitle="Customized popover">
   Customized popover
 </button>

--- a/demo/src/app/components/popover/demos/tplcontent/popover-tplcontent.html
+++ b/demo/src/app/components/popover/demos/tplcontent/popover-tplcontent.html
@@ -4,6 +4,6 @@
 </p>
 
 <template #popContent>Hello, <b>{{name}}</b>!</template>
-<button type="button" class="btn btn-secondary" [ngbPopover]="popContent" title="Fancy content">
+<button type="button" class="btn btn-secondary" [ngbPopover]="popContent" popoverTitle="Fancy content">
   I've got markup and bindings in my popover!
 </button>

--- a/demo/src/app/components/popover/demos/triggers/popover-triggers.html
+++ b/demo/src/app/components/popover/demos/triggers/popover-triggers.html
@@ -2,7 +2,7 @@
   You can easily override open and close triggers by specifying event names (separated by <code>:</code>) in the <code>triggers</code> property.
 </p>
 
-<button type="button" class="btn btn-secondary" ngbPopover="You see, I show up on hover!" triggers="mouseenter:mouseleave" title="Pop title">
+<button type="button" class="btn btn-secondary" ngbPopover="You see, I show up on hover!" triggers="mouseenter:mouseleave" popoverTitle="Pop title">
   Hover over me!
 </button>
 
@@ -11,7 +11,7 @@
   Alternatively you can take full manual control over popover opening / closing events.
 </p>
 
-<button type="button" class="btn btn-secondary" ngbPopover="What a great tip!" triggers="manual" #p="ngbPopover" (click)="p.open()" title="Pop title">
+<button type="button" class="btn btn-secondary" ngbPopover="What a great tip!" triggers="manual" #p="ngbPopover" (click)="p.open()" popoverTitle="Pop title">
   Click me to open a popover
 </button>
 <button type="button" class="btn btn-secondary" (click)="p.close()">

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -42,7 +42,7 @@ describe('ngb-popover', () => {
   describe('basic functionality', () => {
 
     it('should open and close a popover - default settings and content as string', () => {
-      const fixture = createTestComponent(`<div ngbPopover="Great tip!" title="Title"></div>`);
+      const fixture = createTestComponent(`<div ngbPopover="Great tip!" popoverTitle="Title"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
       directive.triggerEventHandler('click', {});
@@ -62,7 +62,7 @@ describe('ngb-popover', () => {
     it('should open and close a popover - default settings and content from a template', () => {
       const fixture = createTestComponent(`
           <template #t>Hello, {{name}}!</template>
-          <div [ngbPopover]="t" title="Title"></div>`);
+          <div [ngbPopover]="t" popoverTitle="Title"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
       const defaultConfig = new NgbPopoverConfig();
 
@@ -81,7 +81,7 @@ describe('ngb-popover', () => {
     });
 
     it('should allow re-opening previously closed popovers', () => {
-      const fixture = createTestComponent(`<div ngbPopover="Great tip!" title="Title"></div>`);
+      const fixture = createTestComponent(`<div ngbPopover="Great tip!" popoverTitle="Title"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
       directive.triggerEventHandler('click', {});
@@ -99,7 +99,7 @@ describe('ngb-popover', () => {
 
     it('should not leave dangling popovers in the DOM', () => {
       const fixture =
-          createTestComponent(`<template [ngIf]="show"><div ngbPopover="Great tip!" title="Title"></div></template>`);
+          createTestComponent(`<template [ngIf]="show"><div ngbPopover="Great tip!" popoverTitle="Title"></div></template>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
       directive.triggerEventHandler('click', {});

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -46,7 +46,7 @@ export class NgbPopover implements OnInit, OnDestroy {
   /**
    * Title of a popover.
    */
-  @Input() title: string;
+  @Input() popoverTitle: string;
   /**
    * Placement of a popover. Accepts: "top", "bottom", "left", "right"
    */
@@ -85,7 +85,7 @@ export class NgbPopover implements OnInit, OnDestroy {
     if (!this._windowRef) {
       this._windowRef = this._popupService.open(this.ngbPopover);
       this._windowRef.instance.placement = this.placement;
-      this._windowRef.instance.title = this.title;
+      this._windowRef.instance.title = this.popoverTitle;
     }
   }
 


### PR DESCRIPTION
BREAKING CHANGE: the title property of the popover directive was renamed to popoverTitle.
Before:

`<div ngbPopover="..." title="...">`

after:

`<div ngbPopover="..." popoverTitle="...">`

Fixes #736