### PR TITLE
feat(rating): allow custom star templates

### DIFF
--- a/demo/src/app/components/rating/demos/index.ts
+++ b/demo/src/app/components/rating/demos/index.ts
@@ -1,8 +1,9 @@
 import {RatingBasicComponent} from './basic/basic.component';
 import {RatingConfigComponent} from './config/config.component';
+import {RatingTemplateComponent} from './template/template.component';
 import {RatingEventsComponent} from './events/events.component';
 
-export const DEMO_DIRECTIVES = [RatingBasicComponent, RatingConfigComponent, RatingEventsComponent];
+export const DEMO_DIRECTIVES = [RatingBasicComponent, RatingConfigComponent, RatingEventsComponent, RatingTemplateComponent];
 
 export const DEMO_SNIPPETS = {
   basic: {
@@ -12,6 +13,10 @@ export const DEMO_SNIPPETS = {
   events: {
     code: require('!!prismjs?lang=typescript!./events/events.component'),
     markup: require('!!prismjs?lang=markup!./events/events.component.html')
+  },
+  template: {
+    code: require('!!prismjs?lang=typescript!./template/template.component'),
+    markup: require('!!prismjs?lang=markup!./template/template.component.html')
   },
   config: {
     code: require('!!prismjs?lang=typescript!./config/config.component'),

--- a/demo/src/app/components/rating/demos/template/index.ts
+++ b/demo/src/app/components/rating/demos/template/index.ts
@@ -1,0 +1,3 @@
+export * from './template.component';
+export const templateTsContent = require('!!prismjs?lang=typescript!./template.component.ts');
+export const templateHtmlContent = require('!!prismjs?lang=markup!./template.component.html');

--- a/demo/src/app/components/rating/demos/template/template.component.html
+++ b/demo/src/app/components/rating/demos/template/template.component.html
@@ -1,0 +1,6 @@
+<template #t let-fill="fill">
+  <span class="star" [class.filled]="fill === 100">&#9733;</span>
+</template>
+<ngb-rating [(rate)]="currentRate" [starTemplate]="t"></ngb-rating>
+<hr>
+<pre>Rate: <b>{{currentRate}}</b></pre>

--- a/demo/src/app/components/rating/demos/template/template.component.ts
+++ b/demo/src/app/components/rating/demos/template/template.component.ts
@@ -1,0 +1,18 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'ngbd-rating-template',
+  templateUrl: './template.component.html',
+  styles: [`
+    .star {
+      font-size: 1.5rem;
+      color: #b0c4de;
+    }
+    .filled {
+      color: #1e90ff;
+    }
+  `]
+})
+export class RatingTemplateComponent {
+  currentRate = 6;
+}

--- a/demo/src/app/components/rating/rating.component.html
+++ b/demo/src/app/components/rating/rating.component.html
@@ -1,11 +1,15 @@
 <ngbd-content-wrapper component="Rating">
   <ngbd-api-docs directive="NgbRating"></ngbd-api-docs>
+  <ngbd-api-docs-class type="StarTemplateContext"></ngbd-api-docs-class>
   <ngbd-api-docs-config type="NgbRatingConfig"></ngbd-api-docs-config>
   <ngbd-example-box demoTitle="Basic demo" [htmlSnippet]="snippets.basic.markup" [tsSnippet]="snippets.basic.code">
     <ngbd-rating-basic></ngbd-rating-basic>
   </ngbd-example-box>
   <ngbd-example-box demoTitle="Events and readonly ratings" [htmlSnippet]="snippets.events.markup" [tsSnippet]="snippets.events.code">
     <ngbd-rating-events></ngbd-rating-events>
+  </ngbd-example-box>
+  <ngbd-example-box demoTitle="Custom star template" [htmlSnippet]="snippets.template.markup" [tsSnippet]="snippets.template.code">
+    <ngbd-rating-template></ngbd-rating-template>
   </ngbd-example-box>
   <ngbd-example-box demoTitle="Global configuration of ratings" [htmlSnippet]="snippets.config.markup" [tsSnippet]="snippets.config.code">
     <ngbd-rating-config></ngbd-rating-config>

--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -12,11 +12,7 @@ const createTestComponent = (html: string) =>
 
 function getAriaState(compiled) {
   const stars = getStars(compiled, '.sr-only');
-  let state = [];
-  for (let i = 0, l = stars.length; i < l; i++) {
-    state.push((stars[i].textContent === '(*)' && stars[i].textContent !== '( )'));
-  }
-  return state;
+  return stars.map(star => star.textContent === '(*)' && star.textContent !== '( )');
 }
 
 function getStar(compiled, num: number) {
@@ -24,16 +20,12 @@ function getStar(compiled, num: number) {
 }
 
 function getStars(element, selector = 'span > span:not(.sr-only)') {
-  return element.querySelectorAll(selector);
+  return <HTMLElement[]>Array.from(element.querySelectorAll(selector));
 }
 
 function getState(compiled) {
   const stars = getStars(compiled);
-  let state = [];
-  for (let i = 0, l = stars.length; i < l; i++) {
-    state.push((stars[i].textContent === String.fromCharCode(9733)));
-  }
-  return state;
+  return stars.map(star => star.textContent.trim() === String.fromCharCode(9733));
 }
 
 describe('ngb-rating', () => {
@@ -96,6 +88,17 @@ describe('ngb-rating', () => {
     const compiled = fixture.nativeElement;
 
     expect(window.getComputedStyle(getStar(compiled, 1)).getPropertyValue('cursor')).toBe('not-allowed');
+  });
+
+  it('should allow custom star template', () => {
+    const fixture = createTestComponent(`
+      <template #t let-fill="fill">{{ fill === 100 ? 'x' : 'o' }}</template>
+      <ngb-rating [starTemplate]="t" rate="2" max="4"></ngb-rating>`);
+
+    const compiled = fixture.nativeElement;
+
+    const textContents = getStars(compiled).map(s => s.textContent.trim());
+    expect(textContents).toEqual(['x', 'x', 'o', 'o']);
   });
 
   describe('aria support', () => {

--- a/src/rating/rating.ts
+++ b/src/rating/rating.ts
@@ -1,5 +1,15 @@
-import {Component, ChangeDetectionStrategy, Input, Output, EventEmitter, OnInit} from '@angular/core';
+import {Component, ChangeDetectionStrategy, Input, Output, EventEmitter, OnInit, TemplateRef} from '@angular/core';
 import {NgbRatingConfig} from './rating-config';
+
+/**
+ * Context for the custom star display template
+ */
+export interface StarTemplateContext {
+  /**
+   * Star fill percentage. An integer value between 0 and 100
+   */
+  fill: number;
+}
 
 /**
  * Rating directive that will take care of visualising a star rating bar.
@@ -8,12 +18,15 @@ import {NgbRatingConfig} from './rating-config';
   selector: 'ngb-rating',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
+    <template #t let-fill="fill">{{ fill === 100 ? '&#9733;' : '&#9734;' }}</template>
     <span tabindex="0" (mouseleave)="reset()" aria-valuemin="0" [attr.aria-valuemax]="max" [attr.aria-valuenow]="rate">
       <template ngFor let-r [ngForOf]="range" let-index="index">
         <span class="sr-only">({{ index < rate ? '*' : ' ' }})</span>
         <span (mouseenter)="enter(index + 1)" (click)="update(index + 1)" [title]="r.title" 
         [attr.aria-valuetext]="r.title" 
-        [style.cursor]="readonly ? 'not-allowed' : 'pointer'">{{ index < rate ? '&#9733;' : '&#9734;' }}</span>
+        [style.cursor]="readonly ? 'not-allowed' : 'pointer'">
+          <template [ngTemplateOutlet]="starTemplate || t" [ngOutletContext]="{fill: index < rate ? 100 : 0}"></template>
+        </span>
       </template>
     </span>
   `
@@ -36,6 +49,11 @@ export class NgbRating implements OnInit {
    * A flag indicating if rating can be updated.
    */
   @Input() readonly: boolean;
+
+  /**
+   * A template to override star display
+   */
+  @Input() starTemplate: TemplateRef<StarTemplateContext>;
 
   /**
    * An event fired when a user is hovering over a given rating.


### PR DESCRIPTION
Part of #801 

Adds a template to allow custom rating display
Default rendering still uses &#9733; and &#9734; symbols

```html
<template #t let-fill="fill">
  <!-- fill is a number between 0-100 to represent how the star is filled -->
</template>

<ngb-rating [(rate)]="currentRate" [starTemplate]="t"></ngb-rating>
```

<img width="530" alt="screen shot 2016-09-29 at 00 05 32" src="https://cloud.githubusercontent.com/assets/8074436/18934149/7cae483c-85d8-11e6-8cb5-e3a14485b8cd.png">
