### PR TITLE
feat(buttons): Add "orientaion" input for buttons group

### DIFF
--- a/demo/src/app/components/buttons/buttons.component.ts
+++ b/demo/src/app/components/buttons/buttons.component.ts
@@ -13,6 +13,9 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Checkbox buttons" [snippets]="snippets" component="buttons" demo="checkbox">
         <ngbd-buttons-checkbox></ngbd-buttons-checkbox>
       </ngbd-example-box>
+      <ngbd-example-box demoTitle="Vertical buttons" [snippets]="snippets" component="buttons" demo="vertical">
+        <ngbd-buttons-vertical></ngbd-buttons-vertical>
+      </ngbd-example-box>
     </ngbd-content-wrapper>
   `
 })

--- a/demo/src/app/components/buttons/demos/index.ts
+++ b/demo/src/app/components/buttons/demos/index.ts
@@ -1,7 +1,8 @@
 import {NgbdButtonsCheckbox} from './checkbox/buttons-checkbox';
 import {NgbdButtonsRadio} from './radio/buttons-radio';
+import {NgbdButtonsVertical} from './vertical/buttons-vertical';
 
-export const DEMO_DIRECTIVES = [NgbdButtonsCheckbox, NgbdButtonsRadio];
+export const DEMO_DIRECTIVES = [NgbdButtonsCheckbox, NgbdButtonsRadio, NgbdButtonsVertical];
 
 export const DEMO_SNIPPETS = {
   checkbox: {
@@ -9,5 +10,8 @@ export const DEMO_SNIPPETS = {
     markup: require('!!prismjs-loader?lang=markup!./checkbox/buttons-checkbox.html')},
   radio: {
     code: require('!!prismjs-loader?lang=typescript!./radio/buttons-radio'),
-    markup: require('!!prismjs-loader?lang=markup!./radio/buttons-radio.html')}
+    markup: require('!!prismjs-loader?lang=markup!./radio/buttons-radio.html')},
+  vertical: {
+    code: require('!!prismjs-loader?lang=typescript!./vertical/buttons-vertical'),
+    markup: require('!!prismjs-loader?lang=markup!./vertical/buttons-vertical.html')}
 };

--- a/demo/src/app/components/buttons/demos/vertical/buttons-vertical.html
+++ b/demo/src/app/components/buttons/demos/vertical/buttons-vertical.html
@@ -1,0 +1,13 @@
+<div [(ngModel)]="model" ngbRadioGroup orientation="vertical" name="radioBasic">
+  <label class="btn btn-primary">
+    <input type="radio" [value]="1"> Left (pre-checked)
+  </label>
+  <label class="btn btn-primary">
+    <input type="radio" value="middle"> Middle
+  </label>
+  <label class="btn btn-primary">
+    <input type="radio" [value]="false"> Right
+  </label>
+</div>
+<hr>
+<pre>{{model}}</pre>

--- a/demo/src/app/components/buttons/demos/vertical/buttons-vertical.ts
+++ b/demo/src/app/components/buttons/demos/vertical/buttons-vertical.ts
@@ -1,0 +1,9 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'ngbd-buttons-vertical',
+  templateUrl: './buttons-vertical.html'
+})
+export class NgbdButtonsVertical {
+  model = 1;
+}

--- a/src/buttons/radio.spec.ts
+++ b/src/buttons/radio.spec.ts
@@ -263,14 +263,45 @@ describe('ngbRadioGroup', () => {
        });
      }));
 
-  it('should add data-toggle="buttons" and "btn-group" CSS class to button group', () => {
+  it('should add data-toggle="buttons" to button group', () => {
     // Bootstrap for uses presence of data-toggle="buttons" to style radio buttons
     const html = `<div class="foo" ngbRadioGroup></div>`;
 
     const fixture = createTestComponent(html);
 
     expect(fixture.nativeElement.children[0].getAttribute('data-toggle')).toBe('buttons');
+  });
+
+  it('should add "btn-group" CSS class to button group when orientation is not specified', () => {
+    const html = `<div class="foo" ngbRadioGroup></div>`;
+
+    const fixture = createTestComponent(html);
+
     expect(fixture.nativeElement.children[0]).toHaveCssClass('btn-group');
+  });
+
+  it('should add "btn-group" CSS class to button group when orientation is "horizontal"', () => {
+    const html = `<div class="foo" ngbRadioGroup orientation="horizontal"></div>`;
+
+    const fixture = createTestComponent(html);
+
+    expect(fixture.nativeElement.children[0]).toHaveCssClass('btn-group');
+  });
+
+  it('should add "btn-group" CSS class to button group when orientation is ivalid value', () => {
+    const html = `<div class="foo" ngbRadioGroup orientation="something"></div>`;
+
+    const fixture = createTestComponent(html);
+
+    expect(fixture.nativeElement.children[0]).toHaveCssClass('btn-group');
+  });
+
+  it('should add "btn-group-vertical" CSS class to button group when orientation is "vertical"', () => {
+    const html = `<div class="foo" ngbRadioGroup orientation="vertical"></div>`;
+
+    const fixture = createTestComponent(html);
+
+    expect(fixture.nativeElement.children[0]).toHaveCssClass('btn-group-vertical');
   });
 
   it('should work with template-driven form validation', async(() => {
@@ -279,7 +310,7 @@ describe('ngbRadioGroup', () => {
           <div ngbRadioGroup [(ngModel)]="model" name="control" required>
             <label class="btn">
               <input type="radio" value="foo"/>
-            </label>          
+            </label>
           </div>
         </form>`;
 
@@ -303,7 +334,7 @@ describe('ngbRadioGroup', () => {
           <div ngbRadioGroup formControlName="control">
             <label class="btn">
               <input type="radio" value="foo"/>
-            </label>          
+            </label>
           </div>
         </form>`;
 
@@ -324,7 +355,7 @@ describe('ngbRadioGroup', () => {
         <div ngbRadioGroup formControlName="control">
           <label class="btn">
             <input type="radio" value="foo"/>
-          </label>          
+          </label>
         </div>
       </form>`;
 
@@ -345,7 +376,7 @@ describe('ngbRadioGroup', () => {
         <div ngbRadioGroup [(ngModel)]="model" name="control" [disabled]="disabled">
           <label class="btn">
             <input type="radio" value="foo"/>
-          </label>          
+          </label>
         </div>
       </form>`;
 
@@ -374,7 +405,7 @@ describe('ngbRadioGroup', () => {
         <div ngbRadioGroup [(ngModel)]="model" name="control">
           <label class="btn">
             <input type="radio" value="foo" [disabled]="disabled"/>
-          </label>          
+          </label>
         </div>
       </form>`;
 
@@ -404,7 +435,7 @@ describe('ngbRadioGroup', () => {
         <div ngbRadioGroup [(ngModel)]="model" name="control" [disabled]="groupDisabled">
           <label class="btn">
             <input type="radio" value="foo" [disabled]="disabled"/>
-          </label>          
+          </label>
         </div>
       </form>`;
 
@@ -432,7 +463,7 @@ describe('ngbRadioGroup', () => {
         <div ngbRadioGroup [(ngModel)]="model" name="control" [disabled]="groupDisabled">
           <label class="btn">
             <input type="radio" value="foo" [disabled]="disabled"/>
-          </label>          
+          </label>
         </div>
       </form>`;
 

--- a/src/buttons/radio.ts
+++ b/src/buttons/radio.ts
@@ -1,4 +1,4 @@
-import {Directive, forwardRef, Optional, Input, Renderer, ElementRef, OnDestroy} from '@angular/core';
+import {Directive, forwardRef, Optional, Input, HostBinding, Renderer, ElementRef, OnDestroy} from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 
 const NGB_RADIO_VALUE_ACCESSOR = {
@@ -11,11 +11,7 @@ const NGB_RADIO_VALUE_ACCESSOR = {
  * Easily create Bootstrap-style radio buttons. A value of a selected button is bound to a variable
  * specified via ngModel.
  */
-@Directive({
-  selector: '[ngbRadioGroup]',
-  host: {'data-toggle': 'buttons', 'class': 'btn-group'},
-  providers: [NGB_RADIO_VALUE_ACCESSOR]
-})
+@Directive({selector: '[ngbRadioGroup]', host: {'data-toggle': 'buttons'}, providers: [NGB_RADIO_VALUE_ACCESSOR]})
 export class NgbRadioGroup implements ControlValueAccessor {
   private _radios: Set<NgbRadio> = new Set<NgbRadio>();
   private _value = null;
@@ -23,6 +19,17 @@ export class NgbRadioGroup implements ControlValueAccessor {
 
   get disabled() { return this._disabled; }
   set disabled(isDisabled: boolean) { this.setDisabledState(isDisabled); }
+
+  /**
+   * Specifies how set of buttons appear (vertically stacked or horizontally).
+   * The default value is "horizontal".
+  */
+  @Input('orientation') orientation: 'horizontal' | 'vertical';
+
+  @HostBinding('class')
+  get hostClass() {
+    return this.orientation === 'vertical' ? 'btn-group-vertical' : 'btn-group';
+  }
 
   onChange = (_: any) => {};
   onTouched = () => {};


### PR DESCRIPTION
Close #1231 

# Warning!
Bootstrap v4.0.0-alpha.6 has a bug for vertically grouped buttons when using "label" elements. So, as a result, the demo looks not so nice. More details are in this two issues: https://github.com/twbs/bootstrap/issues/21793 and https://github.com/twbs/bootstrap/issues/20298

I think it can be better to wait until bootstrap fixes it and then merge this feature.
