### PR TITLE
fix(modal): use Injector of NgbModal for component content

### DIFF
--- a/src/modal/modal-container.ts
+++ b/src/modal/modal-container.ts
@@ -32,9 +32,10 @@ export class NgbModalContainer {
     ngbModalStack.registerContainer(this);
   }
 
-  open(moduleCFR: ComponentFactoryResolver, content: string | TemplateRef<any>, options): NgbModalRef {
+  open(moduleCFR: ComponentFactoryResolver, contentInjector: Injector, content: string | TemplateRef<any>, options):
+      NgbModalRef {
     const activeModal = new NgbActiveModal();
-    const contentRef = this._getContentRef(moduleCFR, content, activeModal);
+    const contentRef = this._getContentRef(moduleCFR, contentInjector, content, activeModal);
     let windowCmptRef: ComponentRef<NgbModalWindow>;
     let backdropCmptRef: ComponentRef<NgbModalBackdrop>;
     let ngbModalRef: NgbModalRef;
@@ -65,7 +66,9 @@ export class NgbModalContainer {
     });
   }
 
-  private _getContentRef(moduleCFR: ComponentFactoryResolver, content: any, context: NgbActiveModal): ContentRef {
+  private _getContentRef(
+      moduleCFR: ComponentFactoryResolver, contentInjector: Injector, content: any,
+      context: NgbActiveModal): ContentRef {
     if (!content) {
       return new ContentRef([]);
     } else if (content instanceof TemplateRef) {
@@ -76,7 +79,7 @@ export class NgbModalContainer {
     } else {
       const contentCmptFactory = moduleCFR.resolveComponentFactory(content);
       const modalContentInjector =
-          ReflectiveInjector.resolveAndCreate([{provide: NgbActiveModal, useValue: context}], this._injector);
+          ReflectiveInjector.resolveAndCreate([{provide: NgbActiveModal, useValue: context}], contentInjector);
       const componentRef = this._viewContainerRef.createComponent(contentCmptFactory, 0, modalContentInjector);
       return new ContentRef([[componentRef.location.nativeElement]], componentRef.hostView, componentRef);
     }

--- a/src/modal/modal-stack.spec.ts
+++ b/src/modal/modal-stack.spec.ts
@@ -4,6 +4,6 @@ describe('modal stack', () => {
 
   it('should throw if a container element was not registered', () => {
     const modalStack = new NgbModalStack();
-    expect(() => { modalStack.open(null, 'foo'); }).toThrowError();
+    expect(() => { modalStack.open(null, null, 'foo'); }).toThrowError();
   });
 });

--- a/src/modal/modal-stack.ts
+++ b/src/modal/modal-stack.ts
@@ -1,4 +1,4 @@
-import {Injectable, ComponentFactoryResolver} from '@angular/core';
+import {Injectable, Injector, ComponentFactoryResolver} from '@angular/core';
 
 import {NgbModalRef} from './modal-ref';
 import {NgbModalContainer} from './modal-container';
@@ -7,13 +7,13 @@ import {NgbModalContainer} from './modal-container';
 export class NgbModalStack {
   private modalContainer: NgbModalContainer;
 
-  open(moduleCFR: ComponentFactoryResolver, content: any, options = {}): NgbModalRef {
+  open(moduleCFR: ComponentFactoryResolver, contentInjector: Injector, content: any, options = {}): NgbModalRef {
     if (!this.modalContainer) {
       throw new Error(
           'Missing modal container, add <template ngbModalContainer></template> to one of your application templates.');
     }
 
-    return this.modalContainer.open(moduleCFR, content, options);
+    return this.modalContainer.open(moduleCFR, contentInjector, content, options);
   }
 
   registerContainer(modalContainer: NgbModalContainer) { this.modalContainer = modalContainer; }

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -1,4 +1,4 @@
-import {Injectable, ComponentFactoryResolver} from '@angular/core';
+import {Injectable, Injector, ComponentFactoryResolver} from '@angular/core';
 
 import {NgbModalStack} from './modal-stack';
 import {NgbModalRef} from './modal-ref';
@@ -35,7 +35,8 @@ export interface NgbModalOptions {
  */
 @Injectable()
 export class NgbModal {
-  constructor(private _moduleCFR: ComponentFactoryResolver, private _modalStack: NgbModalStack) {}
+  constructor(
+      private _moduleCFR: ComponentFactoryResolver, private _injector: Injector, private _modalStack: NgbModalStack) {}
 
   /**
    * Opens a new modal window with the specified content and using supplied options. Content can be provided
@@ -44,6 +45,6 @@ export class NgbModal {
    * NgbActiveModal class to close / dismiss modals from "inside" of a component.
    */
   open(content: any, options: NgbModalOptions = {}): NgbModalRef {
-    return this._modalStack.open(this._moduleCFR, content, options);
+    return this._modalStack.open(this._moduleCFR, this._injector, content, options);
   }
 }


### PR DESCRIPTION
This is a fix that is very similar to 2fb72d8a47225a8f3a5b23ca0483335b6fb24a8d and as with the mentioned sha I'm not sure how to test this one... At least here is a plunker that demonstrates the working fix: http://plnkr.co/edit/vg61WuFPIFGevF2Km45a?p=preview

Fixes #982
