### PR TITLE
fix(rating): replace not-allowed cursor with default one

### DIFF
--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -88,12 +88,12 @@ describe('ngb-rating', () => {
     expect(window.getComputedStyle(getStar(compiled, 1)).getPropertyValue('cursor')).toBe('pointer');
   });
 
-  it('should set not allowed cursor on stars when readonly', () => {
+  it('should set default cursor on stars when readonly', () => {
     const fixture = createTestComponent('<ngb-rating [readonly]="true"></ngb-rating>');
 
     const compiled = fixture.nativeElement;
 
-    expect(window.getComputedStyle(getStar(compiled, 1)).getPropertyValue('cursor')).toBe('not-allowed');
+    expect(window.getComputedStyle(getStar(compiled, 1)).getPropertyValue('cursor')).toBe('default');
   });
 
   it('should allow custom star template', () => {

--- a/src/rating/rating.ts
+++ b/src/rating/rating.ts
@@ -35,7 +35,7 @@ export interface StarTemplateContext {
         <span class="sr-only">({{ index < rate ? '*' : ' ' }})</span>
         <span (mouseenter)="enter(index + 1)" (click)="update(index + 1)" [title]="r.title" 
         [attr.aria-valuetext]="r.title" 
-        [style.cursor]="readonly ? 'not-allowed' : 'pointer'">
+        [style.cursor]="readonly ? 'default' : 'pointer'">
           <template [ngTemplateOutlet]="starTemplate || t" [ngOutletContext]="{fill: getFillValue(index)}"></template>
         </span>
       </template>


### PR DESCRIPTION
Replaces the `not-allowed` cursor with a `default` one for readonly rating. 

- `not-allowed` looks way too restrictive. I think user typically just wants to render a rating not to shout that you're not allowed to click it.

