### PR TITLE
fix(timepicker): handle undefined state when meridian is true

### DIFF
--- a/src/timepicker/timepicker.ts
+++ b/src/timepicker/timepicker.ts
@@ -101,7 +101,7 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
           <template [ngIf]="meridian">
             <td>&nbsp;&nbsp;</td>
             <td>
-              <button type="button" class="btn btn-outline-primary" (click)="toggleMeridian()">{{model.hour >= 12 ? 'PM' : 'AM'}}</button>
+              <button type="button" class="btn btn-outline-primary" (click)="toggleMeridian()">{{model?.hour >= 12 ? 'PM' : 'AM'}}</button>
             </td>
           </template>
         </tr>


### PR DESCRIPTION
Fixes #[1106](https://github.com/ng-bootstrap/ng-bootstrap/issues/1106)
