### PR TITLE
fix(datepicker): navigation arrows not responding on Firefox when navigation == "arrows"

### DIFF
--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -55,6 +55,12 @@ export interface NgbDatepickerNavigateEvent {
     .ngb-dp-header {
       border-bottom: 1px solid rgba(0, 0, 0, 0.125);
     }
+    .ngb-dp-month {
+      pointer-events: none;
+    }
+    ngb-datepicker-month-view {
+      pointer-events: auto;
+    }
     .ngb-dp-month:first-child {
       margin-left: 0 !important;
     }    


### PR DESCRIPTION
When `navigation == "arrows"` on the datepicker component, navigation arrows are under the `div.ngb-dp-month` element, which prevents the click event from reaching navigation arrows on Firefox.

As this is a CSS styling issue and there is not any end-to-end protractor tests configured yet, I have not included any test in this PR. The issue is reproducible on the [demo site](https://ng-bootstrap.github.io/#/components/datepicker), go to the "Multiple months" example, and choose "Without select boxes" in the select. Then click on the arrows to navigate in the date picker, and nothing happens in Firefox.