### PR TITLE
docs(getting_started): installation add'l modules

### DIFF
--- a/demo/src/app/getting-started/getting-started.component.html
+++ b/demo/src/app/getting-started/getting-started.component.html
@@ -21,8 +21,11 @@
 
   <p>Once installed you need to import our main module.</p>
   <pre>import &#123;NgbModule} from '@ng-bootstrap/ng-bootstrap';</pre>
-  <p>The only remaining part is to list the imported module in your application module. The exact method will be slightly
-different for the root (top-level) module for which you should end up with the code similar to (notice <code>NgbModule.forRoot()</code>):
+  <p>
+    The only remaining part is to list the imported module in your root module and any additional application modules that make use
+    use of the components in this library. The exact method will be slightly different for the root (top-level) module for which you 
+    should end up with the code similar to (notice <code>NgbModule.forRoot()</code>):
+  </p>
   <pre>import &#123;NgbModule} from '@ng-bootstrap/ng-bootstrap';
 
 @NgModule(&#123;


### PR DESCRIPTION
From what I can tell you need to install the `NgbModule` in your root module *and* any additional application modules where you use the components. If this is the case, I feel the docs should be more explicit about it.
