### PR TITLE
chore: upgrade webpack to 2.1.0-beta

### DIFF
--- a/demo/src/vendor.ts
+++ b/demo/src/vendor.ts
@@ -1,27 +1,3 @@
-// Angular 2
-import '@angular/platform-browser';
-import '@angular/platform-browser-dynamic';
-import '@angular/core';
-import '@angular/common';
-import '@angular/router';
-import '@angular/forms';
-import '@angular/http';
-
-// RxJS
-import 'rxjs/Observable';
-import 'rxjs/Subject';
-import 'rxjs/Subscription';
-import 'rxjs/add/observable/fromEvent';
-import 'rxjs/add/observable/of';
-import 'rxjs/add/operator/catch';
-import 'rxjs/add/operator/debounceTime';
-import 'rxjs/add/operator/distinctUntilChanged';
-import 'rxjs/add/operator/do';
-import 'rxjs/add/operator/filter';
-import 'rxjs/add/operator/let';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/switchMap';
-
 // Other vendors for example jQuery, Lodash or Bootstrap
 // You can import js, ts, css, sass, ...
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -245,7 +245,7 @@ gulp.task('clean:demo-cache', function() { return del('.publish/'); });
 
 gulp.task(
     'demo-server', ['generate-docs', 'generate-plunks'],
-    shell.task(['webpack-dev-server --port 9090 --config webpack.demo.js --hot --inline --progress']));
+    shell.task(['webpack-dev-server --port 9090 --config webpack.demo.js --inline --progress']));
 
 gulp.task(
     'build:demo', ['clean:demo', 'generate-docs', 'generate-plunks'],

--- a/package.json
+++ b/package.json
@@ -29,10 +29,11 @@
   },
   "devDependencies": {
     "@angular/compiler": "2.0.0",
-    "@angular/compiler-cli": "0.6.1",
+    "@angular/compiler-cli": "0.6.2",
     "@angular/http": "2.0.0",
     "@angular/platform-browser": "2.0.0",
     "@angular/platform-browser-dynamic": "2.0.0",
+    "@angular/platform-server": "2.0.0",
     "@angular/router": "3.0.0",
     "@types/core-js": "^0.9.34",
     "@types/jasmine": "^2.5.37",
@@ -46,7 +47,7 @@
     "core-js": "^2.4.1",
     "css-loader": "^0.25.0",
     "del": "^2.2.2",
-    "extract-text-webpack-plugin": "^1.0.1",
+    "extract-text-webpack-plugin": "^2.0.0-beta.4",
     "file-loader": "^0.9.0",
     "glob": "^7.1.1",
     "gulp": "^3.9.1",
@@ -75,7 +76,7 @@
     "node-sass": "^3.10.1",
     "postcss-loader": "^0.9.1",
     "prismjs": "^1.5.1",
-    "prismjs-loader": "0.0.3",
+    "prismjs-loader": "0.0.4",
     "raw-loader": "^0.5.1",
     "reflect-metadata": "^0.1.8",
     "run-sequence": "^1.2.2",
@@ -87,8 +88,8 @@
     "tslint": "^3.15.1",
     "typescript": "^2.0.6",
     "url-loader": "^0.5.7",
-    "webpack": "^1.13.3",
-    "webpack-dev-server": "^1.16.2",
+    "webpack": "^2.1.0-beta.25",
+    "webpack-dev-server": "^2.1.0-beta.10",
     "zone.js": "^0.6.23"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,14 @@
     "experimentalDecorators": true,
     "noEmitOnError": true,
     "outDir": "temp",
-    "sourceMap": true
+    "sourceMap": true,
+    "baseUrl": "./node_modules",
+    "paths": {
+      "@ng-bootstrap/ng-bootstrap": ["../src/index"]
+    }
   },
   "include": [
-    "src/**/*.ts",
-    "typings/index.d.ts"
+    "src/**/*.ts"
   ],
   "compileOnSave": false
 }


### PR DESCRIPTION
Some quick comments:
- with webpack 2.1.0-beta.25, the build bugs (super slow/hangs), so using 2.1.0-beta.22 for now
- couldn't make `alias` work with existing loaders, so all the demo and src code are copied in a `tmp` folder before processing (this is needed for AoT anyway)
- there was an issue to load reflect-metadata, but it is useless as already available in core-js
- vendors and polyfills could be merged
