### PR TITLE
fix(pagination): emits pageChange when collectionSize changes

### DIFF
--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
+import {TestBed, ComponentFixture, inject, fakeAsync, tick} from '@angular/core/testing';
 import {createGenericTestComponent} from '../test/common';
 
 import {Component} from '@angular/core';
@@ -269,6 +269,28 @@ describe('ngb-pagination', () => {
       expectPages(
           fixture.nativeElement, ['-«« First', '-« Previous', '+1', '2', '3', '-...', '7', '» Next', '»» Last']);
     });
+
+    it('should update page when it becomes out of range', fakeAsync(() => {
+         const html =
+             '<ngb-pagination [collectionSize]="collectionSize" [(page)]="page" [size]="size"></ngb-pagination>';
+         const fixture = createTestComponent(html);
+
+         fixture.componentInstance.collectionSize = 30;
+         fixture.detectChanges();
+         expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
+
+         getLink(fixture.nativeElement, 3).click();
+         fixture.detectChanges();
+         tick();
+         expectPages(fixture.nativeElement, ['« Previous', '1', '2', '+3', '-» Next']);
+         expect(fixture.componentInstance.page).toBe(3);
+
+         fixture.componentInstance.collectionSize = 20;
+         fixture.detectChanges();
+         tick();
+         expectPages(fixture.nativeElement, ['« Previous', '1', '+2', '-» Next']);
+         expect(fixture.componentInstance.page).toBe(2);
+       }));
 
     it('should render and respond to size change', () => {
       const html = '<ngb-pagination [collectionSize]="20" [page]="1" [size]="size"></ngb-pagination>';

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -95,9 +95,9 @@ export class NgbPagination implements OnChanges {
 
   /**
    *  An event fired when the page is changed.
-   *  Event's payload equals the current page.
+   *  Event's payload equals to the newly selected page.
    */
-  @Output() pageChange = new EventEmitter();
+  @Output() pageChange = new EventEmitter<number>(true);
 
   /**
    * Pagination display size: small or large
@@ -121,13 +121,7 @@ export class NgbPagination implements OnChanges {
   hasNext(): boolean { return this.page < this._pageCount; }
 
   selectPage(pageNumber: number): void {
-    let prevPageNo = this.page;
-    this.page = this._getPageNoInRange(pageNumber);
-
-    if (this.page !== prevPageNo) {
-      this.pageChange.emit(this.page);
-    }
-
+    this._setPageInRange(pageNumber);
     this.ngOnChanges(null);
   }
 
@@ -141,8 +135,8 @@ export class NgbPagination implements OnChanges {
       this.pages.push(i);
     }
 
-    // get selected page
-    this.page = this._getPageNoInRange(this.page);
+    // set page within 1..max range
+    this._setPageInRange(this.page);
 
     // apply maxSize if necessary
     if (this.maxSize > 0 && this._pageCount > this.maxSize) {
@@ -224,5 +218,12 @@ export class NgbPagination implements OnChanges {
     return [start, end];
   }
 
-  private _getPageNoInRange(newPageNo): number { return getValueInRange(newPageNo, this._pageCount, 1); }
+  private _setPageInRange(newPageNo) {
+    const prevPageNo = this.page;
+    this.page = getValueInRange(newPageNo, this._pageCount, 1);
+
+    if (this.page !== prevPageNo) {
+      this.pageChange.emit(this.page);
+    }
+  }
 }


### PR DESCRIPTION
Fixes #800

Ensures that `pageChange` is emitted in the case when `collectionSize` changes and current page becomes out of range. `pageChange` emitter has to become asynchronous in this case.