### PR TITLE
chore: update bootstrap to ^4.0.0-alpha.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Check all the directives in action at https://ng-bootstrap.github.io
 
 ## Dependencies
 * [Angular 2](https://angular.io) (tested with 2.0.0)
-* [Bootstrap 4](https://v4-alpha.getbootstrap.com) (tested with 4.0.0-alpha.4)
+* [Bootstrap 4](https://v4-alpha.getbootstrap.com) (tested with 4.0.0-alpha.5)
 
 ## Installation
 After installing the above dependencies, install `ng-bootstrap` via:

--- a/demo/src/app/app.component.html
+++ b/demo/src/app/app.component.html
@@ -10,7 +10,7 @@
           <a class="nav-link" [routerLink]="['/components']">Components</a>
         </li>
       </ul>
-      <p class="github-buttons pull-lg-right">
+      <p class="github-buttons float-lg-right">
         <a class="github-button"
           href="https://github.com/ng-bootstrap/ng-bootstrap"
           target="_blank"

--- a/demo/src/app/components/shared/example-box/example-box.component.html
+++ b/demo/src/app/components/shared/example-box/example-box.component.html
@@ -4,7 +4,7 @@
       <span class="h3">
         {{ demoTitle }}
       </span>
-      <div class="pull-xs-right">
+      <div class="float-xs-right">
         <img role="button" src="img/code-icon.png" (click)="toggleCode()" title="Show source code"/>
         <a target="_blank" href="app/components/{{component}}/demos/{{demo}}/plnkr.html" title="Edit in Plnkr" >
           <img src="img/plunker-icon.png" height="24" width="24"/>

--- a/demo/src/app/getting-started/getting-started.component.html
+++ b/demo/src/app/getting-started/getting-started.component.html
@@ -11,7 +11,7 @@
       <a href="https://angular.io" target="_blank">Angular</a> (<em>requires</em> Angular version 2 or higher, tested with 2.0.0)
     </li>
     <li>
-      <a href="http://v4-alpha.getbootstrap.com" target="_blank">Bootstrap CSS</a> (tested with 4.0.0-alpha.4)
+      <a href="http://v4-alpha.getbootstrap.com" target="_blank">Bootstrap CSS</a> (tested with 4.0.0-alpha.5)
     </li>
   </ul>
   <h3>

--- a/demo/src/app/shared/content-wrapper/content-wrapper.component.html
+++ b/demo/src/app/shared/content-wrapper/content-wrapper.component.html
@@ -4,7 +4,7 @@
   </div>
 </div>
 <div class="container">
-  <div class="col-md-9 col-md-pull-3">
+  <div class="col-md-9 col-md-float-3">
     <ng-content></ng-content>
   </div>
   <div class="col-md-3 col-md-push-9">

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@angular/router": "3.0.0",
     "angular2-template-loader": "^0.4.0",
     "autoprefixer": "^6.3.6",
-    "bootstrap": "^4.0.0-alpha.4",
+    "bootstrap": "^4.0.0-alpha.5",
     "clang-format": "1.0.35",
     "classlist-polyfill": "^1.0.3",
     "copy-webpack-plugin": "^3.0.1",

--- a/src/datepicker/datepicker-navigation-select.ts
+++ b/src/datepicker/datepicker-navigation-select.ts
@@ -12,6 +12,8 @@ import {NgbCalendar} from './ngb-calendar';
       padding: 0.25rem 0.5rem;
       font-size: 0.875rem;      
       line-height: 1.25;
+      /* to cancel the custom height set by custom-select */
+      height: inherit;
       width: 50%;
     }
   `],

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -26,6 +26,7 @@ import {NgbPopoverConfig} from './popover-config';
   selector: 'ngb-popover-window',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {'[class]': '"popover in popover-" + placement', 'role': 'tooltip'},
+  // TODO remove the div.popover-arrow, which is there only to maintain compatibility with bootstrap alpha.4
   template: `
     <div class="popover-arrow"></div>
     <h3 class="popover-title">{{title}}</h3><div class="popover-content"><ng-content></ng-content></div>

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -26,6 +26,7 @@ import {NgbTooltipConfig} from './tooltip-config';
   selector: 'ngb-tooltip-window',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {'[class]': '"tooltip in tooltip-" + placement', 'role': 'tooltip'},
+  // TODO remove the div.tooltip-arrow, which is there only to maintain compatibility with bootstrap alpha.4
   template: `
     <div class="tooltip-arrow"></div>
     <div class="tooltip-inner"><ng-content></ng-content></div>


### PR DESCRIPTION
Closes #915

BREAKING CHANGE: ng-boostrap now uses bootstrap 4.0.0-alpha.5, which modified the markup used to generate tooltip and popover arrows (see https://github.com/twbs/bootstrap/pull/17238). Using ng-bootstrap with an older version of bootstrap will thus not display tooltip and popover arrows anymore.