### PR TITLE
chore(build): remove hardcoded localhost:9090 for the dev server

### DIFF
--- a/webpack.demo.js
+++ b/webpack.demo.js
@@ -51,7 +51,7 @@ module.exports = function makeWebpackConfig() {
    */
   config.output = {
     path: root('demo', 'dist'),
-    publicPath: isProd ? '/' : 'http://localhost:9090/',
+    publicPath: '/',
     filename: isProd ? 'js/[name].[hash].js' : 'js/[name].js',
     chunkFilename: isProd ? '[id].[hash].chunk.js' : '[id].chunk.js'
   };


### PR DESCRIPTION
Not sure why the `localhost:9090` was hardcoded for the demo-server, but it generates scripts the index html, that aren't easily accessed (from the virtual machine for instance):

```html
<script type="text/javascript" src="http://localhost:9090/js/polyfills.js"></script>
```

When this would work just fine for both production and dev:

```html
<script type="text/javascript" src="/js/polyfills.js"></script>
```