### PR TITLE
feat(rating): allows custom template to be a child of ngb-rating

### DIFF
--- a/demo/src/app/components/rating/demos/decimal/decimal.component.html
+++ b/demo/src/app/components/rating/demos/decimal/decimal.component.html
@@ -1,3 +1,5 @@
+<p>Custom rating template provided via a variable. Shows fine-grained rating display</p>
+
 <template #t let-fill="fill">
   <span *ngIf="fill === 100" class="star full">&hearts;</span>
   <span *ngIf="fill === 0" class="star">&hearts;</span>
@@ -5,7 +7,9 @@
     <span class="half" [style.width.%]="fill">&hearts;</span>&hearts;
   </span>
 </template>
+
 <ngb-rating [(rate)]="currentRate" [starTemplate]="t" [readonly]="true" max="5"></ngb-rating>
+
 <hr>
 <pre>Rate: <b>{{currentRate}}</b></pre>
 <button class="btn btn-sm btn-outline-primary" (click)="currentRate = 1.35">1.35</button>

--- a/demo/src/app/components/rating/demos/template/template.component.html
+++ b/demo/src/app/components/rating/demos/template/template.component.html
@@ -1,6 +1,9 @@
-<template #t let-fill="fill">
-  <span class="star" [class.filled]="fill === 100">&#9733;</span>
-</template>
-<ngb-rating [(rate)]="currentRate" [starTemplate]="t"></ngb-rating>
+<p>Custom rating template provided as child element</p>
+
+<ngb-rating [(rate)]="currentRate">
+  <template let-fill="fill">
+    <span class="star" [class.filled]="fill === 100">&#9733;</span>
+  </template>
+</ngb-rating>
 <hr>
 <pre>Rate: <b>{{currentRate}}</b></pre>

--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -105,6 +105,27 @@ describe('ngb-rating', () => {
     expect(getStateText(compiled)).toEqual(['x', 'x', 'o', 'o']);
   });
 
+  it('should allow custom template as a child element', () => {
+    const fixture = createTestComponent(`
+      <ngb-rating rate="2" max="4">
+        <template let-fill="fill">{{ fill === 100 ? 'x' : 'o' }}</template>
+      </ngb-rating>`);
+
+    const compiled = fixture.nativeElement;
+    expect(getStateText(compiled)).toEqual(['x', 'x', 'o', 'o']);
+  });
+
+  it('should prefer explicitly set custom template to a child one', () => {
+    const fixture = createTestComponent(`
+      <template #t let-fill="fill">{{ fill === 100 ? 'a' : 'b' }}</template>
+      <ngb-rating [starTemplate]="t" rate="2" max="4">
+        <template let-fill="fill">{{ fill === 100 ? 'c' : 'd' }}</template>
+      </ngb-rating>`);
+
+    const compiled = fixture.nativeElement;
+    expect(getStateText(compiled)).toEqual(['a', 'a', 'b', 'b']);
+  });
+
   it('should calculate fill percentage correctly', () => {
     const fixture = createTestComponent(`
       <template #t let-fill="fill">{{fill}}</template>

--- a/src/rating/rating.ts
+++ b/src/rating/rating.ts
@@ -7,7 +7,8 @@ import {
   OnInit,
   TemplateRef,
   OnChanges,
-  SimpleChanges
+  SimpleChanges,
+  ContentChild
 } from '@angular/core';
 import {NgbRatingConfig} from './rating-config';
 
@@ -62,9 +63,10 @@ export class NgbRating implements OnInit,
   @Input() readonly: boolean;
 
   /**
-   * A template to override star display
+   * A template to override star display.
+   * Alternatively put a <template> as the only child of <ngb-rating> element
    */
-  @Input() starTemplate: TemplateRef<StarTemplateContext>;
+  @Input() @ContentChild(TemplateRef) starTemplate: TemplateRef<StarTemplateContext>;
 
   /**
    * An event fired when a user is hovering over a given rating.


### PR DESCRIPTION
Part of #801

Allows for custom rating templates to be used in the following way:

```html
<ngb-rating>
  <template let-fill="...">
    ...
  </template>
</ngb-rating>
```