### PR TITLE
docs(README): remove http://issuestats.com/ badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![npm version](https://badge.fury.io/js/%40ng-bootstrap%2Fng-bootstrap.svg)](https://badge.fury.io/js/%40ng-bootstrap%2Fng-bootstrap)
 [![Build Status](https://travis-ci.org/ng-bootstrap/ng-bootstrap.svg?branch=master)](https://travis-ci.org/ng-bootstrap/ng-bootstrap)
 [![devDependency Status](https://david-dm.org/ng-bootstrap/ng-bootstrap/dev-status.svg?branch=master)](https://david-dm.org/ng-bootstrap/ng-bootstrap#info=devDependencies)
-[![Issue Stats](http://issuestats.com/github/ng-bootstrap/ng-bootstrap/badge/pr)](http://issuestats.com/github/ng-bootstrap/ng-bootstrap)
-[![Issue Stats](http://issuestats.com/github/ng-bootstrap/ng-bootstrap/badge/issue)](http://issuestats.com/github/ng-bootstrap/ng-bootstrap)
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/pkozlowski.svg)](https://saucelabs.com/u/pkozlowski)
 
 Welcome to the Angular 2 version of the [Angular UI Bootstrap](https://github.com/angular-ui/bootstrap) library.


### PR DESCRIPTION
http://issuestats.com/ seems to be broken most of the time
and makes our landing page look half-baked.