### PR TITLE
feat(pagination): custom boundary/directional text 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ npm-debug.log
 .publish
 .sw*
 .idea
+.vscode
 coverage
 demo/src/api-docs.ts
 demo/src/public/**/plnkr.html

--- a/demo/src/app/components/pagination/demos/index.ts
+++ b/demo/src/app/components/pagination/demos/index.ts
@@ -2,8 +2,10 @@ import {NgbdPaginationAdvanced} from './advanced/pagination-advanced';
 import {NgbdPaginationBasic} from './basic/pagination-basic';
 import {NgbdPaginationSize} from './size/pagination-size';
 import {NgbdPaginationConfig} from './config/pagination-config';
+import {NgbdPaginationText} from './text/pagination-text';
 
-export const DEMO_DIRECTIVES = [NgbdPaginationAdvanced, NgbdPaginationBasic, NgbdPaginationSize, NgbdPaginationConfig];
+export const DEMO_DIRECTIVES =
+    [NgbdPaginationAdvanced, NgbdPaginationBasic, NgbdPaginationSize, NgbdPaginationConfig, NgbdPaginationText];
 
 export const DEMO_SNIPPETS = {
   advanced: {
@@ -21,5 +23,9 @@ export const DEMO_SNIPPETS = {
   config: {
     code: require('!!prismjs-loader?lang=typescript!./config/pagination-config'),
     markup: require('!!prismjs-loader?lang=markup!./config/pagination-config.html')
+  },
+  text: {
+    code: require('!!prismjs-loader?lang=typescript!./text/pagination-text'),
+    markup: require('!!prismjs-loader?lang=markup!./text/pagination-text.html')
   }
 };

--- a/demo/src/app/components/pagination/demos/text/pagination-text.html
+++ b/demo/src/app/components/pagination/demos/text/pagination-text.html
@@ -1,0 +1,3 @@
+<p>This pagination uses custom text for navigation buttons</p>
+<ngb-pagination [collectionSize]="70" [(page)]="page" [boundaryLinks]="true" [firstText]="'First'" [previousText]="'Previous'"
+ [nextText]="'Next'" [lastText]="'Last'"></ngb-pagination>

--- a/demo/src/app/components/pagination/demos/text/pagination-text.ts
+++ b/demo/src/app/components/pagination/demos/text/pagination-text.ts
@@ -1,0 +1,9 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'ngbd-pagination-text',
+  templateUrl: './pagination-text.html'
+})
+export class NgbdPaginationText {
+  page = 4;
+}

--- a/demo/src/app/components/pagination/pagination.component.ts
+++ b/demo/src/app/components/pagination/pagination.component.ts
@@ -19,6 +19,9 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Global configuration of paginations" [snippets]="snippets" component="pagination" demo="config">
         <ngbd-pagination-config></ngbd-pagination-config>
       </ngbd-example-box>
+      <ngbd-example-box demoTitle="Custom text for navigation buttons" [snippets]="snippets" component="pagination" demo="text">
+        <ngbd-pagination-text></ngbd-pagination-text>
+      </ngbd-example-box>
     </ngbd-content-wrapper>
   `
 })

--- a/src/pagination/pagination-config.spec.ts
+++ b/src/pagination/pagination-config.spec.ts
@@ -7,8 +7,12 @@ describe('ngb-pagination-config', () => {
     expect(config.boundaryLinks).toBe(false);
     expect(config.directionLinks).toBe(true);
     expect(config.ellipses).toBe(true);
+    expect(config.firstText).toBe('««');
+    expect(config.lastText).toBe('»»');
     expect(config.maxSize).toBe(0);
+    expect(config.nextText).toBe('»');
     expect(config.pageSize).toBe(10);
+    expect(config.previousText).toBe('«');
     expect(config.rotate).toBe(false);
     expect(config.size).toBeUndefined();
   });

--- a/src/pagination/pagination-config.ts
+++ b/src/pagination/pagination-config.ts
@@ -10,8 +10,12 @@ export class NgbPaginationConfig {
   boundaryLinks = false;
   directionLinks = true;
   ellipses = true;
+  firstText = '««';
+  lastText = '»»';
   maxSize = 0;
+  nextText = '»';
   pageSize = 10;
+  previousText = '«';
   rotate = false;
   size: 'sm' | 'lg';
 }

--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -51,8 +51,11 @@ function expectSameValues(pagination: NgbPagination, config: NgbPaginationConfig
   expect(pagination.boundaryLinks).toBe(config.boundaryLinks);
   expect(pagination.directionLinks).toBe(config.directionLinks);
   expect(pagination.ellipses).toBe(config.ellipses);
+  expect(pagination.lastText).toBe(config.lastText);
   expect(pagination.maxSize).toBe(config.maxSize);
+  expect(pagination.nextText).toBe(config.nextText);
   expect(pagination.pageSize).toBe(config.pageSize);
+  expect(pagination.previousText).toBe(config.previousText);
   expect(pagination.rotate).toBe(config.rotate);
   expect(pagination.size).toBe(config.size);
 }
@@ -519,6 +522,22 @@ describe('ngb-pagination', () => {
       expectPages(fixture.nativeElement, ['« Previous', '1', '+2', '-» Next']);
     });
 
+    it('should render and respond to direction links changes', () => {
+      const html = `<ngb-pagination [collectionSize]="collectionSize" [page]="1" [firstText]="firstText" 
+      [previousText]="previousText" [nextText]="nextText" [lastText]="lastText" 
+      [boundaryLinks]="boundaryLinks"></ngb-pagination>`;
+      const fixture = createTestComponent(html);
+
+      fixture.componentInstance.boundaryLinks = true;
+      fixture.componentInstance.collectionSize = 20;
+      fixture.componentInstance.firstText = 'TF';
+      fixture.componentInstance.previousText = 'TP';
+      fixture.componentInstance.nextText = 'TN';
+      fixture.componentInstance.lastText = 'TL';
+      fixture.detectChanges();
+      expectPages(fixture.nativeElement, ['-TF TF', '-TP TP', '+1', '2', 'TN TN', 'TL TL']);
+    });
+
     it('should not emit "pageChange" for incorrect input values', fakeAsync(() => {
          const html = `<ngb-pagination [collectionSize]="collectionSize" [pageSize]="pageSize" [maxSize]="maxSize" 
         (pageChange)="onPageChange($event)"></ngb-pagination>`;
@@ -600,9 +619,13 @@ class TestComponent {
   page = 1;
   boundaryLinks = false;
   directionLinks = false;
+  firstText = '««';
+  lastText = '»»';
   size = '';
   maxSize = 0;
+  nextText = '»';
   ellipses = true;
+  previousText = '«';
   rotate = false;
 
   onPageChange = () => {};

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -13,15 +13,15 @@ import {NgbPaginationConfig} from './pagination-config';
       <ul [class]="'pagination' + (size ? ' pagination-' + size : '')">
         <li *ngIf="boundaryLinks" class="page-item" [class.disabled]="!hasPrevious()">
           <a aria-label="First" class="page-link" href (click)="!!selectPage(1)">
-            <span aria-hidden="true">&laquo;&laquo;</span>
-            <span class="sr-only">First</span>
+            <span aria-hidden="true">{{firstText}}</span>
+            <span class="sr-only">{{_firstTextSr}}</span>
           </a>                
         </li>
       
         <li *ngIf="directionLinks" class="page-item" [class.disabled]="!hasPrevious()">
           <a aria-label="Previous" class="page-link" href (click)="!!selectPage(page-1)">
-            <span aria-hidden="true">&laquo;</span>
-            <span class="sr-only">Previous</span>
+            <span aria-hidden="true">{{previousText}}</span>
+            <span class="sr-only">{{_previousTextSr}}</span>
           </a>
         </li>
 
@@ -33,15 +33,15 @@ import {NgbPaginationConfig} from './pagination-config';
 
         <li *ngIf="directionLinks" class="page-item" [class.disabled]="!hasNext()">
           <a aria-label="Next" class="page-link" href (click)="!!selectPage(page+1)">
-            <span aria-hidden="true">&raquo;</span>
-            <span class="sr-only">Next</span>
+            <span aria-hidden="true">{{nextText}}</span>
+            <span class="sr-only">{{_nextTextSr}}</span>
           </a>
         </li>
         
         <li *ngIf="boundaryLinks" class="page-item" [class.disabled]="!hasNext()">
           <a aria-label="Last" class="page-link" href (click)="!!selectPage(pageCount)">
-            <span aria-hidden="true">&raquo;&raquo;</span>
-            <span class="sr-only">Last</span>
+            <span aria-hidden="true">{{lastText}}</span>
+            <span class="sr-only">{{_lastTextSr}}</span>
           </a>                
         </li>        
       </ul>
@@ -49,6 +49,16 @@ import {NgbPaginationConfig} from './pagination-config';
   `
 })
 export class NgbPagination implements OnChanges {
+  private _firstText;
+  private _firstTextSr = 'First';
+  private _lastText;
+  private _lastTextSr = 'Last';
+  private _nextText;
+  private _nextTextSr = 'Next';
+  private _previousText;
+  private _previousTextSr = 'Previous';
+  private _defaultConfig: NgbPaginationConfig;
+
   pageCount = 0;
   pages: number[] = [];
 
@@ -68,6 +78,20 @@ export class NgbPagination implements OnChanges {
   @Input() ellipses: boolean;
 
   /**
+   * Text to display for the first page button. This value will be used for both screen readers and non-screen
+   * reader displays. Default value: «« (for non-screen reader displays); First for screen-reader displays.
+   */
+  @Input()
+  set firstText(value: string) {
+    this._firstText = value;
+    if (value !== this._defaultConfig.firstText) {
+      this._firstTextSr = value;
+    }
+  }
+
+  get firstText() { return this._firstText; }
+
+  /**
    *  Whether to rotate pages when maxSize > number of pages.
    *  Current page will be in the middle
    */
@@ -79,9 +103,37 @@ export class NgbPagination implements OnChanges {
   @Input() collectionSize: number;
 
   /**
+   * Text to display for the last page button. This value will be used for both screen readers and non-screen
+   * reader displays. Default value: »» (for non-screen reader displays); Last for screen-reader displays.
+   */
+  @Input()
+  set lastText(value: string) {
+    this._lastText = value;
+    if (value !== this._defaultConfig.lastText) {
+      this._lastTextSr = value;
+    }
+  }
+
+  get lastText() { return this._lastText; }
+
+  /**
    *  Maximum number of pages to display.
    */
   @Input() maxSize: number;
+
+  /**
+   * Text to display for the next page button. This value will be used for both screen readers and non-screen
+   * reader displays. Default value: » (for non-screen reader displays); Next for screen-reader displays.
+   */
+  @Input()
+  set nextText(value: string) {
+    this._nextText = value;
+    if (value !== this._defaultConfig.nextText) {
+      this._nextTextSr = value;
+    }
+  }
+
+  get nextText() { return this._nextText; }
 
   /**
    *  Current page.
@@ -100,16 +152,35 @@ export class NgbPagination implements OnChanges {
   @Output() pageChange = new EventEmitter<number>(true);
 
   /**
+   * Text to display for the previous page button. This value will be used for both screen readers and non-screen
+   * reader displays. Default value: « (for non-screen reader displays); Previous for screen-reader displays.
+   */
+  @Input()
+  set previousText(value: string) {
+    this._previousText = value;
+    if (value !== this._defaultConfig.previousText) {
+      this._previousTextSr = value;
+    }
+  }
+
+  get previousText() { return this._previousText; }
+
+  /**
    * Pagination display size: small or large
    */
   @Input() size: 'sm' | 'lg';
 
   constructor(config: NgbPaginationConfig) {
+    this._defaultConfig = config;
     this.boundaryLinks = config.boundaryLinks;
     this.directionLinks = config.directionLinks;
     this.ellipses = config.ellipses;
+    this._firstText = config.firstText;
+    this._lastText = config.lastText;
     this.maxSize = config.maxSize;
+    this._nextText = config.nextText;
     this.pageSize = config.pageSize;
+    this._previousText = config.previousText;
     this.rotate = config.rotate;
     this.size = config.size;
   }


### PR DESCRIPTION
Closes #899

Added supported for setting custom text for the boundary and directional links. If the custom text is configured for either of these 4 links, that text will be applied to both the regular link(s) and the screen reader link(s). If these new properties are not set, the old text values are displayed. This also provides the benefit of setting the text in other languages for situations where the default screen reader English text might not be desired.

A new section is added for the pagination demo page that shows an example of how to use these 4 new properties.

This PR replaces PR #1049:
- squashed commits into one
- removed the usage of innerHtml with interpolated strings for binding, if this would work

Please note that I could not get the single/double arrows to bind correctly when their values were expressed as encoded html equivalents (the values were not being decoded at display time). As such, I included in the code the actual unencoded characters for double angle quotation marks.