### PR TITLE
fix(datepicker): protect against invalid min, max and start dates

### DIFF
--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -1,6 +1,6 @@
 import {TestBed, ComponentFixture, fakeAsync, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {createGenericTestComponent} from '../test/common';
+import {createGenericTestComponent, isBrowser} from '../test/common';
 
 import {Component} from '@angular/core';
 import {FormsModule} from '@angular/forms';
@@ -75,11 +75,44 @@ describe('NgbInputDatepicker', () => {
       expect(fixture.componentInstance.date).toEqual({year: 2016, month: 9, day: 10});
     });
 
+    it('should set only valid dates', fakeAsync(() => {
+         const fixture = createTestCmpt(`<input ngbDatepicker [ngModel]="date">`);
+         const input = fixture.nativeElement.querySelector('input');
+
+         fixture.componentInstance.date = <any>{};
+         fixture.detectChanges();
+         tick();
+         expect(input.value).toBe('');
+
+         fixture.componentInstance.date = null;
+         fixture.detectChanges();
+         tick();
+         expect(input.value).toBe('');
+
+         fixture.componentInstance.date = <any>new Date();
+         fixture.detectChanges();
+         tick();
+         expect(input.value).toBe('');
+
+         fixture.componentInstance.date = undefined;
+         fixture.detectChanges();
+         tick();
+         expect(input.value).toBe('');
+
+         fixture.componentInstance.date = new NgbDate(300000, 1, 1);
+         fixture.detectChanges();
+         tick();
+         expect(input.value).toBe('');
+       }));
+
     it('should propagate null to model when a user enters invalid date', () => {
       const fixture = createTestCmpt(`<input ngbDatepicker [(ngModel)]="date">`);
       const inputDebugEl = fixture.debugElement.query(By.css('input'));
 
       inputDebugEl.triggerEventHandler('change', {target: {value: 'aaa'}});
+      expect(fixture.componentInstance.date).toBeNull();
+
+      inputDebugEl.triggerEventHandler('change', {target: {value: '300000-1-1'}});
       expect(fixture.componentInstance.date).toBeNull();
     });
 

--- a/src/datepicker/datepicker-service.spec.ts
+++ b/src/datepicker/datepicker-service.spec.ts
@@ -19,6 +19,8 @@ class MockCalendar extends NgbCalendarGregorian {
   getPrev(date: NgbDate, period = 'd'): NgbDate { return new NgbDate(2000, 2, 1); }
 
   getToday(): NgbDate { return new NgbDate(2000, 1, 1); }
+
+  isValid(date: NgbDate): boolean { return true; }
 }
 
 describe('ngb-datepicker-service', () => {
@@ -103,5 +105,39 @@ describe('ngb-datepicker-service', () => {
            new NgbDate(2016, 10, 10), new NgbDate(2000, 0, 1), new NgbDate(2020, 0, 10), 1, markDisabled);
        expect(result).toEqual({month: 10, year: 2016});
      }));
+
+  describe('toValidDate() for Gregorian Calendar', () => {
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [NgbDatepickerI18n, NgbDatepickerService, {provide: NgbCalendar, useClass: NgbCalendarGregorian}]
+      });
+    });
+
+    it('should convert a valid NgbDate', inject([NgbDatepickerService], (service) => {
+         expect(service.toValidDate(new NgbDate(2016, 10, 5))).toEqual(new NgbDate(2016, 10, 5));
+         expect(service.toValidDate({year: 2016, month: 10, day: 5})).toEqual(new NgbDate(2016, 10, 5));
+         expect(service.toValidDate(new NgbDate(999, 999, 999))).toEqual(new NgbDate(999, 999, 999));
+       }));
+
+    it('should return today for an invalid NgbDate',
+       inject([NgbDatepickerService, NgbCalendar], (service, calendar) => {
+         const today = calendar.getToday();
+         expect(service.toValidDate(null)).toEqual(today);
+         expect(service.toValidDate({})).toEqual(today);
+         expect(service.toValidDate(undefined)).toEqual(today);
+         expect(service.toValidDate(new Date())).toEqual(today);
+       }));
+
+    it('should return today if default value is undefined',
+       inject([NgbDatepickerService, NgbCalendar], (service, calendar) => {
+         expect(service.toValidDate(null, undefined)).toEqual(calendar.getToday());
+       }));
+
+    it('should return default value for an invalid NgbDate if provided', inject([NgbDatepickerService], (service) => {
+         expect(service.toValidDate(null, new NgbDate(1066, 6, 6))).toEqual(new NgbDate(1066, 6, 6));
+         expect(service.toValidDate(null, null)).toEqual(null);
+       }));
+  });
 
 });

--- a/src/datepicker/datepicker-service.ts
+++ b/src/datepicker/datepicker-service.ts
@@ -48,6 +48,14 @@ export class NgbDatepickerService {
     return month;
   }
 
+  toValidDate(date: {year: number, month: number, day?: number}, defaultValue?: NgbDate): NgbDate {
+    const ngbDate = NgbDate.from(date);
+    if (defaultValue === undefined) {
+      defaultValue = this._calendar.getToday();
+    }
+    return this._calendar.isValid(ngbDate) ? ngbDate : defaultValue;
+  }
+
   private _getFirstViewDate(date: NgbDate, firstDayOfWeek: number): NgbDate {
     const currentMonth = date.month;
     let today = new NgbDate(date.year, date.month, date.day);

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -85,6 +85,117 @@ describe('ngb-datepicker', () => {
     }).toThrowError();
   });
 
+  it('should handle incorrect startDate values', () => {
+    const fixture = createTestComponent(`<ngb-datepicker [startDate]="date"></ngb-datepicker>`);
+    const today = new Date();
+    const currentMonth = `${today.getMonth() + 1}`;
+    const currentYear = `${today.getFullYear()}`;
+
+    expect(getMonthSelect(fixture.nativeElement).value).toBe('8');
+    expect(getYearSelect(fixture.nativeElement).value).toBe('2016');
+
+    fixture.componentInstance.date = null;
+    fixture.detectChanges();
+    expect(getMonthSelect(fixture.nativeElement).value).toBe(currentMonth);
+    expect(getYearSelect(fixture.nativeElement).value).toBe(currentYear);
+
+    fixture.componentInstance.date = undefined;
+    fixture.detectChanges();
+    expect(getMonthSelect(fixture.nativeElement).value).toBe(currentMonth);
+    expect(getYearSelect(fixture.nativeElement).value).toBe(currentYear);
+
+    fixture.componentInstance.date = <any>{};
+    fixture.detectChanges();
+    expect(getMonthSelect(fixture.nativeElement).value).toBe(currentMonth);
+    expect(getYearSelect(fixture.nativeElement).value).toBe(currentYear);
+
+    fixture.componentInstance.date = <any>new Date();
+    fixture.detectChanges();
+    expect(getMonthSelect(fixture.nativeElement).value).toBe(currentMonth);
+    expect(getYearSelect(fixture.nativeElement).value).toBe(currentYear);
+
+    fixture.componentInstance.date = new NgbDate(3000000, 1, 1);
+    fixture.detectChanges();
+    expect(getMonthSelect(fixture.nativeElement).value).toBe(currentMonth);
+    expect(getYearSelect(fixture.nativeElement).value).toBe(currentYear);
+  });
+
+  it('should handle incorrect minDate values', () => {
+    const fixture = createTestComponent(
+        `<ngb-datepicker [minDate]="minDate" [maxDate]="maxDate" [startDate]="date"></ngb-datepicker>`);
+
+    function expectMinDate(year: number, month: number) {
+      fixture.componentInstance.date = {year: 0, month: 1};
+      fixture.detectChanges();
+      expect(getMonthSelect(fixture.nativeElement).value).toBe(`${month}`);
+      expect(getYearSelect(fixture.nativeElement).value).toBe(`${year}`);
+
+      // resetting
+      fixture.componentInstance.date = {year: 1000, month: 1};
+      fixture.detectChanges();
+    }
+
+    expectMinDate(2010, 1);
+
+    fixture.componentInstance.minDate = null;
+    fixture.detectChanges();
+    expectMinDate(990, 1);
+
+    fixture.componentInstance.minDate = undefined;
+    fixture.detectChanges();
+    expectMinDate(990, 1);
+
+    fixture.componentInstance.minDate = <any>{};
+    fixture.detectChanges();
+    expectMinDate(990, 1);
+
+    fixture.componentInstance.minDate = <any>new Date();
+    fixture.detectChanges();
+    expectMinDate(990, 1);
+
+    fixture.componentInstance.minDate = new NgbDate(3000000, 1, 1);
+    fixture.detectChanges();
+    expectMinDate(990, 1);
+  });
+
+  it('should handle incorrect maxDate values', () => {
+    const fixture = createTestComponent(
+        `<ngb-datepicker [minDate]="minDate" [maxDate]="maxDate" [startDate]="date"></ngb-datepicker>`);
+
+    function expectMaxDate(year: number, month: number) {
+      fixture.componentInstance.date = {year: 10000, month: 1};
+      fixture.detectChanges();
+      expect(getMonthSelect(fixture.nativeElement).value).toBe(`${month}`);
+      expect(getYearSelect(fixture.nativeElement).value).toBe(`${year}`);
+
+      // resetting
+      fixture.componentInstance.date = {year: 3000, month: 1};
+      fixture.detectChanges();
+    }
+
+    expectMaxDate(2020, 12);
+
+    fixture.componentInstance.maxDate = null;
+    fixture.detectChanges();
+    expectMaxDate(3010, 12);
+
+    fixture.componentInstance.maxDate = undefined;
+    fixture.detectChanges();
+    expectMaxDate(3010, 12);
+
+    fixture.componentInstance.maxDate = <any>{};
+    fixture.detectChanges();
+    expectMaxDate(3010, 12);
+
+    fixture.componentInstance.maxDate = <any>new Date();
+    fixture.detectChanges();
+    expectMaxDate(3010, 12);
+
+    fixture.componentInstance.maxDate = new NgbDate(3000000, 1, 1);
+    fixture.detectChanges();
+    expectMaxDate(3010, 12);
+  });
+
   it('should support disabling dates via callback', () => {
     const fixture = createTestComponent(
         `<ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [markDisabled]="markDisabled"></ngb-datepicker>`);

--- a/src/datepicker/ngb-calendar.spec.ts
+++ b/src/datepicker/ngb-calendar.spec.ts
@@ -1,5 +1,6 @@
 import {NgbCalendarGregorian} from './ngb-calendar';
 import {NgbDate} from './ngb-date';
+import {isBrowser} from '../test/common';
 
 describe('ngb-calendar-gregorian', () => {
 
@@ -62,5 +63,28 @@ describe('ngb-calendar-gregorian', () => {
   it('should subtract years from date', () => {
     expect(calendar.getPrev(new NgbDate(2016, 12, 22), 'y')).toEqual(new NgbDate(2015, 1, 1));
     expect(calendar.getPrev(new NgbDate(2017, 1, 22), 'y')).toEqual(new NgbDate(2016, 1, 1));
+  });
+
+  it('should check that NgbDate is a valid javascript date', () => {
+
+    // invalid values
+    expect(calendar.isValid(null)).toBeFalsy();
+    expect(calendar.isValid(undefined)).toBeFalsy();
+    expect(calendar.isValid(<any>NaN)).toBeFalsy();
+    expect(calendar.isValid(<any>new Date())).toBeFalsy();
+    expect(calendar.isValid(new NgbDate(null, null, null))).toBeFalsy();
+    expect(calendar.isValid(new NgbDate(undefined, undefined, undefined))).toBeFalsy();
+    expect(calendar.isValid(new NgbDate(NaN, NaN, NaN))).toBeFalsy();
+
+    // min/max dates
+    expect(calendar.isValid(new NgbDate(275760, 9, 12))).toBeTruthy();
+    expect(calendar.isValid(new NgbDate(275760, 9, 14))).toBeFalsy();
+    expect(calendar.isValid(new NgbDate(-271821, 4, 19))).toBeFalsy();
+    expect(calendar.isValid(new NgbDate(-271821, 4, 21))).toBeTruthy();
+
+    // valid dates
+    expect(calendar.isValid(new NgbDate(2016, 8, 8))).toBeTruthy();
+    expect(calendar.isValid(new NgbDate(0, 0, 0))).toBeTruthy();
+    expect(calendar.isValid(new NgbDate(-1, -1, -1))).toBeTruthy();
   });
 });

--- a/src/datepicker/ngb-calendar.ts
+++ b/src/datepicker/ngb-calendar.ts
@@ -1,11 +1,17 @@
 import {NgbDate} from './ngb-date';
 import {Injectable} from '@angular/core';
+import {isNumber} from '../util/util';
 
 function fromJSDate(jsDate: Date) {
   return new NgbDate(jsDate.getFullYear(), jsDate.getMonth() + 1, jsDate.getDate());
 }
 function toJSDate(date: NgbDate) {
-  return new Date(date.year, date.month - 1, date.day);
+  const jsDate = new Date(date.year, date.month - 1, date.day);
+  // this is done avoid 30 -> 1930 conversion
+  if (!isNaN(jsDate.getTime())) {
+    jsDate.setFullYear(date.year);
+  }
+  return jsDate;
 }
 
 export type NgbPeriod = 'y' | 'm' | 'd';
@@ -23,6 +29,8 @@ export abstract class NgbCalendar {
   abstract getWeekNumber(week: NgbDate[], firstDayOfWeek: number): number;
 
   abstract getToday(): NgbDate;
+
+  abstract isValid(date: NgbDate): boolean;
 }
 
 @Injectable()
@@ -79,4 +87,9 @@ export class NgbCalendarGregorian extends NgbCalendar {
   }
 
   getToday(): NgbDate { return fromJSDate(new Date()); }
+
+  isValid(date: NgbDate): boolean {
+    return date && isNumber(date.year) && isNumber(date.month) && isNumber(date.day) &&
+        !isNaN(toJSDate(date).getTime());
+  }
 }


### PR DESCRIPTION
This will protect against invalid inputs for `minDate`, `maxDate` and `startDate` as well as `navigateTo(date)` and set them to default values

Fixes #1062 