### PR TITLE
fix(typeahead): catch click select

### DIFF
--- a/src/typeahead/typeahead-window.spec.ts
+++ b/src/typeahead/typeahead-window.spec.ts
@@ -138,9 +138,12 @@ describe('ngb-typeahead-window', () => {
 
       expectResults(fixture.nativeElement, ['+bar', 'baz']);
 
-      links[1].triggerEventHandler('click', {});
+      const event = jasmine.createSpyObj('event', ['preventDefault', 'stopPropagation']);
+      links[1].triggerEventHandler('click', event);
       fixture.detectChanges();
       expect(fixture.componentInstance.selected).toBe('baz');
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(event.stopPropagation).toHaveBeenCalled();
     });
 
     it('should return selected row via getActive()', () => {

--- a/src/typeahead/typeahead-window.ts
+++ b/src/typeahead/typeahead-window.ts
@@ -28,7 +28,7 @@ export interface ResultTemplateContext {
     <template ngFor [ngForOf]="results" let-result let-idx="index">
       <button type="button" class="dropdown-item" [class.active]="idx === activeIdx" 
         (mouseenter)="markActive(idx)" 
-        (click)="select(result)">
+        (click)="select($event, result)">
           <template [ngTemplateOutlet]="resultTemplate || rt" 
           [ngOutletContext]="{result: result, term: term, formatter: formatter}"></template>
       </button>
@@ -91,7 +91,11 @@ export class NgbTypeaheadWindow implements OnInit {
     }
   }
 
-  select(item) { this.selectEvent.emit(item); }
+  select(event, item) {
+    event.preventDefault();
+    event.stopPropagation();
+    this.selectEvent.emit(item);
+  }
 
   ngOnInit() { this.activeIdx = this.focusFirst ? 0 : -1; }
 }

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -197,8 +197,11 @@ describe('ngb-typeahead', () => {
            fixture.detectChanges();
            expectWindowResults(compiled, ['+one', 'one more']);
 
-           getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
+           const event = jasmine.createSpyObj('event', ['preventDefault', 'stopPropagation']);
+           getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', event);
            fixture.detectChanges();
+           expect(event.preventDefault).toHaveBeenCalled();
+           expect(event.stopPropagation).toHaveBeenCalled();
            expect(getWindow(compiled)).toBeNull();
            expectInputValue(compiled, 'one');
            expect(fixture.componentInstance.model).toBe('one');
@@ -209,7 +212,9 @@ describe('ngb-typeahead', () => {
            expectWindowResults(compiled, ['+one', 'one more']);
            expectInputValue(compiled, 'o');
 
-           getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
+           getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', event);
+           expect(event.preventDefault).toHaveBeenCalledTimes(2);
+           expect(event.stopPropagation).toHaveBeenCalledTimes(2);
            fixture.detectChanges();
            expect(getWindow(compiled)).toBeNull();
            expectInputValue(compiled, 'one');
@@ -512,9 +517,12 @@ describe('ngb-typeahead', () => {
       // clicking selected
       changeInput(fixture.nativeElement, 'o');
       fixture.detectChanges();
-      getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
+      const event = jasmine.createSpyObj('event', ['preventDefault', 'stopPropagation']);
+      getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', event);
       fixture.detectChanges();
 
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(event.stopPropagation).toHaveBeenCalled();
       expect(fixture.componentInstance.selectEventValue).toBe('one');
     });
 
@@ -526,9 +534,14 @@ describe('ngb-typeahead', () => {
          // clicking selected
          changeInput(fixture.nativeElement, 'o');
          fixture.detectChanges();
-         getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
+         const event = jasmine.createSpyObj('event', ['preventDefault', 'stopPropagation']);
+         getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', event);
          fixture.detectChanges();
-         fixture.whenStable().then(() => { expect(fixture.componentInstance.model).toBe('o'); });
+         fixture.whenStable().then(() => {
+           expect(event.preventDefault).toHaveBeenCalled();
+           expect(event.stopPropagation).toHaveBeenCalled();
+           expect(fixture.componentInstance.model).toBe('o');
+         });
        }));
   });
 


### PR DESCRIPTION
Figured it was fine to just catch the click event which prevents the modal from closing when a typeahead is inside.

Closes #1040