### PR TITLE
fix(build): properly reference rxjs from the UMD bundle

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,24 +55,30 @@ gulp.task('umd', function(cb) {
     return {root: ['ng', ns], commonjs: ng2Ns, commonjs2: ng2Ns, amd: ng2Ns};
   }
 
+  function rxjsExternal(context, request, cb) {
+    if (/^rxjs\/add\/observable\//.test(request)) {
+      return cb(null, {root: ['Rx', 'Observable'], commonjs: request, commonjs2: request, amd: request});
+    } else if (/^rxjs\/add\/operator\//.test(request)) {
+      return cb(null, {root: ['Rx', 'Observable', 'prototype'], commonjs: request, commonjs2: request, amd: request});
+    } else if (/^rxjs\//.test(request)) {
+      return cb(null, {root: ['Rx'], commonjs: request, commonjs2: request, amd: request});
+    }
+    cb();
+  }
+
   webpack(
       {
         entry: './temp/index.js',
         output: {filename: 'dist/bundles/ng-bootstrap.js', library: 'ngb', libraryTarget: 'umd'},
         devtool: 'source-map',
-        externals: {
-          '@angular/core': ngExternal('core'),
-          '@angular/common': ngExternal('common'),
-          '@angular/forms': ngExternal('forms'),
-          'rxjs/Rx': {root: 'Rx', commonjs: 'rxjs/Rx', commonjs2: 'rxjs/Rx', amd: 'rxjs/Rx'},
-          // 'rxjs/add/operator/let': 'rxjs/add/operator/let'
-          'rxjs/add/operator/let': {
-            root: ['Rx', 'Observable', 'prototype'],
-            commonjs: 'rxjs/add/operator/let',
-            commonjs2: 'rxjs/add/operator/let',
-            amd: 'rxjs/add/operator/let'
-          }
-        }
+        externals: [
+          {
+            '@angular/core': ngExternal('core'),
+            '@angular/common': ngExternal('common'),
+            '@angular/forms': ngExternal('forms')
+          },
+          rxjsExternal
+        ]
       },
       webpackCallBack('webpack', cb));
 });


### PR DESCRIPTION
alpha.7 has a subtle bug where externals were not configured
properly and as a result our bundle doesn't work correctly
in certain environements (SystemJS).