### PR TITLE
feat(rating): enable form integration

### DIFF
--- a/demo/src/app/components/rating/demos/form/rating-form.html
+++ b/demo/src/app/components/rating/demos/form/rating-form.html
@@ -1,0 +1,16 @@
+<p>NgModel and reactive forms can be used without the 'rate' binding</p>
+
+<div class="form-group" [class.has-success]="ctrl.valid" [class.has-danger]="ctrl.invalid">
+  <ngb-rating [formControl]="ctrl"></ngb-rating>
+  <div class="form-control-feedback">
+    <div *ngIf="ctrl.valid">Thanks!</div>
+    <div *ngIf="ctrl.errors">Please rate us</div>
+  </div>
+</div>
+
+<hr>
+<pre>Model: <b>{{ ctrl.value }}</b></pre>
+<button class="btn btn-sm btn-outline-{{ ctrl.disabled ? 'danger' : 'success'}}" (click)="toggle()">
+  {{ ctrl.disabled ? "control disabled" : " control enabled" }}
+</button>
+<button class="btn btn-sm btn-outline-primary" (click)="ctrl.setValue(null)">Clear</button>

--- a/demo/src/app/components/rating/demos/form/rating-form.ts
+++ b/demo/src/app/components/rating/demos/form/rating-form.ts
@@ -1,0 +1,18 @@
+import {Component} from '@angular/core';
+import {FormControl, Validators} from '@angular/forms';
+
+@Component({
+  selector: 'ngbd-rating-form',
+  templateUrl: './rating-form.html'
+})
+export class NgbdRatingForm {
+  ctrl = new FormControl(null, Validators.required);
+
+  toggle() {
+    if (this.ctrl.disabled) {
+      this.ctrl.enable();
+    } else {
+      this.ctrl.disable();
+    }
+  }
+}

--- a/demo/src/app/components/rating/demos/index.ts
+++ b/demo/src/app/components/rating/demos/index.ts
@@ -3,9 +3,10 @@ import {NgbdRatingConfig} from './config/rating-config';
 import {NgbdRatingTemplate} from './template/rating-template';
 import {NgbdRatingEvents} from './events/rating-events';
 import {NgbdRatingDecimal} from './decimal/rating-decimal';
+import {NgbdRatingForm} from './form/rating-form';
 
 export const DEMO_DIRECTIVES = [NgbdRatingBasic, NgbdRatingConfig,
-  NgbdRatingTemplate, NgbdRatingEvents, NgbdRatingDecimal];
+  NgbdRatingTemplate, NgbdRatingEvents, NgbdRatingDecimal, NgbdRatingForm];
 
 export const DEMO_SNIPPETS = {
   basic: {
@@ -23,6 +24,10 @@ export const DEMO_SNIPPETS = {
   decimal: {
     code: require('!!prismjs-loader?lang=typescript!./decimal/rating-decimal'),
     markup: require('!!prismjs-loader?lang=markup!./decimal/rating-decimal.html')
+  },
+  form: {
+    code: require('!!prismjs-loader?lang=typescript!./form/rating-form'),
+    markup: require('!!prismjs-loader?lang=markup!./form/rating-form.html')
   },
   config: {
     code: require('!!prismjs-loader?lang=typescript!./config/rating-config'),

--- a/demo/src/app/components/rating/rating.component.html
+++ b/demo/src/app/components/rating/rating.component.html
@@ -14,6 +14,9 @@
   <ngbd-example-box demoTitle="Custom decimal rating" [snippets]="snippets" component="rating" demo="decimal">
     <ngbd-rating-decimal></ngbd-rating-decimal>
   </ngbd-example-box>
+  <ngbd-example-box demoTitle="Form integration" [snippets]="snippets" component="rating" demo="form">
+    <ngbd-rating-form></ngbd-rating-form>
+  </ngbd-example-box>
   <ngbd-example-box demoTitle="Global configuration of ratings" [snippets]="snippets" component="rating" demo="config">
     <ngbd-rating-config></ngbd-rating-config>
   </ngbd-example-box>


### PR DESCRIPTION
Enables form integration for rating:

- both template driven and reactive forms tests
- `rate` event emitter becomes asynchronous (same story as pagination)
- ability to use both `[(rate)]` and `[(ngModel)]`
- form integration demo with reactive

Fixes #1087 