### PR TITLE
chore(build): remove internal on ControlValueAccessor methods

### DIFF
--- a/misc/api-doc.js
+++ b/misc/api-doc.js
@@ -10,7 +10,7 @@ function getNamesCompareFn(name) {
 
 const ANGULAR_LIFECYCLE_METHODS = [
   'ngOnInit', 'ngOnChanges', 'ngDoCheck', 'ngOnDestroy', 'ngAfterContentInit', 'ngAfterContentChecked',
-  'ngAfterViewInit', 'ngAfterViewChecked'
+  'ngAfterViewInit', 'ngAfterViewChecked', 'writeValue', 'registerOnChange', 'registerOnTouched', 'setDisabledState'
 ];
 
 function isInternalMember(member) {

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -101,27 +101,15 @@ export class NgbInputDatepicker implements ControlValueAccessor {
     });
   }
 
-  /**
-   * @internal
-   */
   registerOnChange(fn: (value: any) => any): void { this._onChange = fn; }
 
-  /**
-   * @internal
-   */
   registerOnTouched(fn: () => any): void { this._onTouched = fn; }
 
-  /**
-   * @internal
-   */
   writeValue(value) {
     this._model = value ? new NgbDate(value.year, value.month, value.day) : null;
     this._writeModelValue(this._model);
   }
 
-  /**
-   * @internal
-   */
   setDisabledState(isDisabled: boolean): void {
     this._renderer.setElementProperty(this._elRef.nativeElement, 'disabled', isDisabled);
     if (this.isOpen()) {

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -181,24 +181,12 @@ export class NgbDatepicker implements OnChanges,
     this._updateData();
   }
 
-  /**
-   * @internal
-   */
   registerOnChange(fn: (value: any) => any): void { this.onChange = fn; }
 
-  /**
-   * @internal
-   */
   registerOnTouched(fn: () => any): void { this.onTouched = fn; }
 
-  /**
-   * @internal
-   */
   writeValue(value) { this.model = value ? new NgbDate(value.year, value.month, value.day) : null; }
 
-  /**
-   * @internal
-   */
   setDisabledState(isDisabled: boolean) { this.disabled = isDisabled; }
 
   private _setDates() {


### PR DESCRIPTION
The `@internal` comment annotation causes the methods not to be included in the generated .d.ts file, which in turn cause error messages when building the demo:

```
error TS2420: Class 'NgbDatepicker' incorrectly implements interface 'ControlValueAccessor'.
  Property 'writeValue' is missing in type 'NgbDatepicker'.
```

I thus removed the `@internal`, and added these methods in the list of angular lifecycle methods, since we don't want them to be documented.