### PR TITLE
demo(typeahead): use catch to handle search failures

### DIFF
--- a/demo/src/app/components/typeahead/demos/http/typeahead-http.html
+++ b/demo/src/app/components/typeahead/demos/http/typeahead-http.html
@@ -5,8 +5,14 @@ A typeahead example that gets values from the <code>WikipediaService</code>
   <li><code>do</code> operator</li>
   <li><code>distinctUntilChanged</code> operator</li>
   <li><code>switchMap</code> operator</li>
+  <li><code>catch</code> operator to display an error message in case of connectivity issue</li>
 </ul>
 
-<input type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search" placeholder="Wikipedia search" /><span *ngIf="searching"> searching...</span>
+<div class="form-group" [class.has-danger]="searchFailed">
+  <input type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search" placeholder="Wikipedia search" />
+  <span *ngIf="searching">searching...</span>
+  <div class="form-control-feedback" *ngIf="searchFailed">Sorry, suggestions could not be loaded.</div>
+</div>
+
 <hr>
 <pre>Model: {{ model | json }}</pre>


### PR DESCRIPTION
It allows displaying an error message, and it also makes the code more robust, because it survives to failures: when the connectivity comes back, it's able to search again.

fix #816