### PR TITLE
fix(modal): add `forRoot` to modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 
 @NgModule({
   declarations: [AppComponent, ...],
-  imports: [NgbModule, ...],  
+  imports: [NgbModule.forRoot(), ...],  
   bootstrap: [AppComponent]
 })
 export class AppModule {

--- a/demo/src/app/app.module.ts
+++ b/demo/src/app/app.module.ts
@@ -19,7 +19,7 @@ import {NgbdSharedModule} from './shared';
   imports: [
     BrowserModule,
     routing,
-    NgbModule,
+    NgbModule.forRoot(),
     NgbdDemoModule,
     NgbdSharedModule
   ],

--- a/demo/src/app/getting-started/getting-started.component.html
+++ b/demo/src/app/getting-started/getting-started.component.html
@@ -26,7 +26,7 @@
 
 @NgModule(&#123;
   declarations: [AppComponent, ...],
-  imports: [NgbModule, ...],
+  imports: [NgbModule.forRoot(), ...],
   bootstrap: [AppComponent]
 })
 export class AppModule &#123;

--- a/src/accordion/accordion.module.ts
+++ b/src/accordion/accordion.module.ts
@@ -1,4 +1,4 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NGB_ACCORDION_DIRECTIVES} from './accordion';
@@ -7,11 +7,7 @@ import {NgbAccordionConfig} from './accordion-config';
 export {NgbPanelChangeEvent} from './accordion';
 export {NgbAccordionConfig} from './accordion-config';
 
-@NgModule({
-  declarations: NGB_ACCORDION_DIRECTIVES,
-  exports: NGB_ACCORDION_DIRECTIVES,
-  imports: [CommonModule],
-  providers: [NgbAccordionConfig]
-})
+@NgModule({declarations: NGB_ACCORDION_DIRECTIVES, exports: NGB_ACCORDION_DIRECTIVES, imports: [CommonModule]})
 export class NgbAccordionModule {
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbAccordionModule, providers: [NgbAccordionConfig]}; }
 }

--- a/src/accordion/accordion.spec.ts
+++ b/src/accordion/accordion.spec.ts
@@ -43,7 +43,7 @@ describe('ngb-accordion', () => {
   `;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAccordionModule]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAccordionModule.forRoot()]});
     TestBed.overrideComponent(TestComponent, {set: {template: html}});
   });
 
@@ -316,7 +316,7 @@ describe('ngb-accordion', () => {
   describe('Custom config', () => {
     let config: NgbAccordionConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbAccordionModule]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbAccordionModule.forRoot()]}); });
 
     beforeEach(inject([NgbAccordionConfig], (c: NgbAccordionConfig) => {
       config = c;
@@ -341,7 +341,7 @@ describe('ngb-accordion', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbAccordionModule], providers: [{provide: NgbAccordionConfig, useValue: config}]});
+          {imports: [NgbAccordionModule.forRoot()], providers: [{provide: NgbAccordionConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/alert/alert.module.ts
+++ b/src/alert/alert.module.ts
@@ -1,4 +1,4 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NGB_ALERT_DIRECTIVES, NgbAlert} from './alert';
@@ -10,8 +10,8 @@ export {NgbAlertConfig} from './alert-config';
   declarations: NGB_ALERT_DIRECTIVES,
   exports: NGB_ALERT_DIRECTIVES,
   imports: [CommonModule],
-  entryComponents: [NgbAlert],
-  providers: [NgbAlertConfig]
+  entryComponents: [NgbAlert]
 })
 export class NgbAlertModule {
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbAlertModule, providers: [NgbAlertConfig]}; }
 }

--- a/src/alert/alert.spec.ts
+++ b/src/alert/alert.spec.ts
@@ -20,7 +20,8 @@ function getCloseButton(element: HTMLElement): HTMLButtonElement {
 
 describe('ngb-alert', () => {
 
-  beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAlertModule]}); });
+  beforeEach(
+      () => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAlertModule.forRoot()]}); });
 
   it('should initialize inputs with default values', () => {
     const defaultConfig = new NgbAlertConfig();
@@ -52,7 +53,7 @@ describe('ngb-alert', () => {
   describe('Custom config', () => {
     let config: NgbAlertConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbAlertModule]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbAlertModule.forRoot()]}); });
 
     beforeEach(inject([NgbAlertConfig], (c: NgbAlertConfig) => {
       config = c;
@@ -77,7 +78,7 @@ describe('ngb-alert', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbAlertModule], providers: [{provide: NgbAlertConfig, useValue: config}]});
+          {imports: [NgbAlertModule.forRoot()], providers: [{provide: NgbAlertConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/buttons/radio.module.ts
+++ b/src/buttons/radio.module.ts
@@ -1,6 +1,7 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 import {NGB_RADIO_DIRECTIVES} from './radio';
 
 @NgModule({declarations: NGB_RADIO_DIRECTIVES, exports: NGB_RADIO_DIRECTIVES})
 export class NgbButtonsModule {
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbButtonsModule, providers: []}; }
 }

--- a/src/carousel/carousel.module.ts
+++ b/src/carousel/carousel.module.ts
@@ -1,4 +1,4 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NGB_CAROUSEL_DIRECTIVES} from './carousel';
@@ -6,11 +6,7 @@ import {NgbCarouselConfig} from './carousel-config';
 
 export {NgbCarouselConfig} from './carousel-config';
 
-@NgModule({
-  declarations: NGB_CAROUSEL_DIRECTIVES,
-  exports: NGB_CAROUSEL_DIRECTIVES,
-  imports: [CommonModule],
-  providers: [NgbCarouselConfig]
-})
+@NgModule({declarations: NGB_CAROUSEL_DIRECTIVES, exports: NGB_CAROUSEL_DIRECTIVES, imports: [CommonModule]})
 export class NgbCarouselModule {
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbCarouselModule, providers: [NgbCarouselConfig]}; }
 }

--- a/src/carousel/carousel.spec.ts
+++ b/src/carousel/carousel.spec.ts
@@ -30,7 +30,9 @@ function expectActiveSlides(nativeEl: HTMLDivElement, active: boolean[]) {
 }
 
 describe('ngb-carousel', () => {
-  beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbCarouselModule]}); });
+  beforeEach(() => {
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbCarouselModule.forRoot()]});
+  });
 
   it('should initialize inputs with default values', () => {
     const defaultConfig = new NgbCarouselConfig();
@@ -347,7 +349,7 @@ describe('ngb-carousel', () => {
   describe('Custom config', () => {
     let config: NgbCarouselConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbCarouselModule]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbCarouselModule.forRoot()]}); });
 
     beforeEach(inject([NgbCarouselConfig], (c: NgbCarouselConfig) => {
       config = c;
@@ -375,7 +377,7 @@ describe('ngb-carousel', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbCarouselModule], providers: [{provide: NgbCarouselConfig, useValue: config}]});
+          {imports: [NgbCarouselModule.forRoot()], providers: [{provide: NgbCarouselConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/collapse/collapse.module.ts
+++ b/src/collapse/collapse.module.ts
@@ -1,6 +1,7 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 import {NGB_COLLAPSE_DIRECTIVES} from './collapse';
 
 @NgModule({declarations: NGB_COLLAPSE_DIRECTIVES, exports: NGB_COLLAPSE_DIRECTIVES})
 export class NgbCollapseModule {
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbCollapseModule, providers: []}; }
 }

--- a/src/datepicker/datepicker-day-view.spec.ts
+++ b/src/datepicker/datepicker-day-view.spec.ts
@@ -13,7 +13,7 @@ describe('ngbDatepickerDayView', () => {
 
   beforeEach(() => {
     TestBed.overrideModule(NgbDatepickerModule, {set: {exports: [NgbDatepickerDayView]}});
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot()]});
   });
 
   it('should display date', () => {

--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -16,7 +16,8 @@ const createTestCmpt = (html: string) =>
 describe('NgbInputDatepicker', () => {
 
   beforeEach(() => {
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule, FormsModule]});
+    TestBed.configureTestingModule(
+        {declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot(), FormsModule]});
   });
 
   describe('open, close and toggle', () => {

--- a/src/datepicker/datepicker-month-view.spec.ts
+++ b/src/datepicker/datepicker-month-view.spec.ts
@@ -43,7 +43,7 @@ describe('ngbDatepickerMonthView', () => {
 
   beforeEach(() => {
     TestBed.overrideModule(NgbDatepickerModule, {set: {exports: [NgbDatepickerMonthView, NgbDatepickerDayView]}});
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot()]});
   });
 
   it('should show/hide weekdays', () => {

--- a/src/datepicker/datepicker-navigation-select.spec.ts
+++ b/src/datepicker/datepicker-navigation-select.spec.ts
@@ -26,7 +26,7 @@ describe('ngb-datepicker-navigation-select', () => {
 
   beforeEach(() => {
     TestBed.overrideModule(NgbDatepickerModule, {set: {exports: [NgbDatepickerNavigationSelect]}});
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot()]});
   });
 
   it('should generate month options correctly', () => {

--- a/src/datepicker/datepicker-navigation.spec.ts
+++ b/src/datepicker/datepicker-navigation.spec.ts
@@ -25,7 +25,7 @@ describe('ngbDatepickerNavigation', () => {
   beforeEach(() => {
     TestBed.overrideModule(
         NgbDatepickerModule, {set: {exports: [NgbDatepickerNavigation, NgbDatepickerNavigationSelect]}});
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot()]});
   });
 
   it('should render navigation select component for \'select\' type', () => {

--- a/src/datepicker/datepicker.module.ts
+++ b/src/datepicker/datepicker.module.ts
@@ -1,4 +1,4 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {NgbDatepicker} from './datepicker';
 import {NgbDatepickerMonthView} from './datepicker-month-view';
@@ -25,12 +25,18 @@ export {NgbDateParserFormatter} from './ngb-date-parser-formatter';
   ],
   exports: [NgbDatepicker, NgbInputDatepicker],
   imports: [CommonModule, FormsModule],
-  entryComponents: [NgbDatepicker],
-  providers: [
-    {provide: NgbCalendar, useClass: NgbCalendarGregorian},
-    {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nDefault},
-    {provide: NgbDateParserFormatter, useClass: NgbDateISOParserFormatter}, NgbDatepickerService, NgbDatepickerConfig
-  ]
+  entryComponents: [NgbDatepicker]
 })
 export class NgbDatepickerModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: NgbDatepickerModule,
+      providers: [
+        {provide: NgbCalendar, useClass: NgbCalendarGregorian},
+        {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nDefault},
+        {provide: NgbDateParserFormatter, useClass: NgbDateISOParserFormatter}, NgbDatepickerService,
+        NgbDatepickerConfig
+      ]
+    };
+  }
 }

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -55,7 +55,7 @@ describe('ngb-datepicker', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule(
-        {declarations: [TestComponent], imports: [NgbDatepickerModule, FormsModule, ReactiveFormsModule]});
+        {declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot(), FormsModule, ReactiveFormsModule]});
   });
 
   it('should initialize inputs with provided config', () => {
@@ -346,7 +346,7 @@ describe('ngb-datepicker', () => {
   describe('Custom config', () => {
     let config: NgbDatepickerConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbDatepickerModule]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbDatepickerModule.forRoot()]}); });
 
     beforeEach(inject([NgbDatepickerConfig], (c: NgbDatepickerConfig) => {
       config = c;
@@ -367,7 +367,7 @@ describe('ngb-datepicker', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbDatepickerModule], providers: [{provide: NgbDatepickerConfig, useValue: config}]});
+          {imports: [NgbDatepickerModule.forRoot()], providers: [{provide: NgbDatepickerConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/dropdown/dropdown.module.ts
+++ b/src/dropdown/dropdown.module.ts
@@ -1,9 +1,10 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 import {NGB_DROPDOWN_DIRECTIVES} from './dropdown';
 import {NgbDropdownConfig} from './dropdown-config';
 
 export {NgbDropdownConfig} from './dropdown-config';
 
-@NgModule({declarations: NGB_DROPDOWN_DIRECTIVES, exports: NGB_DROPDOWN_DIRECTIVES, providers: [NgbDropdownConfig]})
+@NgModule({declarations: NGB_DROPDOWN_DIRECTIVES, exports: NGB_DROPDOWN_DIRECTIVES})
 export class NgbDropdownModule {
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbDropdownModule, providers: [NgbDropdownConfig]}; }
 }

--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -16,7 +16,9 @@ function getDropdownEl(tc) {
 }
 
 describe('ngb-dropdown', () => {
-  beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDropdownModule]}); });
+  beforeEach(() => {
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDropdownModule.forRoot()]});
+  });
 
   it('should initialize inputs with provided config', () => {
     const defaultConfig = new NgbDropdownConfig();
@@ -162,7 +164,9 @@ describe('ngb-dropdown', () => {
 });
 
 describe('ngb-dropdown-toggle', () => {
-  beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDropdownModule]}); });
+  beforeEach(() => {
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDropdownModule.forRoot()]});
+  });
 
   it('should toggle dropdown on click', () => {
     const html = `
@@ -347,7 +351,7 @@ describe('ngb-dropdown-toggle', () => {
     let config: NgbDropdownConfig;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({imports: [NgbDropdownModule]});
+      TestBed.configureTestingModule({imports: [NgbDropdownModule.forRoot()]});
       TestBed.overrideComponent(TestComponent, {set: {template: '<div ngbDropdown></div>'}});
     });
 
@@ -372,7 +376,7 @@ describe('ngb-dropdown-toggle', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbDropdownModule], providers: [{provide: NgbDropdownConfig, useValue: config}]});
+          {imports: [NgbDropdownModule.forRoot()], providers: [{provide: NgbDropdownConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 
 import {NgbAccordionModule, NgbPanelChangeEvent} from './accordion/accordion.module';
 import {NgbAlertModule} from './alert/alert.module';
@@ -40,12 +40,26 @@ export {NgbTimepickerModule, NgbTimepickerConfig, NgbTimeStruct} from './timepic
 export {NgbTooltipModule, NgbTooltipConfig} from './tooltip/tooltip.module';
 export {NgbTypeaheadModule, NgbTypeaheadConfig, NgbTypeaheadSelectItemEvent} from './typeahead/typeahead.module';
 
+const NGB_MODULES = [
+  NgbAccordionModule, NgbAlertModule, NgbButtonsModule, NgbCarouselModule, NgbCollapseModule, NgbDatepickerModule,
+  NgbDropdownModule, NgbModalModule, NgbPaginationModule, NgbPopoverModule, NgbProgressbarModule, NgbRatingModule,
+  NgbTabsetModule, NgbTimepickerModule, NgbTooltipModule, NgbTypeaheadModule
+];
+
 @NgModule({
-  exports: [
-    NgbAccordionModule, NgbAlertModule, NgbButtonsModule, NgbCarouselModule, NgbCollapseModule, NgbDatepickerModule,
-    NgbDropdownModule, NgbModalModule, NgbPaginationModule, NgbPopoverModule, NgbProgressbarModule, NgbRatingModule,
-    NgbTabsetModule, NgbTimepickerModule, NgbTooltipModule, NgbTypeaheadModule
-  ]
+  imports: [
+    NgbAlertModule.forRoot(), NgbButtonsModule.forRoot(), NgbCollapseModule.forRoot(), NgbProgressbarModule.forRoot(),
+    NgbTooltipModule.forRoot(), NgbTypeaheadModule.forRoot(), NgbAccordionModule.forRoot(), NgbCarouselModule.forRoot(),
+    NgbDatepickerModule.forRoot(), NgbDropdownModule.forRoot(), NgbModalModule.forRoot(), NgbPaginationModule.forRoot(),
+    NgbPopoverModule.forRoot(), NgbProgressbarModule.forRoot(), NgbRatingModule.forRoot(), NgbTabsetModule.forRoot(),
+    NgbTimepickerModule.forRoot(), NgbTooltipModule.forRoot()
+  ],
+  exports: NGB_MODULES
 })
+export class NgbRootModule {
+}
+
+@NgModule({imports: NGB_MODULES, exports: NGB_MODULES})
 export class NgbModule {
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbRootModule}; }
 }

--- a/src/modal/modal.module.ts
+++ b/src/modal/modal.module.ts
@@ -1,4 +1,4 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 
 import {NgbModalContainer} from './modal-container';
 import {NgbModalBackdrop} from './modal-backdrop';
@@ -13,8 +13,8 @@ export {ModalDismissReasons} from './modal-dismiss-reasons';
 @NgModule({
   declarations: [NgbModalContainer, NgbModalBackdrop, NgbModalWindow],
   entryComponents: [NgbModalBackdrop, NgbModalWindow],
-  exports: [NgbModalContainer],
-  providers: [NgbModal, NgbModalStack]
+  exports: [NgbModalContainer]
 })
 export class NgbModalModule {
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbModalModule, providers: [NgbModal, NgbModalStack]}; }
 }

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -63,7 +63,7 @@ describe('ngb-modal', () => {
   });
 
   beforeEach(() => {
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbModalModule]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbModalModule.forRoot()]});
     fixture = TestBed.createComponent(TestComponent);
   });
 

--- a/src/pagination/pagination.module.ts
+++ b/src/pagination/pagination.module.ts
@@ -1,4 +1,4 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NGB_PAGINATION_DIRECTIVES} from './pagination';
@@ -6,11 +6,7 @@ import {NgbPaginationConfig} from './pagination-config';
 
 export {NgbPaginationConfig} from './pagination-config';
 
-@NgModule({
-  declarations: NGB_PAGINATION_DIRECTIVES,
-  exports: NGB_PAGINATION_DIRECTIVES,
-  imports: [CommonModule],
-  providers: [NgbPaginationConfig]
-})
+@NgModule({declarations: NGB_PAGINATION_DIRECTIVES, exports: NGB_PAGINATION_DIRECTIVES, imports: [CommonModule]})
 export class NgbPaginationModule {
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbPaginationModule, providers: [NgbPaginationConfig]}; }
 }

--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -129,8 +129,9 @@ describe('ngb-pagination', () => {
 
   describe('UI logic', () => {
 
-    beforeEach(
-        () => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPaginationModule]}); });
+    beforeEach(() => {
+      TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPaginationModule.forRoot()]});
+    });
 
     it('should render and respond to collectionSize change', () => {
       const html = '<ngb-pagination [collectionSize]="collectionSize" [page]="1"></ngb-pagination>';
@@ -422,7 +423,7 @@ describe('ngb-pagination', () => {
   describe('Custom config', () => {
     let config: NgbPaginationConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbPaginationModule]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbPaginationModule.forRoot()]}); });
 
     beforeEach(inject([NgbPaginationConfig], (c: NgbPaginationConfig) => {
       config = c;
@@ -456,7 +457,7 @@ describe('ngb-pagination', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbPaginationModule], providers: [{provide: NgbPaginationConfig, useValue: config}]});
+          {imports: [NgbPaginationModule.forRoot()], providers: [{provide: NgbPaginationConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/popover/popover.module.ts
+++ b/src/popover/popover.module.ts
@@ -1,15 +1,11 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 
 import {NGB_POPOVER_DIRECTIVES, NgbPopoverWindow} from './popover';
 import {NgbPopoverConfig} from './popover-config';
 
 export {NgbPopoverConfig} from './popover-config';
 
-@NgModule({
-  declarations: NGB_POPOVER_DIRECTIVES,
-  exports: NGB_POPOVER_DIRECTIVES,
-  entryComponents: [NgbPopoverWindow],
-  providers: [NgbPopoverConfig]
-})
+@NgModule({declarations: NGB_POPOVER_DIRECTIVES, exports: NGB_POPOVER_DIRECTIVES, entryComponents: [NgbPopoverWindow]})
 export class NgbPopoverModule {
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbPopoverModule, providers: [NgbPopoverConfig]}; }
 }

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -15,7 +15,9 @@ const createOnPushTestComponent =
     (html: string) => <ComponentFixture<TestOnPushComponent>>createGenericTestComponent(html, TestOnPushComponent);
 
 describe('ngb-popover-window', () => {
-  beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPopoverModule]}); });
+  beforeEach(() => {
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPopoverModule.forRoot()]});
+  });
 
   it('should render popover on top by default', () => {
     const fixture = TestBed.createComponent(NgbPopoverWindow);
@@ -39,7 +41,8 @@ describe('ngb-popover-window', () => {
 describe('ngb-popover', () => {
 
   beforeEach(() => {
-    TestBed.configureTestingModule({declarations: [TestComponent, TestOnPushComponent], imports: [NgbPopoverModule]});
+    TestBed.configureTestingModule(
+        {declarations: [TestComponent, TestOnPushComponent], imports: [NgbPopoverModule.forRoot()]});
   });
 
   function getWindow(fixture) { return fixture.nativeElement.querySelector('ngb-popover-window'); }
@@ -163,7 +166,9 @@ describe('ngb-popover', () => {
   });
 
   describe('triggers', () => {
-    beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPopoverModule]}); });
+    beforeEach(() => {
+      TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPopoverModule.forRoot()]});
+    });
 
     it('should support toggle triggers', () => {
       const fixture = createTestComponent(`<div ngbPopover="Great tip!" triggers="click"></div>`);
@@ -274,7 +279,7 @@ describe('ngb-popover', () => {
     let config: NgbPopoverConfig;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({imports: [NgbPopoverModule]});
+      TestBed.configureTestingModule({imports: [NgbPopoverModule.forRoot()]});
       TestBed.overrideComponent(TestComponent, {set: {template: `<div ngbPopover="Great tip!"></div>`}});
     });
 
@@ -302,7 +307,7 @@ describe('ngb-popover', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbPopoverModule], providers: [{provide: NgbPopoverConfig, useValue: config}]});
+          {imports: [NgbPopoverModule.forRoot()], providers: [{provide: NgbPopoverConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/progressbar/progressbar.module.ts
+++ b/src/progressbar/progressbar.module.ts
@@ -1,10 +1,10 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 import {NGB_PROGRESSBAR_DIRECTIVES} from './progressbar';
 import {NgbProgressbarConfig} from './progressbar-config';
 
 export {NgbProgressbarConfig} from './progressbar-config';
 
-@NgModule(
-    {declarations: NGB_PROGRESSBAR_DIRECTIVES, exports: NGB_PROGRESSBAR_DIRECTIVES, providers: [NgbProgressbarConfig]})
+@NgModule({declarations: NGB_PROGRESSBAR_DIRECTIVES, exports: NGB_PROGRESSBAR_DIRECTIVES})
 export class NgbProgressbarModule {
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbProgressbarModule, providers: [NgbProgressbarConfig]}; }
 }

--- a/src/progressbar/progressbar.spec.ts
+++ b/src/progressbar/progressbar.spec.ts
@@ -81,8 +81,9 @@ describe('ngb-progressbar', () => {
 
   describe('UI logic', () => {
 
-    beforeEach(
-        () => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbProgressbarModule]}); });
+    beforeEach(() => {
+      TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbProgressbarModule.forRoot()]});
+    });
 
     it('accepts a value and respond to value changes', () => {
       const html = '<ngb-progressbar [value]="value"></ngb-progressbar>';
@@ -168,7 +169,7 @@ describe('ngb-progressbar', () => {
   describe('Custom config', () => {
     let config: NgbProgressbarConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbProgressbarModule]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbProgressbarModule.forRoot()]}); });
 
     beforeEach(inject([NgbProgressbarConfig], (c: NgbProgressbarConfig) => {
       config = c;
@@ -199,7 +200,7 @@ describe('ngb-progressbar', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbProgressbarModule], providers: [{provide: NgbProgressbarConfig, useValue: config}]});
+          {imports: [NgbProgressbarModule.forRoot()], providers: [{provide: NgbProgressbarConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/rating/rating.module.ts
+++ b/src/rating/rating.module.ts
@@ -1,4 +1,4 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {NgbRatingConfig} from './rating-config';
 
@@ -6,11 +6,7 @@ import {NGB_RATING_DIRECTIVES} from './rating';
 
 export {NgbRatingConfig} from './rating-config';
 
-@NgModule({
-  declarations: NGB_RATING_DIRECTIVES,
-  exports: NGB_RATING_DIRECTIVES,
-  imports: [CommonModule],
-  providers: [NgbRatingConfig]
-})
+@NgModule({declarations: NGB_RATING_DIRECTIVES, exports: NGB_RATING_DIRECTIVES, imports: [CommonModule]})
 export class NgbRatingModule {
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbRatingModule, providers: [NgbRatingConfig]}; }
 }

--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -37,7 +37,8 @@ function getState(compiled) {
 }
 
 describe('ngb-rating', () => {
-  beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbRatingModule]}); });
+  beforeEach(
+      () => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbRatingModule.forRoot()]}); });
 
   it('should initialize inputs with default values', () => {
     const defaultConfig = new NgbRatingConfig();
@@ -147,7 +148,7 @@ describe('ngb-rating', () => {
   describe('Custom config', () => {
     let config: NgbRatingConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbRatingModule]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbRatingModule.forRoot()]}); });
 
     beforeEach(inject([NgbRatingConfig], (c: NgbRatingConfig) => {
       config = c;
@@ -172,7 +173,7 @@ describe('ngb-rating', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbRatingModule], providers: [{provide: NgbRatingConfig, useValue: config}]});
+          {imports: [NgbRatingModule.forRoot()], providers: [{provide: NgbRatingConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/tabset/tabset.module.ts
+++ b/src/tabset/tabset.module.ts
@@ -1,4 +1,4 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NGB_TABSET_DIRECTIVES} from './tabset';
@@ -7,11 +7,7 @@ import {NgbTabsetConfig} from './tabset-config';
 export {NgbTabChangeEvent} from './tabset';
 export {NgbTabsetConfig} from './tabset-config';
 
-@NgModule({
-  declarations: NGB_TABSET_DIRECTIVES,
-  exports: NGB_TABSET_DIRECTIVES,
-  imports: [CommonModule],
-  providers: [NgbTabsetConfig]
-})
+@NgModule({declarations: NGB_TABSET_DIRECTIVES, exports: NGB_TABSET_DIRECTIVES, imports: [CommonModule]})
 export class NgbTabsetModule {
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbTabsetModule, providers: [NgbTabsetConfig]}; }
 }

--- a/src/tabset/tabset.spec.ts
+++ b/src/tabset/tabset.spec.ts
@@ -52,7 +52,8 @@ function getButton(nativeEl: HTMLElement) {
 }
 
 describe('ngb-tabset', () => {
-  beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTabsetModule]}); });
+  beforeEach(
+      () => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTabsetModule.forRoot()]}); });
 
   it('should initialize inputs with default values', () => {
     const defaultConfig = new NgbTabsetConfig();
@@ -350,7 +351,7 @@ describe('ngb-tabset', () => {
   describe('Custom config', () => {
     let config: NgbTabsetConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbTabsetModule]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbTabsetModule.forRoot()]}); });
 
     beforeEach(inject([NgbTabsetConfig], (c: NgbTabsetConfig) => {
       config = c;
@@ -372,7 +373,7 @@ describe('ngb-tabset', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbTabsetModule], providers: [{provide: NgbTabsetConfig, useValue: config}]});
+          {imports: [NgbTabsetModule.forRoot()], providers: [{provide: NgbTabsetConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/timepicker/timepicker.module.ts
+++ b/src/timepicker/timepicker.module.ts
@@ -1,4 +1,4 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NGB_TIMEPICKER_DIRECTIVES} from './timepicker';
@@ -7,11 +7,7 @@ import {NgbTimepickerConfig} from './timepicker-config';
 export {NgbTimepickerConfig} from './timepicker-config';
 export {NgbTimeStruct} from './ngb-time-struct';
 
-@NgModule({
-  declarations: NGB_TIMEPICKER_DIRECTIVES,
-  exports: NGB_TIMEPICKER_DIRECTIVES,
-  imports: [CommonModule],
-  providers: [NgbTimepickerConfig]
-})
+@NgModule({declarations: NGB_TIMEPICKER_DIRECTIVES, exports: NGB_TIMEPICKER_DIRECTIVES, imports: [CommonModule]})
 export class NgbTimepickerModule {
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbTimepickerModule, providers: [NgbTimepickerConfig]}; }
 }

--- a/src/timepicker/timepicker.spec.ts
+++ b/src/timepicker/timepicker.spec.ts
@@ -76,7 +76,7 @@ describe('ngb-timepicker', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule(
-        {declarations: [TestComponent], imports: [NgbTimepickerModule, FormsModule, ReactiveFormsModule]});
+        {declarations: [TestComponent], imports: [NgbTimepickerModule.forRoot(), FormsModule, ReactiveFormsModule]});
   });
 
   describe('initialization', () => {
@@ -828,7 +828,7 @@ describe('ngb-timepicker', () => {
     let config: NgbTimepickerConfig;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({imports: [NgbTimepickerModule]});
+      TestBed.configureTestingModule({imports: [NgbTimepickerModule.forRoot()]});
       TestBed.overrideComponent(NgbTimepicker, {set: {template: ''}});
     });
 
@@ -851,7 +851,7 @@ describe('ngb-timepicker', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbTimepickerModule], providers: [{provide: NgbTimepickerConfig, useValue: config}]});
+          {imports: [NgbTimepickerModule.forRoot()], providers: [{provide: NgbTimepickerConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/tooltip/tooltip.module.ts
+++ b/src/tooltip/tooltip.module.ts
@@ -1,15 +1,11 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 
 import {NgbTooltip, NgbTooltipWindow} from './tooltip';
 import {NgbTooltipConfig} from './tooltip-config';
 
 export {NgbTooltipConfig} from './tooltip-config';
 
-@NgModule({
-  declarations: [NgbTooltip, NgbTooltipWindow],
-  exports: [NgbTooltip],
-  entryComponents: [NgbTooltipWindow],
-  providers: [NgbTooltipConfig]
-})
+@NgModule({declarations: [NgbTooltip, NgbTooltipWindow], exports: [NgbTooltip], entryComponents: [NgbTooltipWindow]})
 export class NgbTooltipModule {
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbTooltipModule, providers: [NgbTooltipConfig]}; }
 }

--- a/src/tooltip/tooltip.spec.ts
+++ b/src/tooltip/tooltip.spec.ts
@@ -15,7 +15,7 @@ const createOnPushTestComponent =
     (html: string) => <ComponentFixture<TestOnPushComponent>>createGenericTestComponent(html, TestOnPushComponent);
 
 describe('ngb-tooltip-window', () => {
-  beforeEach(() => { TestBed.configureTestingModule({imports: [NgbTooltipModule]}); });
+  beforeEach(() => { TestBed.configureTestingModule({imports: [NgbTooltipModule.forRoot()]}); });
 
   it('should render tooltip on top by default', () => {
     const fixture = TestBed.createComponent(NgbTooltipWindow);
@@ -37,7 +37,8 @@ describe('ngb-tooltip-window', () => {
 describe('ngb-tooltip', () => {
 
   beforeEach(() => {
-    TestBed.configureTestingModule({declarations: [TestComponent, TestOnPushComponent], imports: [NgbTooltipModule]});
+    TestBed.configureTestingModule(
+        {declarations: [TestComponent, TestOnPushComponent], imports: [NgbTooltipModule.forRoot()]});
   });
 
   function getWindow(fixture) { return fixture.nativeElement.querySelector('ngb-tooltip-window'); }
@@ -296,7 +297,7 @@ describe('ngb-tooltip', () => {
     let config: NgbTooltipConfig;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({imports: [NgbTooltipModule]});
+      TestBed.configureTestingModule({imports: [NgbTooltipModule.forRoot()]});
       TestBed.overrideComponent(TestComponent, {set: {template: `<div ngbTooltip="Great tip!"></div>`}});
     });
 
@@ -323,7 +324,7 @@ describe('ngb-tooltip', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbTooltipModule], providers: [{provide: NgbTooltipConfig, useValue: config}]});
+          {imports: [NgbTooltipModule.forRoot()], providers: [{provide: NgbTooltipConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/typeahead/highlight.spec.ts
+++ b/src/typeahead/highlight.spec.ts
@@ -36,7 +36,7 @@ describe('ngb-highlight', () => {
 
   beforeEach(() => {
     TestBed.overrideModule(NgbTypeaheadModule, {set: {exports: [NgbHighlight]}});
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTypeaheadModule]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTypeaheadModule.forRoot()]});
   });
 
   it('should render highlighted text when there is one match', () => {

--- a/src/typeahead/typeahead-window.spec.ts
+++ b/src/typeahead/typeahead-window.spec.ts
@@ -14,7 +14,7 @@ describe('ngb-typeahead-window', () => {
 
   beforeEach(() => {
     TestBed.overrideModule(NgbTypeaheadModule, {set: {exports: [NgbTypeaheadWindow]}});
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTypeaheadModule]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTypeaheadModule.forRoot()]});
   });
 
   describe('display', () => {

--- a/src/typeahead/typeahead.module.ts
+++ b/src/typeahead/typeahead.module.ts
@@ -1,4 +1,4 @@
-import {NgModule} from '@angular/core';
+import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NgbHighlight} from './highlight';
@@ -13,8 +13,8 @@ export {NgbTypeaheadSelectItemEvent} from './typeahead';
   declarations: [NgbTypeahead, NgbHighlight, NgbTypeaheadWindow],
   exports: [NgbTypeahead],
   imports: [CommonModule],
-  entryComponents: [NgbTypeaheadWindow],
-  providers: [NgbTypeaheadConfig]
+  entryComponents: [NgbTypeaheadWindow]
 })
 export class NgbTypeaheadModule {
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbTypeaheadModule, providers: [NgbTypeaheadConfig]}; }
 }

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -68,7 +68,7 @@ describe('ngb-typeahead', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [TestComponent, TestOnPushComponent],
-      imports: [NgbTypeaheadModule, FormsModule, ReactiveFormsModule]
+      imports: [NgbTypeaheadModule.forRoot(), FormsModule, ReactiveFormsModule]
     });
   });
 
@@ -512,9 +512,9 @@ describe('ngb-typeahead', () => {
          }));
 
       it('should take input formatter into account when displaying hints', async(() => {
-           const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" 
-                [ngbTypeahead]="findAnywhere" 
-                [inputFormatter]="uppercaseFormatter" 
+           const fixture = createTestComponent(`<input type="text" [(ngModel)]="model"
+                [ngbTypeahead]="findAnywhere"
+                [inputFormatter]="uppercaseFormatter"
                 [showHint]="true"/>`);
            const compiled = fixture.nativeElement;
            const inputEl = getNativeInput(compiled);


### PR DESCRIPTION
I converted all modules to follow the same pattern as pretty much all of them expose a configuration service of some kind.

BREAKING CHANGE: The root app module must now import using the forRoot() static method.

Closes #784