### PR TITLE
refactor(modal): removal usage of 'fade in' classes

### DIFF
--- a/src/modal/modal-backdrop.ts
+++ b/src/modal/modal-backdrop.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
 
-@Component({selector: 'ngb-modal-backdrop', template: '', host: {'class': 'modal-backdrop fade in'}})
+@Component({selector: 'ngb-modal-backdrop', template: '', host: {'class': 'modal-backdrop', '[style.opacity]': '0.5'}})
 export class NgbModalBackdrop {
 }

--- a/src/modal/modal-window.ts
+++ b/src/modal/modal-window.ts
@@ -15,7 +15,7 @@ import {ModalDismissReasons} from './modal-dismiss-reasons';
 @Component({
   selector: 'ngb-modal-window',
   host: {
-    '[class]': '"modal fade in" + (windowClass ? " " + windowClass : "")',
+    '[class]': '"modal" + (windowClass ? " " + windowClass : "")',
     'role': 'dialog',
     'tabindex': '-1',
     'style': 'display: block;',


### PR DESCRIPTION
Bootstrap [renamed](https://github.com/twbs/bootstrap/commit/aa11f002182877fe545933d6ac6009cd5363072c) 'in' to 'active' so moving to next alpha
would break modal. But more importantly we won't need those
classes anyway as soon as we move to Angular-powered animations