### PR TITLE
feat(carousel): add support to turn off interval

### DIFF
--- a/src/carousel/carousel.spec.ts
+++ b/src/carousel/carousel.spec.ts
@@ -196,6 +196,29 @@ describe('ngb-carousel', () => {
        discardPeriodicTasks();
      }));
 
+  it('should not change slide on time passage (custom interval value is zero)', fakeAsync(() => {
+       const html = `
+      <ngb-carousel [interval]="0">
+        <template ngbSlide>foo</template>
+        <template ngbSlide>bar</template>
+      </ngb-carousel>
+    `;
+
+       const fixture = createTestComponent(html);
+
+       expectActiveSlides(fixture.nativeElement, [true, false]);
+
+       tick(1000);
+       fixture.detectChanges();
+       expectActiveSlides(fixture.nativeElement, [true, false]);
+
+       tick(1200);
+       fixture.detectChanges();
+       expectActiveSlides(fixture.nativeElement, [true, false]);
+
+       discardPeriodicTasks();
+     }));
+
   it('should pause / resume slide change with time passage on mouse enter / leave', fakeAsync(() => {
        const html = `
       <ngb-carousel>

--- a/src/carousel/carousel.ts
+++ b/src/carousel/carousel.ts
@@ -178,7 +178,9 @@ export class NgbCarousel implements AfterContentChecked,
   }
 
   private _startTimer() {
-    this._slideChangeInterval = setInterval(() => { this.cycleToNext(); }, this.interval);
+    if (this.interval > 0) {
+      this._slideChangeInterval = setInterval(() => { this.cycleToNext(); }, this.interval);
+    }
   }
 
   private _stopTimer() { clearInterval(this._slideChangeInterval); }


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [] built and tested the changes locally.
 - [] added/updated any applicable tests.
 - [] added/updated any applicable API documentation.
 - [] added/updated any applicable demos.

Just added the same functionality as setting interval to zero that was on ui-bootstrap.