### PR TITLE
demo(API): don't extract API docs from typings

### DIFF
--- a/misc/api-doc.js
+++ b/misc/api-doc.js
@@ -39,6 +39,11 @@ class APIDocVisitor {
       throw new Error(`File doesn't exist: ${fileName}.`)
     }
 
+    // don't extract anything from typings
+    if (/typings/.test(fileName)) {
+      return [];
+    }
+
     return sourceFile.statements.reduce((directivesSoFar, statement) => {
       if (statement.kind === ts.SyntaxKind.ClassDeclaration) {
         return directivesSoFar.concat(this.visitClassDeclaration(fileName, statement));

--- a/misc/api-doc.spec.js
+++ b/misc/api-doc.spec.js
@@ -5,6 +5,9 @@ describe('APIDocVisitor', function() {
   it('should return [] if there are no docs to extract',
      function() { expect(apiDoc(['./misc/api-doc-test-cases/no-docs.ts'])).toEqual({}); });
 
+  it('should not extract anything from typings',
+     function() { expect(apiDoc(['./typings/globals/node/index.d.ts'])).toEqual({}); });
+
   it('should extract basic info from directives and components', function() {
     var docs = apiDoc(['misc/api-doc-test-cases/directives-no-in-out.ts']);
 


### PR DESCRIPTION
Till now we were extracting all the class info / docs
from all the classes referenced in typings (Promise etc.).
This is obviously not needed and wasteful.