### PR TITLE
demo: use lazy loading

### DIFF
--- a/demo/src/app/app.module.ts
+++ b/demo/src/app/app.module.ts
@@ -1,29 +1,21 @@
 import {NgModule} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 
-import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
-
 import {DefaultComponent} from './default';
-import {GettingStarted} from './getting-started';
 import {AppComponent} from './app.component';
 import {routing} from './app.routing';
-import {NgbdDemoModule} from './components';
 import {NgbdSharedModule} from './shared';
 
 @NgModule({
   declarations: [
     AppComponent,
-    DefaultComponent,
-    GettingStarted
+    DefaultComponent
   ],
   imports: [
     BrowserModule,
     routing,
-    NgbModule.forRoot(),
-    NgbdDemoModule,
     NgbdSharedModule
   ],
   bootstrap: [AppComponent]
 })
-export class NgbdModule {
-}
+export class NgbdModule {}

--- a/demo/src/app/app.routing.ts
+++ b/demo/src/app/app.routing.ts
@@ -1,47 +1,12 @@
 import {Routes, RouterModule} from '@angular/router';
 import {ModuleWithProviders} from '@angular/core';
 import {DefaultComponent} from './default';
-import {GettingStarted} from './getting-started';
-import {
-  NgbdAccordion,
-  NgbdAlert,
-  NgbdButtons,
-  NgbdCarousel,
-  NgbdCollapse,
-  NgbdDatepicker,
-  NgbdDropdown,
-  NgbdModal,
-  NgbdPagination,
-  NgbdPopover,
-  NgbdProgressbar,
-  NgbdRating,
-  NgbdTabs,
-  NgbdTimepicker,
-  NgbdTooltip,
-  NgbdTypeahead
-} from './components';
 
 const routes: Routes = [
   {path: '', pathMatch: 'full', redirectTo: 'home'},
   {path: 'home', component: DefaultComponent},
-  {path: 'getting-started', component: GettingStarted},
-  {path: 'components', redirectTo: 'components/accordion'},
-  {path: 'components/accordion', component: NgbdAccordion},
-  {path: 'components/alert', component: NgbdAlert},
-  {path: 'components/buttons', component: NgbdButtons},
-  {path: 'components/carousel', component: NgbdCarousel},
-  {path: 'components/collapse', component: NgbdCollapse},
-  {path: 'components/datepicker', component: NgbdDatepicker},
-  {path: 'components/dropdown', component: NgbdDropdown},
-  {path: 'components/modal', component: NgbdModal},
-  {path: 'components/pagination', component: NgbdPagination},
-  {path: 'components/popover', component: NgbdPopover},
-  {path: 'components/progressbar', component: NgbdProgressbar},
-  {path: 'components/rating', component: NgbdRating},
-  {path: 'components/tabs', component: NgbdTabs},
-  {path: 'components/timepicker', component: NgbdTimepicker},
-  {path: 'components/tooltip', component: NgbdTooltip},
-  {path: 'components/typeahead', component: NgbdTypeahead}
+  {path: 'getting-started', loadChildren: 'demo/src/app/getting-started/index#GettingStartedModule'},
+  {path: 'components', loadChildren: 'demo/src/app/components/index#NgbdDemoModule'}
 ];
 
 export const routing: ModuleWithProviders = RouterModule.forRoot(routes, {useHash: true});

--- a/demo/src/app/components/index.ts
+++ b/demo/src/app/components/index.ts
@@ -16,47 +16,56 @@ export * from './tooltip';
 export * from './typeahead';
 
 import {NgModule} from '@angular/core';
+import {Routes, RouterModule} from '@angular/router';
+import {JsonpModule} from '@angular/http';
+
+import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 
 import {NgbdSharedModule} from '../shared';
 
-import {NgbdAccordionModule} from './accordion';
-import {NgbdAlertModule} from './alert';
-import {NgbdButtonsModule} from './buttons';
-import {NgbdCarouselModule} from './carousel';
-import {NgbdCollapseModule} from './collapse';
-import {NgbdDatepickerModule} from './datepicker';
-import {NgbdDropdownModule} from './dropdown';
-import {NgbdModalModule} from './modal';
-import {NgbdPaginationModule} from './pagination';
-import {NgbdPopoverModule} from './popover';
-import {NgbdProgressbarModule} from './progressbar';
-import {NgbdRatingModule} from './rating';
-import {NgbdTabsModule} from './tabset';
-import {NgbdTimepickerModule} from './timepicker';
-import {NgbdTooltipModule} from './tooltip';
-import {NgbdTypeaheadModule} from './typeahead';
+import {NgbdAccordionModule, NgbdAccordion} from './accordion';
+import {NgbdAlertModule, NgbdAlert} from './alert';
+import {NgbdButtonsModule, NgbdButtons} from './buttons';
+import {NgbdCarouselModule, NgbdCarousel} from './carousel';
+import {NgbdCollapseModule, NgbdCollapse} from './collapse';
+import {NgbdDatepickerModule, NgbdDatepicker} from './datepicker';
+import {NgbdDropdownModule, NgbdDropdown} from './dropdown';
+import {NgbdModalModule, NgbdModal} from './modal';
+import {NgbdPaginationModule, NgbdPagination} from './pagination';
+import {NgbdPopoverModule, NgbdPopover} from './popover';
+import {NgbdProgressbarModule, NgbdProgressbar} from './progressbar';
+import {NgbdRatingModule, NgbdRating} from './rating';
+import {NgbdTabsModule, NgbdTabs} from './tabset';
+import {NgbdTimepickerModule, NgbdTimepicker} from './timepicker';
+import {NgbdTooltipModule, NgbdTooltip} from './tooltip';
+import {NgbdTypeaheadModule, NgbdTypeahead} from './typeahead';
+
+const routes: Routes = [
+  {path: '', pathMatch: 'full', redirectTo: 'accordion'},
+  {path: 'accordion', component: NgbdAccordion},
+  {path: 'alert', component: NgbdAlert},
+  {path: 'buttons', component: NgbdButtons},
+  {path: 'carousel', component: NgbdCarousel},
+  {path: 'collapse', component: NgbdCollapse},
+  {path: 'datepicker', component: NgbdDatepicker},
+  {path: 'dropdown', component: NgbdDropdown},
+  {path: 'modal', component: NgbdModal},
+  {path: 'pagination', component: NgbdPagination},
+  {path: 'popover', component: NgbdPopover},
+  {path: 'progressbar', component: NgbdProgressbar},
+  {path: 'rating', component: NgbdRating},
+  {path: 'tabs', component: NgbdTabs},
+  {path: 'timepicker', component: NgbdTimepicker},
+  {path: 'tooltip', component: NgbdTooltip},
+  {path: 'typeahead', component: NgbdTypeahead}
+];
 
 @NgModule({
   imports: [
     NgbdSharedModule,
-    NgbdAccordionModule,
-    NgbdAlertModule,
-    NgbdButtonsModule,
-    NgbdCarouselModule,
-    NgbdCollapseModule,
-    NgbdDatepickerModule,
-    NgbdDropdownModule,
-    NgbdModalModule,
-    NgbdPaginationModule,
-    NgbdPopoverModule,
-    NgbdProgressbarModule,
-    NgbdRatingModule,
-    NgbdTabsModule,
-    NgbdTimepickerModule,
-    NgbdTooltipModule,
-    NgbdTypeaheadModule
-  ],
-  exports: [
+    RouterModule.forChild(routes),
+    NgbModule.forRoot(),
+    JsonpModule,
     NgbdAccordionModule,
     NgbdAlertModule,
     NgbdButtonsModule,

--- a/demo/src/app/getting-started/index.ts
+++ b/demo/src/app/getting-started/index.ts
@@ -1,1 +1,17 @@
 export * from './getting-started.component';
+
+import {NgModule} from '@angular/core';
+import {Routes, RouterModule} from '@angular/router';
+
+import {GettingStarted} from './getting-started.component';
+import {NgbdSharedModule} from '../shared';
+
+const routes: Routes = [
+  {path: '', component: GettingStarted},
+];
+
+@NgModule({
+  imports: [NgbdSharedModule, RouterModule.forChild(routes)],
+  declarations: [GettingStarted]
+})
+export class GettingStartedModule {}

--- a/demo/src/app/shared/index.ts
+++ b/demo/src/app/shared/index.ts
@@ -2,7 +2,6 @@ import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {RouterModule} from '@angular/router';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {JsonpModule} from '@angular/http';
 
 import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 
@@ -19,8 +18,7 @@ import {Analytics} from './analytics/analytics';
     SideNavComponent,
     NgbModule,
     FormsModule,
-    ReactiveFormsModule,
-    JsonpModule
+    ReactiveFormsModule
   ],
   declarations: [
     ContentWrapper,

--- a/tsconfig-aot.json
+++ b/tsconfig-aot.json
@@ -9,13 +9,15 @@
     "noEmitOnError": true,
     "outDir": "temp",
     "sourceMap": true,
-    "baseUrl": "./node_modules",
+    "baseUrl": ".",
     "paths": {
-      "@ng-bootstrap/ng-bootstrap": ["../src/index"]
+      "@ng-bootstrap/ng-bootstrap": ["src/index"]
     }
   },
   "include": [
-    "./demo/src/main.ts"
+    "./demo/src/main.ts",
+    "./demo/src/app/getting-started/index.ts",
+    "./demo/src/app/components/index.ts"
   ],
   "angularCompilerOptions": {
     "strictMetadataEmit": true

--- a/webpack.demo.js
+++ b/webpack.demo.js
@@ -53,7 +53,7 @@ module.exports = function makeWebpackConfig() {
     path: root('demo', 'dist'),
     publicPath: isProd ? '/' : 'http://localhost:9090/',
     filename: isProd ? 'js/[name].[hash].js' : 'js/[name].js',
-    chunkFilename: isProd ? '[id].[hash].chunk.js' : '[id].chunk.js'
+    chunkFilename: isProd ? 'js/[id].[chunkhash].chunk.js' : 'js/[id].chunk.js'
   };
 
   /**
@@ -206,6 +206,14 @@ module.exports = function makeWebpackConfig() {
       new CopyWebpackPlugin([{
         from: root('demo/src/public')
       }])
+    );
+  } else {
+    config.plugins.push(
+      // Paths for lazy loaded routes in dev mode
+      new webpack.ContextReplacementPlugin(/.*/, root('demo', 'src', 'app'), {
+        "demo/src/app/getting-started/index": "./getting-started/index.ts",
+        "demo/src/app/components/index": "./components/index.ts"
+      })
     );
   }
 


### PR DESCRIPTION
This PR introduces lazy loading for the demo application.
It was done with the following setup which could be changed:
- 18 chunks: main page, the "Getting started" page and one for each component demo
- no pre-loading, chunks are downloaded only when a navigation happens

Om my machine, the size of the main bundle goes from 2.09MB to 605kB, and the site loads around twice faster! 

Note that some code (the shared modules) is duplicated in most chunks for some reason. It can be improved later.

