### PR TITLE
feat(popover): add isOpen() and shown/hidden events

### DIFF
--- a/demo/src/app/components/popover/demos/index.ts
+++ b/demo/src/app/components/popover/demos/index.ts
@@ -1,9 +1,10 @@
 import {NgbdPopoverBasic} from './basic/popover-basic';
 import {NgbdPopoverTplcontent} from './tplcontent/popover-tplcontent';
 import {NgbdPopoverTriggers} from './triggers/popover-triggers';
+import {NgbdPopoverVisibility} from './visibility/popover-visibility';
 import {NgbdPopoverConfig} from './config/popover-config';
 
-export const DEMO_DIRECTIVES = [NgbdPopoverBasic, NgbdPopoverTplcontent, NgbdPopoverTriggers, NgbdPopoverConfig];
+export const DEMO_DIRECTIVES = [NgbdPopoverBasic, NgbdPopoverTplcontent, NgbdPopoverTriggers, NgbdPopoverVisibility, NgbdPopoverConfig];
 
 export const DEMO_SNIPPETS = {
   basic: {
@@ -17,6 +18,10 @@ export const DEMO_SNIPPETS = {
   triggers: {
     code: require('!!prismjs?lang=typescript!./triggers/popover-triggers'),
     markup: require('!!prismjs?lang=markup!./triggers/popover-triggers.html')
+  },
+  visibility: {
+    code: require('!!prismjs?lang=typescript!./visibility/popover-visibility'),
+    markup: require('!!prismjs?lang=markup!./visibility/popover-visibility.html')
   },
   config: {
     code: require('!!prismjs?lang=typescript!./config/popover-config'),

--- a/demo/src/app/components/popover/demos/visibility/popover-visibility.html
+++ b/demo/src/app/components/popover/demos/visibility/popover-visibility.html
@@ -1,0 +1,11 @@
+<button type="button" class="btn btn-secondary" placement="top"
+        ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on top" 
+        #popover="ngbPopover">
+  Open Popover
+</button>
+
+<hr />
+
+<p>
+  Popover is currently: <code>{{ popover.isOpen() ? 'open' : 'closed' }}</code>
+</p>

--- a/demo/src/app/components/popover/demos/visibility/popover-visibility.ts
+++ b/demo/src/app/components/popover/demos/visibility/popover-visibility.ts
@@ -1,0 +1,9 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'ngbd-popover-visibility',
+  templateUrl: './popover-visibility.html'
+})
+export class NgbdPopoverVisibility {
+
+}

--- a/demo/src/app/components/popover/popover.component.ts
+++ b/demo/src/app/components/popover/popover.component.ts
@@ -19,6 +19,10 @@ import {DEMO_SNIPPETS} from './demos';
         <ngbd-popover-triggers></ngbd-popover-triggers>
       </ngbd-example-box>
       <ngbd-example-box
+        demoTitle="Popover visibility events" [htmlSnippet]="snippets.visibility.markup" [tsSnippet]="snippets.visibility.code">
+        <ngbd-popover-visibility></ngbd-popover-visibility>
+      </ngbd-example-box>
+      <ngbd-example-box
         demoTitle="Global configuration of popovers" [htmlSnippet]="snippets.config.markup" [tsSnippet]="snippets.config.code">
         <ngbd-popover-config></ngbd-popover-config>
       </ngbd-example-box>

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -193,7 +193,8 @@ describe('ngb-popover', () => {
 
   describe('visibility', () => {
     it('should emit events when showing and hiding popover', () => {
-      const fixture = createTestComponent(`<div ngbPopover="Great tip!" triggers="click" (shown)="shown()" (hidden)="hidden()"></div>`);
+      const fixture = createTestComponent(
+          `<div ngbPopover="Great tip!" triggers="click" (shown)="shown()" (hidden)="hidden()"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
       let shownSpy = spyOn(fixture.componentInstance, 'shown');
@@ -211,7 +212,8 @@ describe('ngb-popover', () => {
     });
 
     it('should not emit close event when already closed', () => {
-      const fixture = createTestComponent(`<div ngbPopover="Great tip!" triggers="manual" (shown)="shown()" (hidden)="hidden()"></div>`);
+      const fixture = createTestComponent(
+          `<div ngbPopover="Great tip!" triggers="manual" (shown)="shown()" (hidden)="hidden()"></div>`);
 
       let shownSpy = spyOn(fixture.componentInstance, 'shown');
       let hiddenSpy = spyOn(fixture.componentInstance, 'hidden');
@@ -229,7 +231,8 @@ describe('ngb-popover', () => {
     });
 
     it('should not emit open event when already opened', () => {
-      const fixture = createTestComponent(`<div ngbPopover="Great tip!" triggers="manual" (shown)="shown()" (hidden)="hidden()"></div>`);
+      const fixture = createTestComponent(
+          `<div ngbPopover="Great tip!" triggers="manual" (shown)="shown()" (hidden)="hidden()"></div>`);
 
       let shownSpy = spyOn(fixture.componentInstance, 'shown');
       let hiddenSpy = spyOn(fixture.componentInstance, 'hidden');
@@ -421,9 +424,8 @@ export class TestComponent {
 
   @ViewChild(NgbPopover) popover: NgbPopover;
 
-  shown() { }
-  hidden() { }
-
+  shown() {}
+  hidden() {}
 }
 
 @Component({selector: 'test-onpush-cmpt', changeDetection: ChangeDetectionStrategy.OnPush, template: ``})

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -191,6 +191,72 @@ describe('ngb-popover', () => {
     });
   });
 
+  describe('visibility', () => {
+    it('should emit events when showing and hiding popover', () => {
+      const fixture = createTestComponent(`<div ngbPopover="Great tip!" triggers="click" (shown)="shown()" (hidden)="hidden()"></div>`);
+      const directive = fixture.debugElement.query(By.directive(NgbPopover));
+
+      let shownSpy = spyOn(fixture.componentInstance, 'shown');
+      let hiddenSpy = spyOn(fixture.componentInstance, 'hidden');
+
+      directive.triggerEventHandler('click', {});
+      fixture.detectChanges();
+      expect(getWindow(fixture)).not.toBeNull();
+      expect(shownSpy).toHaveBeenCalled();
+
+      directive.triggerEventHandler('click', {});
+      fixture.detectChanges();
+      expect(getWindow(fixture)).toBeNull();
+      expect(hiddenSpy).toHaveBeenCalled();
+    });
+
+    it('should not emit close event when already closed', () => {
+      const fixture = createTestComponent(`<div ngbPopover="Great tip!" triggers="manual" (shown)="shown()" (hidden)="hidden()"></div>`);
+
+      let shownSpy = spyOn(fixture.componentInstance, 'shown');
+      let hiddenSpy = spyOn(fixture.componentInstance, 'hidden');
+
+      fixture.componentInstance.popover.open();
+      fixture.detectChanges();
+
+      fixture.componentInstance.popover.open();
+      fixture.detectChanges();
+
+      expect(getWindow(fixture)).not.toBeNull();
+      expect(shownSpy).toHaveBeenCalled();
+      expect(shownSpy.calls.count()).toEqual(1);
+      expect(hiddenSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not emit open event when already opened', () => {
+      const fixture = createTestComponent(`<div ngbPopover="Great tip!" triggers="manual" (shown)="shown()" (hidden)="hidden()"></div>`);
+
+      let shownSpy = spyOn(fixture.componentInstance, 'shown');
+      let hiddenSpy = spyOn(fixture.componentInstance, 'hidden');
+
+      fixture.componentInstance.popover.close();
+      fixture.detectChanges();
+      expect(getWindow(fixture)).toBeNull();
+      expect(shownSpy).not.toHaveBeenCalled();
+      expect(hiddenSpy).not.toHaveBeenCalled();
+    });
+
+    it('should report correct visibility', () => {
+      const fixture = createTestComponent(`<div ngbPopover="Great tip!" triggers="manual"></div>`);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.popover.isOpen()).toBeFalsy();
+
+      fixture.componentInstance.popover.open();
+      fixture.detectChanges();
+      expect(fixture.componentInstance.popover.isOpen()).toBeTruthy();
+
+      fixture.componentInstance.popover.close();
+      fixture.detectChanges();
+      expect(fixture.componentInstance.popover.isOpen()).toBeFalsy();
+    });
+  });
+
   describe('triggers', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPopoverModule.forRoot()]});
@@ -354,6 +420,10 @@ export class TestComponent {
   placement: string;
 
   @ViewChild(NgbPopover) popover: NgbPopover;
+
+  shown() { }
+  hidden() { }
+
 }
 
 @Component({selector: 'test-onpush-cmpt', changeDetection: ChangeDetectionStrategy.OnPush, template: ``})

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -2,6 +2,8 @@ import {
   Component,
   Directive,
   Input,
+  Output,
+  EventEmitter,
   ChangeDetectionStrategy,
   OnInit,
   OnDestroy,
@@ -55,6 +57,14 @@ export class NgbPopover implements OnInit, OnDestroy {
    * Specifies events that should trigger. Supports a space separated list of event names.
    */
   @Input() triggers: string;
+  /**
+   * Emits an event when the popover is shown
+   */
+  @Output() shown = new EventEmitter();
+  /**
+   * Emits an event when the popover is hidden
+   */
+  @Output() hidden = new EventEmitter();
 
   private _popupService: PopupService<NgbPopoverWindow>;
   private _windowRef: ComponentRef<NgbPopoverWindow>;
@@ -77,7 +87,6 @@ export class NgbPopover implements OnInit, OnDestroy {
     });
   }
 
-
   /**
    * Opens an element’s popover. This is considered a “manual” triggering of the popover.
    */
@@ -89,6 +98,7 @@ export class NgbPopover implements OnInit, OnDestroy {
       // we need to manually invoke change detection since events registered via
       // Renderer::listen() are not picked up by change detection with the OnPush strategy
       this._windowRef.changeDetectorRef.markForCheck();
+      this.shown.emit();
     }
   }
 
@@ -96,8 +106,11 @@ export class NgbPopover implements OnInit, OnDestroy {
    * Closes an element’s popover. This is considered a “manual” triggering of the popover.
    */
   close(): void {
-    this._popupService.close();
-    this._windowRef = null;
+    if (this._windowRef) {
+      this._popupService.close();
+      this._windowRef = null;
+      this.hidden.emit();
+    }
   }
 
   /**
@@ -109,6 +122,13 @@ export class NgbPopover implements OnInit, OnDestroy {
     } else {
       this.open();
     }
+  }
+
+  /**
+   * Returns whether or not the popover is currently being shown
+   */
+  isOpen(): boolean {
+    return this._windowRef != null;
   }
 
   ngOnInit() {

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -127,9 +127,7 @@ export class NgbPopover implements OnInit, OnDestroy {
   /**
    * Returns whether or not the popover is currently being shown
    */
-  isOpen(): boolean {
-    return this._windowRef != null;
-  }
+  isOpen(): boolean { return this._windowRef != null; }
 
   ngOnInit() {
     this._unregisterListenersFn = listenToTriggers(

--- a/src/tooltip/tooltip.spec.ts
+++ b/src/tooltip/tooltip.spec.ts
@@ -293,6 +293,75 @@ describe('ngb-tooltip', () => {
     });
   });
 
+  describe('visibility', () => {
+    it('should emit events when showing and hiding popover', () => {
+      const fixture = createTestComponent(
+          `<div ngbTooltip="Great tip!" triggers="click" (shown)="shown()" (hidden)="hidden()"></div>`);
+      const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+
+      let shownSpy = spyOn(fixture.componentInstance, 'shown');
+      let hiddenSpy = spyOn(fixture.componentInstance, 'hidden');
+
+      directive.triggerEventHandler('click', {});
+      fixture.detectChanges();
+      expect(getWindow(fixture)).not.toBeNull();
+      expect(shownSpy).toHaveBeenCalled();
+
+      directive.triggerEventHandler('click', {});
+      fixture.detectChanges();
+      expect(getWindow(fixture)).toBeNull();
+      expect(hiddenSpy).toHaveBeenCalled();
+    });
+
+    it('should not emit close event when already closed', () => {
+      const fixture = createTestComponent(
+          `<div ngbTooltip="Great tip!" triggers="manual" (shown)="shown()" (hidden)="hidden()"></div>`);
+
+      let shownSpy = spyOn(fixture.componentInstance, 'shown');
+      let hiddenSpy = spyOn(fixture.componentInstance, 'hidden');
+
+      fixture.componentInstance.tooltip.open();
+      fixture.detectChanges();
+
+      fixture.componentInstance.tooltip.open();
+      fixture.detectChanges();
+
+      expect(getWindow(fixture)).not.toBeNull();
+      expect(shownSpy).toHaveBeenCalled();
+      expect(shownSpy.calls.count()).toEqual(1);
+      expect(hiddenSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not emit open event when already opened', () => {
+      const fixture = createTestComponent(
+          `<div ngbTooltip="Great tip!" triggers="manual" (shown)="shown()" (hidden)="hidden()"></div>`);
+
+      let shownSpy = spyOn(fixture.componentInstance, 'shown');
+      let hiddenSpy = spyOn(fixture.componentInstance, 'hidden');
+
+      fixture.componentInstance.tooltip.close();
+      fixture.detectChanges();
+      expect(getWindow(fixture)).toBeNull();
+      expect(shownSpy).not.toHaveBeenCalled();
+      expect(hiddenSpy).not.toHaveBeenCalled();
+    });
+
+    it('should report correct visibility', () => {
+      const fixture = createTestComponent(`<div ngbTooltip="Great tip!" triggers="manual"></div>`);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.tooltip.isOpen()).toBeFalsy();
+
+      fixture.componentInstance.tooltip.open();
+      fixture.detectChanges();
+      expect(fixture.componentInstance.tooltip.isOpen()).toBeTruthy();
+
+      fixture.componentInstance.tooltip.close();
+      fixture.detectChanges();
+      expect(fixture.componentInstance.tooltip.isOpen()).toBeFalsy();
+    });
+  });
+
   describe('Custom config', () => {
     let config: NgbTooltipConfig;
 
@@ -343,6 +412,9 @@ export class TestComponent {
   show = true;
 
   @ViewChild(NgbTooltip) tooltip: NgbTooltip;
+
+  shown() {}
+  hidden() {}
 }
 
 @Component({selector: 'test-onpush-cmpt', changeDetection: ChangeDetectionStrategy.OnPush, template: ``})

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -2,6 +2,8 @@ import {
   Component,
   Directive,
   Input,
+  Output,
+  EventEmitter,
   ChangeDetectionStrategy,
   OnInit,
   OnDestroy,
@@ -46,6 +48,14 @@ export class NgbTooltip implements OnInit, OnDestroy {
    * Specifies events that should trigger. Supports a space separated list of event names.
    */
   @Input() triggers: string;
+  /**
+ * Emits an event when the tooltip is shown
+ */
+  @Output() shown = new EventEmitter();
+  /**
+   * Emits an event when the tooltip is hidden
+   */
+  @Output() hidden = new EventEmitter();
 
   private _ngbTooltip: string | TemplateRef<any>;
   private _popupService: PopupService<NgbTooltipWindow>;
@@ -92,6 +102,7 @@ export class NgbTooltip implements OnInit, OnDestroy {
       // we need to manually invoke change detection since events registered via
       // Renderer::listen() - to be determined if this is a bug in the Angular 2
       this._windowRef.changeDetectorRef.markForCheck();
+      this.shown.emit();
     }
   }
 
@@ -99,8 +110,11 @@ export class NgbTooltip implements OnInit, OnDestroy {
    * Closes an element’s tooltip. This is considered a “manual” triggering of the tooltip.
    */
   close(): void {
-    this._popupService.close();
-    this._windowRef = null;
+    if (this._windowRef != null) {
+      this._popupService.close();
+      this._windowRef = null;
+      this.hidden.emit();
+    }
   }
 
   /**
@@ -113,6 +127,11 @@ export class NgbTooltip implements OnInit, OnDestroy {
       this.open();
     }
   }
+
+  /**
+   * Returns whether or not the tooltip is currently being shown
+   */
+  isOpen(): boolean { return this._windowRef != null; }
 
   ngOnInit() {
     this._unregisterListenersFn = listenToTriggers(


### PR DESCRIPTION
Adds an `isOpen()` method to the popover, as well as shown and hidden events. Putting this up to get feedback on it, as I work on the same for tooltip and add documentation.

Closes #841