### PR TITLE
chore(api): don't extract info from non-documented members

### DIFF
--- a/misc/api-doc-test-cases/directives-with-methods.ts
+++ b/misc/api-doc-test-cases/directives-with-methods.ts
@@ -24,4 +24,7 @@ export class Foo implements OnInit {
 
   private _dontSerialize() {
   }
+
+  noCommentDontExtract() {
+  }
 }

--- a/misc/api-doc-test-cases/services-with-methods.ts
+++ b/misc/api-doc-test-cases/services-with-methods.ts
@@ -13,6 +13,9 @@ export class ModalService {
     return Promise.resolve();
   }
 
+  /**
+   * Checks if a modal is open
+   */
   isOpen(): boolean {
     return false;
   }

--- a/misc/api-doc.js
+++ b/misc/api-doc.js
@@ -15,7 +15,7 @@ const ANGULAR_LIFECYCLE_METHODS = [
 
 function isInternalMember(member) {
   const jsDoc = ts.displayPartsToString(member.symbol.getDocumentationComment());
-  return jsDoc.indexOf('@internal') > -1;
+  return jsDoc.trim().length === 0 || jsDoc.indexOf('@internal') > -1;
 }
 
 function isAngularLifecycleHook(methodName) {

--- a/misc/api-doc.spec.js
+++ b/misc/api-doc.spec.js
@@ -127,7 +127,7 @@ describe('APIDocVisitor', function() {
     expect(serviceDocs.methods[0].returnType).toBe('Promise<any>');
 
     expect(serviceDocs.methods[1].name).toBe('isOpen');
-    expect(serviceDocs.methods[1].description).toBe('');
+    expect(serviceDocs.methods[1].description).toBe('Checks if a modal is open');
     expect(serviceDocs.methods[1].args.length).toBe(0);
     expect(serviceDocs.methods[1].returnType).toBe('boolean');
   });


### PR DESCRIPTION
Due to AoT we need to keep all members accessed from templates as `public` and we can't annotate them with `@internal` (this prevents TS from generating .d.ts files). To prevent internal members from showing up in the docs we eliminate ones that are not documented.