### PR TITLE
fix(pagination): better protect against invalid inputs

### DIFF
--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -440,6 +440,107 @@ describe('ngb-pagination', () => {
       fixture.detectChanges();
       expectPages(fixture.nativeElement, ['« Previous', '1', '2', '3', '4', '+5', '6', '7', '» Next']);
     });
+
+    it('should handle edge "maxSize" values', () => {
+      const html = '<ngb-pagination [collectionSize]="50" [maxSize]="maxSize"></ngb-pagination>';
+      const fixture = createTestComponent(html);
+
+      fixture.componentInstance.maxSize = 2;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '-...', '5', '» Next']);
+
+      fixture.componentInstance.maxSize = 0;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '4', '5', '» Next']);
+
+      fixture.componentInstance.maxSize = 100;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '4', '5', '» Next']);
+
+      fixture.componentInstance.maxSize = NaN;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '4', '5', '» Next']);
+
+      fixture.componentInstance.maxSize = null;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '4', '5', '» Next']);
+    });
+
+    it('should handle edge "collectionSize" values', () => {
+      const html = '<ngb-pagination [collectionSize]="collectionSize"></ngb-pagination>';
+      const fixture = createTestComponent(html);
+
+      fixture.componentInstance.collectionSize = 0;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '-» Next']);
+
+      fixture.componentInstance.collectionSize = NaN;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '-» Next']);
+
+      fixture.componentInstance.collectionSize = null;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '-» Next']);
+    });
+
+    it('should handle edge "pageSize" values', () => {
+      const html = '<ngb-pagination [collectionSize]="50" [pageSize]="pageSize"></ngb-pagination>';
+      const fixture = createTestComponent(html);
+
+      fixture.componentInstance.pageSize = 0;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '-» Next']);
+
+      fixture.componentInstance.pageSize = NaN;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '-» Next']);
+
+      fixture.componentInstance.pageSize = null;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '-» Next']);
+    });
+
+    it('should handle edge "page" values', () => {
+      const html = '<ngb-pagination [collectionSize]="20" [page]="page"></ngb-pagination>';
+      const fixture = createTestComponent(html);
+
+      fixture.componentInstance.page = 0;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '» Next']);
+
+      fixture.componentInstance.page = 2016;
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['« Previous', '1', '+2', '-» Next']);
+
+      fixture.componentInstance.page = NaN;
+      expectPages(fixture.nativeElement, ['« Previous', '1', '+2', '-» Next']);
+
+      fixture.componentInstance.page = null;
+      expectPages(fixture.nativeElement, ['« Previous', '1', '+2', '-» Next']);
+    });
+
+    it('should not emit "pageChange" for incorrect input values', fakeAsync(() => {
+         const html = `<ngb-pagination [collectionSize]="collectionSize" [pageSize]="pageSize" [maxSize]="maxSize" 
+        (pageChange)="onPageChange($event)"></ngb-pagination>`;
+         const fixture = createTestComponent(html);
+         tick();
+
+         spyOn(fixture.componentInstance, 'onPageChange');
+
+         fixture.componentInstance.collectionSize = NaN;
+         fixture.detectChanges();
+         tick();
+
+         fixture.componentInstance.maxSize = NaN;
+         fixture.detectChanges();
+         tick();
+
+         fixture.componentInstance.pageSize = NaN;
+         fixture.detectChanges();
+         tick();
+
+         expect(fixture.componentInstance.onPageChange).not.toHaveBeenCalled();
+       }));
   });
 
   describe('Custom config', () => {
@@ -503,4 +604,6 @@ class TestComponent {
   maxSize = 0;
   ellipses = true;
   rotate = false;
+
+  onPageChange = () => {};
 }

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -1,5 +1,5 @@
 import {Component, EventEmitter, Input, Output, OnChanges, ChangeDetectionStrategy, SimpleChanges} from '@angular/core';
-import {getValueInRange} from '../util/util';
+import {getValueInRange, isNumber} from '../util/util';
 import {NgbPaginationConfig} from './pagination-config';
 
 /**
@@ -118,42 +118,9 @@ export class NgbPagination implements OnChanges {
 
   hasNext(): boolean { return this.page < this.pageCount; }
 
-  selectPage(pageNumber: number): void {
-    this._setPageInRange(pageNumber);
-    this.ngOnChanges(null);
-  }
+  selectPage(pageNumber: number): void { this._updatePages(pageNumber); }
 
-  ngOnChanges(changes: SimpleChanges): void {
-    // re-calculate new length of pages
-    this.pageCount = Math.ceil(this.collectionSize / this.pageSize);
-
-    // fill-in model needed to render pages
-    this.pages.length = 0;
-    for (let i = 1; i <= this.pageCount; i++) {
-      this.pages.push(i);
-    }
-
-    // set page within 1..max range
-    this._setPageInRange(this.page);
-
-    // apply maxSize if necessary
-    if (this.maxSize > 0 && this.pageCount > this.maxSize) {
-      let start = 0;
-      let end = this.pageCount;
-
-      // either paginating or rotating page numbers
-      if (this.rotate) {
-        [start, end] = this._applyRotation();
-      } else {
-        [start, end] = this._applyPagination();
-      }
-
-      this.pages = this.pages.slice(start, end);
-
-      // adding ellipses
-      this._applyEllipses(start, end);
-    }
-  }
+  ngOnChanges(changes: SimpleChanges): void { this._updatePages(this.page); }
 
   /**
    * @internal
@@ -222,6 +189,41 @@ export class NgbPagination implements OnChanges {
 
     if (this.page !== prevPageNo) {
       this.pageChange.emit(this.page);
+    }
+  }
+
+  private _updatePages(newPage: number) {
+    this.pageCount = Math.ceil(this.collectionSize / this.pageSize);
+
+    if (!isNumber(this.pageCount)) {
+      this.pageCount = 0;
+    }
+
+    // fill-in model needed to render pages
+    this.pages.length = 0;
+    for (let i = 1; i <= this.pageCount; i++) {
+      this.pages.push(i);
+    }
+
+    // set page within 1..max range
+    this._setPageInRange(newPage);
+
+    // apply maxSize if necessary
+    if (this.maxSize > 0 && this.pageCount > this.maxSize) {
+      let start = 0;
+      let end = this.pageCount;
+
+      // either paginating or rotating page numbers
+      if (this.rotate) {
+        [start, end] = this._applyRotation();
+      } else {
+        [start, end] = this._applyPagination();
+      }
+
+      this.pages = this.pages.slice(start, end);
+
+      // adding ellipses
+      this._applyEllipses(start, end);
     }
   }
 }


### PR DESCRIPTION
Second attempt to improve situation with pagination invalid inputs (related to #898)

- Added tests for edge cases for `collectionSize`, `page`, `maxSize` and `pageSize` to see the pagination behaviour
- Cleaned up `ngOnChanges`
- Essentially the main change is:

```ts
if (!isNumber(this.pageCount)) {
  this.pageCount = 0;
}
```