### PR TITLE
chore: don't preserve licence comments in demo bundles

### DIFF
--- a/webpack.demo.js
+++ b/webpack.demo.js
@@ -183,6 +183,7 @@ module.exports = function makeWebpackConfig() {
       // Reference: http://webpack.github.io/docs/list-of-plugins.html#uglifyjsplugin
       // Minify all javascript, switch loaders to minimizing mode
       new webpack.optimize.UglifyJsPlugin({
+        comments: false,
         mangle: true
       }),
 


### PR DESCRIPTION
Without this option we are including licence info from each and every file.

