### PR TITLE
feat(NgbDatepickerService): change private datepicker service to protected

### DIFF
--- a/src/datepicker/datepicker-service.ts
+++ b/src/datepicker/datepicker-service.ts
@@ -12,7 +12,7 @@ export class NgbDatepickerService {
       markDisabled: (date: NgbDate, current: {month: number, year: number}) => boolean): MonthViewModel {
     const month: MonthViewModel = {firstDate: null, number: date.month, year: date.year, weeks: [], weekdays: []};
 
-    date = this._getFirstViewDate(date, firstDayOfWeek);
+    date = this.getFirstViewDate(date, firstDayOfWeek);
 
     // month has weeks
     for (let w = 0; w < this._calendar.getWeeksPerMonth(); w++) {
@@ -56,7 +56,7 @@ export class NgbDatepickerService {
     return this._calendar.isValid(ngbDate) ? ngbDate : defaultValue;
   }
 
-  private _getFirstViewDate(date: NgbDate, firstDayOfWeek: number): NgbDate {
+  protected getFirstViewDate(date: NgbDate, firstDayOfWeek: number): NgbDate {
     const currentMonth = date.month;
     let today = new NgbDate(date.year, date.month, date.day);
     let yesterday = this._calendar.getPrev(today);


### PR DESCRIPTION
# Motivation:

Expose the `_getFirstViewDate` within the `NgbDatepickerService` class to `protected` to give more capabilities to derived classes.

----

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
