### PR TITLE
chore: upgrade documentation to bootstrap-4.0.0-alpha.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ View all the directives in action at https://ng-bootstrap.github.io
 
 ## Dependencies
 * [Angular 2](https://angular.io) (tested with 2.0.0)
-* [Bootstrap 4](https://v4-alpha.getbootstrap.com) (tested with 4.0.0-alpha.5)
+* [Bootstrap 4](https://v4-alpha.getbootstrap.com) (tested with 4.0.0-alpha.6)
 
 ## Installation
 After installing the above dependencies, install `ng-bootstrap` via:

--- a/demo/src/app/getting-started/getting-started.component.html
+++ b/demo/src/app/getting-started/getting-started.component.html
@@ -11,7 +11,7 @@
       <a href="https://angular.io" target="_blank">Angular</a> (<em>requires</em> Angular version 2 or higher, tested with 2.0.0)
     </li>
     <li>
-      <a href="http://v4-alpha.getbootstrap.com" target="_blank">Bootstrap CSS</a> (tested with 4.0.0-alpha.5)
+      <a href="http://v4-alpha.getbootstrap.com" target="_blank">Bootstrap CSS</a> (tested with 4.0.0-alpha.6)
     </li>
   </ul>
   <h3>


### PR DESCRIPTION
refs #1178

BREAKING CHANGE: This version is compatible with bootstrap-4.0.0-alpha.6, and is not backward-compatible with previous versions of bootstrap. If you choose to upgrade to this version of ng-bootstrap, you will thus also have to migrate to bootstrap-4.0.0-alpha.6.
