### PR TITLE
chore: freeze typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "systemjs": "^0.19.40",
     "ts-loader": "1.2.1",
     "tslint": "^3.15.1",
-    "typescript": "^2.0.6",
+    "typescript": "2.0.10",
     "url-loader": "^0.5.7",
     "webpack": "2.1.0-beta.27",
     "webpack-dev-server": "2.1.0-beta.11",

--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -28,7 +28,7 @@ function createKeyDownEvent(key: number) {
 
 function getAriaState(compiled) {
   const stars = getStars(compiled, '.sr-only');
-  return stars.map(star => star.textContent === '(*)' && star.textContent !== '( )');
+  return stars.map(star => star.textContent === '(*)');
 }
 
 function getStar(compiled, num: number) {


### PR DESCRIPTION
`typescript: ^2.0.6` installs the latest `2.1.4` version that breaks the build. 
So to unblock for now:

- freezing to latest `2.0.10` (angular doesn't work with `2.1` yet, and our ngc build fails)
- future-proofing: removing the useless check that breaks `2.1` in tests