### PR TITLE
Stack Modals in Opening Order

### DIFF
--- a/src/modal/modal-container.ts
+++ b/src/modal/modal-container.ts
@@ -35,14 +35,18 @@ export class NgbModalContainer {
   open(content: string | TemplateRef<any>, options): NgbModalRef {
     const activeModal = new NgbActiveModal();
     const contentRef = this._getContentRef(content, activeModal);
-    const windowCmptRef =
-        this._viewContainerRef.createComponent(this._windowFactory, 0, this._injector, contentRef.nodes);
+    let windowCmptRef: ComponentRef<NgbModalWindow>;
     let backdropCmptRef: ComponentRef<NgbModalBackdrop>;
     let ngbModalRef: NgbModalRef;
 
     if (options.backdrop !== false) {
-      backdropCmptRef = this._viewContainerRef.createComponent(this._backdropFactory, 0, this._injector);
+      backdropCmptRef =
+          this._viewContainerRef.createComponent(this._backdropFactory, this._viewContainerRef.length, this._injector);
     }
+
+    windowCmptRef = this._viewContainerRef.createComponent(
+        this._windowFactory, this._viewContainerRef.length, this._injector, contentRef.nodes);
+
     ngbModalRef = new NgbModalRef(this._viewContainerRef, windowCmptRef, backdropCmptRef, contentRef.viewRef);
 
     activeModal.close = (result: any) => { ngbModalRef.close(result); };

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -371,6 +371,21 @@ describe('ngb-modal', () => {
       expect(document.activeElement).toBe(document.body);
     });
   });
+
+  describe('window element ordering', () => {
+    it('should place newer windows on top of older ones', () => {
+      fixture.componentInstance.open('foo', {windowClass: 'window-1'}).result.catch(NOOP);
+      fixture.detectChanges();
+
+      fixture.componentInstance.open('bar', {windowClass: 'window-2'}).result.catch(NOOP);
+      fixture.detectChanges();
+
+      let windows = fixture.nativeElement.querySelectorAll('ngb-modal-window');
+      expect(windows.length).toBe(2);
+      expect(windows[0]).toHaveCssClass('window-1');
+      expect(windows[1]).toHaveCssClass('window-2');
+    });
+  });
 });
 
 @Component({selector: 'destroyable-cmpt', template: 'Some content'})


### PR DESCRIPTION
Small change to attach modal elements in the order that they were opened (rather than always prepending everything)

Actually, this change alone seems to allow most of what's necessary for #643 - at least in terms of presenting multiple modals. There's still work to do for visually making it better (hiding inactive modals, backdrop management, etc)