### PR TITLE
refactor(datepicker): use ISO 8601 for month and weekday numbers

### DIFF
--- a/demo/src/app/components/datepicker/demos/basic/datepicker-basic.html
+++ b/demo/src/app/components/datepicker/demos/basic/datepicker-basic.html
@@ -6,7 +6,7 @@
 
 <button class="btn btn-sm btn-outline-primary" (click)="selectToday()">Select Today</button>
 <button class="btn btn-sm btn-outline-primary" (click)="dp.navigateTo()">To current month</button>
-<button class="btn btn-sm btn-outline-primary" (click)="dp.navigateTo({year: 2013, month: 1})">To Feb 2013</button>
+<button class="btn btn-sm btn-outline-primary" (click)="dp.navigateTo({year: 2013, month: 2})">To Feb 2013</button>
 
 <hr/>
 

--- a/demo/src/app/components/datepicker/demos/basic/datepicker-basic.ts
+++ b/demo/src/app/components/datepicker/demos/basic/datepicker-basic.ts
@@ -12,6 +12,6 @@ export class NgbdDatepickerBasic {
   model: NgbDateStruct;
 
   selectToday() {
-    this.model = {year: now.getFullYear(), month: now.getMonth(), day: now.getDate()};
+    this.model = {year: now.getFullYear(), month: now.getMonth() + 1, day: now.getDate()};
   }
 }

--- a/demo/src/app/components/datepicker/demos/config/datepicker-config.ts
+++ b/demo/src/app/components/datepicker/demos/config/datepicker-config.ts
@@ -12,12 +12,12 @@ export class NgbdDatepickerConfig {
 
   constructor(config: NgbDatepickerConfig) {
     // customize default values of datepickers used by this component tree
-    config.minDate = {year: 1900, month: 0, day: 1};
-    config.maxDate = {year: 2099, month: 11, day: 31};
+    config.minDate = {year: 1900, month: 1, day: 1};
+    config.maxDate = {year: 2099, month: 12, day: 31};
 
     // weekends are disabled
     config.markDisabled = (date: NgbDateStruct) => {
-      const d = new Date(date.year, date.month, date.day);
+      const d = new Date(date.year, date.month - 1, date.day);
       return d.getDay() === 0 || d.getDay() === 6;
     };
   }

--- a/demo/src/app/components/datepicker/demos/customday/datepicker-customday.ts
+++ b/demo/src/app/components/datepicker/demos/customday/datepicker-customday.ts
@@ -26,7 +26,7 @@ export class NgbdDatepickerCustomDay {
   model: NgbDateStruct;
 
   isWeekend(date: NgbDateStruct) {
-    const d = new Date(date.year, date.month, date.day);
+    const d = new Date(date.year, date.month - 1, date.day);
     return d.getDay() === 0 || d.getDay() === 6;
   }
 }

--- a/demo/src/app/components/datepicker/demos/i18n/datepicker-i18n.ts
+++ b/demo/src/app/components/datepicker/demos/i18n/datepicker-i18n.ts
@@ -3,11 +3,11 @@ import {NgbDatepickerI18n} from '@ng-bootstrap/ng-bootstrap';
 
 const I18N_VALUES = {
   en: {
-    weekdays: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],
+    weekdays: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'],
     months: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
   },
   fr: {
-    weekdays: ['Di', 'Lu', 'Ma', 'Me', 'Je', 'Ve', 'Sa'],
+    weekdays: ['Lu', 'Ma', 'Me', 'Je', 'Ve', 'Sa', 'Di'],
     months: ['Jan', 'Fév', 'Mar', 'Avr', 'Mai', 'Juin', 'Juil', 'Aou', 'Sep', 'Oct', 'Nov', 'Déc'],
   }
 };
@@ -27,10 +27,10 @@ export class CustomDatepickerI18n extends NgbDatepickerI18n {
   }
 
   getWeekdayName(weekday: number): string {
-    return I18N_VALUES[this._i18n.language].weekdays[weekday];
+    return I18N_VALUES[this._i18n.language].weekdays[weekday - 1];
   }
   getMonthName(month: number): string {
-    return I18N_VALUES[this._i18n.language].months[month];
+    return I18N_VALUES[this._i18n.language].months[month - 1];
   }
 }
 

--- a/src/datepicker/datepicker-i18n.spec.ts
+++ b/src/datepicker/datepicker-i18n.spec.ts
@@ -5,15 +5,17 @@ describe('ngb-datepicker-i18n-default', () => {
   const i18n = new NgbDatepickerI18nDefault();
 
   it('should return month name', () => {
-    expect(i18n.getMonthName(0)).toBe('Jan');
-    expect(i18n.getMonthName(11)).toBe('Dec');
-    expect(i18n.getMonthName(12)).toBe(undefined);
+    expect(i18n.getMonthName(0)).toBe(undefined);
+    expect(i18n.getMonthName(1)).toBe('Jan');
+    expect(i18n.getMonthName(12)).toBe('Dec');
+    expect(i18n.getMonthName(13)).toBe(undefined);
   });
 
   it('should return weekday name', () => {
-    expect(i18n.getWeekdayName(0)).toBe('Su');
-    expect(i18n.getWeekdayName(6)).toBe('Sa');
-    expect(i18n.getWeekdayName(7)).toBe(undefined);
+    expect(i18n.getWeekdayName(0)).toBe(undefined);
+    expect(i18n.getWeekdayName(1)).toBe('Mo');
+    expect(i18n.getWeekdayName(7)).toBe('Su');
+    expect(i18n.getWeekdayName(8)).toBe(undefined);
   });
 
 });

--- a/src/datepicker/datepicker-i18n.ts
+++ b/src/datepicker/datepicker-i18n.ts
@@ -1,6 +1,6 @@
 import {Injectable} from '@angular/core';
 
-const WEEKDAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+const WEEKDAYS = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
 /**
@@ -11,20 +11,20 @@ const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', '
 export abstract class NgbDatepickerI18n {
   /**
    * Returns the short week day name to display in the heading of the month view.
-   * `weekday` is 0 for Sunday, 1 for Monday, etc.
+   * With default calendar we use ISO 8601: 'weekday' is 1=Mon ... 7=Sun
    */
   abstract getWeekdayName(weekday: number): string;
 
   /**
    * Returns the month name to display in the date picker navigation.
-   * `month` is 0 for January, 1 for February, etc.
+   * With default calendar we use ISO 8601: 'month' is 1=Jan ... 12=Dec
    */
   abstract getMonthName(month: number): string;
 }
 
 @Injectable()
 export class NgbDatepickerI18nDefault extends NgbDatepickerI18n {
-  getWeekdayName(weekday: number): string { return WEEKDAYS[weekday]; }
+  getWeekdayName(weekday: number): string { return WEEKDAYS[weekday - 1]; }
 
-  getMonthName(month: number): string { return MONTHS[month]; }
+  getMonthName(month: number): string { return MONTHS[month - 1]; }
 }

--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -54,12 +54,12 @@ describe('NgbInputDatepicker', () => {
          const fixture = createTestCmpt(`<input ngbDatepicker [ngModel]="date">`);
          const input = fixture.nativeElement.querySelector('input');
 
-         fixture.componentInstance.date = {year: 2016, month: 9, day: 10};
+         fixture.componentInstance.date = {year: 2016, month: 10, day: 10};
          fixture.detectChanges();
          tick();
          expect(input.value).toBe('2016-10-10');
 
-         fixture.componentInstance.date = {year: 2016, month: 9, day: 15};
+         fixture.componentInstance.date = {year: 2016, month: 10, day: 15};
          fixture.detectChanges();
          tick();
          expect(input.value).toBe('2016-10-15');
@@ -70,7 +70,7 @@ describe('NgbInputDatepicker', () => {
       const inputDebugEl = fixture.debugElement.query(By.css('input'));
 
       inputDebugEl.triggerEventHandler('change', {target: {value: '2016-09-10'}});
-      expect(fixture.componentInstance.date).toEqual({year: 2016, month: 8, day: 10});
+      expect(fixture.componentInstance.date).toEqual({year: 2016, month: 9, day: 10});
     });
 
     it('should propagate null to model when a user enters invalid date', () => {

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -47,7 +47,7 @@ export class NgbInputDatepicker implements ControlValueAccessor {
   @Input() dayTemplate: TemplateRef<DayTemplateContext>;
 
   /**
-   * First day of the week, 0=Sun, 1=Mon, etc.
+  * First day of the week. With default calendar we use ISO 8601: 1=Mon ... 7=Sun
    */
   @Input() firstDayOfWeek: number;
 
@@ -67,7 +67,7 @@ export class NgbInputDatepicker implements ControlValueAccessor {
   @Input() maxDate: NgbDateStruct;
 
   /**
-   * Whether to display navigation or not
+   * Whether to display navigation
    */
   @Input() showNavigation: boolean;
 
@@ -82,7 +82,9 @@ export class NgbInputDatepicker implements ControlValueAccessor {
   @Input() showWeekNumbers: boolean;
 
   /**
-   * Date to open calendar with. If nothing provided, calendar will open with current month.
+   * Date to open calendar with.
+   * With default calendar we use ISO 8601: 'month' is 1=Jan ... 12=Dec.
+   * If nothing provided, calendar will open with current month.
    * Use 'navigateTo(date)' as an alternative
    */
   @Input() startDate: {year: number, month: number};
@@ -172,7 +174,9 @@ export class NgbInputDatepicker implements ControlValueAccessor {
   }
 
   /**
-   * Navigates current view to provided date. If nothing provided calendar will open current month.
+   * Navigates current view to provided date.
+   * With default calendar we use ISO 8601: 'month' is 1=Jan ... 12=Dec.
+   * If nothing provided calendar will open current month.
    * Use 'startDate' input as an alternative
    */
   navigateTo(date?: {year: number, month: number}) {

--- a/src/datepicker/datepicker-navigation-select.spec.ts
+++ b/src/datepicker/datepicker-navigation-select.spec.ts
@@ -34,7 +34,7 @@ describe('ngb-datepicker-navigation-select', () => {
         createTestComponent(`<ngb-datepicker-navigation-select [date]="date" [minYear]="minYear" [maxYear]="maxYear">`);
 
     expect(getOptionValues(getMonthSelect(fixture.nativeElement))).toEqual([
-      '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11'
+      '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'
     ]);
   });
 

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -43,8 +43,8 @@ function customizeConfig(config: NgbDatepickerConfig) {
   config.dayTemplate = {} as TemplateRef<DayTemplateContext>;
   config.firstDayOfWeek = 2;
   config.markDisabled = (date) => false;
-  config.minDate = {year: 2000, month: 0, day: 1};
-  config.maxDate = {year: 2030, month: 11, day: 31};
+  config.minDate = {year: 2000, month: 1, day: 1};
+  config.maxDate = {year: 2030, month: 12, day: 31};
   config.showNavigation = false;
   config.showWeekdays = false;
   config.showWeekNumbers = true;
@@ -68,7 +68,7 @@ describe('ngb-datepicker', () => {
     const fixture = createTestComponent(`<ngb-datepicker></ngb-datepicker>`);
 
     const today = new Date();
-    expect(getMonthSelect(fixture.nativeElement).value).toBe(`${today.getMonth()}`);
+    expect(getMonthSelect(fixture.nativeElement).value).toBe(`${today.getMonth() + 1}`);
     expect(getYearSelect(fixture.nativeElement).value).toBe(`${today.getFullYear()}`);
   });
 
@@ -90,8 +90,8 @@ describe('ngb-datepicker', () => {
     const fixture = createTestComponent(
         `<ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate"></ngb-datepicker>`);
 
-    fixture.componentInstance.minDate = {year: 2016, month: 7, day: 20};
-    fixture.componentInstance.maxDate = {year: 2016, month: 7, day: 25};
+    fixture.componentInstance.minDate = {year: 2016, month: 8, day: 20};
+    fixture.componentInstance.maxDate = {year: 2016, month: 8, day: 25};
     fixture.detectChanges();
 
     // 19 AUG 2016
@@ -112,10 +112,10 @@ describe('ngb-datepicker', () => {
 
       const dates = getDates(fixture.nativeElement);
       dates[0].click();  // 1 AUG 2016
-      expect(fixture.componentInstance.model).toEqual({year: 2016, month: 7, day: 1});
+      expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 1});
 
       dates[1].click();
-      expect(fixture.componentInstance.model).toEqual({year: 2016, month: 7, day: 2});
+      expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 2});
     });
 
     it('should not update model based on calendar clicks when disabled', async(() => {
@@ -143,7 +143,7 @@ describe('ngb-datepicker', () => {
          const fixture = createTestComponent(
              `<ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="model"></ngb-datepicker>`);
 
-         fixture.componentInstance.model = {year: 2016, month: 7, day: 1};
+         fixture.componentInstance.model = {year: 2016, month: 8, day: 1};
 
          fixture.detectChanges();
          fixture.whenStable()
@@ -154,7 +154,7 @@ describe('ngb-datepicker', () => {
              .then(() => {
                expect(getDay(fixture.nativeElement, 0)).toHaveCssClass('bg-primary');
 
-               fixture.componentInstance.model = {year: 2016, month: 7, day: 2};
+               fixture.componentInstance.model = {year: 2016, month: 8, day: 2};
                fixture.detectChanges();
                return fixture.whenStable();
              })
@@ -177,7 +177,7 @@ describe('ngb-datepicker', () => {
            let dates = getDates(fixture.nativeElement);
 
            dates[31].click();  // 1 SEP 2016
-           expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 1});
+           expect(fixture.componentInstance.model).toEqual({year: 2016, month: 9, day: 1});
 
            // month changes to SEP
            fixture.detectChanges();
@@ -194,38 +194,38 @@ describe('ngb-datepicker', () => {
       const navigation = getNavigationLinks(fixture.nativeElement);
 
       dates[0].click();  // 1 AUG 2016
-      expect(fixture.componentInstance.model).toEqual({year: 2016, month: 7, day: 1});
+      expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 1});
 
       // PREV
       navigation[0].click();
       fixture.detectChanges();
       dates = getDates(fixture.nativeElement);
       dates[4].click();  // 1 JUL 2016
-      expect(fixture.componentInstance.model).toEqual({year: 2016, month: 6, day: 1});
+      expect(fixture.componentInstance.model).toEqual({year: 2016, month: 7, day: 1});
 
       // NEXT
       navigation[1].click();
       fixture.detectChanges();
       dates = getDates(fixture.nativeElement);
       dates[0].click();  // 1 AUG 2016
-      expect(fixture.componentInstance.model).toEqual({year: 2016, month: 7, day: 1});
+      expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 1});
     });
 
     it('should switch month using navigateTo({date})', () => {
       const fixture = createTestComponent(
           `<ngb-datepicker #dp [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="model"></ngb-datepicker>
-       <button id="btn"(click)="dp.navigateTo({year: 2015, month: 5})"></button>`);
+       <button id="btn"(click)="dp.navigateTo({year: 2015, month: 6})"></button>`);
 
       const button = fixture.nativeElement.querySelector('button#btn');
       button.click();
 
       fixture.detectChanges();
-      expect(getMonthSelect(fixture.nativeElement).value).toBe('5');
+      expect(getMonthSelect(fixture.nativeElement).value).toBe('6');
       expect(getYearSelect(fixture.nativeElement).value).toBe('2015');
 
       const dates = getDates(fixture.nativeElement);
       dates[0].click();  // 1 JUN 2015
-      expect(fixture.componentInstance.model).toEqual({year: 2015, month: 5, day: 1});
+      expect(fixture.componentInstance.model).toEqual({year: 2015, month: 6, day: 1});
     });
 
     it('should switch to current month using navigateTo() without arguments', () => {
@@ -238,7 +238,7 @@ describe('ngb-datepicker', () => {
 
       fixture.detectChanges();
       const today = new Date();
-      expect(getMonthSelect(fixture.nativeElement).value).toBe(`${today.getMonth()}`);
+      expect(getMonthSelect(fixture.nativeElement).value).toBe(`${today.getMonth() + 1}`);
       expect(getYearSelect(fixture.nativeElement).value).toBe(`${today.getFullYear()}`);
     });
 
@@ -286,7 +286,7 @@ describe('ngb-datepicker', () => {
                expect(getDatepicker(compiled)).toHaveCssClass('ng-invalid');
                expect(getDatepicker(compiled)).not.toHaveCssClass('ng-valid');
 
-               fixture.componentInstance.model = {year: 2016, month: 7, day: 1};
+               fixture.componentInstance.model = {year: 2016, month: 8, day: 1};
                fixture.detectChanges();
                return fixture.whenStable();
              })
@@ -381,11 +381,11 @@ describe('ngb-datepicker', () => {
 
 @Component({selector: 'test-cmp', template: ''})
 class TestComponent {
-  date = {year: 2016, month: 7};
-  minDate: NgbDateStruct = {year: 2010, month: 0, day: 1};
-  maxDate: NgbDateStruct = {year: 2020, month: 11, day: 31};
+  date = {year: 2016, month: 8};
+  minDate: NgbDateStruct = {year: 2010, month: 1, day: 1};
+  maxDate: NgbDateStruct = {year: 2020, month: 12, day: 31};
   form = new FormGroup({control: new FormControl('', Validators.required)});
   disabledForm = new FormGroup({control: new FormControl({value: null, disabled: true})});
   model;
-  markDisabled = (date: NgbDateStruct) => { return NgbDate.from(date).equals(new NgbDate(2016, 7, 22)); };
+  markDisabled = (date: NgbDateStruct) => { return NgbDate.from(date).equals(new NgbDate(2016, 8, 22)); };
 }

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnChanges, SimpleChanges, TemplateRef, forwardRef, OnInit} from '@angular/core';
+import {Component, Input, OnChanges, TemplateRef, forwardRef, OnInit} from '@angular/core';
 import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
 import {NgbCalendar} from './ngb-calendar';
 import {NgbDate} from './ngb-date';
@@ -65,7 +65,7 @@ export class NgbDatepicker implements OnChanges,
   @Input() dayTemplate: TemplateRef<DayTemplateContext>;
 
   /**
-   * First day of the week, 0=Sun, 1=Mon, etc.
+   * First day of the week. With default calendar we use ISO 8601: `weekday` is 1=Mon ... 12=Sun
    */
   @Input() firstDayOfWeek: number;
 
@@ -85,7 +85,7 @@ export class NgbDatepicker implements OnChanges,
   @Input() maxDate: NgbDateStruct;
 
   /**
-   * Whether to display navigation or not
+   * Whether to display navigation
    */
   @Input() showNavigation: boolean;
 
@@ -100,7 +100,9 @@ export class NgbDatepicker implements OnChanges,
   @Input() showWeekNumbers: boolean;
 
   /**
-   * Date to open calendar with. If nothing provided, calendar will open with current month.
+   * Date to open calendar with.
+   * With default calendar we use ISO 8601: 'month' is 1=Jan ... 12=Dec.
+   * If nothing provided, calendar will open with current month.
    * Use 'navigateTo(date)' as an alternative
    */
   @Input() startDate: {year: number, month: number};
@@ -123,7 +125,9 @@ export class NgbDatepicker implements OnChanges,
   }
 
   /**
-   * Navigates current view to provided date. If nothing provided calendar will open current month.
+   * Navigates current view to provided date.
+   * With default calendar we use ISO 8601: 'month' is 1=Jan ... 12=Dec.
+   * If nothing provided calendar will open current month.
    * Use 'startDate' input as an alternative
    */
   navigateTo(date?: {year: number, month: number}) {
@@ -136,7 +140,7 @@ export class NgbDatepicker implements OnChanges,
     this.navigateTo(this.startDate);
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges() {
     this._setDates();
     this.navigateTo(this.startDate);
   }

--- a/src/datepicker/ngb-calendar.spec.ts
+++ b/src/datepicker/ngb-calendar.spec.ts
@@ -1,4 +1,4 @@
-import {NgbCalendarGregorian, NgbPeriod} from './ngb-calendar';
+import {NgbCalendarGregorian} from './ngb-calendar';
 import {NgbDate} from './ngb-date';
 
 describe('ngb-calendar-gregorian', () => {
@@ -7,7 +7,7 @@ describe('ngb-calendar-gregorian', () => {
 
   it('should return todays date', () => {
     const jsToday = new Date();
-    const today = new NgbDate(jsToday.getFullYear(), jsToday.getMonth(), jsToday.getDate());
+    const today = new NgbDate(jsToday.getFullYear(), jsToday.getMonth() + 1, jsToday.getDate());
 
     expect(calendar.getToday()).toEqual(today);
   });
@@ -17,40 +17,50 @@ describe('ngb-calendar-gregorian', () => {
   it('should return number of weeks per month', () => { expect(calendar.getWeeksPerMonth()).toBe(6); });
 
   it('should return months of a year', () => {
-    expect(calendar.getMonths()).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+    expect(calendar.getMonths()).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+  });
+
+  it('should return day of week', () => {
+    expect(calendar.getWeekday(new NgbDate(2017, 1, 2))).toBe(1);  // Mon, 2 Jan 2017
+    expect(calendar.getWeekday(new NgbDate(2017, 1, 3))).toBe(2);
+    expect(calendar.getWeekday(new NgbDate(2017, 1, 4))).toBe(3);
+    expect(calendar.getWeekday(new NgbDate(2017, 1, 5))).toBe(4);
+    expect(calendar.getWeekday(new NgbDate(2017, 1, 6))).toBe(5);
+    expect(calendar.getWeekday(new NgbDate(2017, 1, 7))).toBe(6);
+    expect(calendar.getWeekday(new NgbDate(2017, 1, 8))).toBe(7);  // Sun, 8 Jan 2017
   });
 
   it('should add days to date', () => {
-    expect(calendar.getNext(new NgbDate(2016, 11, 31))).toEqual(new NgbDate(2017, 0, 1));
-    expect(calendar.getNext(new NgbDate(2016, 1, 28))).toEqual(new NgbDate(2016, 1, 29));
-    expect(calendar.getNext(new NgbDate(2017, 1, 28))).toEqual(new NgbDate(2017, 2, 1));
+    expect(calendar.getNext(new NgbDate(2016, 12, 31))).toEqual(new NgbDate(2017, 1, 1));
+    expect(calendar.getNext(new NgbDate(2016, 2, 28))).toEqual(new NgbDate(2016, 2, 29));
+    expect(calendar.getNext(new NgbDate(2017, 2, 28))).toEqual(new NgbDate(2017, 3, 1));
   });
 
   it('should subtract days from date', () => {
-    expect(calendar.getPrev(new NgbDate(2017, 0, 1))).toEqual(new NgbDate(2016, 11, 31));
-    expect(calendar.getPrev(new NgbDate(2016, 1, 29))).toEqual(new NgbDate(2016, 1, 28));
-    expect(calendar.getPrev(new NgbDate(2017, 2, 1))).toEqual(new NgbDate(2017, 1, 28));
+    expect(calendar.getPrev(new NgbDate(2017, 1, 1))).toEqual(new NgbDate(2016, 12, 31));
+    expect(calendar.getPrev(new NgbDate(2016, 2, 29))).toEqual(new NgbDate(2016, 2, 28));
+    expect(calendar.getPrev(new NgbDate(2017, 3, 1))).toEqual(new NgbDate(2017, 2, 28));
   });
 
   it('should add months to date', () => {
     expect(calendar.getNext(new NgbDate(2016, 7, 22), 'm')).toEqual(new NgbDate(2016, 8, 1));
     expect(calendar.getNext(new NgbDate(2016, 7, 1), 'm')).toEqual(new NgbDate(2016, 8, 1));
-    expect(calendar.getNext(new NgbDate(2016, 11, 22), 'm')).toEqual(new NgbDate(2017, 0, 1));
+    expect(calendar.getNext(new NgbDate(2016, 12, 22), 'm')).toEqual(new NgbDate(2017, 1, 1));
   });
 
   it('should subtract months from date', () => {
     expect(calendar.getPrev(new NgbDate(2016, 7, 22), 'm')).toEqual(new NgbDate(2016, 6, 1));
     expect(calendar.getPrev(new NgbDate(2016, 8, 1), 'm')).toEqual(new NgbDate(2016, 7, 1));
-    expect(calendar.getPrev(new NgbDate(2017, 0, 22), 'm')).toEqual(new NgbDate(2016, 11, 1));
+    expect(calendar.getPrev(new NgbDate(2017, 1, 22), 'm')).toEqual(new NgbDate(2016, 12, 1));
   });
 
   it('should add years to date', () => {
-    expect(calendar.getNext(new NgbDate(2016, 1, 22), 'y')).toEqual(new NgbDate(2017, 0, 1));
-    expect(calendar.getNext(new NgbDate(2017, 11, 22), 'y')).toEqual(new NgbDate(2018, 0, 1));
+    expect(calendar.getNext(new NgbDate(2016, 1, 22), 'y')).toEqual(new NgbDate(2017, 1, 1));
+    expect(calendar.getNext(new NgbDate(2017, 12, 22), 'y')).toEqual(new NgbDate(2018, 1, 1));
   });
 
   it('should subtract years from date', () => {
-    expect(calendar.getPrev(new NgbDate(2016, 11, 22), 'y')).toEqual(new NgbDate(2015, 0, 1));
-    expect(calendar.getPrev(new NgbDate(2017, 1, 22), 'y')).toEqual(new NgbDate(2016, 0, 1));
+    expect(calendar.getPrev(new NgbDate(2016, 12, 22), 'y')).toEqual(new NgbDate(2015, 1, 1));
+    expect(calendar.getPrev(new NgbDate(2017, 1, 22), 'y')).toEqual(new NgbDate(2016, 1, 1));
   });
 });

--- a/src/datepicker/ngb-calendar.ts
+++ b/src/datepicker/ngb-calendar.ts
@@ -2,10 +2,10 @@ import {NgbDate} from './ngb-date';
 import {Injectable} from '@angular/core';
 
 function fromJSDate(jsDate: Date) {
-  return new NgbDate(jsDate.getFullYear(), jsDate.getMonth(), jsDate.getDate());
+  return new NgbDate(jsDate.getFullYear(), jsDate.getMonth() + 1, jsDate.getDate());
 }
 function toJSDate(date: NgbDate) {
-  return new Date(date.year, date.month, date.day);
+  return new Date(date.year, date.month - 1, date.day);
 }
 
 export type NgbPeriod = 'y' | 'm' | 'd';
@@ -29,7 +29,7 @@ export abstract class NgbCalendar {
 export class NgbCalendarGregorian extends NgbCalendar {
   getDaysPerWeek() { return 7; }
 
-  getMonths() { return [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]; }
+  getMonths() { return [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]; }
 
   getWeeksPerMonth() { return 6; }
 
@@ -38,9 +38,9 @@ export class NgbCalendarGregorian extends NgbCalendar {
 
     switch (period) {
       case 'y':
-        return new NgbDate(date.year + number, 0, 1);
+        return new NgbDate(date.year + number, 1, 1);
       case 'm':
-        jsDate = new Date(date.year, date.month + number, 1);
+        jsDate = new Date(date.year, date.month + number - 1, 1);
         break;
       case 'd':
         jsDate.setDate(jsDate.getDate() + number);
@@ -56,10 +56,17 @@ export class NgbCalendarGregorian extends NgbCalendar {
 
   getWeekday(date: NgbDate) {
     let jsDate = toJSDate(date);
-    return jsDate.getDay();
+    let day = jsDate.getDay();
+    // in JS Date Sun=0, in ISO 8601 Sun=7
+    return day === 0 ? 7 : day;
   }
 
   getWeekNumber(week: NgbDate[], firstDayOfWeek: number) {
+    // in JS Date Sun=0, in ISO 8601 Sun=7
+    if (firstDayOfWeek === 7) {
+      firstDayOfWeek = 0;
+    }
+
     const thursdayIndex = (4 + 7 - firstDayOfWeek) % 7;
     let date = week[thursdayIndex];
 

--- a/src/datepicker/ngb-date-parser-formatter.spec.ts
+++ b/src/datepicker/ngb-date-parser-formatter.spec.ts
@@ -1,4 +1,3 @@
-import {NgbDate} from './ngb-date';
 import {NgbDateISOParserFormatter} from './ngb-date-parser-formatter';
 
 describe('ngb-date parsing and formatting', () => {
@@ -15,7 +14,7 @@ describe('ngb-date parsing and formatting', () => {
       expect(pf.parse('   ')).toBeNull();
     });
 
-    it('should parse valid date', () => { expect(pf.parse('2016-05-12')).toEqual({year: 2016, month: 4, day: 12}); });
+    it('should parse valid date', () => { expect(pf.parse('2016-05-12')).toEqual({year: 2016, month: 5, day: 12}); });
 
     it('should parse non-date as null', () => {
       expect(pf.parse('foo-bar-baz')).toBeNull();
@@ -24,7 +23,7 @@ describe('ngb-date parsing and formatting', () => {
     });
 
     it('should do its best parsing incomplete dates',
-       () => { expect(pf.parse('2011-5')).toEqual({year: 2011, month: 4, day: null}); });
+       () => { expect(pf.parse('2011-5')).toEqual({year: 2011, month: 5, day: null}); });
   });
 
   describe('formatting', () => {
@@ -34,10 +33,10 @@ describe('ngb-date parsing and formatting', () => {
       expect(pf.format(undefined)).toBe('');
     });
 
-    it('should format a valid date', () => { expect(pf.format({year: 2016, month: 9, day: 15})).toBe('2016-10-15'); });
+    it('should format a valid date', () => { expect(pf.format({year: 2016, month: 10, day: 15})).toBe('2016-10-15'); });
 
     it('should format a valid date with padding',
-       () => { expect(pf.format({year: 2016, month: 9, day: 5})).toBe('2016-10-05'); });
+       () => { expect(pf.format({year: 2016, month: 10, day: 5})).toBe('2016-10-05'); });
 
     it('should try its best with invalid dates', () => {
       expect(pf.format({year: 2016, month: NaN, day: undefined})).toBe('2016--');

--- a/src/datepicker/ngb-date-parser-formatter.ts
+++ b/src/datepicker/ngb-date-parser-formatter.ts
@@ -1,10 +1,9 @@
-import {NgbDate} from './ngb-date';
 import {padNumber, toInteger, isNumber} from '../util/util';
 import {NgbDateStruct} from './ngb-date-struct';
 
 /**
  * Abstract type serving as a DI token for the service parsing and formatting dates for the NgbInputDatepicker
- * directive. A default implementation using the ISO format is provided, but you can provide another implementation
+ * directive. A default implementation using the ISO 8601 format is provided, but you can provide another implementation
  * to use an alternative format.
  */
 export abstract class NgbDateParserFormatter {
@@ -30,9 +29,9 @@ export class NgbDateISOParserFormatter extends NgbDateParserFormatter {
       if (dateParts.length === 1 && isNumber(dateParts[0])) {
         return {year: toInteger(dateParts[0]), month: null, day: null};
       } else if (dateParts.length === 2 && isNumber(dateParts[0]) && isNumber(dateParts[1])) {
-        return {year: toInteger(dateParts[0]), month: toInteger(dateParts[1]) - 1, day: null};
+        return {year: toInteger(dateParts[0]), month: toInteger(dateParts[1]), day: null};
       } else if (dateParts.length === 3 && isNumber(dateParts[0]) && isNumber(dateParts[1]) && isNumber(dateParts[2])) {
-        return {year: toInteger(dateParts[0]), month: toInteger(dateParts[1]) - 1, day: toInteger(dateParts[2])};
+        return {year: toInteger(dateParts[0]), month: toInteger(dateParts[1]), day: toInteger(dateParts[2])};
       }
     }
     return null;
@@ -40,7 +39,7 @@ export class NgbDateISOParserFormatter extends NgbDateParserFormatter {
 
   format(date: NgbDateStruct): string {
     return date ?
-        `${date.year}-${isNumber(date.month) ? padNumber(date.month + 1) : ''}-${isNumber(date.day) ? padNumber(date.day) : ''}` :
+        `${date.year}-${isNumber(date.month) ? padNumber(date.month) : ''}-${isNumber(date.day) ? padNumber(date.day) : ''}` :
         '';
   }
 }

--- a/src/datepicker/ngb-date-struct.ts
+++ b/src/datepicker/ngb-date-struct.ts
@@ -8,7 +8,7 @@ export interface NgbDateStruct {
   year: number;
 
   /**
-   * The month, starting at 0 for January (in the gregorian calendar), to be consistent with the standard Date class
+   * The month, with default calendar we use ISO 8601: 1=Jan ... 12=Dec
    */
   month: number;
 


### PR DESCRIPTION
Fixes #728

BREAKING CHANGE: now datepicker uses ISO 8601 for month and weekday numbers with default calendar
Before
0=Jan; 1=Feb; ... 11=Dec
0=Sun; 1=Mon; ... 6=Sat

Now
1=Jan; 2=Feb; ... 12=Dec
1=Mon; 2=Tue; ... 7=Sun