### PR TITLE
feat(datepicker): pass current month value to 'markDisabled' callback

### DIFF
--- a/demo/src/app/components/datepicker/demos/customday/datepicker-customday.html
+++ b/demo/src/app/components/datepicker/demos/customday/datepicker-customday.html
@@ -4,7 +4,7 @@
   <div class="form-group">
     <div class="input-group">
       <input class="form-control" placeholder="yyyy-mm-dd"
-             name="dp" [(ngModel)]="model" ngbDatepicker [dayTemplate]="customDay" #d="ngbDatepicker">
+             name="dp" [(ngModel)]="model" ngbDatepicker [dayTemplate]="customDay" [markDisabled]="isDisabled" #d="ngbDatepicker">
       <div class="input-group-addon" (click)="d.toggle()" >
         <img src="img/calendar-icon.svg" style="width: 1.2rem; cursor: pointer;"/>
       </div>
@@ -14,7 +14,7 @@
 
 <template #customDay let-date="date" let-currentMonth="currentMonth" let-selected="selected" let-disabled="disabled">
   <span class="custom-day" [class.weekend]="isWeekend(date)"
-        [class.bg-primary]="selected" [class.text-muted]="date.month !== currentMonth || disabled">
+        [class.bg-primary]="selected" [class.hidden]="date.month !== currentMonth" [class.text-muted]="disabled">
     {{ date.day }}
   </span>
 </template>

--- a/demo/src/app/components/datepicker/demos/customday/datepicker-customday.ts
+++ b/demo/src/app/components/datepicker/demos/customday/datepicker-customday.ts
@@ -20,6 +20,9 @@ import {NgbDateStruct} from '@ng-bootstrap/ng-bootstrap';
       border-radius: 1rem;
       color: white;
     }
+    .hidden {
+      display: none;
+    }
   `]
 })
 export class NgbdDatepickerCustomDay {
@@ -28,5 +31,9 @@ export class NgbdDatepickerCustomDay {
   isWeekend(date: NgbDateStruct) {
     const d = new Date(date.year, date.month - 1, date.day);
     return d.getDay() === 0 || d.getDay() === 6;
+  }
+
+  isDisabled(date: NgbDateStruct, current: {month: number}) {
+    return date.month !== current.month;
   }
 }

--- a/src/datepicker/datepicker-config.ts
+++ b/src/datepicker/datepicker-config.ts
@@ -11,7 +11,7 @@ import {NgbDateStruct} from './ngb-date-struct';
 export class NgbDatepickerConfig {
   dayTemplate: TemplateRef<DayTemplateContext>;
   firstDayOfWeek = 1;
-  markDisabled: (date: NgbDateStruct) => boolean;
+  markDisabled: (date: NgbDateStruct, current: {year: number, month: number}) => boolean;
   minDate: NgbDateStruct;
   maxDate: NgbDateStruct;
   showNavigation = true;

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -52,9 +52,10 @@ export class NgbInputDatepicker implements ControlValueAccessor {
   @Input() firstDayOfWeek: number;
 
   /**
-   * Callback to mark a given date as disabled
+   * Callback to mark a given date as disabled.
+   * 'Current' contains the month that will be displayed in the view
    */
-  @Input() markDisabled: (date: NgbDateStruct) => boolean;
+  @Input() markDisabled: (date: NgbDateStruct, current: {year: number, month: number}) => boolean;
 
   /**
    * Min date for the navigation. If not provided will be 10 years before today or `startDate`

--- a/src/datepicker/datepicker-service.spec.ts
+++ b/src/datepicker/datepicker-service.spec.ts
@@ -83,4 +83,20 @@ describe('ngb-datepicker-service', () => {
          weekdays: [1]
        });
      }));
+
+  it('markDisabled should pass the correct year and month',
+     inject([NgbDatepickerService, NgbCalendar], (service, calendar) => {
+
+       let result;
+
+       const markDisabled = (date, current) => {
+         result = current;
+         return false;
+       };
+
+       service.generateMonthViewModel(
+           new NgbDate(2016, 10, 10), new NgbDate(2000, 0, 1), new NgbDate(2020, 0, 10), 1, markDisabled);
+       expect(result).toEqual({month: 10, year: 2016});
+     }));
+
 });

--- a/src/datepicker/datepicker-service.ts
+++ b/src/datepicker/datepicker-service.ts
@@ -9,7 +9,7 @@ export class NgbDatepickerService {
 
   generateMonthViewModel(
       date: NgbDate, minDate: NgbDate, maxDate: NgbDate, firstDayOfWeek: number,
-      markDisabled: (date: NgbDate) => boolean): MonthViewModel {
+      markDisabled: (date: NgbDate, current: {month: number, year: number}) => boolean): MonthViewModel {
     const month: MonthViewModel = {number: date.month, year: date.year, weeks: [], weekdays: []};
 
     date = this._getFirstViewDate(date, firstDayOfWeek);
@@ -28,7 +28,7 @@ export class NgbDatepickerService {
 
         let disabled = (minDate && newDate.before(minDate)) || (maxDate && newDate.after(maxDate));
         if (!disabled && markDisabled) {
-          disabled = markDisabled(newDate);
+          disabled = markDisabled(newDate, {month: month.number, year: month.year});
         }
 
         days.push({date: newDate, disabled: disabled});

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -42,7 +42,7 @@ function expectSameValues(datepicker: NgbDatepicker, config: NgbDatepickerConfig
 function customizeConfig(config: NgbDatepickerConfig) {
   config.dayTemplate = {} as TemplateRef<DayTemplateContext>;
   config.firstDayOfWeek = 2;
-  config.markDisabled = (date) => false;
+  config.markDisabled = (date, current) => false;
   config.minDate = {year: 2000, month: 1, day: 1};
   config.maxDate = {year: 2030, month: 12, day: 31};
   config.showNavigation = false;

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -65,14 +65,15 @@ export class NgbDatepicker implements OnChanges,
   @Input() dayTemplate: TemplateRef<DayTemplateContext>;
 
   /**
-   * First day of the week. With default calendar we use ISO 8601: `weekday` is 1=Mon ... 12=Sun
+   * First day of the week. With default calendar we use ISO 8601: 'weekday' is 1=Mon ... 7=Sun
    */
   @Input() firstDayOfWeek: number;
 
   /**
-   * Callback to mark a given date as disabled
+   * Callback to mark a given date as disabled.
+   * 'Current' contains the month that will be displayed in the view
    */
-  @Input() markDisabled: (date: NgbDateStruct) => boolean;
+  @Input() markDisabled: (date: NgbDateStruct, current: {year: number, month: number}) => boolean;
 
   /**
    * Min date for the navigation. If not provided will be 10 years before today or `startDate`


### PR DESCRIPTION
Small datepicker enhancement: now able to access current month value both in custom template and `markDisabled` callback.

That allows for instance to disable completely days that are outside of current month and collapse them (see 'custom day view' demo):

```typescript
[markDisabled]='markDisabled'

...

markDisabled = (date, current: {month: number}) {
  return date.month != current.month;
};

...

<template let-date='date' let-currentMonth='currentMonth'>
  <span [class.hide_day]='date.month !== currentMonth' ...>
</template>

...

.hide_day {
  display: none; // or visibility: hidden; to avoid line collapse
}

```

Contains an example for #847 and #753