### PR TITLE
feat(datepicker): add accessibility (work in progress)

### DIFF
--- a/demo/src/app/components/datepicker/demos/basic/datepicker-basic.html
+++ b/demo/src/app/components/datepicker/demos/basic/datepicker-basic.html
@@ -1,6 +1,6 @@
 <p>Simple datepicker</p>
 
-<ngb-datepicker #dp [(ngModel)]="model" (navigate)="date = $event.next"></ngb-datepicker>
+<ngb-datepicker #dp [(ngModel)]="model" (navigate)="date = $event.next" aria-label="Please select a date"></ngb-datepicker>
 
 <hr/>
 

--- a/demo/src/app/components/datepicker/demos/customday/datepicker-customday.html
+++ b/demo/src/app/components/datepicker/demos/customday/datepicker-customday.html
@@ -12,8 +12,8 @@
   </div>
 </form>
 
-<template #customDay let-date="date" let-currentMonth="currentMonth" let-selected="selected" let-disabled="disabled">
-  <span class="custom-day" [class.weekend]="isWeekend(date)"
+<template #customDay let-date="date" let-currentMonth="currentMonth" let-selected="selected" let-disabled="disabled" let-focused="focused">
+  <span class="custom-day" [class.weekend]="isWeekend(date)" [class.focused]="focused"
         [class.bg-primary]="selected" [class.hidden]="date.month !== currentMonth" [class.text-muted]="disabled">
     {{ date.day }}
   </span>

--- a/demo/src/app/components/datepicker/demos/customday/datepicker-customday.ts
+++ b/demo/src/app/components/datepicker/demos/customday/datepicker-customday.ts
@@ -12,7 +12,7 @@ import {NgbDateStruct} from '@ng-bootstrap/ng-bootstrap';
       display: inline-block;
       width: 2rem;
     }
-    .custom-day:hover {
+    .custom-day:hover, .custom-day.focused {
       background-color: #e6e6e6;
     }
     .weekend {

--- a/demo/src/app/components/datepicker/demos/i18n/datepicker-i18n.ts
+++ b/demo/src/app/components/datepicker/demos/i18n/datepicker-i18n.ts
@@ -29,6 +29,11 @@ export class CustomDatepickerI18n extends NgbDatepickerI18n {
   getWeekdayShortName(weekday: number): string {
     return I18N_VALUES[this._i18n.language].weekdays[weekday - 1];
   }
+
+  getWeekdayFullName(weekday: number): string {
+    return this.getWeekdayShortName(weekday);
+  }
+
   getMonthShortName(month: number): string {
     return I18N_VALUES[this._i18n.language].months[month - 1];
   }

--- a/src/datepicker/datepicker-day-template-context.ts
+++ b/src/datepicker/datepicker-day-template-context.ts
@@ -22,4 +22,9 @@ export interface DayTemplateContext {
    * True if current date is selected
    */
   selected: boolean;
+
+  /**
+   * True if current date is focused
+   */
+  focused: boolean;
 }

--- a/src/datepicker/datepicker-day-template-context.ts
+++ b/src/datepicker/datepicker-day-template-context.ts
@@ -4,6 +4,13 @@ import {NgbDateStruct} from './ngb-date-struct';
  */
 export interface DayTemplateContext {
   /**
+   * Id to be used for the day (will be referenced by the aria-activedescendent attribute
+   * of the datepicker when the day is focused). This can be undefined if no id has to be
+   * used (for days outside the current month).
+   */
+  id: string;
+
+  /**
    * Month currently displayed by the datepicker
    */
   currentMonth: number;
@@ -12,6 +19,12 @@ export interface DayTemplateContext {
    * Date that corresponds to the template
    */
   date: NgbDateStruct;
+
+  /**
+   * Day of the week
+   * With default calendar we use ISO 8601: 'weekday' is 1=Mon ... 7=Sun
+   */
+  weekday: number;
 
   /**
    * True if current date is disabled

--- a/src/datepicker/datepicker-day-view.ts
+++ b/src/datepicker/datepicker-day-view.ts
@@ -1,5 +1,6 @@
 import {Component, Input} from '@angular/core';
 import {NgbDateStruct} from './ngb-date-struct';
+import {NgbDatepickerI18n} from './datepicker-i18n';
 
 @Component({
   selector: '[ngbDatepickerDayView]',
@@ -16,6 +17,11 @@ import {NgbDateStruct} from './ngb-date-struct';
     }
   `],
   host: {
+    'role': 'gridcell',
+    '[attr.aria-label]': 'getAriaLabel()',
+    '[attr.id]': 'id',
+    '[attr.aria-selected]': 'selected',
+    '[attr.aria-disabled]': 'disabled ? "true" : undefined',
     '[class.bg-primary]': 'selected',
     '[class.text-white]': 'selected',
     '[class.text-muted]': 'isMuted()',
@@ -26,11 +32,21 @@ import {NgbDateStruct} from './ngb-date-struct';
   template: `{{ date.day }}`
 })
 export class NgbDatepickerDayView {
+  @Input() id: string;
   @Input() currentMonth: number;
   @Input() date: NgbDateStruct;
+  @Input() weekday: number;
   @Input() disabled: boolean;
   @Input() selected: boolean;
   @Input() focused: boolean;
 
+  constructor(public i18n: NgbDatepickerI18n) {}
+
   isMuted() { return !this.selected && (this.date.month !== this.currentMonth || this.disabled); }
+
+  getAriaLabel() {
+    const i18n = this.i18n;
+    const date = this.date;
+    return `${i18n.getWeekdayFullName(this.weekday)} ${date.day} ${i18n.getMonthFullName(date.month)} ${date.year}`;
+  }
 }

--- a/src/datepicker/datepicker-day-view.ts
+++ b/src/datepicker/datepicker-day-view.ts
@@ -20,7 +20,8 @@ import {NgbDateStruct} from './ngb-date-struct';
     '[class.text-white]': 'selected',
     '[class.text-muted]': 'isMuted()',
     '[class.outside]': 'isMuted()',
-    '[class.btn-secondary]': '!disabled'
+    '[class.btn-secondary]': 'true',
+    '[class.active]': 'focused'
   },
   template: `{{ date.day }}`
 })
@@ -29,6 +30,7 @@ export class NgbDatepickerDayView {
   @Input() date: NgbDateStruct;
   @Input() disabled: boolean;
   @Input() selected: boolean;
+  @Input() focused: boolean;
 
   isMuted() { return !this.selected && (this.date.month !== this.currentMonth || this.disabled); }
 }

--- a/src/datepicker/datepicker-i18n.ts
+++ b/src/datepicker/datepicker-i18n.ts
@@ -1,6 +1,7 @@
 import {Injectable} from '@angular/core';
 
 const WEEKDAYS_SHORT = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
+const WEEKDAYS_FULL = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
 const MONTHS_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 const MONTHS_FULL = [
   'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November',
@@ -20,6 +21,12 @@ export abstract class NgbDatepickerI18n {
   abstract getWeekdayShortName(weekday: number): string;
 
   /**
+   * Returns the full weekday name to be used in the aria-label of the default day view.
+   * With default calendar we use ISO 8601: 'weekday' is 1=Mon ... 7=Sun
+   */
+  abstract getWeekdayFullName(weekday: number): string;
+
+  /**
    * Returns the short month name to display in the date picker navigation.
    * With default calendar we use ISO 8601: 'month' is 1=Jan ... 12=Dec
    */
@@ -35,6 +42,8 @@ export abstract class NgbDatepickerI18n {
 @Injectable()
 export class NgbDatepickerI18nDefault extends NgbDatepickerI18n {
   getWeekdayShortName(weekday: number): string { return WEEKDAYS_SHORT[weekday - 1]; }
+
+  getWeekdayFullName(weekday: number): string { return WEEKDAYS_FULL[weekday - 1]; }
 
   getMonthShortName(month: number): string { return MONTHS_SHORT[month - 1]; }
 

--- a/src/datepicker/datepicker-month-view.ts
+++ b/src/datepicker/datepicker-month-view.ts
@@ -43,7 +43,8 @@ import {DayTemplateContext} from './datepicker-day-template-context';
           [ngOutletContext]="{date: {year: day.date.year, month: day.date.month, day: day.date.day},
             currentMonth: month.number,
             disabled: isDisabled(day),
-            selected: isSelected(day.date)}">
+            selected: isSelected(day.date),
+            focused: isFocused(day.date)}">
           </template>
       </div>
     </div>
@@ -55,6 +56,7 @@ export class NgbDatepickerMonthView {
   @Input() month: MonthViewModel;
   @Input() outsideDays: 'visible' | 'hidden' | 'collapsed';
   @Input() selectedDate: NgbDate;
+  @Input() focusedDate: NgbDate;
   @Input() showWeekdays;
   @Input() showWeekNumbers;
 
@@ -70,7 +72,11 @@ export class NgbDatepickerMonthView {
 
   isDisabled(day: DayViewModel) { return this.disabled || day.disabled; }
 
-  isSelected(date: NgbDate) { return this.selectedDate && this.selectedDate.equals(date); }
+  isSelected(date: NgbDate) { return !!(this.selectedDate && this.selectedDate.equals(date)); }
+
+  isFocused(date: NgbDate) {
+    return !!(this.focusedDate && this.focusedDate.equals(date) && this.month.number === date.month);
+  }
 
   isCollapsed(day: DayViewModel) { return this.outsideDays === 'collapsed' && this.month.number !== day.date.month; }
 

--- a/src/datepicker/datepicker-month-view.ts
+++ b/src/datepicker/datepicker-month-view.ts
@@ -37,10 +37,12 @@ import {DayTemplateContext} from './datepicker-day-template-context';
     </div>
     <div *ngFor="let week of month.weeks" class="ngb-dp-week d-flex">
       <div *ngIf="showWeekNumbers" class="ngb-dp-week-number small text-center font-italic text-muted">{{ week.number }}</div>
-      <div *ngFor="let day of week.days" (click)="doSelect(day)" class="ngb-dp-day" [class.disabled]="isDisabled(day)"
+      <div *ngFor="let day of week.days; let dayIndex = index" (click)="doSelect(day)" class="ngb-dp-day" [class.disabled]="isDisabled(day)"
       [class.collapsed]="isCollapsed(day)" [class.hidden]="isHidden(day)">
           <template [ngTemplateOutlet]="dayTemplate"
           [ngOutletContext]="{date: {year: day.date.year, month: day.date.month, day: day.date.day},
+            id: getId(day.date),
+            weekday: month.weekdays[dayIndex],
             currentMonth: month.number,
             disabled: isDisabled(day),
             selected: isSelected(day.date),
@@ -51,6 +53,7 @@ import {DayTemplateContext} from './datepicker-day-template-context';
   `
 })
 export class NgbDatepickerMonthView {
+  @Input() datepickerId: String;
   @Input() dayTemplate: TemplateRef<DayTemplateContext>;
   @Input() disabled: boolean;
   @Input() month: MonthViewModel;
@@ -81,4 +84,10 @@ export class NgbDatepickerMonthView {
   isCollapsed(day: DayViewModel) { return this.outsideDays === 'collapsed' && this.month.number !== day.date.month; }
 
   isHidden(day: DayViewModel) { return this.outsideDays === 'hidden' && this.month.number !== day.date.month; }
+
+  getId(date: NgbDate) {
+    if (this.month.number === date.month) {
+      return `${this.datepickerId}-${date.toString()}`;
+    }
+  }
 }

--- a/src/datepicker/datepicker-navigation-select.ts
+++ b/src/datepicker/datepicker-navigation-select.ts
@@ -18,11 +18,20 @@ import {NgbCalendar} from './ngb-calendar';
     }
   `],
   template: `
-    <select [disabled]="disabled" class="custom-select d-inline-block" [value]="date?.month" (change)="changeMonth($event.target.value)">
-      <option *ngFor="let m of months" [value]="m">{{ i18n.getMonthShortName(m) }}</option>
-    </select>` +
-      `<select [disabled]="disabled" class="custom-select d-inline-block" [value]="date?.year" (change)="changeYear($event.target.value)">
-      <option *ngFor="let y of years" [value]="y">{{ y }}</option>
+    <select
+      [disabled]="disabled"
+      class="custom-select d-inline-block"
+      [value]="date?.month"
+      (change)="changeMonth($event.target.value)"
+      tabindex="-1">
+        <option *ngFor="let m of months" [value]="m">{{ i18n.getMonthShortName(m) }}</option>
+    </select><select
+      [disabled]="disabled"
+      class="custom-select d-inline-block"
+      [value]="date?.year"
+      (change)="changeYear($event.target.value)"
+      tabindex="-1">
+        <option *ngFor="let y of years" [value]="y">{{ y }}</option>
     </select> 
   `  // template needs to be formatted in a certain way so we don't add empty text nodes
 })

--- a/src/datepicker/datepicker-navigation.ts
+++ b/src/datepicker/datepicker-navigation.ts
@@ -43,7 +43,7 @@ import {NgbCalendar} from './ngb-calendar';
     }    
   `],
   template: `
-    <button type="button" class="btn-link" (click)="!!doNavigate(navigation.PREV)" [disabled]="prevDisabled()">
+    <button type="button" class="btn-link" (click)="!!doNavigate(navigation.PREV)" [disabled]="prevDisabled()" tabindex="-1">
       <span class="ngb-dp-navigation-chevron"></span>    
     </button>
     
@@ -55,7 +55,7 @@ import {NgbCalendar} from './ngb-calendar';
       (select)="selectDate($event)">
     </ngb-datepicker-navigation-select>
     
-    <button type="button" class="btn-link" (click)="!!doNavigate(navigation.NEXT)" [disabled]="nextDisabled()">
+    <button type="button" class="btn-link" (click)="!!doNavigate(navigation.NEXT)" [disabled]="nextDisabled()" tabindex="-1">
       <span class="ngb-dp-navigation-chevron right"></span>
     </button>
   `

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -2,7 +2,7 @@ import {TestBed, ComponentFixture, async, inject} from '@angular/core/testing';
 import {createGenericTestComponent} from '../test/common';
 import {getMonthSelect, getYearSelect, getNavigationLinks} from '../test/datepicker/common';
 
-import {Component, TemplateRef} from '@angular/core';
+import {Component, TemplateRef, DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
 import {FormsModule, ReactiveFormsModule, FormGroup, FormControl, Validators} from '@angular/forms';
 
@@ -13,6 +13,7 @@ import {NgbDatepicker} from './datepicker';
 import {DayTemplateContext} from './datepicker-day-template-context';
 import {NgbDateStruct} from './ngb-date-struct';
 import {NgbDatepickerMonthView} from './datepicker-month-view';
+import {NgbDatepickerDayView} from './datepicker-day-view';
 import {NgbDatepickerNavigationSelect} from './datepicker-navigation-select';
 import {NgbDatepickerNavigation} from './datepicker-navigation';
 
@@ -29,6 +30,40 @@ function getDay(element: HTMLElement, index: number): HTMLElement {
 
 function getDatepicker(element: HTMLElement): HTMLElement {
   return element.querySelector('ngb-datepicker') as HTMLElement;
+}
+
+function triggerKeyDown(element: DebugElement, keyCode: number, shiftKey = false) {
+  let event = {
+    keyCode: keyCode,
+    shiftKey: shiftKey,
+    defaultPrevented: false,
+    propagationStopped: false,
+    stopPropagation: function() { this.propagationStopped = true; },
+    preventDefault: function() { this.defaultPrevented = true; }
+  };
+  element.triggerEventHandler('keydown', event);
+  return event;
+}
+
+function triggerFocus(element: DebugElement) {
+  element.triggerEventHandler('focus', null);
+}
+
+function expectFilteredDaysToBe(
+    element: DebugElement, expectedDates: NgbDate[],
+    filterFn: (dayView: NgbDatepickerDayView, element: DebugElement) => boolean) {
+  const days = element.queryAll(By.directive(NgbDatepickerDayView))
+                   .filter((day: DebugElement) => { return filterFn(day.componentInstance, day); })
+                   .map((value: DebugElement) => NgbDate.from(value.componentInstance.date));
+  expect(days).toEqual(expectedDates);
+}
+
+function expectSelectedDate(element: DebugElement, date: NgbDate) {
+  expectFilteredDaysToBe(element, date ? [date] : [], (dayView: NgbDatepickerDayView) => dayView.selected);
+}
+
+function expectFocusedDate(element: DebugElement, date: NgbDate) {
+  expectFilteredDaysToBe(element, date ? [date] : [], (dayView: NgbDatepickerDayView) => dayView.focused);
 }
 
 function expectSameValues(datepicker: NgbDatepicker, config: NgbDatepickerConfig) {
@@ -539,6 +574,143 @@ describe('ngb-datepicker', () => {
       const today = new Date();
       expect(getMonthSelect(fixture.nativeElement).value).toBe(`${today.getMonth() + 1}`);
       expect(getYearSelect(fixture.nativeElement).value).toBe(`${today.getFullYear()}`);
+    });
+
+    it('should correctly navigate with keyboard', () => {
+      const fixture = createTestComponent(`<ngb-datepicker #dp
+        [startDate]="date" [minDate]="minDate"
+        [maxDate]="maxDate" [displayMonths]="2"
+        [markDisabled]="markDisabled"></ngb-datepicker>`);
+
+      const datepicker = fixture.debugElement.query(By.directive(NgbDatepicker));
+      expectFocusedDate(datepicker, null);
+      expectSelectedDate(datepicker, null);
+
+      datepicker.triggerEventHandler('focus', {});
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 1));
+      expectSelectedDate(datepicker, null);
+
+      triggerKeyDown(datepicker, 40 /* down arrow */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 8));
+      expectSelectedDate(datepicker, null);
+
+      triggerKeyDown(datepicker, 32 /* space */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 8));
+      expectSelectedDate(datepicker, new NgbDate(2016, 8, 8));
+
+      triggerKeyDown(datepicker, 39 /* right arrow */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 9));
+      expectSelectedDate(datepicker, new NgbDate(2016, 8, 8));
+
+      triggerKeyDown(datepicker, 38 /* up arrow */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 2));
+      expectSelectedDate(datepicker, new NgbDate(2016, 8, 8));
+
+      triggerKeyDown(datepicker, 37 /* left arrow */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 1));
+      expectSelectedDate(datepicker, new NgbDate(2016, 8, 8));
+
+      triggerKeyDown(datepicker, 33 /* page up */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 7, 1));
+      expectSelectedDate(datepicker, new NgbDate(2016, 8, 8));
+
+      triggerKeyDown(datepicker, 35 /* end */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 31));
+      expectSelectedDate(datepicker, new NgbDate(2016, 8, 8));
+
+      triggerKeyDown(datepicker, 13 /* enter */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 31));
+      expectSelectedDate(datepicker, new NgbDate(2016, 8, 31));
+
+      triggerKeyDown(datepicker, 36 /* home */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 7, 1));
+      expectSelectedDate(datepicker, new NgbDate(2016, 8, 31));
+
+      triggerKeyDown(datepicker, 33 /* page up */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 6, 1));
+      expectSelectedDate(datepicker, null);  // selection is no longer visible
+
+      triggerKeyDown(datepicker, 34 /* page down */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 7, 1));
+      expectSelectedDate(datepicker, null);  // selection is still no longer visible
+
+      triggerKeyDown(datepicker, 35 /* end */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 7, 31));
+      expectSelectedDate(datepicker, null);  // selection is still no longer visible
+
+      triggerKeyDown(datepicker, 39 /* right arrow */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 1));
+      expectSelectedDate(datepicker, new NgbDate(2016, 8, 31));  // selection is visible again
+
+      triggerKeyDown(datepicker, 40 /* down arrow */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 8));
+      expectSelectedDate(datepicker, new NgbDate(2016, 8, 31));
+
+      triggerKeyDown(datepicker, 40 /* down arrow */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 15));
+      expectSelectedDate(datepicker, new NgbDate(2016, 8, 31));
+
+      triggerKeyDown(datepicker, 40 /* down arrow */);
+      fixture.detectChanges();
+      // we can reach the disabled date
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 22));
+      expectSelectedDate(datepicker, new NgbDate(2016, 8, 31));
+
+      triggerKeyDown(datepicker, 32 /* space */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 22));
+      expectSelectedDate(datepicker, new NgbDate(2016, 8, 31));  // space on a disabled date does not select it
+
+      triggerKeyDown(datepicker, 13 /* enter */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 22));
+      expectSelectedDate(datepicker, new NgbDate(2016, 8, 31));  // enter on a disabled date does not select it
+
+      triggerKeyDown(datepicker, 35 /* end */, true /* with shift */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2020, 12, 31));  // maximum date
+      expectSelectedDate(datepicker, null);                      // selection is again no longer visible
+
+      triggerKeyDown(datepicker, 39 /* right arrow */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2020, 12, 31));  // stays at the maximum date
+
+      triggerKeyDown(datepicker, 36 /* home */, true /* with shift */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2010, 1, 1));  // minimum date
+
+      triggerKeyDown(datepicker, 37 /* left arrow */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2010, 1, 1));  // stays at the minimum date
+
+      triggerKeyDown(datepicker, 34 /* page down */, true /* with shift */);
+      fixture.detectChanges();
+
+      expectFocusedDate(datepicker, new NgbDate(2011, 1, 1));
+      triggerKeyDown(datepicker, 33 /* page up */, true /* with shift */);
+      fixture.detectChanges();
+
+      expectFocusedDate(datepicker, new NgbDate(2010, 1, 1));
+      datepicker.triggerEventHandler('blur', {});
+      fixture.detectChanges();
+
+      expectFocusedDate(datepicker, null);
     });
 
     it('should support disabling all dates and navigation via the disabled attribute', async(() => {


### PR DESCRIPTION
This PR is built on top of #1273 
It adds ARIA attributes to make the `ngb-datepicker` usable with screen readers.

I checked with the latest version of [NVDA](https://www.nvaccess.org/) on the latest version of Chrome and it works.

**This is a work in progress**
Here is the remaining work to do:
- [ ] Add some tests
- [ ] Check on other combinations of browsers / screen readers