### PR TITLE
fix(rating): improves rating accessibility

### DIFF
--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -199,6 +199,17 @@ describe('ngb-rating', () => {
 
       expect(compiled.querySelector('span').getAttribute('aria-valuenow')).toBe('7');
     });
+
+    it('updates aria-valuetext when the rate changes', () => {
+      const fixture = createTestComponent('<ngb-rating [max]="max" rate="3"></ngb-rating>');
+
+      const compiled = fixture.nativeElement;
+
+      getStar(compiled, 7).click();
+      fixture.detectChanges();
+
+      expect(compiled.querySelector('span').getAttribute('aria-valuetext')).toBe('7 out of 10');
+    });
   });
 
   describe('Custom config', () => {

--- a/src/rating/rating.ts
+++ b/src/rating/rating.ts
@@ -30,11 +30,11 @@ export interface StarTemplateContext {
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <template #t let-fill="fill">{{ fill === 100 ? '&#9733;' : '&#9734;' }}</template>
-    <span tabindex="0" (mouseleave)="reset()" aria-valuemin="0" [attr.aria-valuemax]="max" [attr.aria-valuenow]="rate">
-      <template ngFor let-r [ngForOf]="range" let-index="index">
+    <span tabindex="0" (mouseleave)="reset()" role="slider" aria-valuemin="0"
+      [attr.aria-valuemax]="max" [attr.aria-valuenow]="rate" [attr.aria-valuetext]="ariaValueText">
+      <template ngFor [ngForOf]="range" let-index="index">
         <span class="sr-only">({{ index < rate ? '*' : ' ' }})</span>
-        <span (mouseenter)="enter(index + 1)" (click)="update(index + 1)" [title]="r.title" 
-        [attr.aria-valuetext]="r.title" 
+        <span (mouseenter)="enter(index + 1)" (click)="update(index + 1)" 
         [style.cursor]="readonly ? 'default' : 'pointer'">
           <template [ngTemplateOutlet]="starTemplate || t" [ngOutletContext]="{fill: getFillValue(index)}"></template>
         </span>
@@ -91,6 +91,8 @@ export class NgbRating implements OnInit,
     this.readonly = config.readonly;
   }
 
+  get ariaValueText() { return `${this.rate} out of ${this.max}`; }
+
   enter(value: number): void {
     if (!this.readonly) {
       this.rate = value;
@@ -117,7 +119,7 @@ export class NgbRating implements OnInit,
     }
   }
 
-  ngOnInit(): void { this.range = this._buildTemplateObjects(); }
+  ngOnInit(): void { this.range = Array.from({length: this.max}, (v, k) => k + 1); }
 
   reset(): void {
     this.leave.emit(this.rate);
@@ -130,13 +132,5 @@ export class NgbRating implements OnInit,
       this.rate = value;
       this.rateChange.emit(value);
     }
-  }
-
-  private _buildTemplateObjects(): number[] {
-    let range = [];
-    for (let i = 1; i <= this.max; i++) {
-      range.push({title: i});
-    }
-    return range;
   }
 }


### PR DESCRIPTION
Two changes for (#952):

- removing the title from each span with the star, as it looks confusing. It's still easily possible to add a title to the rating for the whole component if necessary
- adding `role=slider` and moving `[attr.aria-valuetext]` next to other attributes. Tested with VoiceOver on the Mac → it doesn't work without these two

https://www.w3.org/TR/wai-aria/roles#slider
https://www.w3.org/TR/wai-aria/states_and_properties#aria-valuetext