### PR TITLE
feat(modal): add support for custom windowClass on modals

### DIFF
--- a/demo/src/app/components/modal/demos/customclass/modal-customclass.css
+++ b/demo/src/app/components/modal/demos/customclass/modal-customclass.css
@@ -1,0 +1,4 @@
+.dark-modal .modal-content {
+  background-color: black;
+  color: white;
+}

--- a/demo/src/app/components/modal/demos/customclass/modal-customclass.html
+++ b/demo/src/app/components/modal/demos/customclass/modal-customclass.html
@@ -1,0 +1,20 @@
+<template #content let-c="close" let-d="dismiss">
+  <div class="modal-header">
+    <button type="button" class="close" aria-label="Close" (click)="d('Cross click')">
+      <span aria-hidden="true">&times;</span>
+    </button>
+    <h4 class="modal-title">Modal title</h4>
+  </div>
+  <div class="modal-body">
+    <p>One fine body&hellip;</p>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-secondary" (click)="c('Close click')">Close</button>
+  </div>
+</template>
+
+<button class="btn btn-lg btn-outline-primary" (click)="open(content)">Launch demo modal</button>
+
+<hr>
+
+<pre>{{closeResult}}</pre>

--- a/demo/src/app/components/modal/demos/customclass/modal-customclass.html
+++ b/demo/src/app/components/modal/demos/customclass/modal-customclass.html
@@ -14,7 +14,3 @@
 </template>
 
 <button class="btn btn-lg btn-outline-primary" (click)="open(content)">Launch demo modal</button>
-
-<hr>
-
-<pre>{{closeResult}}</pre>

--- a/demo/src/app/components/modal/demos/customclass/modal-customclass.ts
+++ b/demo/src/app/components/modal/demos/customclass/modal-customclass.ts
@@ -1,0 +1,33 @@
+import {Component, ViewEncapsulation} from '@angular/core';
+
+import {NgbModal, ModalDismissReasons} from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+  selector: 'ngbd-modal-customclass',
+  templateUrl: './modal-customclass.html',
+  encapsulation: ViewEncapsulation.None,
+  styleUrls: [ './modal-customclass.css' ]
+})
+export class NgbdModalCustomClass {
+  closeResult: string;
+
+  constructor(private modalService: NgbModal) {}
+
+  open(content) {
+    this.modalService.open(content, { windowClass: 'dark-modal' }).result.then((result) => {
+      this.closeResult = `Closed with: ${result}`;
+    }, (reason) => {
+      this.closeResult = `Dismissed ${this.getDismissReason(reason)}`;
+    });
+  }
+
+  private getDismissReason(reason: any): string {
+    if (reason === ModalDismissReasons.ESC) {
+      return 'by pressing ESC';
+    } else if (reason === ModalDismissReasons.BACKDROP_CLICK) {
+      return 'by clicking on a backdrop';
+    } else {
+      return `with: ${reason}`;
+    }
+  }
+}

--- a/demo/src/app/components/modal/demos/customclass/modal-customclass.ts
+++ b/demo/src/app/components/modal/demos/customclass/modal-customclass.ts
@@ -16,5 +16,5 @@ export class NgbdModalCustomClass {
   open(content) {
     this.modalService.open(content, { windowClass: 'dark-modal' });
   }
-  
+
 }

--- a/demo/src/app/components/modal/demos/customclass/modal-customclass.ts
+++ b/demo/src/app/components/modal/demos/customclass/modal-customclass.ts
@@ -14,20 +14,7 @@ export class NgbdModalCustomClass {
   constructor(private modalService: NgbModal) {}
 
   open(content) {
-    this.modalService.open(content, { windowClass: 'dark-modal' }).result.then((result) => {
-      this.closeResult = `Closed with: ${result}`;
-    }, (reason) => {
-      this.closeResult = `Dismissed ${this.getDismissReason(reason)}`;
-    });
+    this.modalService.open(content, { windowClass: 'dark-modal' });
   }
-
-  private getDismissReason(reason: any): string {
-    if (reason === ModalDismissReasons.ESC) {
-      return 'by pressing ESC';
-    } else if (reason === ModalDismissReasons.BACKDROP_CLICK) {
-      return 'by clicking on a backdrop';
-    } else {
-      return `with: ${reason}`;
-    }
-  }
+  
 }

--- a/demo/src/app/components/modal/demos/index.ts
+++ b/demo/src/app/components/modal/demos/index.ts
@@ -1,10 +1,16 @@
 import {NgbdModalBasic} from './basic/modal-basic';
+import {NgbdModalCustomClass} from './customclass/modal-customclass';
 
-export const DEMO_DIRECTIVES = [NgbdModalBasic];
+export const DEMO_DIRECTIVES = [NgbdModalBasic, NgbdModalCustomClass];
 
 export const DEMO_SNIPPETS = {
   basic: {
     code: require('!!prismjs?lang=typescript!./basic/modal-basic'),
-    markup: require('!!prismjs?lang=markup!./basic/modal-basic.html')}
+    markup: require('!!prismjs?lang=markup!./basic/modal-basic.html')
+  },
+  customclass: {
+    code: require('!!prismjs?lang=typescript!./customclass/modal-customclass'),
+    markup: require('!!prismjs?lang=markup!./customclass/modal-customclass.html')
+  }
 };
 

--- a/demo/src/app/components/modal/modal.component.ts
+++ b/demo/src/app/components/modal/modal.component.ts
@@ -19,7 +19,9 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Modal with default options" [htmlSnippet]="snippets.basic.markup" [tsSnippet]="snippets.basic.code">
           <ngbd-modal-basic></ngbd-modal-basic>
       </ngbd-example-box>
-      <ngbd-example-box demoTitle="Modal with custom class" [htmlSnippet]="snippets.customclass.markup" [tsSnippet]="snippets.customclass.code">
+      <ngbd-example-box demoTitle="Modal with custom class" 
+              [htmlSnippet]="snippets.customclass.markup" 
+              [tsSnippet]="snippets.customclass.code">
           <ngbd-modal-customclass></ngbd-modal-customclass>
       </ngbd-example-box>
     </ngbd-content-wrapper>

--- a/demo/src/app/components/modal/modal.component.ts
+++ b/demo/src/app/components/modal/modal.component.ts
@@ -19,6 +19,9 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Modal with default options" [htmlSnippet]="snippets.basic.markup" [tsSnippet]="snippets.basic.code">
           <ngbd-modal-basic></ngbd-modal-basic>
       </ngbd-example-box>
+      <ngbd-example-box demoTitle="Modal with custom class" [htmlSnippet]="snippets.customclass.markup" [tsSnippet]="snippets.customclass.code">
+          <ngbd-modal-customclass></ngbd-modal-customclass>
+      </ngbd-example-box>
     </ngbd-content-wrapper>
   `
 })

--- a/src/modal/modal-container.ts
+++ b/src/modal/modal-container.ts
@@ -58,7 +58,7 @@ export class NgbModalContainer {
   }
 
   private _applyWindowOptions(windowInstance: NgbModalWindow, options: Object): void {
-    ['backdrop', 'keyboard', 'size'].forEach((optionName: string) => {
+    ['backdrop', 'keyboard', 'size', 'windowClass'].forEach((optionName: string) => {
       if (isDefined(options[optionName])) {
         windowInstance[optionName] = options[optionName];
       }

--- a/src/modal/modal-window.spec.ts
+++ b/src/modal/modal-window.spec.ts
@@ -33,6 +33,13 @@ describe('ngb-modal-dialog', () => {
       expect(dialogEl).toHaveCssClass('modal-sm');
     });
 
+    it('should render default modal window with a specified class', () => {
+      fixture.componentInstance.windowClass = 'custom-class';
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement).toHaveCssClass('custom-class');
+    });
+
     it('aria attributes', () => {
       fixture.detectChanges();
       const dialogEl: Element = fixture.nativeElement.querySelector('.modal-dialog');

--- a/src/modal/modal-window.ts
+++ b/src/modal/modal-window.ts
@@ -15,7 +15,7 @@ import {ModalDismissReasons} from './modal-dismiss-reasons';
 @Component({
   selector: 'ngb-modal-window',
   host: {
-    'class': 'modal fade in',
+    '[class]': '"modal fade in" + (windowClass ? " " + windowClass : "")',
     'role': 'dialog',
     'tabindex': '-1',
     'style': 'display: block;',
@@ -35,6 +35,7 @@ export class NgbModalWindow implements OnInit,
   @Input() backdrop: boolean | string = true;
   @Input() keyboard = true;
   @Input() size: string;
+  @Input() windowClass: string;
 
   @Output('dismiss') dismissEvent = new EventEmitter();
 

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -299,7 +299,7 @@ describe('ngb-modal', () => {
     });
   });
 
-  describe('size options', () => {
+  describe('other options', () => {
 
     it('should render modals with specified size', () => {
       fixture.componentInstance.open('foo', {size: 'sm'});
@@ -307,6 +307,14 @@ describe('ngb-modal', () => {
       expect(fixture.nativeElement).toHaveModal('foo');
       expect(fixture.nativeElement.querySelector('.modal-dialog')).toHaveCssClass('modal-sm');
     });
+
+    it('should render modals with the correct custom classes', () => {
+      fixture.componentInstance.open('foo', {windowClass: 'bar'});
+      fixture.detectChanges();
+      expect(fixture.nativeElement).toHaveModal('foo');
+      expect(fixture.nativeElement.querySelector('ngb-modal-window')).toHaveCssClass('bar');
+    });
+
   });
 
   describe('focus management', () => {

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -299,7 +299,7 @@ describe('ngb-modal', () => {
     });
   });
 
-  describe('other options', () => {
+  describe('size options', () => {
 
     it('should render modals with specified size', () => {
       fixture.componentInstance.open('foo', {size: 'sm'});
@@ -307,6 +307,10 @@ describe('ngb-modal', () => {
       expect(fixture.nativeElement).toHaveModal('foo');
       expect(fixture.nativeElement.querySelector('.modal-dialog')).toHaveCssClass('modal-sm');
     });
+
+  });
+
+  describe('custom class options', () => {
 
     it('should render modals with the correct custom classes', () => {
       fixture.componentInstance.open('foo', {windowClass: 'bar'});

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -22,6 +22,11 @@ export interface NgbModalOptions {
    * Size of a new modal window.
    */
   size?: 'sm' | 'lg';
+
+  /**
+   * Custom class to append to the modal window
+   */
+  windowClass?: string;
 }
 
 /**


### PR DESCRIPTION
Adds the ability to add a custom class to a modal when it's opened.

Note that this does not (yet) add support for adding a custom backdrop class. That may need more discussion to talk about what should happen when, for example, multiple modals are open. Whose backdrop gets applied?

Fixes (at least part of) #818 