### PR TITLE
feat(pagination): add horizontal alignment config option

### DIFF
--- a/demo/src/app/components/pagination/demos/index.ts
+++ b/demo/src/app/components/pagination/demos/index.ts
@@ -3,9 +3,11 @@ import {NgbdPaginationBasic} from './basic/pagination-basic';
 import {NgbdPaginationSize} from './size/pagination-size';
 import {NgbdPaginationConfig} from './config/pagination-config';
 import {NgbdPaginationDisabled} from './disabled/pagination-disabled';
+import {NgbdPaginationJustify} from './justify/pagination-justify';
 
 export const DEMO_DIRECTIVES = [
-  NgbdPaginationAdvanced, NgbdPaginationBasic, NgbdPaginationSize, NgbdPaginationConfig, NgbdPaginationDisabled
+  NgbdPaginationAdvanced, NgbdPaginationBasic, NgbdPaginationSize, NgbdPaginationConfig, NgbdPaginationDisabled,
+  NgbdPaginationJustify
 ];
 
 export const DEMO_SNIPPETS = {
@@ -28,5 +30,9 @@ export const DEMO_SNIPPETS = {
   config: {
     code: require('!!prismjs-loader?lang=typescript!./config/pagination-config'),
     markup: require('!!prismjs-loader?lang=markup!./config/pagination-config.html')
+  },
+  justify: {
+    code: require('!!prismjs-loader?lang=typescript!./justify/pagination-justify'),
+    markup: require('!!prismjs-loader?lang=markup!./justify/pagination-justify.html')
   }
 };

--- a/demo/src/app/components/pagination/demos/justify/pagination-justify.html
+++ b/demo/src/app/components/pagination/demos/justify/pagination-justify.html
@@ -1,0 +1,5 @@
+<p>The <code>justify</code> configuration manages horizontal alignment:</p>
+
+<ngb-pagination [collectionSize]="50" [(page)]="currentPage"></ngb-pagination>
+<ngb-pagination [collectionSize]="50" [(page)]="currentPage" justify="center"></ngb-pagination>
+<ngb-pagination [collectionSize]="50" [(page)]="currentPage" justify="end"></ngb-pagination>

--- a/demo/src/app/components/pagination/demos/justify/pagination-justify.ts
+++ b/demo/src/app/components/pagination/demos/justify/pagination-justify.ts
@@ -1,0 +1,6 @@
+import {Component} from '@angular/core';
+
+@Component({selector: 'ngbd-pagination-justify', templateUrl: './pagination-justify.html'})
+export class NgbdPaginationJustify {
+  currentPage = 3;
+}

--- a/demo/src/app/components/pagination/pagination.component.ts
+++ b/demo/src/app/components/pagination/pagination.component.ts
@@ -22,6 +22,9 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Global configuration" [snippets]="snippets" component="pagination" demo="config">
         <ngbd-pagination-config></ngbd-pagination-config>
       </ngbd-example-box>
+      <ngbd-example-box demoTitle="Justify configuration" [snippets]="snippets" component="pagination" demo="justify">
+        <ngbd-pagination-justify></ngbd-pagination-justify>
+      </ngbd-example-box>
     </ngbd-content-wrapper>
   `
 })

--- a/src/pagination/pagination-config.spec.ts
+++ b/src/pagination/pagination-config.spec.ts
@@ -12,5 +12,6 @@ describe('ngb-pagination-config', () => {
     expect(config.pageSize).toBe(10);
     expect(config.rotate).toBe(false);
     expect(config.size).toBeUndefined();
+    expect(config.justify).toBe('start');
   });
 });

--- a/src/pagination/pagination-config.spec.ts
+++ b/src/pagination/pagination-config.spec.ts
@@ -4,14 +4,14 @@ describe('ngb-pagination-config', () => {
   it('should have sensible default values', () => {
     const config = new NgbPaginationConfig();
 
-    expect(config.disabled).toBe(false);
     expect(config.boundaryLinks).toBe(false);
     expect(config.directionLinks).toBe(true);
+    expect(config.disabled).toBe(false);
     expect(config.ellipses).toBe(true);
+    expect(config.justify).toBe('start');
     expect(config.maxSize).toBe(0);
     expect(config.pageSize).toBe(10);
     expect(config.rotate).toBe(false);
     expect(config.size).toBeUndefined();
-    expect(config.justify).toBe('start');
   });
 });

--- a/src/pagination/pagination-config.ts
+++ b/src/pagination/pagination-config.ts
@@ -15,4 +15,5 @@ export class NgbPaginationConfig {
   pageSize = 10;
   rotate = false;
   size: 'sm' | 'lg';
+  justify: 'start' | 'center' | 'end' = 'start';
 }

--- a/src/pagination/pagination-config.ts
+++ b/src/pagination/pagination-config.ts
@@ -7,13 +7,13 @@ import {Injectable} from '@angular/core';
  */
 @Injectable()
 export class NgbPaginationConfig {
-  disabled = false;
   boundaryLinks = false;
   directionLinks = true;
+  disabled = false;
   ellipses = true;
+  justify: 'start' | 'center' | 'end' = 'start';
   maxSize = 0;
   pageSize = 10;
   rotate = false;
   size: 'sm' | 'lg';
-  justify: 'start' | 'center' | 'end' = 'start';
 }

--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -54,10 +54,11 @@ function normalizeText(txt: string): string {
 }
 
 function expectSameValues(pagination: NgbPagination, config: NgbPaginationConfig) {
-  expect(pagination.disabled).toBe(config.disabled);
   expect(pagination.boundaryLinks).toBe(config.boundaryLinks);
   expect(pagination.directionLinks).toBe(config.directionLinks);
+  expect(pagination.disabled).toBe(config.disabled);
   expect(pagination.ellipses).toBe(config.ellipses);
+  expect(pagination.justify).toBe(config.justify);
   expect(pagination.maxSize).toBe(config.maxSize);
   expect(pagination.pageSize).toBe(config.pageSize);
   expect(pagination.rotate).toBe(config.rotate);
@@ -590,11 +591,11 @@ describe('ngb-pagination', () => {
       config.boundaryLinks = true;
       config.directionLinks = false;
       config.ellipses = false;
+      config.justify = 'center';
       config.maxSize = 42;
       config.pageSize = 7;
       config.rotate = true;
       config.size = 'sm';
-      config.justify = 'center';
     }));
 
     it('should initialize inputs with provided config', () => {
@@ -608,15 +609,15 @@ describe('ngb-pagination', () => {
 
   describe('Custom config as provider', () => {
     let config = new NgbPaginationConfig();
-    config.disabled = true;
     config.boundaryLinks = true;
     config.directionLinks = false;
+    config.disabled = true;
     config.ellipses = false;
+    config.justify = 'center';
     config.maxSize = 42;
     config.pageSize = 7;
     config.rotate = true;
     config.size = 'sm';
-    config.justify = 'center';
 
     beforeEach(() => {
       TestBed.configureTestingModule(
@@ -635,15 +636,15 @@ describe('ngb-pagination', () => {
 
 @Component({selector: 'test-cmp', template: ''})
 class TestComponent {
-  pageSize = 10;
-  collectionSize = 100;
-  page = 1;
   boundaryLinks = false;
+  collectionSize = 100;
   directionLinks = false;
-  size = '';
-  maxSize = 0;
   ellipses = true;
+  maxSize = 0;
+  page = 1;
+  pageSize = 10;
   rotate = false;
+  size = '';
 
   onPageChange = () => {};
 }

--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -559,6 +559,25 @@ describe('ngb-pagination', () => {
            expect(buttons[i]).toHaveCssClass('disabled');
          }
        }));
+
+    it('should be left aligned by default', () => {
+      const html = '<ngb-pagination [collectionSize]="20" [page]="page"></ngb-pagination>';
+      const fixture = createTestComponent(html);
+      expect(fixture.nativeElement.querySelector('ul')).toHaveCssClass('justify-content-start');
+    });
+
+    it('should be center aligned when justify is set to "center"', () => {
+      const html = '<ngb-pagination [collectionSize]="20" [page]="page" justify="center"></ngb-pagination>';
+      const fixture = createTestComponent(html);
+      expect(fixture.nativeElement.querySelector('ul')).toHaveCssClass('justify-content-center');
+    });
+
+
+    it('should be right aligned when justify is set to "end"', () => {
+      const html = '<ngb-pagination [collectionSize]="20" [page]="page" justify="end"></ngb-pagination>';
+      const fixture = createTestComponent(html);
+      expect(fixture.nativeElement.querySelector('ul')).toHaveCssClass('justify-content-end');
+    });
   });
 
   describe('Custom config', () => {
@@ -575,6 +594,7 @@ describe('ngb-pagination', () => {
       config.pageSize = 7;
       config.rotate = true;
       config.size = 'sm';
+      config.justify = 'center';
     }));
 
     it('should initialize inputs with provided config', () => {
@@ -596,6 +616,7 @@ describe('ngb-pagination', () => {
     config.pageSize = 7;
     config.rotate = true;
     config.size = 'sm';
+    config.justify = 'center';
 
     beforeEach(() => {
       TestBed.configureTestingModule(

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -10,7 +10,7 @@ import {NgbPaginationConfig} from './pagination-config';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <nav>
-      <ul [class]="'pagination' + (size ? ' pagination-' + size : '')">
+      <ul [class]="'pagination' + (size ? ' pagination-' + size : '') + ' justify-content-' + justify">
         <li *ngIf="boundaryLinks" class="page-item" 
           [class.disabled]="!hasPrevious() || disabled">
           <a aria-label="First" class="page-link" href (click)="!!selectPage(1)" [attr.tabindex]="hasPrevious() ? null : '-1'">
@@ -109,6 +109,11 @@ export class NgbPagination implements OnChanges {
    */
   @Input() size: 'sm' | 'lg';
 
+  /**
+   * Horizontal positioning with Flex justification: start, center, or end
+   */
+  @Input() justify: 'start' | 'center' | 'end';
+
   constructor(config: NgbPaginationConfig) {
     this.disabled = config.disabled;
     this.boundaryLinks = config.boundaryLinks;
@@ -118,6 +123,7 @@ export class NgbPagination implements OnChanges {
     this.pageSize = config.pageSize;
     this.rotate = config.rotate;
     this.size = config.size;
+    this.justify = config.justify;
   }
 
   hasPrevious(): boolean { return this.page > 1; }

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -49,13 +49,8 @@ import {NgbPaginationConfig} from './pagination-config';
   `
 })
 export class NgbPagination implements OnChanges {
-  pageCount = 0;
   pages: number[] = [];
-
-  /**
-   * Whether to disable buttons from user input
-   */
-  @Input() disabled: boolean;
+  pageCount = 0;
 
   /**
    *  Whether to show the "First" and "Last" page links
@@ -63,9 +58,19 @@ export class NgbPagination implements OnChanges {
   @Input() boundaryLinks: boolean;
 
   /**
+   *  Number of items in collection.
+   */
+  @Input() collectionSize: number;
+
+  /**
    *  Whether to show the "Next" and "Previous" page links
    */
   @Input() directionLinks: boolean;
+
+  /**
+   * Whether to disable buttons from user input
+   */
+  @Input() disabled: boolean;
 
   /**
    *  Whether to show ellipsis symbols and first/last page numbers when maxSize > number of pages
@@ -73,15 +78,9 @@ export class NgbPagination implements OnChanges {
   @Input() ellipses: boolean;
 
   /**
-   *  Whether to rotate pages when maxSize > number of pages.
-   *  Current page will be in the middle
+   * Horizontal positioning with Flex justification: start, center, or end
    */
-  @Input() rotate: boolean;
-
-  /**
-   *  Number of items in collection.
-   */
-  @Input() collectionSize: number;
+  @Input() justify: 'start' | 'center' | 'end';
 
   /**
    *  Maximum number of pages to display.
@@ -99,10 +98,10 @@ export class NgbPagination implements OnChanges {
   @Input() pageSize: number;
 
   /**
-   *  An event fired when the page is changed.
-   *  Event's payload equals to the newly selected page.
+   *  Whether to rotate pages when maxSize > number of pages.
+   *  Current page will be in the middle
    */
-  @Output() pageChange = new EventEmitter<number>(true);
+  @Input() rotate: boolean;
 
   /**
    * Pagination display size: small or large
@@ -110,20 +109,21 @@ export class NgbPagination implements OnChanges {
   @Input() size: 'sm' | 'lg';
 
   /**
-   * Horizontal positioning with Flex justification: start, center, or end
+   *  An event fired when the page is changed.
+   *  Event's payload equals to the newly selected page.
    */
-  @Input() justify: 'start' | 'center' | 'end';
+  @Output() pageChange = new EventEmitter<number>(true);
 
   constructor(config: NgbPaginationConfig) {
-    this.disabled = config.disabled;
     this.boundaryLinks = config.boundaryLinks;
     this.directionLinks = config.directionLinks;
+    this.disabled = config.disabled;
     this.ellipses = config.ellipses;
+    this.justify = config.justify;
     this.maxSize = config.maxSize;
-    this.pageSize = config.pageSize;
     this.rotate = config.rotate;
     this.size = config.size;
-    this.justify = config.justify;
+    this.pageSize = config.pageSize;
   }
 
   hasPrevious(): boolean { return this.page > 1; }


### PR DESCRIPTION
This is similar to pull request #1210 -- except applied to the pagination component -- so I used the same configuration name (`justify`) and configurable values for consistency: 

* 'start' (default)
* 'center'
* 'end'