### PR TITLE
fix(typeahead): properly handle components using OnPush strategy

### DIFF
--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -156,6 +156,11 @@ export class NgbTypeahead implements OnInit,
               this._windowRef.instance.resultTemplate = this.resultTemplate;
             }
             this._showHint();
+
+            // The observable stream we are subscribing to might have async steps
+            // and if a component containing typeahead is using the OnPush strategy
+            // the change detection turn wouldn't be invoked automatically.
+            this._windowRef.changeDetectorRef.detectChanges();
           }
         });
   }


### PR DESCRIPTION
Fixes #775

Background info in https://github.com/ng-bootstrap/ng-bootstrap/issues/775#issuecomment-248652544

I'm not sure how I feel about this fix but I guess having it is less harmful than not having it... 