### PR TITLE
demo(datepicker): fix 'displayMonths' select value to number

### DIFF
--- a/demo/src/app/components/datepicker/demos/multiple/datepicker-multiple.html
+++ b/demo/src/app/components/datepicker/demos/multiple/datepicker-multiple.html
@@ -18,9 +18,9 @@
 <hr/>
 
 <select class="custom-select" [(ngModel)]="displayMonths">
-  <option [value]="1">One month</option>
-  <option [value]="2">Two months</option>
-  <option [value]="3">Three months</option>
+  <option [ngValue]="1">One month</option>
+  <option [ngValue]="2">Two months</option>
+  <option [ngValue]="3">Three months</option>
 </select>
 
 <select class="custom-select" [(ngModel)]="navigation">


### PR DESCRIPTION
Otherwise the datepicker's `displayMonths` input gets `"2"` instead of `2`