### PR TITLE
feat(datepicker): ability to display several months

### DIFF
--- a/demo/src/app/components/datepicker/datepicker.component.ts
+++ b/demo/src/app/components/datepicker/datepicker.component.ts
@@ -18,6 +18,9 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Datepicker in a popup" [snippets]="snippets" component="datepicker" demo="popup">
         <ngbd-datepicker-popup></ngbd-datepicker-popup>
       </ngbd-example-box>
+      <ngbd-example-box demoTitle="Multiple months" [snippets]="snippets" component="datepicker" demo="multiple">
+        <ngbd-datepicker-multiple></ngbd-datepicker-multiple>
+      </ngbd-example-box>
       <ngbd-example-box demoTitle="Disabled datepicker" [snippets]="snippets" component="datepicker" demo="disabled">
         <ngbd-datepicker-disabled></ngbd-datepicker-disabled>
       </ngbd-example-box>

--- a/demo/src/app/components/datepicker/demos/index.ts
+++ b/demo/src/app/components/datepicker/demos/index.ts
@@ -4,9 +4,11 @@ import {NgbdDatepickerI18n} from './i18n/datepicker-i18n';
 import {NgbdDatepickerDisabled} from './disabled/datepicker-disabled';
 import {NgbdDatepickerPopup} from './popup/datepicker-popup';
 import {NgbdDatepickerCustomday} from './customday/datepicker-customday';
+import {NgbdDatepickerMultiple} from './multiple/datepicker-multiple';
 
 export const DEMO_DIRECTIVES = [
-  NgbdDatepickerBasic, NgbdDatepickerPopup, NgbdDatepickerDisabled, NgbdDatepickerI18n, NgbdDatepickerCustomday, NgbdDatepickerConfig
+  NgbdDatepickerBasic, NgbdDatepickerPopup, NgbdDatepickerDisabled, NgbdDatepickerI18n,
+  NgbdDatepickerCustomday, NgbdDatepickerConfig, NgbdDatepickerMultiple
 ];
 
 export const DEMO_SNIPPETS = {
@@ -29,6 +31,10 @@ export const DEMO_SNIPPETS = {
   customday: {
     code: require('!!prismjs?lang=typescript!./customday/datepicker-customday'),
     markup: require('!!prismjs?lang=markup!./customday/datepicker-customday.html')
+  },
+  multiple: {
+    code: require('!!prismjs?lang=typescript!./multiple/datepicker-multiple'),
+    markup: require('!!prismjs?lang=markup!./multiple/datepicker-multiple.html')
   },
   config: {
     code: require('!!prismjs?lang=typescript!./config/datepicker-config'),

--- a/demo/src/app/components/datepicker/demos/multiple/datepicker-multiple.html
+++ b/demo/src/app/components/datepicker/demos/multiple/datepicker-multiple.html
@@ -1,0 +1,31 @@
+
+<ngb-datepicker [displayMonths]="displayMonths" [navigation]="navigation"></ngb-datepicker>
+
+<hr/>
+
+<form class="form-inline">
+  <div class="form-group">
+    <div class="input-group">
+      <input class="form-control" placeholder="yyyy-mm-dd"
+            name="dp" [displayMonths]="displayMonths" [navigation]="navigation" ngbDatepicker #d="ngbDatepicker">
+      <div class="input-group-addon" (click)="d.toggle()" >
+        <img src="img/calendar-icon.svg" style="width: 1.2rem; height: 1rem; cursor: pointer;"/>
+      </div>
+    </div>
+  </div>
+</form>
+
+<hr/>
+
+<select class="custom-select" [(ngModel)]="displayMonths">
+  <option [value]="1">One month</option>
+  <option [value]="2">Two months</option>
+  <option [value]="3">Three months</option>
+</select>
+
+<select class="custom-select" [(ngModel)]="navigation">
+  <option value="none">Without navigation</option>
+  <option value="select">With select boxes</option>
+  <option value="arrows">Without select boxes</option>
+</select>
+

--- a/demo/src/app/components/datepicker/demos/multiple/datepicker-multiple.ts
+++ b/demo/src/app/components/datepicker/demos/multiple/datepicker-multiple.ts
@@ -1,0 +1,11 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'ngbd-datepicker-multiple',
+  templateUrl: './datepicker-multiple.html'
+})
+export class NgbdDatepickerMultiple {
+
+  displayMonths = 2;
+  navigation = 'select';
+}

--- a/src/datepicker/datepicker-config.spec.ts
+++ b/src/datepicker/datepicker-config.spec.ts
@@ -5,12 +5,13 @@ describe('ngb-datepicker-config', () => {
     const config = new NgbDatepickerConfig();
 
     expect(config.dayTemplate).toBeUndefined();
+    expect(config.displayMonths).toBe(1);
     expect(config.firstDayOfWeek).toBe(1);
     expect(config.markDisabled).toBeUndefined();
     expect(config.minDate).toBeUndefined();
     expect(config.maxDate).toBeUndefined();
+    expect(config.navigation).toBe('select');
     expect(config.outsideDays).toBe('visible');
-    expect(config.showNavigation).toBe(true);
     expect(config.showWeekdays).toBe(true);
     expect(config.showWeekNumbers).toBe(false);
     expect(config.startDate).toBeUndefined();

--- a/src/datepicker/datepicker-config.ts
+++ b/src/datepicker/datepicker-config.ts
@@ -10,12 +10,13 @@ import {NgbDateStruct} from './ngb-date-struct';
 @Injectable()
 export class NgbDatepickerConfig {
   dayTemplate: TemplateRef<DayTemplateContext>;
+  displayMonths = 1;
   firstDayOfWeek = 1;
   markDisabled: (date: NgbDateStruct, current: {year: number, month: number}) => boolean;
   minDate: NgbDateStruct;
   maxDate: NgbDateStruct;
+  navigation: 'select' | 'arrows' | 'none' = 'select';
   outsideDays: 'visible' | 'collapsed' | 'hidden' = 'visible';
-  showNavigation = true;
   showWeekdays = true;
   showWeekNumbers = false;
   startDate: {year: number, month: number};

--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -157,6 +157,17 @@ describe('NgbInputDatepicker', () => {
       expect(dp.dayTemplate).toBeDefined();
     });
 
+    it('should propagate the "displayMonths" option', () => {
+      const fixture = createTestCmpt(`<input ngbDatepicker [displayMonths]="3">`);
+      const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
+
+      dpInput.open();
+      fixture.detectChanges();
+
+      const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+      expect(dp.displayMonths).toBe(3);
+    });
+
     it('should propagate the "firstDayOfWeek" option', () => {
       const fixture = createTestCmpt(`<input ngbDatepicker [firstDayOfWeek]="5">`);
       const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
@@ -212,15 +223,15 @@ describe('NgbInputDatepicker', () => {
       expect(dp.outsideDays).toEqual('collapsed');
     });
 
-    it('should propagate the "showNavigation" option', () => {
-      const fixture = createTestCmpt(`<input ngbDatepicker [showNavigation]="true">`);
+    it('should propagate the "navigation" option', () => {
+      const fixture = createTestCmpt(`<input ngbDatepicker navigation="none">`);
       const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
 
       dpInput.open();
       fixture.detectChanges();
 
       const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
-      expect(dp.showNavigation).toBeTruthy();
+      expect(dp.navigation).toBe('none');
     });
 
     it('should propagate the "showWeekdays" option', () => {

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -47,6 +47,11 @@ export class NgbInputDatepicker implements ControlValueAccessor {
   @Input() dayTemplate: TemplateRef<DayTemplateContext>;
 
   /**
+   * Number of months to display
+   */
+  @Input() displayMonths: number;
+
+  /**
   * First day of the week. With default calendar we use ISO 8601: 1=Mon ... 7=Sun
    */
   @Input() firstDayOfWeek: number;
@@ -68,15 +73,16 @@ export class NgbInputDatepicker implements ControlValueAccessor {
   @Input() maxDate: NgbDateStruct;
 
   /**
+   * Navigation type: `select` (default with select boxes for month and year), `arrows`
+   * (without select boxes, only navigation arrows) or `none` (no navigation at all)
+   */
+  @Input() navigation: 'select' | 'arrows' | 'none';
+
+  /**
    * The way to display days that don't belong to current month: `visible` (default),
    * `hidden` (not displayed) or `collapsed` (not displayed with empty space collapsed)
    */
   @Input() outsideDays: 'visible' | 'collapsed' | 'hidden';
-
-  /**
-   * Whether to display navigation
-   */
-  @Input() showNavigation: boolean;
 
   /**
    * Whether to display days of the week
@@ -192,8 +198,8 @@ export class NgbInputDatepicker implements ControlValueAccessor {
   onBlur() { this._onTouched(); }
 
   private _applyDatepickerInputs(datepickerInstance: NgbDatepicker): void {
-    ['dayTemplate', 'firstDayOfWeek', 'markDisabled', 'minDate', 'maxDate', 'outsideDays', 'showNavigation',
-     'showWeekdays', 'showWeekNumbers']
+    ['dayTemplate', 'displayMonths', 'firstDayOfWeek', 'markDisabled', 'minDate', 'maxDate', 'navigation',
+     'outsideDays', 'showNavigation', 'showWeekdays', 'showWeekNumbers']
         .forEach((optionName: string) => {
           if (this[optionName] !== undefined) {
             datepickerInstance[optionName] = this[optionName];

--- a/src/datepicker/datepicker-month-view.spec.ts
+++ b/src/datepicker/datepicker-month-view.spec.ts
@@ -39,7 +39,7 @@ function expectDates(element: HTMLElement, dates: string[]) {
   expect(result).toEqual(dates);
 }
 
-describe('ngbDatepickerMonthView', () => {
+describe('ngb-datepicker-month-view', () => {
 
   beforeEach(() => {
     TestBed.overrideModule(NgbDatepickerModule, {set: {exports: [NgbDatepickerMonthView, NgbDatepickerDayView]}});
@@ -47,8 +47,8 @@ describe('ngbDatepickerMonthView', () => {
   });
 
   it('should show/hide weekdays', () => {
-    const fixture =
-        createTestComponent('<tbody ngbDatepickerMonthView [month]="month" [showWeekdays]="showWeekdays"></tbody>');
+    const fixture = createTestComponent(
+        '<ngb-datepicker-month-view [month]="month" [showWeekdays]="showWeekdays"></ngb-datepicker-month-view>');
 
     expectWeekdays(fixture.nativeElement, ['Mo']);
 
@@ -59,7 +59,7 @@ describe('ngbDatepickerMonthView', () => {
 
   it('should show/hide week numbers', () => {
     const fixture = createTestComponent(
-        '<tbody ngbDatepickerMonthView [month]="month" [showWeekNumbers]="showWeekNumbers"></tbody>');
+        '<ngb-datepicker-month-view [month]="month" [showWeekNumbers]="showWeekNumbers"></ngb-datepicker-month-view>');
 
     expectWeekNumbers(fixture.nativeElement, ['2']);
 
@@ -71,7 +71,7 @@ describe('ngbDatepickerMonthView', () => {
   it('should use custom template to display dates', () => {
     const fixture = createTestComponent(`
         <template #tpl let-date="date">{{ date.day }}</template>
-        <tbody ngbDatepickerMonthView [month]="month" [dayTemplate]="tpl"></tbody>
+        <ngb-datepicker-month-view [month]="month" [dayTemplate]="tpl"></ngb-datepicker-month-view>
       `);
     expectDates(fixture.nativeElement, ['22', '23']);
   });
@@ -79,7 +79,7 @@ describe('ngbDatepickerMonthView', () => {
   it('should send date selection events', () => {
     const fixture = createTestComponent(`
         <template #tpl let-date="date">{{ date.day }}</template>
-        <tbody ngbDatepickerMonthView [month]="month" [dayTemplate]="tpl" (select)="onClick($event)"></tbody>
+        <ngb-datepicker-month-view [month]="month" [dayTemplate]="tpl" (select)="onClick($event)"></ngb-datepicker-month-view>
       `);
 
     spyOn(fixture.componentInstance, 'onClick');
@@ -93,7 +93,7 @@ describe('ngbDatepickerMonthView', () => {
   it('should not send date selection events for disabled dates', () => {
     const fixture = createTestComponent(`
         <template #tpl let-date="date">{{ date.day }}</template>
-        <tbody ngbDatepickerMonthView [month]="month" [dayTemplate]="tpl" (select)="onClick($event)"></tbody>
+        <ngb-datepicker-month-view [month]="month" [dayTemplate]="tpl" (select)="onClick($event)"></ngb-datepicker-month-view>
       `);
 
     fixture.componentInstance.month.weeks[0].days[0].disabled = true;
@@ -110,7 +110,8 @@ describe('ngbDatepickerMonthView', () => {
   it('should not send date selection events if disabled', () => {
     const fixture = createTestComponent(`
         <template #tpl let-date="date">{{ date.day }}</template>
-        <tbody ngbDatepickerMonthView [month]="month" [dayTemplate]="tpl" [disabled]="true" (select)="onClick($event)"></tbody>
+        <ngb-datepicker-month-view [month]="month" [dayTemplate]="tpl" [disabled]="true" (select)="onClick($event)">        
+        </ngb-datepicker-month-view>
       `);
 
     fixture.detectChanges();
@@ -127,8 +128,7 @@ describe('ngbDatepickerMonthView', () => {
     it('should set cursor to pointer', () => {
       const fixture = createTestComponent(`
         <template #tpl let-date="date">{{ date.day }}</template>
-        <table><tbody ngbDatepickerMonthView [month]="month" [dayTemplate]="tpl"
-        (change)="onClick($event)"></tbody></table>
+        <ngb-datepicker-month-view [month]="month" [dayTemplate]="tpl" (change)="onClick($event)"></ngb-datepicker-month-view>
       `);
 
       const dates = getDates(fixture.nativeElement);
@@ -140,8 +140,7 @@ describe('ngbDatepickerMonthView', () => {
     it('should set default cursor for disabled dates', () => {
       const fixture = createTestComponent(`
         <template #tpl let-date="date">{{ date.day }}</template>
-        <table><tbody ngbDatepickerMonthView [month]="month" [dayTemplate]="tpl"
-        (change)="onClick($event)"></tbody></table>
+        <ngb-datepicker-month-view [month]="month" [dayTemplate]="tpl" (change)="onClick($event)"></ngb-datepicker-month-view>
       `);
 
       fixture.componentInstance.month.weeks[0].days[0].disabled = true;
@@ -154,8 +153,8 @@ describe('ngbDatepickerMonthView', () => {
     it('should set default cursor for all dates if disabled', () => {
       const fixture = createTestComponent(`
         <template #tpl let-date="date">{{ date.day }}</template>
-        <table><tbody ngbDatepickerMonthView [month]="month" [dayTemplate]="tpl"
-        (change)="onClick($event)" [disabled]="true"></tbody></table>
+        <ngb-datepicker-month-view [month]="month" [dayTemplate]="tpl" (change)="onClick($event)" [disabled]="true">        
+        </ngb-datepicker-month-view>
       `);
 
       fixture.detectChanges();
@@ -165,8 +164,8 @@ describe('ngbDatepickerMonthView', () => {
     });
 
     it('should set default cursor for other months days', () => {
-      const fixture =
-          createTestComponent('<tbody ngbDatepickerMonthView [month]="month" [outsideDays]="outsideDays"></tbody>');
+      const fixture = createTestComponent(
+          '<ngb-datepicker-month-view [month]="month" [outsideDays]="outsideDays"></ngb-datepicker-month-view>');
 
       const dates = getDates(fixture.nativeElement);
       expect(window.getComputedStyle(dates[1]).getPropertyValue('cursor')).toBe('pointer');
@@ -182,8 +181,8 @@ describe('ngbDatepickerMonthView', () => {
   }
 
   it('should apply proper visibility to other months days', () => {
-    const fixture =
-        createTestComponent('<tbody ngbDatepickerMonthView [month]="month" [outsideDays]="outsideDays"></tbody>');
+    const fixture = createTestComponent(
+        '<ngb-datepicker-month-view [month]="month" [outsideDays]="outsideDays"></ngb-datepicker-month-view>');
 
     let dates = getDates(fixture.nativeElement);
     expect(dates[0]).not.toHaveCssClass('hidden');
@@ -211,6 +210,7 @@ describe('ngbDatepickerMonthView', () => {
 @Component({selector: 'test-cmp', template: ''})
 class TestComponent {
   month: MonthViewModel = {
+    firstDate: new NgbDate(2016, 7, 22),
     year: 2016,
     number: 7,
     weekdays: [1],

--- a/src/datepicker/datepicker-month-view.ts
+++ b/src/datepicker/datepicker-month-view.ts
@@ -5,12 +5,11 @@ import {NgbDatepickerI18n} from './datepicker-i18n';
 import {DayTemplateContext} from './datepicker-day-template-context';
 
 @Component({
-  selector: '[ngbDatepickerMonthView]',
+  selector: 'ngb-datepicker-month-view',
   styles: [`
     .weekday {
-      padding-bottom: 0.25rem;
     }
-    .weeknumber {    
+    .weeknumber {
     }
     .day {
       padding: 0;
@@ -20,30 +19,32 @@ import {DayTemplateContext} from './datepicker-day-template-context';
     .day.disabled, .day.hidden, .day.collapsed {
       cursor: default;
     }
-    :host/deep/.day.collapsed > * {      
+    :host/deep/.day.collapsed > * {
       display: none;
     }
     :host/deep/.day.hidden > * {
       visibility: hidden;
-    }    
+    }
   `],
   template: `
-    <tr *ngIf="showWeekdays">
-      <td *ngIf="showWeekNumbers"></td>
-      <td *ngFor="let w of month.weekdays" class="weekday text-xs-center font-weight-bold">{{ i18n.getWeekdayName(w) }}</td>
-    </tr>
-    <tr *ngFor="let week of month.weeks">
-      <td *ngIf="showWeekNumbers" class="weeknumber small text-xs-center">{{ week.number }}</td>
-      <td *ngFor="let day of week.days" (click)="doSelect(day)" class="day" [class.disabled]="isDisabled(day)" 
-      [class.collapsed]="isCollapsed(day)" [class.hidden]="isHidden(day)">
-          <template [ngTemplateOutlet]="dayTemplate" 
-          [ngOutletContext]="{date: {year: day.date.year, month: day.date.month, day: day.date.day}, 
-            currentMonth: month.number, 
-            disabled: isDisabled(day), 
-            selected: isSelected(day.date)}">
-          </template>
-      </td>
-    </tr>
+    <table>
+      <tr *ngIf="showWeekdays">
+        <td *ngIf="showWeekNumbers"></td>
+        <td *ngFor="let w of month.weekdays" class="weekday text-xs-center font-weight-bold">{{ i18n.getWeekdayName(w) }}</td>
+      </tr>
+      <tr *ngFor="let week of month.weeks">
+        <td *ngIf="showWeekNumbers" class="weeknumber small text-xs-center">{{ week.number }}</td>
+        <td *ngFor="let day of week.days" (click)="doSelect(day)" class="day" [class.disabled]="isDisabled(day)"
+        [class.collapsed]="isCollapsed(day)" [class.hidden]="isHidden(day)">
+            <template [ngTemplateOutlet]="dayTemplate"
+            [ngOutletContext]="{date: {year: day.date.year, month: day.date.month, day: day.date.day},
+              currentMonth: month.number,
+              disabled: isDisabled(day),
+              selected: isSelected(day.date)}">
+            </template>
+        </td>
+      </tr>
+    </table>
   `
 })
 export class NgbDatepickerMonthView {

--- a/src/datepicker/datepicker-navigation.spec.ts
+++ b/src/datepicker/datepicker-navigation.spec.ts
@@ -1,4 +1,5 @@
 import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
 import {createGenericTestComponent} from '../test/common';
 import {getMonthSelect, getYearSelect, getNavigationLinks} from '../test/datepicker/common';
 
@@ -20,7 +21,7 @@ function changeSelect(element: HTMLSelectElement, value: string) {
   element.dispatchEvent(evt);
 }
 
-describe('ngbDatepickerNavigation', () => {
+describe('ngb-datepicker-navigation', () => {
 
   beforeEach(() => {
     TestBed.overrideModule(
@@ -28,21 +29,24 @@ describe('ngbDatepickerNavigation', () => {
     TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot()]});
   });
 
-  it('should render navigation select component for \'select\' type', () => {
-    const fixture = createTestComponent(
-        `<tbody ngbDatepickerNavigation type="select" [date]="date" [minDate]="minDate" [maxDate]="maxDate"></tbody>`);
+  it('should toggle navigation select component', () => {
+    const fixture =
+        createTestComponent(`<ngb-datepicker-navigation [showSelect]="showSelect" [date]="date" [firstDate]="firstDate" 
+          [minDate]="minDate" [maxDate]="maxDate"></ngb-datepicker-navigation>`);
+
+    expect(fixture.debugElement.query(By.directive(NgbDatepickerNavigationSelect))).not.toBeNull();
     expect(getMonthSelect(fixture.nativeElement).value).toBe('8');
     expect(getYearSelect(fixture.nativeElement).value).toBe('2016');
-  });
 
-  it('should not render navigation select component for a different type', () => {
-    const fixture = createTestComponent(`<tbody ngbDatepickerNavigation type="blah" [date]="date"></tbody>`);
-    expect(fixture.nativeElement.querySelector('ngbDatepickerNavigation-select')).toBeFalsy();
+    fixture.componentInstance.showSelect = false;
+    fixture.detectChanges();
+    expect(fixture.debugElement.query(By.directive(NgbDatepickerNavigationSelect))).toBeNull();
   });
 
   it('should send date selection event', () => {
-    const fixture = createTestComponent(`<tbody ngbDatepickerNavigation type="select" [date]="date" [minDate]="minDate" 
-          [maxDate]="maxDate" (select)="onSelect($event)"></tbody>`);
+    const fixture =
+        createTestComponent(`<ngb-datepicker-navigation [showSelect]="true" [date]="date" [firstDate]="firstDate" 
+          [minDate]="minDate" [maxDate]="maxDate" (select)="onSelect($event)"></ngb-datepicker-navigation>`);
 
     const monthSelect = getMonthSelect(fixture.nativeElement);
     const yearSelect = getYearSelect(fixture.nativeElement);
@@ -56,8 +60,9 @@ describe('ngbDatepickerNavigation', () => {
   });
 
   it('should make navigation buttons disabled', () => {
-    const fixture = createTestComponent(
-        `<tbody ngbDatepickerNavigation type="select" [date]="date" [minDate]="minDate" [maxDate]="maxDate"></tbody>`);
+    const fixture =
+        createTestComponent(`<ngb-datepicker-navigation [showSelect]="true" [date]="date" [firstDate]="firstDate" 
+          [minDate]="minDate" [maxDate]="maxDate"></ngb-datepicker-navigation>`);
 
     const links = getNavigationLinks(fixture.nativeElement);
     expect(links[0].hasAttribute('disabled')).toBeFalsy();
@@ -68,6 +73,7 @@ describe('ngbDatepickerNavigation', () => {
     expect(links[0].hasAttribute('disabled')).toBeTruthy();
     expect(links[1].hasAttribute('disabled')).toBeFalsy();
 
+    fixture.componentInstance.firstDate = new NgbDate(2016, 9, 1);
     fixture.componentInstance.date = new NgbDate(2016, 9, 1);
     fixture.detectChanges();
     expect(links[0].hasAttribute('disabled')).toBeFalsy();
@@ -80,8 +86,8 @@ describe('ngbDatepickerNavigation', () => {
   });
 
   it('should have disabled navigation buttons and year and month select boxes when disabled', () => {
-    const fixture = createTestComponent(
-        `<tbody ngbDatepickerNavigation [disabled]="true" type="select" [date]="date" [minDate]="minDate" [maxDate]="maxDate"></tbody>`);
+    const fixture = createTestComponent(`<ngb-datepicker-navigation [disabled]="true" [showSelect]="true" [date]="date" 
+          [firstDate]="firstDate" [minDate]="minDate" [maxDate]="maxDate"></ngb-datepicker-navigation>`);
 
     const links = getNavigationLinks(fixture.nativeElement);
     expect(links[0].hasAttribute('disabled')).toBeTruthy();
@@ -91,8 +97,9 @@ describe('ngbDatepickerNavigation', () => {
   });
 
   it('should send navigation events', () => {
-    const fixture = createTestComponent(`<tbody ngbDatepickerNavigation [type]="type" [date]="date" [minDate]="minDate" 
-          [maxDate]="maxDate" (navigate)="onNavigate($event)"></tbody>`);
+    const fixture =
+        createTestComponent(`<ngb-datepicker-navigation [date]="date" [firstDate]="firstDate" [minDate]="minDate" 
+          [maxDate]="maxDate" (navigate)="onNavigate($event)"></ngb-datepicker-navigation>`);
 
     const links = getNavigationLinks(fixture.nativeElement);
     spyOn(fixture.componentInstance, 'onNavigate');
@@ -107,8 +114,9 @@ describe('ngbDatepickerNavigation', () => {
   });
 
   it('should have buttons of type button', () => {
-    const fixture = createTestComponent(
-        `<tbody ngbDatepickerNavigation type="select" [date]="date" [minDate]="minDate" [maxDate]="maxDate"></tbody>`);
+    const fixture =
+        createTestComponent(`<ngb-datepicker-navigation [date]="date" [firstDate]="firstDate" [minDate]="minDate" 
+        [maxDate]="maxDate"></ngb-datepicker-navigation>`);
 
     const links = getNavigationLinks(fixture.nativeElement);
     links.forEach((link) => { expect(link.getAttribute('type')).toBe('button'); });
@@ -118,10 +126,11 @@ describe('ngbDatepickerNavigation', () => {
 
 @Component({selector: 'test-cmp', template: ''})
 class TestComponent {
-  type = 'select';
+  firstDate = new NgbDate(2016, 8, 1);
   date = new NgbDate(2016, 8, 22);
   minDate = new NgbDate(2015, 0, 1);
   maxDate = new NgbDate(2020, 11, 31);
+  showSelect = true;
 
   onNavigate = () => {};
   onSelect = () => {};

--- a/src/datepicker/datepicker-navigation.ts
+++ b/src/datepicker/datepicker-navigation.ts
@@ -5,33 +5,36 @@ import {NgbDatepickerI18n} from './datepicker-i18n';
 import {NgbCalendar} from './ngb-calendar';
 
 @Component({
-  selector: '[ngbDatepickerNavigation]',
+  selector: 'ngb-datepicker-navigation',
   styles: [`
-    td {
-      text-align: center;
-      padding-bottom: 0.25rem;
+    .collapsed {
+        margin-bottom: -1.7rem;
     }
   `],
   template: `
-    <tr>
-      <td>
-        <button type="button" (click)="doNavigate(navigation.PREV)" class="btn btn-sm btn-secondary btn-block" 
-          [disabled]="prevDisabled()">&lt;</button>
-      </td>
-      <td [attr.colspan]="showWeekNumbers ? 6 : 5">      
-        <ngb-datepicker-navigation-select *ngIf="type === 'select'"
-          [date]="date"
-          [minYear]="minDate.year"
-          [maxYear]="maxDate.year"
-          [disabled] = "disabled"
-          (select)="selectDate($event)">
-        </ngb-datepicker-navigation-select>
-      </td>
-      <td>
-        <button type="button" (click)="doNavigate(navigation.NEXT)" class="btn btn-sm btn-secondary btn-block" 
-          [disabled]="nextDisabled()">&gt;</button>
-      </td>
-    </tr>
+    <table class="w-100" [class.collapsed]="!showSelect">
+      <tr>
+        <td class="text-sm-left">
+          <button type="button" (click)="doNavigate(navigation.PREV)" class="btn btn-sm btn-secondary btn-inline" 
+            [disabled]="prevDisabled()">&lt;</button>
+        </td>
+        
+        <td *ngIf="showSelect">
+          <ngb-datepicker-navigation-select
+            [date]="firstDate"
+            [minYear]="minDate.year"
+            [maxYear]="maxDate.year"
+            [disabled] = "disabled"
+            (select)="selectDate($event)">
+          </ngb-datepicker-navigation-select>
+        </td>        
+        
+        <div class="text-sm-right">
+          <button type="button" (click)="doNavigate(navigation.NEXT)" class="next btn btn-sm btn-secondary btn-inline" 
+            [disabled]="nextDisabled()">&gt;</button>
+        </div>
+      </tr>
+    </table>
   `
 })
 export class NgbDatepickerNavigation {
@@ -39,10 +42,11 @@ export class NgbDatepickerNavigation {
 
   @Input() date: NgbDate;
   @Input() disabled: boolean;
+  @Input() firstDate: NgbDate;
   @Input() maxDate: NgbDate;
   @Input() minDate: NgbDate;
+  @Input() showSelect: boolean;
   @Input() showWeekNumbers: boolean;
-  @Input() type = 'select';
 
   @Output() navigate = new EventEmitter<NavigationEvent>();
   @Output() select = new EventEmitter<NgbDate>();
@@ -52,11 +56,11 @@ export class NgbDatepickerNavigation {
   doNavigate(event: NavigationEvent) { this.navigate.emit(event); }
 
   nextDisabled() {
-    return this.disabled || (this.maxDate && this._calendar.getNext(this.date, 'm').after(this.maxDate));
+    return this.disabled || (this.maxDate && this._calendar.getNext(this.firstDate, 'm').after(this.maxDate));
   }
 
   prevDisabled() {
-    return this.disabled || (this.minDate && this._calendar.getPrev(this.date, 'm').before(this.minDate));
+    return this.disabled || (this.minDate && this._calendar.getPrev(this.firstDate, 'm').before(this.minDate));
   }
 
   selectDate(date: NgbDate) { this.select.emit(date); }

--- a/src/datepicker/datepicker-service.spec.ts
+++ b/src/datepicker/datepicker-service.spec.ts
@@ -34,6 +34,7 @@ describe('ngb-datepicker-service', () => {
        expect(monthViewModel).toEqual({
          number: 1,
          year: 2000,
+         firstDate: new NgbDate(2000, 1, 1),
          weeks: [{number: 1, days: [{date: new NgbDate(2000, 1, 1), disabled: false}]}],
          weekdays: [1]
        });
@@ -46,6 +47,7 @@ describe('ngb-datepicker-service', () => {
        expect(monthViewModel).toEqual({
          number: 1,
          year: 2000,
+         firstDate: new NgbDate(2000, 1, 1),
          weeks: [{number: 1, days: [{date: new NgbDate(2000, 1, 1), disabled: true}]}],
          weekdays: [1]
        });
@@ -55,6 +57,7 @@ describe('ngb-datepicker-service', () => {
        expect(monthViewModel).toEqual({
          number: 1,
          year: 2000,
+         firstDate: new NgbDate(2000, 1, 1),
          weeks: [{number: 1, days: [{date: new NgbDate(2000, 1, 1), disabled: true}]}],
          weekdays: [1]
        });
@@ -67,6 +70,7 @@ describe('ngb-datepicker-service', () => {
        expect(monthViewModel).toEqual({
          number: 1,
          year: 2000,
+         firstDate: new NgbDate(2000, 1, 1),
          weeks: [{number: 1, days: [{date: new NgbDate(2000, 1, 1), disabled: true}]}],
          weekdays: [1]
        });
@@ -79,6 +83,7 @@ describe('ngb-datepicker-service', () => {
        expect(monthViewModel).toEqual({
          number: 1,
          year: 2000,
+         firstDate: new NgbDate(2000, 1, 1),
          weeks: [{number: 1, days: [{date: new NgbDate(2000, 1, 1), disabled: true}]}],
          weekdays: [1]
        });

--- a/src/datepicker/datepicker-service.ts
+++ b/src/datepicker/datepicker-service.ts
@@ -10,7 +10,7 @@ export class NgbDatepickerService {
   generateMonthViewModel(
       date: NgbDate, minDate: NgbDate, maxDate: NgbDate, firstDayOfWeek: number,
       markDisabled: (date: NgbDate, current: {month: number, year: number}) => boolean): MonthViewModel {
-    const month: MonthViewModel = {number: date.month, year: date.year, weeks: [], weekdays: []};
+    const month: MonthViewModel = {firstDate: null, number: date.month, year: date.year, weeks: [], weekdays: []};
 
     date = this._getFirstViewDate(date, firstDayOfWeek);
 
@@ -29,6 +29,11 @@ export class NgbDatepickerService {
         let disabled = (minDate && newDate.before(minDate)) || (maxDate && newDate.after(maxDate));
         if (!disabled && markDisabled) {
           disabled = markDisabled(newDate, {month: month.number, year: month.year});
+        }
+
+        // saving first date of the month
+        if (month.firstDate === null && date.month === month.number) {
+          month.firstDate = newDate;
         }
 
         days.push({date: newDate, disabled: disabled});

--- a/src/datepicker/datepicker-view-model.ts
+++ b/src/datepicker/datepicker-view-model.ts
@@ -11,6 +11,7 @@ export type WeekViewModel = {
 }
 
 export type MonthViewModel = {
+  firstDate: NgbDate,
   number: number,
   year: number,
   weeks: WeekViewModel[],


### PR DESCRIPTION
Multiple month display support for the datepicker (part of #862):
Not that many changes here, but many files touched...
- `[displayMonths]` → new input to specify number of months
- `[showNavigationSelect]` → new input to toggle month/year select boxes in navigation

Looks like this with the select boxes:

![screen shot 2016-10-28 at 15 12 15](https://cloud.githubusercontent.com/assets/8074436/19808105/6b690640-9d23-11e6-92a3-795bef38f24a.png)

And like this without them:

![screen shot 2016-10-28 at 15 11 16](https://cloud.githubusercontent.com/assets/8074436/19808125/7b69d57e-9d23-11e6-8307-add952fc1e5f.png)
