### PR TITLE
demo(rating): shows enter/leave usage and readonly ratings

### DIFF
--- a/demo/src/app/components/rating/demos/events/events.component.html
+++ b/demo/src/app/components/rating/demos/events/events.component.html
@@ -1,0 +1,9 @@
+<ngb-rating [(rate)]="selected" (hover)="hovered=$event" (leave)="hovered=0" [readonly]="readonly"></ngb-rating>
+<hr>
+<pre>
+Selected: <b>{{selected}}</b>
+Hovered: <b>{{hovered}}</b>
+</pre>
+<button class="btn btn-sm btn-outline-{{readonly ? 'danger' : 'success'}}" (click)="readonly = !readonly">
+  {{ readonly ? "readonly" : "editable"}}
+</button>

--- a/demo/src/app/components/rating/demos/events/events.component.ts
+++ b/demo/src/app/components/rating/demos/events/events.component.ts
@@ -1,0 +1,11 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'ngbd-rating-events',
+  templateUrl: 'events.component.html'
+})
+export class RatingEventsComponent {
+  selected = 0;
+  hovered = 0;
+  readonly = false;
+}

--- a/demo/src/app/components/rating/demos/events/index.ts
+++ b/demo/src/app/components/rating/demos/events/index.ts
@@ -1,0 +1,3 @@
+export * from './events.component';
+export const basicTsContent = require('!!prismjs?lang=typescript!./events.component.ts');
+export const basicHtmlContent = require('!!prismjs?lang=markup!./events.component.html');

--- a/demo/src/app/components/rating/demos/index.ts
+++ b/demo/src/app/components/rating/demos/index.ts
@@ -1,12 +1,17 @@
 import {RatingBasicComponent} from './basic/basic.component';
 import {RatingConfigComponent} from './config/config.component';
+import {RatingEventsComponent} from './events/events.component';
 
-export const DEMO_DIRECTIVES = [RatingBasicComponent, RatingConfigComponent];
+export const DEMO_DIRECTIVES = [RatingBasicComponent, RatingConfigComponent, RatingEventsComponent];
 
 export const DEMO_SNIPPETS = {
   basic: {
     code: require('!!prismjs?lang=typescript!./basic/basic.component'),
     markup: require('!!prismjs?lang=markup!./basic/basic.component.html')
+  },
+  events: {
+    code: require('!!prismjs?lang=typescript!./events/events.component'),
+    markup: require('!!prismjs?lang=markup!./events/events.component.html')
   },
   config: {
     code: require('!!prismjs?lang=typescript!./config/config.component'),

--- a/demo/src/app/components/rating/rating.component.html
+++ b/demo/src/app/components/rating/rating.component.html
@@ -4,9 +4,10 @@
   <ngbd-example-box demoTitle="Basic demo" [htmlSnippet]="snippets.basic.markup" [tsSnippet]="snippets.basic.code">
     <ngbd-rating-basic></ngbd-rating-basic>
   </ngbd-example-box>
-  <ngbd-example-box demoTitle="Global configuration of ratings"
-                    [htmlSnippet]="snippets.config.markup"
-                    [tsSnippet]="snippets.config.code">
+  <ngbd-example-box demoTitle="Events and readonly ratings" [htmlSnippet]="snippets.events.markup" [tsSnippet]="snippets.events.code">
+    <ngbd-rating-events></ngbd-rating-events>
+  </ngbd-example-box>
+  <ngbd-example-box demoTitle="Global configuration of ratings" [htmlSnippet]="snippets.config.markup" [tsSnippet]="snippets.config.code">
     <ngbd-rating-config></ngbd-rating-config>
   </ngbd-example-box>
 </ngbd-content-wrapper>


### PR DESCRIPTION
Just a small demo to show the rating `[readonly]` feature and `(hover)` / `(leave)` events

<img width="537" alt="screen shot 2016-09-28 at 22 17 14" src="https://cloud.githubusercontent.com/assets/8074436/18930821/e1ce3c9a-85c9-11e6-80cf-e05dd84fd9ce.png">
