### PR TITLE
chore: bump browser versions for sauce labs

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -137,7 +137,9 @@ function startKarmaServer(isTddMode, isSaucelabs, done) {
 
   if (isSaucelabs) {
     config['reporters'] = ['dots', 'saucelabs'];
-    config['browsers'] = ['SL_CHROME', 'SL_FIREFOX', 'SL_IE9', 'SL_IE10', 'SL_IE11', 'SL_EDGE', 'SL_SAFARI9'];
+    config['browsers'] = [
+      'SL_CHROME', 'SL_FIREFOX', 'SL_IE9', 'SL_IE10', 'SL_IE11', 'SL_EDGE13', 'SL_EDGE14', 'SL_SAFARI9', 'SL_SAFARI10'
+    ];
 
     if (process.env.TRAVIS) {
       var buildId = `TRAVIS #${process.env.TRAVIS_BUILD_NUMBER} (${process.env.TRAVIS_BUILD_ID})`;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -42,12 +42,12 @@ module.exports = function(config) {
       'SL_CHROME': {
         base: 'SauceLabs',
         browserName: 'chrome',
-        version: '52'
+        version: 'latest'
       },
       'SL_FIREFOX': {
         base: 'SauceLabs',
         browserName: 'firefox',
-        version: '46'
+        version: 'latest'
       },
       'SL_IE9': {
         base: 'SauceLabs',
@@ -67,17 +67,29 @@ module.exports = function(config) {
         platform: 'Windows 8.1',
         version: '11'
       },
-      'SL_EDGE': {
+      'SL_EDGE13': {
         base: 'SauceLabs',
         browserName: 'MicrosoftEdge',
         platform: 'Windows 10',
         version: '13.10586'
+      },
+      'SL_EDGE14': {
+        base: 'SauceLabs',
+        browserName: 'MicrosoftEdge',
+        platform: 'Windows 10',
+        version: '14.14393'
       },
       'SL_SAFARI9': {
         base: 'SauceLabs',
         browserName: 'safari',
         platform: 'OS X 10.11',
         version: '9.0'
+      },
+      'SL_SAFARI10': {
+        base: 'SauceLabs',
+        browserName: 'safari',
+        platform: 'OS X 10.11',
+        version: '10.0'
       }
     },
 
@@ -88,7 +100,6 @@ module.exports = function(config) {
       recordVideo: false,
       recordScreenshots: false,
       options: {
-        'selenium-version': '2.53.0',
         'command-timeout': 600,
         'idle-timeout': 600,
         'max-duration': 5400


### PR DESCRIPTION
- updating evergreen browsers to `latest` version
- adding `edge 14` and `safari 10`
- always using the latest selenium version