### PR TITLE
fix(demo): fix cell sizing of class documentation

### DIFF
--- a/demo/src/app/components/shared/api-docs/api-docs-class.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs-class.component.html
@@ -11,7 +11,7 @@
         <tbody>
         <tr *ngFor="let prop of apiDocs.properties">
           <td class="label-cell"><code>{{prop.name}}</code></td>
-          <td class="conent-cell">
+          <td class="content-cell">
             <div><i>Type: </i><code>{{ prop.type }}</code></div>
             <template [ngIf]="prop.defaultValue">
               <div><i>Default value: </i><code>{{prop.defaultValue || '-'}}</code></div>


### PR DESCRIPTION
Fixes a typo introduced in e146a7a9f8c041b1ce6510ef4c41aa7becda2a10

cc @jnizet 