### PR TITLE
fix(datepicker): restores selected day text color

### DIFF
--- a/src/datepicker/datepicker-day-view.spec.ts
+++ b/src/datepicker/datepicker-day-view.spec.ts
@@ -57,10 +57,12 @@ describe('ngbDatepickerDayView', () => {
     fixture.detectChanges();
 
     const el = getElement(fixture.nativeElement);
+    expect(el).not.toHaveCssClass('text-white');
     expect(el).not.toHaveCssClass('bg-primary');
 
     fixture.componentInstance.selected = true;
     fixture.detectChanges();
+    expect(el).toHaveCssClass('text-white');
     expect(el).toHaveCssClass('bg-primary');
   });
 

--- a/src/datepicker/datepicker-day-view.ts
+++ b/src/datepicker/datepicker-day-view.ts
@@ -10,7 +10,12 @@ import {NgbDateStruct} from './ngb-date-struct';
       border-radius: 0.25rem;
     }
   `],
-  host: {'[class.bg-primary]': 'selected', '[class.text-muted]': 'isMuted()', '[class.btn-secondary]': '!disabled'},
+  host: {
+    '[class.bg-primary]': 'selected',
+    '[class.text-white]': 'selected',
+    '[class.text-muted]': 'isMuted()',
+    '[class.btn-secondary]': '!disabled'
+  },
   template: `{{ date.day }}`
 })
 export class NgbDatepickerDayView {


### PR DESCRIPTION
BS4 alpha 5 "Separated `background` and `color` utilities for more explicit styling"
So `bg-primary` should become `bg-primary` + `text-white`