### PR TITLE
fix(datepicker): propagate null for invalid dates entered manually

### DIFF
--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -116,6 +116,46 @@ describe('NgbInputDatepicker', () => {
       expect(fixture.componentInstance.date).toBeNull();
     });
 
+    it('should propagate null to model when a user date outside of specified range', () => {
+      const fixture = createTestCmpt(`<input ngbDatepicker [(ngModel)]="date" 
+          [minDate]="{year: 2010, month: 5, day: 1}" 
+          [maxDate]="{year: 2017, month: 2, day: 1}">`);
+      const inputDebugEl = fixture.debugElement.query(By.css('input'));
+
+      inputDebugEl.triggerEventHandler('change', {target: {value: '2000-01-15'}});
+      expect(fixture.componentInstance.date).toBeNull();
+
+      inputDebugEl.triggerEventHandler('change', {target: {value: '2020-1-1'}});
+      expect(fixture.componentInstance.date).toBeNull();
+
+      inputDebugEl.triggerEventHandler('change', {target: {value: '2015-9-11'}});
+      expect(fixture.componentInstance.date).toEqual({year: 2015, month: 9, day: 11});
+    });
+
+    it('should propagate null to model when a user date below min range', () => {
+      const fixture =
+          createTestCmpt(`<input ngbDatepicker [(ngModel)]="date" [minDate]="{year: 2010, month: 5, day: 1}">`);
+      const inputDebugEl = fixture.debugElement.query(By.css('input'));
+
+      inputDebugEl.triggerEventHandler('change', {target: {value: '2000-01-15'}});
+      expect(fixture.componentInstance.date).toBeNull();
+
+      inputDebugEl.triggerEventHandler('change', {target: {value: '2015-9-11'}});
+      expect(fixture.componentInstance.date).toEqual({year: 2015, month: 9, day: 11});
+    });
+
+    it('should propagate null to model when a user date above max range', () => {
+      const fixture =
+          createTestCmpt(`<input ngbDatepicker [(ngModel)]="date" [maxDate]="{year: 2017, month: 2, day: 1}">`);
+      const inputDebugEl = fixture.debugElement.query(By.css('input'));
+
+      inputDebugEl.triggerEventHandler('change', {target: {value: '2020-01-15'}});
+      expect(fixture.componentInstance.date).toBeNull();
+
+      inputDebugEl.triggerEventHandler('change', {target: {value: '2015-9-11'}});
+      expect(fixture.componentInstance.date).toEqual({year: 2015, month: 9, day: 11});
+    });
+
     it('should propagate disabled state', fakeAsync(() => {
          const fixture = createTestCmpt(`
         <input ngbDatepicker [(ngModel)]="date" #d="ngbDatepicker" [disabled]="isDisabled">

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -145,6 +145,15 @@ export class NgbInputDatepicker implements ControlValueAccessor {
 
   manualDateChange(value: string) {
     this._model = this._service.toValidDate(this._parserFormatter.parse(value), null);
+
+    if (this._model && this.minDate && this._model.before(NgbDate.from(this.minDate))) {
+      this._model = null;
+    }
+
+    if (this._model && this.maxDate && this._model.after(NgbDate.from(this.maxDate))) {
+      this._model = null;
+    }
+
     this._onChange(this._model ? {year: this._model.year, month: this._model.month, day: this._model.day} : null);
     this._writeModelValue(this._model);
   }


### PR DESCRIPTION
This is part of #1222. To fix #1222 we also need to add implementation of the `Validator` interface (this will be done in a separate PR).