### PR TITLE
feat(datepicker): allow outsideDays for any number of displayMonths

### DIFF
--- a/src/datepicker/datepicker-config.spec.ts
+++ b/src/datepicker/datepicker-config.spec.ts
@@ -11,7 +11,7 @@ describe('ngb-datepicker-config', () => {
     expect(config.minDate).toBeUndefined();
     expect(config.maxDate).toBeUndefined();
     expect(config.navigation).toBe('select');
-    expect(config.outsideDays).toBe('visible');
+    expect(config.outsideDays).toBeUndefined();
     expect(config.showWeekdays).toBe(true);
     expect(config.showWeekNumbers).toBe(false);
     expect(config.startDate).toBeUndefined();

--- a/src/datepicker/datepicker-config.ts
+++ b/src/datepicker/datepicker-config.ts
@@ -16,7 +16,7 @@ export class NgbDatepickerConfig {
   minDate: NgbDateStruct;
   maxDate: NgbDateStruct;
   navigation: 'select' | 'arrows' | 'none' = 'select';
-  outsideDays: 'visible' | 'collapsed' | 'hidden' = 'visible';
+  outsideDays: 'visible' | 'collapsed' | 'hidden';
   showWeekdays = true;
   showWeekNumbers = false;
   startDate: {year: number, month: number};

--- a/src/datepicker/datepicker-day-view.ts
+++ b/src/datepicker/datepicker-day-view.ts
@@ -8,7 +8,7 @@ import {NgbDateStruct} from './ngb-date-struct';
       text-align: center;
       width: 2rem;
       height: 2rem;
-      line-height: 2rem;      
+      line-height: 2rem;
       border-radius: 0.25rem;
     }
     :host.outside {

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -259,18 +259,29 @@ describe('ngb-datepicker', () => {
     expect(fixture.debugElement.query(By.directive(NgbDatepickerNavigation))).toBeNull();
   });
 
-  it('should override outside days to "hidden" if there are multiple months displayed', () => {
-    const fixture = createTestComponent(
-        `<ngb-datepicker [displayMonths]="displayMonths" [outsideDays]="'collapsed'"></ngb-datepicker>`);
+  it('should set outside days to "visible" if not provided when there is a single month displayed', () => {
+    const fixture = createTestComponent(`<ngb-datepicker [displayMonths]="1"></ngb-datepicker>`);
+    let [month] = fixture.debugElement.queryAll(By.directive(NgbDatepickerMonthView));
+    expect(month.componentInstance.outsideDays).toBe('visible');
+  });
 
+  it('should set outside days to "hidden" if provided when there is a single month displayed', () => {
+    const fixture = createTestComponent(`<ngb-datepicker [displayMonths]="1" outsideDays="hidden"></ngb-datepicker>`);
+    let [month] = fixture.debugElement.queryAll(By.directive(NgbDatepickerMonthView));
+    expect(month.componentInstance.outsideDays).toBe('hidden');
+  });
 
-    let months = fixture.debugElement.queryAll(By.directive(NgbDatepickerMonthView));
-    expect(months[0].componentInstance.outsideDays).toBe('collapsed');
+  it('should set outside days to "hidden" if not provided when there are multiple months displayed', () => {
+    const fixture = createTestComponent(`<ngb-datepicker [displayMonths]="2"></ngb-datepicker>`);
+    let [month] = fixture.debugElement.queryAll(By.directive(NgbDatepickerMonthView));
+    expect(month.componentInstance.outsideDays).toBe('hidden');
+  });
 
-    fixture.componentInstance.displayMonths = 2;
-    fixture.detectChanges();
-    months = fixture.debugElement.queryAll(By.directive(NgbDatepickerMonthView));
-    expect(months[0].componentInstance.outsideDays).toBe('hidden');
+  it('should set outside days if provided when there are multiple months displayed', () => {
+    const fixture =
+        createTestComponent(`<ngb-datepicker [displayMonths]="2" [outsideDays]="'visible'"></ngb-datepicker>`);
+    let [month] = fixture.debugElement.queryAll(By.directive(NgbDatepickerMonthView));
+    expect(month.componentInstance.outsideDays).toBe('visible');
   });
 
   it('should toggle month names display for a single month', () => {

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -103,7 +103,7 @@ export interface NgbDatepickerNavigateEvent {
             [showWeekdays]="showWeekdays"
             [showWeekNumbers]="showWeekNumbers"
             [disabled]="disabled"
-            [outsideDays]="displayMonths === 1 ? outsideDays : 'hidden'"
+            [outsideDays]="outsideDays || (displayMonths === 1 ? 'visible' : 'hidden')"
             (select)="onDateSelect($event)">
           </ngb-datepicker-month-view>
         </div>


### PR DESCRIPTION
# Motivation

I would expect the outside days to be present on any value of `displayMonths`. Foremost, the `outsideDays` for multiple months can be explicitly set to hidden to achieve the hidden outside days, so it does not make sense to inhibit potentially useful functionality. In addition, day display can be controlled through the `dayTemplate` input.

# Issues:

This is obviously a breaking change. However, since the project is still in alpha I would prefer nipping this one in the bud now to allow for more customizeable calendars in the future.

----

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
