### PR TITLE
feat(datepicker): improve default look and feel

### DIFF
--- a/src/datepicker/datepicker-day-view.spec.ts
+++ b/src/datepicker/datepicker-day-view.spec.ts
@@ -40,16 +40,18 @@ describe('ngbDatepickerDayView', () => {
     expect(el).toHaveCssClass('text-muted');
   });
 
-  it('should apply text-muted style for days of a different month', () => {
+  it('should apply text-muted and outside classes for days of a different month', () => {
     const fixture = TestBed.createComponent(TestComponent);
     fixture.detectChanges();
 
     const el = getElement(fixture.nativeElement);
     expect(el).not.toHaveCssClass('text-muted');
+    expect(el).not.toHaveCssClass('outside');
 
     fixture.componentInstance.date = {year: 2016, month: 8, day: 22};
     fixture.detectChanges();
     expect(el).toHaveCssClass('text-muted');
+    expect(el).toHaveCssClass('outside');
   });
 
   it('should apply selected style', () => {

--- a/src/datepicker/datepicker-day-view.ts
+++ b/src/datepicker/datepicker-day-view.ts
@@ -4,16 +4,22 @@ import {NgbDateStruct} from './ngb-date-struct';
 @Component({
   selector: '[ngbDatepickerDayView]',
   styles: [`
-    :host {      
+    :host {
       text-align: center;
-      padding: 0.185rem 0.25rem;      
+      width: 2rem;
+      height: 2rem;
+      line-height: 2rem;      
       border-radius: 0.25rem;
+    }
+    :host.outside {
+      opacity: 0.5;
     }
   `],
   host: {
     '[class.bg-primary]': 'selected',
     '[class.text-white]': 'selected',
     '[class.text-muted]': 'isMuted()',
+    '[class.outside]': 'isMuted()',
     '[class.btn-secondary]': '!disabled'
   },
   template: `{{ date.day }}`

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -222,8 +222,7 @@ export class NgbInputDatepicker implements ControlValueAccessor {
 
   private _applyPopupStyling(nativeElement: any) {
     this._renderer.setElementClass(nativeElement, 'dropdown-menu', true);
-    this._renderer.setElementStyle(nativeElement, 'display', 'block');
-    this._renderer.setElementStyle(nativeElement, 'padding', '0.40rem');
+    this._renderer.setElementStyle(nativeElement, 'padding', '0');
   }
 
   private _subscribeForDatepickerOutputs(datepickerInstance: NgbDatepicker) {

--- a/src/datepicker/datepicker-month-view.spec.ts
+++ b/src/datepicker/datepicker-month-view.spec.ts
@@ -13,15 +13,15 @@ const createTestComponent = (html: string) =>
     createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
 function getWeekdays(element: HTMLElement): HTMLElement[] {
-  return <HTMLElement[]>Array.from(element.querySelectorAll('td.weekday'));
+  return <HTMLElement[]>Array.from(element.querySelectorAll('.ngb-dp-weekday'));
 }
 
 function getWeekNumbers(element: HTMLElement): HTMLElement[] {
-  return <HTMLElement[]>Array.from(element.querySelectorAll('td.weeknumber'));
+  return <HTMLElement[]>Array.from(element.querySelectorAll('.ngb-dp-week-number'));
 }
 
 function getDates(element: HTMLElement): HTMLElement[] {
-  return <HTMLElement[]>Array.from(element.querySelectorAll('td.day'));
+  return <HTMLElement[]>Array.from(element.querySelectorAll('.ngb-dp-day'));
 }
 
 function expectWeekdays(element: HTMLElement, weekdays: string[]) {

--- a/src/datepicker/datepicker-month-view.ts
+++ b/src/datepicker/datepicker-month-view.ts
@@ -6,45 +6,47 @@ import {DayTemplateContext} from './datepicker-day-template-context';
 
 @Component({
   selector: 'ngb-datepicker-month-view',
+  host: {'class': 'd-block'},
   styles: [`
-    .weekday {
+    .ngb-dp-weekday, .ngb-dp-week-number {
+      line-height: 2rem;
     }
-    .weeknumber {
+    .ngb-dp-day, .ngb-dp-weekday, .ngb-dp-week-number {
+      width: 2rem;
+      height: 2rem;      
     }
-    .day {
-      padding: 0;
-      height: 100%;
+    .ngb-dp-day {
       cursor: pointer;
     }
-    .day.disabled, .day.hidden, .day.collapsed {
+    .ngb-dp-day.disabled, .ngb-dp-day.hidden, .ngb-dp-day.collapsed {
       cursor: default;
     }
-    :host/deep/.day.collapsed > * {
+    :host/deep/.ngb-dp-day.collapsed > * {
       display: none;
     }
-    :host/deep/.day.hidden > * {
+    :host/deep/.ngb-dp-day.hidden > * {
       visibility: hidden;
     }
   `],
   template: `
-    <table>
-      <tr *ngIf="showWeekdays">
-        <td *ngIf="showWeekNumbers"></td>
-        <td *ngFor="let w of month.weekdays" class="weekday text-center font-weight-bold">{{ i18n.getWeekdayName(w) }}</td>
-      </tr>
-      <tr *ngFor="let week of month.weeks">
-        <td *ngIf="showWeekNumbers" class="weeknumber small text-center">{{ week.number }}</td>
-        <td *ngFor="let day of week.days" (click)="doSelect(day)" class="day" [class.disabled]="isDisabled(day)"
-        [class.collapsed]="isCollapsed(day)" [class.hidden]="isHidden(day)">
-            <template [ngTemplateOutlet]="dayTemplate"
-            [ngOutletContext]="{date: {year: day.date.year, month: day.date.month, day: day.date.day},
-              currentMonth: month.number,
-              disabled: isDisabled(day),
-              selected: isSelected(day.date)}">
-            </template>
-        </td>
-      </tr>
-    </table>
+    <div *ngIf="showWeekdays" class="ngb-dp-week d-flex">
+      <div *ngIf="showWeekNumbers" class="ngb-dp-weekday"></div>
+      <div *ngFor="let w of month.weekdays" class="ngb-dp-weekday small text-center text-info font-italic">
+        {{ i18n.getWeekdayName(w) }}
+      </div>
+    </div>
+    <div *ngFor="let week of month.weeks" class="ngb-dp-week d-flex">
+      <div *ngIf="showWeekNumbers" class="ngb-dp-week-number small text-center font-italic text-muted">{{ week.number }}</div>
+      <div *ngFor="let day of week.days" (click)="doSelect(day)" class="ngb-dp-day" [class.disabled]="isDisabled(day)"
+      [class.collapsed]="isCollapsed(day)" [class.hidden]="isHidden(day)">
+          <template [ngTemplateOutlet]="dayTemplate"
+          [ngOutletContext]="{date: {year: day.date.year, month: day.date.month, day: day.date.day},
+            currentMonth: month.number,
+            disabled: isDisabled(day),
+            selected: isSelected(day.date)}">
+          </template>
+      </div>
+    </div>
   `
 })
 export class NgbDatepickerMonthView {

--- a/src/datepicker/datepicker-navigation.ts
+++ b/src/datepicker/datepicker-navigation.ts
@@ -6,35 +6,58 @@ import {NgbCalendar} from './ngb-calendar';
 
 @Component({
   selector: 'ngb-datepicker-navigation',
+  host: {'class': 'd-flex justify-content-between', '[class.collapsed]': '!showSelect'},
   styles: [`
-    .collapsed {
-        margin-bottom: -1.7rem;
+    :host {
+      height: 2rem;
+      line-height: 1.85rem;
     }
+    :host.collapsed {
+      margin-bottom: -2rem;        
+    }
+    .ngb-dp-navigation-chevron::before {
+      border-style: solid;
+      border-width: 0.2em 0.2em 0 0;
+      content: '';
+      display: inline-block;
+      height: 0.75em;
+      transform: rotate(-135deg);
+      -webkit-transform: rotate(-135deg);
+      -ms-transform: rotate(-135deg);
+      width: 0.75em;
+      margin: 0 0 0 0.5rem;
+    }    
+    .ngb-dp-navigation-chevron.right:before {
+      -webkit-transform: rotate(45deg);
+      -ms-transform: rotate(45deg);
+      transform: rotate(45deg);
+      margin: 0 0.5rem 0 0;
+    }
+    .btn-link {
+      cursor: pointer;
+      outline: 0;
+    }
+    .btn-link[disabled] {
+      cursor: not-allowed;
+      opacity: .65;
+    }    
   `],
   template: `
-    <table class="w-100" [class.collapsed]="!showSelect">
-      <tr>
-        <td class="text-sm-left">
-          <button type="button" (click)="doNavigate(navigation.PREV)" class="btn btn-sm btn-secondary btn-inline" 
-            [disabled]="prevDisabled()">&lt;</button>
-        </td>
-        
-        <td *ngIf="showSelect">
-          <ngb-datepicker-navigation-select
-            [date]="date"
-            [minDate]="minDate"
-            [maxDate]="maxDate"
-            [disabled] = "disabled"
-            (select)="selectDate($event)">
-          </ngb-datepicker-navigation-select>
-        </td>        
-        
-        <td class="text-sm-right">
-          <button type="button" (click)="doNavigate(navigation.NEXT)" class="next btn btn-sm btn-secondary btn-inline" 
-            [disabled]="nextDisabled()">&gt;</button>
-        </td>
-      </tr>
-    </table>
+    <button type="button" class="btn-link" (click)="!!doNavigate(navigation.PREV)" [disabled]="prevDisabled()">
+      <span class="ngb-dp-navigation-chevron"></span>    
+    </button>
+    
+    <ngb-datepicker-navigation-select *ngIf="showSelect" class="d-block" [style.width.rem]="months * 9"
+      [date]="date"
+      [minDate]="minDate"
+      [maxDate]="maxDate"
+      [disabled] = "disabled"
+      (select)="selectDate($event)">
+    </ngb-datepicker-navigation-select>
+    
+    <button type="button" class="btn-link" (click)="!!doNavigate(navigation.NEXT)" [disabled]="nextDisabled()">
+      <span class="ngb-dp-navigation-chevron right"></span>
+    </button>
   `
 })
 export class NgbDatepickerNavigation {
@@ -44,6 +67,7 @@ export class NgbDatepickerNavigation {
   @Input() disabled: boolean;
   @Input() maxDate: NgbDate;
   @Input() minDate: NgbDate;
+  @Input() months: number;
   @Input() showSelect: boolean;
   @Input() showWeekNumbers: boolean;
 

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -20,7 +20,7 @@ const createTestComponent = (html: string) =>
     createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
 function getDates(element: HTMLElement): HTMLElement[] {
-  return <HTMLElement[]>Array.from(element.querySelectorAll('td.day'));
+  return <HTMLElement[]>Array.from(element.querySelectorAll('.ngb-dp-day'));
 }
 
 function getDay(element: HTMLElement, index: number): HTMLElement {
@@ -277,39 +277,35 @@ describe('ngb-datepicker', () => {
     const fixture = createTestComponent(
         `<ngb-datepicker [startDate]="date" [displayMonths]="1" [navigation]="navigation"></ngb-datepicker>`);
 
-    let sections = fixture.debugElement.queryAll(By.css('ngb-datepicker > table > tbody > tr'));
-    expect(sections.length).toBe(1);
+    let months = fixture.debugElement.queryAll(By.css('.ngb-dp-month-name'));
+    expect(months.length).toBe(0);
 
     fixture.componentInstance.navigation = 'arrows';
     fixture.detectChanges();
-    sections = fixture.debugElement.queryAll(By.css('ngb-datepicker > table > tbody > tr'));
-    expect(sections.length).toBe(2);
-    expect(sections[0].children.map(c => c.nativeElement.innerText.trim())).toEqual(['Aug 2016']);
+    months = fixture.debugElement.queryAll(By.css('.ngb-dp-month-name'));
+    expect(months.length).toBe(1);
+    expect(months.map(c => c.nativeElement.innerText.trim())).toEqual(['Aug 2016']);
 
     fixture.componentInstance.navigation = 'none';
     fixture.detectChanges();
-    sections = fixture.debugElement.queryAll(By.css('ngb-datepicker > table > tbody > tr'));
-    expect(sections.length).toBe(2);
-    expect(sections[0].children.map(c => c.nativeElement.innerText.trim())).toEqual(['Aug 2016']);
+    months = fixture.debugElement.queryAll(By.css('.ngb-dp-month-name'));
+    expect(months.length).toBe(1);
+    expect(months.map(c => c.nativeElement.innerText.trim())).toEqual(['Aug 2016']);
   });
 
   it('should always display month names for multiple months', () => {
     const fixture = createTestComponent(
         `<ngb-datepicker [startDate]="date" [displayMonths]="3" [navigation]="navigation"></ngb-datepicker>`);
 
-    let sections = fixture.debugElement.queryAll(By.css('ngb-datepicker > table > tbody > tr'));
-    expect(sections.length).toBe(2);
-    expect(sections[0].children.map(c => c.nativeElement.innerText.trim())).toEqual([
-      'Aug 2016', 'Sep 2016', 'Oct 2016'
-    ]);
+    let months = fixture.debugElement.queryAll(By.css('.ngb-dp-month-name'));
+    expect(months.length).toBe(3);
+    expect(months.map(c => c.nativeElement.innerText.trim())).toEqual(['Aug 2016', 'Sep 2016', 'Oct 2016']);
 
     fixture.componentInstance.navigation = 'arrows';
     fixture.detectChanges();
-    sections = fixture.debugElement.queryAll(By.css('ngb-datepicker > table > tbody > tr'));
-    expect(sections.length).toBe(2);
-    expect(sections[0].children.map(c => c.nativeElement.innerText.trim())).toEqual([
-      'Aug 2016', 'Sep 2016', 'Oct 2016'
-    ]);
+    months = fixture.debugElement.queryAll(By.css('.ngb-dp-month-name'));
+    expect(months.length).toBe(3);
+    expect(months.map(c => c.nativeElement.innerText.trim())).toEqual(['Aug 2016', 'Sep 2016', 'Oct 2016']);
   });
 
   it('should emit navigate event when startDate is defined', () => {
@@ -363,6 +359,44 @@ describe('ngb-datepicker', () => {
     fixture.detectChanges();
     expect(fixture.componentInstance.onNavigate)
         .toHaveBeenCalledWith({current: {year: 2016, month: 8}, next: {year: 2015, month: 6}});
+  });
+
+  it('should calculate header dimensions correctly', () => {
+    const datepicker = TestBed.createComponent(NgbDatepicker).componentInstance;
+
+    // 1, 'select', weekdays
+    expect(datepicker.getHeaderHeight()).toBe(4.25);
+    expect(datepicker.getHeaderMargin()).toBe(2);
+
+    // 1, 'select', no weekdays
+    datepicker.showWeekdays = false;
+    expect(datepicker.getHeaderHeight()).toBe(2.25);
+    expect(datepicker.getHeaderMargin()).toBe(0);
+
+    // 1, 'none', no weekdays
+    datepicker.navigation = 'none';
+    expect(datepicker.getHeaderHeight()).toBe(2.25);
+    expect(datepicker.getHeaderMargin()).toBe(2);
+
+    // 2, 'none', no weekdays
+    datepicker.displayMonths = 2;
+    expect(datepicker.getHeaderHeight()).toBe(2.25);
+    expect(datepicker.getHeaderMargin()).toBe(2);
+
+    // 2, 'select', no weekdays
+    datepicker.navigation = 'select';
+    expect(datepicker.getHeaderHeight()).toBe(4.25);
+    expect(datepicker.getHeaderMargin()).toBe(2);
+
+    // 2, 'select', weekdays
+    datepicker.showWeekdays = true;
+    expect(datepicker.getHeaderHeight()).toBe(6.25);
+    expect(datepicker.getHeaderMargin()).toBe(4);
+
+    // 2, 'none', weekdays
+    datepicker.navigation = 'none';
+    expect(datepicker.getHeaderHeight()).toBe(4.25);
+    expect(datepicker.getHeaderMargin()).toBe(4);
   });
 
   describe('ngModel', () => {
@@ -650,6 +684,7 @@ class TestComponent {
   form = new FormGroup({control: new FormControl('', Validators.required)});
   disabledForm = new FormGroup({control: new FormControl({value: null, disabled: true})});
   model;
+  showWeekdays = true;
   markDisabled = (date: NgbDateStruct) => { return NgbDate.from(date).equals(new NgbDate(2016, 8, 22)); };
   onNavigate = () => {};
 }

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -47,36 +47,49 @@ export interface NgbDatepickerNavigateEvent {
 @Component({
   exportAs: 'ngbDatepicker',
   selector: 'ngb-datepicker',
-  host: {'class': 'd-inline-block'},
+  host: {'class': 'd-inline-block rounded'},
   styles: [`
-    .month:first-child {
-      padding-left: 0 !important;
+    :host {
+      border: 1px solid rgba(0, 0, 0, 0.125);
     }
+    .ngb-dp-header {
+      border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+    }
+    .ngb-dp-month:first-child {
+      margin-left: 0 !important;
+    }    
+    .ngb-dp-month-name {
+      font-size: larger;
+      height: 2rem;
+      line-height: 2rem;
+    }    
   `],
   template: `
     <template #dt let-date="date" let-currentMonth="currentMonth" let-selected="selected" let-disabled="disabled">
        <div ngbDatepickerDayView [date]="date" [currentMonth]="currentMonth" [selected]="selected" [disabled]="disabled"></div>
     </template>
+    
+    <div class="ngb-dp-header bg-faded pt-1 rounded-top" [style.height.rem]="getHeaderHeight()" 
+      [style.marginBottom.rem]="-getHeaderMargin()">
+      <ngb-datepicker-navigation *ngIf="navigation !== 'none'"
+        [date]="months[0]?.firstDate"
+        [minDate]="_minDate"
+        [maxDate]="_maxDate"
+        [months]="months.length"
+        [disabled]="disabled"
+        [showWeekNumbers]="showWeekNumbers"
+        [showSelect]="navigation === 'select'"
+        (navigate)="onNavigateEvent($event)"
+        (select)="onNavigateDateSelect($event)">
+      </ngb-datepicker-navigation>
+    </div>
 
-    <ngb-datepicker-navigation *ngIf="navigation !== 'none'"
-      [date]="months[0]?.firstDate"
-      [minDate]="_minDate"
-      [maxDate]="_maxDate"
-      [disabled]="disabled"
-      [showWeekNumbers]="showWeekNumbers"
-      [showSelect]="navigation === 'select'"
-      (navigate)="onNavigateEvent($event)"
-      (select)="onNavigateDateSelect($event)">
-    </ngb-datepicker-navigation>
-
-    <table>
-      <tr *ngIf="navigation !== 'select' || displayMonths > 1">
-        <td *ngFor="let month of months" class="text-center font-weight-bold">
-          {{ i18n.getMonthName(month.number) }} {{ month.year }}
-        </td>
-      </tr>
-      <tr>
-        <td *ngFor="let month of months" class="pl-1 month">
+    <div class="ngb-dp-months d-flex px-1 pb-1">
+      <template ngFor let-month [ngForOf]="months" let-i="index">
+        <div class="ngb-dp-month d-block ml-3">            
+          <div *ngIf="navigation !== 'select' || displayMonths > 1" class="ngb-dp-month-name text-center">
+            {{ i18n.getMonthName(month.number) }} {{ month.year }}
+          </div>
           <ngb-datepicker-month-view
             [month]="month"
             [selectedDate]="model"
@@ -87,9 +100,9 @@ export interface NgbDatepickerNavigateEvent {
             [outsideDays]="displayMonths === 1 ? outsideDays : 'hidden'"
             (select)="onDateSelect($event)">
           </ngb-datepicker-month-view>
-        </td>
-      </tr>
-    </table>
+        </div>
+      </template>
+    </div>
   `,
   providers: [NGB_DATEPICKER_VALUE_ACCESSOR]
 })
@@ -188,6 +201,16 @@ export class NgbDatepicker implements OnChanges,
     this.showWeekdays = config.showWeekdays;
     this.showWeekNumbers = config.showWeekNumbers;
     this.startDate = config.startDate;
+  }
+
+  getHeaderHeight() {
+    const h = this.showWeekdays ? 6.25 : 4.25;
+    return this.displayMonths === 1 || this.navigation !== 'select' ? h - 2 : h;
+  }
+
+  getHeaderMargin() {
+    const m = this.showWeekdays ? 2 : 0;
+    return this.displayMonths !== 1 || this.navigation !== 'select' ? m + 2 : m;
   }
 
   /**


### PR DESCRIPTION
Updating default datepicker look and feel as a part of #862 :

* Moving to flex layout instead of table layout
* More space and border around the datepicker
* Less pronounced weekdays
* Visual separation of the header from the body
* Buttons same as in the timepicker
* Prefixing css classes with `ngb-dp-`

Before:
![screen shot 2017-01-10 at 11 38 46](https://cloud.githubusercontent.com/assets/8074436/21803211/600fd3c4-d729-11e6-9015-6049a7be2951.png)

After:
![screen shot 2017-01-10 at 11 39 17](https://cloud.githubusercontent.com/assets/8074436/21803229/7223732c-d729-11e6-9cdf-9b9be4875c3e.png)

![screen shot 2017-01-10 at 11 41 47](https://cloud.githubusercontent.com/assets/8074436/21803309/ce39295e-d729-11e6-9b99-6cdb03a94aa2.png)

P.S. Will also add full month names with a separate request later

BREAKING CHANGES: switched to flex layout instead of table-based (drop IE9 support) and prefixed datepicker-related css classes with `ngb-dp-`

Fixes #706
