### PR TITLE
feat(popover): Support 'outsideClick' close trigger

### DIFF
--- a/demo/src/app/components/popover/demos/triggers/popover-triggers.html
+++ b/demo/src/app/components/popover/demos/triggers/popover-triggers.html
@@ -8,6 +8,15 @@
 
 <hr>
 <p>
+  A special <code>outsideClick</code> close trigger is also supported.
+</p>
+
+<button type="button" class="btn btn-secondary" ngbPopover="I close when you click outside the popover!" triggers="click:outsideClick" popoverTitle="Pop title">
+  Click me!
+</button>
+
+<hr>
+<p>
   Alternatively you can take full manual control over popover opening / closing events.
 </p>
 

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -400,6 +400,21 @@ describe('ngb-popover', () => {
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
     });
+
+    it('should close the popover when the `outsideClick` close trigger is used', () => {
+      const fixture =
+          createTestComponent(`<div class="card" ngbPopover="Great tip!" triggers="click:outsideClick"></div>`);
+      const directive = fixture.debugElement.query(By.directive(NgbPopover));
+
+      /// Have to actually trigger the DOM event so that the document click handler gets called, too.
+      directive.nativeElement.click();
+      fixture.detectChanges();
+      expect(getWindow(fixture.nativeElement)).not.toBeNull();
+
+      window.document.body.click();
+      fixture.detectChanges();
+      expect(getWindow(fixture.nativeElement)).toBeNull();
+    });
   });
 
   describe('Custom config', () => {

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -40,8 +40,13 @@ export class NgbPopoverWindow {
 /**
  * A lightweight, extensible directive for fancy popover creation.
  */
-@Directive({selector: '[ngbPopover]', exportAs: 'ngbPopover'})
-export class NgbPopover implements OnInit, OnDestroy {
+@Directive({
+  selector: '[ngbPopover]',
+  exportAs: 'ngbPopover',
+  host: {'(document:click)': '_handleClickOutsidePopover($event)'}
+})
+export class NgbPopover implements OnInit,
+    OnDestroy {
   /**
    * Content to be displayed as popover.
    */
@@ -77,6 +82,12 @@ export class NgbPopover implements OnInit, OnDestroy {
   private _unregisterListenersFn;
   private _zoneSubscription: any;
 
+  /**
+   * Set to `true` after the popover opens; used to cancel the document click
+   * handler so it doesn't immediately close the popover.
+   */
+  private _triggered: boolean;
+
   constructor(
       private _elementRef: ElementRef, private _renderer: Renderer, injector: Injector,
       componentFactoryResolver: ComponentFactoryResolver, viewContainerRef: ViewContainerRef, config: NgbPopoverConfig,
@@ -96,6 +107,36 @@ export class NgbPopover implements OnInit, OnDestroy {
     });
   }
 
+  private _handleClickOutsidePopover(e) {
+    if (this._triggered) {
+      return this._triggered = false;
+    }
+
+    if (!this._windowRef) {
+      return;
+    }
+
+    /* Make sure click didn't happen inside popover */
+    if (e.target !== this._windowRef.location.nativeElement &&
+        !this._windowRef.location.nativeElement.contains(e.target)) {
+      /**
+       * Trigger event called 'outsideClick' so that the `listenToTriggers` utility function automatically handles the
+       * close action when the close trigger is set to 'outsideClick'.
+       */
+      let ocEvent = document.createEvent('Event');
+      if (ocEvent.initEvent) {
+        /* IE-compatible event initialization */
+        ocEvent.initEvent('outsideClick', true, true);
+      } else {
+        /**
+         * IE-compatible solution is deprecated. Use Event constructor instead if `initEvent` becomes unavailable.
+         */
+        ocEvent = new Event('outsideClick');
+      }
+      this._elementRef.nativeElement.dispatchEvent(ocEvent);
+    }
+  }
+
   /**
    * Opens an element’s popover. This is considered a “manual” triggering of the popover.
    */
@@ -108,6 +149,8 @@ export class NgbPopover implements OnInit, OnDestroy {
       if (this.container === 'body') {
         window.document.querySelector(this.container).appendChild(this._windowRef.location.nativeElement);
       }
+
+      this._triggered = true;
 
       // we need to manually invoke change detection since events registered via
       // Renderer::listen() are not picked up by change detection with the OnPush strategy
@@ -124,6 +167,7 @@ export class NgbPopover implements OnInit, OnDestroy {
       this._popupService.close();
       this._windowRef = null;
       this.hidden.emit();
+      this._triggered = false;
     }
   }
 


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.

Add support for a special `outsideClick` close trigger to close popovers when a click occurs outside of it. Closes #933.