### PR TITLE
chore: don't import from catch-all rxjs/Rx

### DIFF
--- a/demo/src/app/components/alert/demos/selfclosing/alert-selfclosing.ts
+++ b/demo/src/app/components/alert/demos/selfclosing/alert-selfclosing.ts
@@ -1,5 +1,5 @@
-import {Component, Input, OnInit} from '@angular/core';
-import {Subject} from 'rxjs/Rx';
+import {Component, OnInit} from '@angular/core';
+import {Subject} from 'rxjs/Subject';
 
 @Component({
   selector: 'ngbd-alert-selfclosing',

--- a/demo/src/app/components/typeahead/demos/basic/typeahead-basic.ts
+++ b/demo/src/app/components/typeahead/demos/basic/typeahead-basic.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {Observable} from 'rxjs/Rx';
+import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/debounceTime';
 import 'rxjs/add/operator/distinctUntilChanged';

--- a/demo/src/app/components/typeahead/demos/config/typeahead-config.ts
+++ b/demo/src/app/components/typeahead/demos/config/typeahead-config.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {Observable} from 'rxjs/Rx';
+import {Observable} from 'rxjs/Observable';
 import {NgbTypeaheadConfig} from '@ng-bootstrap/ng-bootstrap';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/debounceTime';

--- a/demo/src/app/components/typeahead/demos/format/typeahead-format.ts
+++ b/demo/src/app/components/typeahead/demos/format/typeahead-format.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {Observable} from 'rxjs/Rx';
+import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/debounceTime';
 

--- a/demo/src/app/components/typeahead/demos/http/typeahead-http.ts
+++ b/demo/src/app/components/typeahead/demos/http/typeahead-http.ts
@@ -1,6 +1,6 @@
 import {Component, Injectable} from '@angular/core';
 import {Jsonp, URLSearchParams} from '@angular/http';
-import {Observable} from 'rxjs/Rx';
+import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/operator/debounceTime';
 import 'rxjs/add/operator/distinctUntilChanged';
 import 'rxjs/add/operator/do';

--- a/demo/src/app/components/typeahead/demos/template/typeahead-template.ts
+++ b/demo/src/app/components/typeahead/demos/template/typeahead-template.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {Observable} from 'rxjs/Rx';
+import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/operator/debounceTime';
 import 'rxjs/add/operator/distinctUntilChanged';
 import 'rxjs/add/operator/map';

--- a/demo/src/vendor.ts
+++ b/demo/src/vendor.ts
@@ -5,9 +5,18 @@ import '@angular/core';
 import '@angular/common';
 import '@angular/router';
 import '@angular/forms';
+import '@angular/http';
 
 // RxJS
-import 'rxjs';
+import 'rxjs/Observable';
+import 'rxjs/Subject';
+import 'rxjs/Subscription';
+import 'rxjs/add/operator/debounceTime';
+import 'rxjs/add/operator/distinctUntilChanged';
+import 'rxjs/add/operator/do';
+import 'rxjs/add/operator/let';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/switchMap';
 
 // Other vendors for example jQuery, Lodash or Bootstrap
 // You can import js, ts, css, sass, ...

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -5,7 +5,7 @@ import {expectResults, getWindowLinks} from '../test/typeahead/common';
 import {Component, DebugElement, ViewChild, ChangeDetectionStrategy} from '@angular/core';
 import {Validators, FormControl, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {By} from '@angular/platform-browser';
-import {Observable} from 'rxjs/Rx';
+import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/debounceTime';
 

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -16,7 +16,9 @@ import {
   NgZone
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
-import {Observable, Subscription} from 'rxjs/Rx';
+import {Observable} from 'rxjs/Observable';
+import {Subscription} from 'rxjs/Subscription';
+import 'rxjs/add/observable/fromEvent';
 import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/let';
 import {positionElements} from '../util/positioning';


### PR DESCRIPTION
Changing rxjs imports as in this PR reduces our bundle size
from ~190k -> ~45k (before minification / gzip). Non-scientific
testing on my machine shows that the site load time drops by
around 300 - 400ms.