### PR TITLE
fix: restore AoT compatibility with 2.1.1

### DIFF
--- a/src/accordion/accordion.module.ts
+++ b/src/accordion/accordion.module.ts
@@ -1,11 +1,13 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
-import {NGB_ACCORDION_DIRECTIVES} from './accordion';
+import {NgbAccordion, NgbPanel, NgbPanelTitle, NgbPanelContent, NgbPanelChangeEvent} from './accordion';
 import {NgbAccordionConfig} from './accordion-config';
 
-export {NgbPanelChangeEvent} from './accordion';
+export {NgbAccordion, NgbPanel, NgbPanelTitle, NgbPanelContent, NgbPanelChangeEvent} from './accordion';
 export {NgbAccordionConfig} from './accordion-config';
+
+const NGB_ACCORDION_DIRECTIVES = [NgbAccordion, NgbPanel, NgbPanelTitle, NgbPanelContent];
 
 @NgModule({declarations: NGB_ACCORDION_DIRECTIVES, exports: NGB_ACCORDION_DIRECTIVES, imports: [CommonModule]})
 export class NgbAccordionModule {

--- a/src/accordion/accordion.ts
+++ b/src/accordion/accordion.ts
@@ -209,5 +209,3 @@ export class NgbAccordion implements AfterContentChecked {
     });
   }
 }
-
-export const NGB_ACCORDION_DIRECTIVES = [NgbAccordion, NgbPanel, NgbPanelTitle, NgbPanelContent];

--- a/src/buttons/radio.module.ts
+++ b/src/buttons/radio.module.ts
@@ -1,5 +1,9 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
-import {NGB_RADIO_DIRECTIVES} from './radio';
+import {NgbRadio, NgbActiveLabel, NgbRadioGroup} from './radio';
+
+export {NgbRadio, NgbActiveLabel, NgbRadioGroup} from './radio';
+
+const NGB_RADIO_DIRECTIVES = [NgbRadio, NgbActiveLabel, NgbRadioGroup];
 
 @NgModule({declarations: NGB_RADIO_DIRECTIVES, exports: NGB_RADIO_DIRECTIVES})
 export class NgbButtonsModule {

--- a/src/buttons/radio.ts
+++ b/src/buttons/radio.ts
@@ -146,5 +146,3 @@ export class NgbRadio implements OnDestroy {
     this._label.disabled = this._disabled;
   }
 }
-
-export const NGB_RADIO_DIRECTIVES = [NgbRadio, NgbActiveLabel, NgbRadioGroup];

--- a/src/collapse/collapse.module.ts
+++ b/src/collapse/collapse.module.ts
@@ -1,7 +1,9 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
-import {NGB_COLLAPSE_DIRECTIVES} from './collapse';
+import {NgbCollapse} from './collapse';
 
-@NgModule({declarations: NGB_COLLAPSE_DIRECTIVES, exports: NGB_COLLAPSE_DIRECTIVES})
+export {NgbCollapse} from './collapse';
+
+@NgModule({declarations: [NgbCollapse], exports: [NgbCollapse]})
 export class NgbCollapseModule {
   static forRoot(): ModuleWithProviders { return {ngModule: NgbCollapseModule, providers: []}; }
 }

--- a/src/collapse/collapse.ts
+++ b/src/collapse/collapse.ts
@@ -14,5 +14,3 @@ export class NgbCollapse {
    */
   @Input('ngbCollapse') collapsed = false;
 }
-
-export const NGB_COLLAPSE_DIRECTIVES = [NgbCollapse];

--- a/src/datepicker/datepicker.module.ts
+++ b/src/datepicker/datepicker.module.ts
@@ -14,6 +14,7 @@ import {NgbDatepickerNavigationSelect} from './datepicker-navigation-select';
 import {NgbDatepickerConfig} from './datepicker-config';
 
 export {NgbDatepicker} from './datepicker';
+export {NgbInputDatepicker} from './datepicker-input';
 export {NgbDatepickerMonthView} from './datepicker-month-view';
 export {NgbDatepickerDayView} from './datepicker-day-view';
 export {NgbDatepickerNavigation} from './datepicker-navigation';

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnChanges, TemplateRef, forwardRef, OnInit} from '@angular/core';
+import {Component, Input, OnChanges, TemplateRef, forwardRef, OnInit, SimpleChanges} from '@angular/core';
 import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
 import {NgbCalendar} from './ngb-calendar';
 import {NgbDate} from './ngb-date';
@@ -149,7 +149,7 @@ export class NgbDatepicker implements OnChanges,
     this.navigateTo(this.startDate);
   }
 
-  ngOnChanges() {
+  ngOnChanges(changes: SimpleChanges) {
     this._setDates();
     this.navigateTo(this.startDate);
   }

--- a/src/dropdown/dropdown.module.ts
+++ b/src/dropdown/dropdown.module.ts
@@ -1,8 +1,11 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
-import {NGB_DROPDOWN_DIRECTIVES} from './dropdown';
+import {NgbDropdown, NgbDropdownToggle} from './dropdown';
 import {NgbDropdownConfig} from './dropdown-config';
 
+export {NgbDropdown, NgbDropdownToggle} from './dropdown';
 export {NgbDropdownConfig} from './dropdown-config';
+
+const NGB_DROPDOWN_DIRECTIVES = [NgbDropdownToggle, NgbDropdown];
 
 @NgModule({declarations: NGB_DROPDOWN_DIRECTIVES, exports: NGB_DROPDOWN_DIRECTIVES})
 export class NgbDropdownModule {

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -31,7 +31,7 @@ export class NgbDropdown {
   /**
    *  Defines whether or not the dropdown-menu is open initially.
    */
-  @Input('open') private _open = false;
+  @Input('open') _open = false;
 
   /**
    *  An event fired when the dropdown is opened or closed.
@@ -120,5 +120,3 @@ export class NgbDropdownToggle {
 
   toggleOpen() { this.dropdown.toggle(); }
 }
-
-export const NGB_DROPDOWN_DIRECTIVES = [NgbDropdownToggle, NgbDropdown];

--- a/src/tabset/tabset.module.ts
+++ b/src/tabset/tabset.module.ts
@@ -1,11 +1,13 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
-import {NGB_TABSET_DIRECTIVES} from './tabset';
+import {NgbTabset, NgbTab, NgbTabContent, NgbTabTitle, NgbTabChangeEvent} from './tabset';
 import {NgbTabsetConfig} from './tabset-config';
 
-export {NgbTabChangeEvent} from './tabset';
+export {NgbTabset, NgbTab, NgbTabContent, NgbTabTitle, NgbTabChangeEvent} from './tabset';
 export {NgbTabsetConfig} from './tabset-config';
+
+const NGB_TABSET_DIRECTIVES = [NgbTabset, NgbTab, NgbTabContent, NgbTabTitle];
 
 @NgModule({declarations: NGB_TABSET_DIRECTIVES, exports: NGB_TABSET_DIRECTIVES, imports: [CommonModule]})
 export class NgbTabsetModule {

--- a/src/tabset/tabset.ts
+++ b/src/tabset/tabset.ts
@@ -145,5 +145,3 @@ export class NgbTabset implements AfterContentChecked {
     return tabsWithId.length ? tabsWithId[0] : null;
   }
 }
-
-export const NGB_TABSET_DIRECTIVES = [NgbTabset, NgbTab, NgbTabContent, NgbTabTitle];


### PR DESCRIPTION
It turns out that 2.1.1 is generating different code and this different code generation method uncovered some more bugs we had when it comes to AoT support (technically not all items are bugs on our end - there is an issue in ng2 as well which we need to work-around - it is already fixed in master but not released; having said this the workaround makes sense for us anyway).

Fixes #953