### PR TITLE
chore(popover): upgrade popover to v4-alpha.6

### DIFF
--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -26,9 +26,7 @@ import {NgbPopoverConfig} from './popover-config';
   selector: 'ngb-popover-window',
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {'[class]': '"popover in popover-" + placement', 'role': 'tooltip'},
-  // TODO remove the div.popover-arrow, which is there only to maintain compatibility with bootstrap alpha.4
   template: `
-    <div class="popover-arrow"></div>
     <h3 class="popover-title">{{title}}</h3><div class="popover-content"><ng-content></ng-content></div>
     `
 })


### PR DESCRIPTION
Not really linked to alpha-6, but since the migration to alpha-6 isn't backward-compatible, keeping the caret for compatibility with alpha.4 isn't needed anymore.

refs #1178
