### PR TITLE
chore: adjust some test helpers

### DIFF
--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -47,8 +47,6 @@ export function getBrowser(ua = window.navigator.userAgent) {
   if (browser === 'unknown') {
     throw new Error('Browser detection failed for: ' + ua);
   }
-
-  return browser;
 }
 
 export function isBrowser(browsers: Browser | Browser[], ua = window.navigator.userAgent) {

--- a/src/test/matchers.ts
+++ b/src/test/matchers.ts
@@ -7,9 +7,7 @@ beforeEach(() => {
         return function(actual: HTMLElement, className: string) {
           return {
             pass: actual.classList.contains(className) === !isNot,
-            get message() {
-              return `Expected ${actual.outerHTML} ${isNot ? 'not ' : ''}to contain the CSS class "${className}"`;
-            }
+            message: `Expected ${actual.outerHTML} ${isNot ? 'not ' : ''}to contain the CSS class "${className}"`
           };
         };
       }


### PR DESCRIPTION
on common.ts, that return browser is never reached, that hurts the coverage.

On matchers, the message is a bit overcomplex and fails the coverage as well, now it pass coverage and works as expected as well.
