### PR TITLE
feat(datepicker): Add option to keep invalid input

### DIFF
--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -83,6 +83,17 @@ describe('NgbInputDatepicker', () => {
       expect(fixture.componentInstance.date).toBeNull();
     });
 
+    it('should keep invalid input when a user enters invalid date with keepInvalidInput', fakeAsync(() => {
+      const fixture = createTestCmpt(`<input ngbDatepicker [(ngModel)]="date" [keepInvalidInput]="true">`);
+      const inputDebugEl = fixture.debugElement.query(By.css('input'));
+      inputDebugEl.nativeElement.value = 'aaa';
+
+      inputDebugEl.triggerEventHandler('change', {target: {value: 'aaa'}});
+      tick();
+      fixture.detectChanges();
+      expect(inputDebugEl.nativeElement.value).toEqual('aaa');
+    }));
+
     it('should propagate disabled state', fakeAsync(() => {
          const fixture = createTestCmpt(`
         <input ngbDatepicker [(ngModel)]="date" #d="ngbDatepicker" [disabled]="isDisabled">

--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -84,15 +84,15 @@ describe('NgbInputDatepicker', () => {
     });
 
     it('should keep invalid input when a user enters invalid date with keepInvalidInput', fakeAsync(() => {
-      const fixture = createTestCmpt(`<input ngbDatepicker [(ngModel)]="date" [keepInvalidInput]="true">`);
-      const inputDebugEl = fixture.debugElement.query(By.css('input'));
-      inputDebugEl.nativeElement.value = 'aaa';
+         const fixture = createTestCmpt(`<input ngbDatepicker [(ngModel)]="date" [keepInvalidInput]="true">`);
+         const inputDebugEl = fixture.debugElement.query(By.css('input'));
+         inputDebugEl.nativeElement.value = 'aaa';
 
-      inputDebugEl.triggerEventHandler('change', {target: {value: 'aaa'}});
-      tick();
-      fixture.detectChanges();
-      expect(inputDebugEl.nativeElement.value).toEqual('aaa');
-    }));
+         inputDebugEl.triggerEventHandler('change', {target: {value: 'aaa'}});
+         tick();
+         fixture.detectChanges();
+         expect(inputDebugEl.nativeElement.value).toEqual('aaa');
+       }));
 
     it('should propagate disabled state', fakeAsync(() => {
          const fixture = createTestCmpt(`

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -62,7 +62,7 @@ export class NgbInputDatepicker implements ControlValueAccessor {
    * Keep invalid dates in input field instead of resetting it to null.
    */
   @Input() keepInvalidInput: boolean;
-  
+
   /**
    * Callback to mark a given date as disabled.
    * 'Current' contains the month that will be displayed in the view

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -59,6 +59,11 @@ export class NgbInputDatepicker implements ControlValueAccessor {
   @Input() firstDayOfWeek: number;
 
   /**
+   * Keep invalid dates in input field instead of resetting it to null.
+   */
+  @Input() keepInvalidInput: boolean;
+  
+  /**
    * Callback to mark a given date as disabled.
    * 'Current' contains the month that will be displayed in the view
    */
@@ -142,8 +147,10 @@ export class NgbInputDatepicker implements ControlValueAccessor {
 
   manualDateChange(value: string) {
     this._model = NgbDate.from(this._parserFormatter.parse(value));
-    this._onChange(this._model ? {year: this._model.year, month: this._model.month, day: this._model.day} : null);
-    this._writeModelValue(this._model);
+    if (!this.keepInvalidInput || this._model || !value) {
+      this._onChange(this._model ? {year: this._model.year, month: this._model.month, day: this._model.day} : null);
+      this._writeModelValue(this._model);
+    }
   }
 
   isOpen() { return !!this._cRef; }


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [] added/updated any applicable API documentation.
 - [] added/updated any applicable demos.

Add input property keepInvalidInput. When set to true, the input field is
not cleared, when input cannot be parsed by the Parser.