### PR TITLE
fix(timepicker): Seconds input was misaligned

### DIFF
--- a/src/timepicker/timepicker.ts
+++ b/src/timepicker/timepicker.ts
@@ -98,9 +98,11 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
           </td>
           <template [ngIf]="seconds">
             <td>&nbsp;:&nbsp;</td>
-            <input type="text" class="form-control" [ngClass]="setFormControlSize()" maxlength="2" size="2" placeholder="SS"
-              [value]="formatMinSec(model?.second)" (change)="updateSecond($event.target.value)"
-              [readonly]="readonlyInputs" [disabled]="disabled">
+            <td>
+              <input type="text" class="form-control" [ngClass]="setFormControlSize()" maxlength="2" size="2" placeholder="SS"
+                [value]="formatMinSec(model?.second)" (change)="updateSecond($event.target.value)"
+                [readonly]="readonlyInputs" [disabled]="disabled">
+            </td>
           </template>
           <template [ngIf]="meridian">
             <td>&nbsp;&nbsp;</td>


### PR DESCRIPTION
The input element for seconds wasn’t properly wrapped by a table
data/cell element.

As you can see from the official time picker examples -
https://ng-bootstrap.github.io/#/components/timepicker

Misaligned: 
![screen shot 2017-02-01 at 9 24 01 am](https://cloud.githubusercontent.com/assets/5892147/22513128/cad22d86-e860-11e6-91b6-5e7c43e20c74.png)

Aligned:
![screen shot 2017-02-01 at 9 24 11 am](https://cloud.githubusercontent.com/assets/5892147/22513140/d07b9c7c-e860-11e6-9100-4ea8dfd98d24.png)
