### PR TITLE
fix(datepicker): add default month to prevent infinite loop

### DIFF
--- a/src/datepicker/ngb-date.spec.ts
+++ b/src/datepicker/ngb-date.spec.ts
@@ -60,4 +60,13 @@ describe('ngb-date', () => {
       expect(date.after(new NgbDate(2017, 8, 18))).toBeFalsy();
     });
   });
+
+  describe('from', () => {
+    it('should return null for invalid object', () => { expect(NgbDate.from(null)).toBeNull(); });
+    it('should return null for dates that are not convertable to javascript Date objects', () => {
+      expect(NgbDate.from({year: 275760, month: 10, day: 1})).toBeNull();
+      expect(NgbDate.from({year: 275759, month: 1, day: 11}).equals(new NgbDate(275759, 1, 11))).toBeTruthy();
+      expect(NgbDate.from({year: -275760, day: 1})).toBeNull();
+    });
+  });
 });

--- a/src/datepicker/ngb-date.ts
+++ b/src/datepicker/ngb-date.ts
@@ -1,6 +1,15 @@
 export class NgbDate {
-  static from(date: {year: number, month: number, day?: number}) {
-    return date ? new NgbDate(date.year, date.month ? date.month : 1, date.day ? date.day : 1) : null;
+  static from(date: {year: number, month?: number, day?: number}) {
+    let nDate = date ? new NgbDate(date.year, date.month ? date.month : 1, date.day ? date.day : 1) : null;
+    if (nDate) {
+      // add 1 to year to prevent any date in last valid javascript Date being picked and causing issues around
+      // September
+      let jDate = new Date(nDate.year + 1, nDate.month - 1, nDate.day);
+      if (isNaN(jDate.getTime())) {
+        nDate = null;
+      }
+    }
+    return nDate;
   }
 
   constructor(public year: number, public month: number, public day: number) {}

--- a/src/datepicker/ngb-date.ts
+++ b/src/datepicker/ngb-date.ts
@@ -1,6 +1,6 @@
 export class NgbDate {
   static from(date: {year: number, month: number, day?: number}) {
-    return date ? new NgbDate(date.year, date.month, date.day ? date.day : 1) : null;
+    return date ? new NgbDate(date.year, date.month ? date.month : 1, date.day ? date.day : 1) : null;
   }
 
   constructor(public year: number, public month: number, public day: number) {}


### PR DESCRIPTION
Without a default month, this causes an infinite loop in datepicker.ts `navigateTo` function looking for the first day, of the last week, of the previous month to display. `_calendar.getNext` returns `NaN` values causing an infinite loop.

Solution was to set a default month of 1 following the same pattern as the default day of 1.

Closes #1062