### PR TITLE
fix(time picker): Inputs too narrow for values

### DIFF
--- a/src/timepicker/timepicker.ts
+++ b/src/timepicker/timepicker.ts
@@ -86,20 +86,20 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
         </tr>
         <tr>
           <td>
-            <input type="text" class="form-control" [ngClass]="setFormControlSize()" maxlength="2" size="2" placeholder="HH"
+            <input type="text" class="form-control" [ngClass]="setFormControlSize()" maxlength="2" size="3" placeholder="HH"
               [value]="formatHour(model?.hour)" (change)="updateHour($event.target.value)"
               [readonly]="readonlyInputs" [disabled]="disabled">
           </td>
           <td>&nbsp;:&nbsp;</td>
           <td>
-            <input type="text" class="form-control" [ngClass]="setFormControlSize()" maxlength="2" size="2" placeholder="MM"
+            <input type="text" class="form-control" [ngClass]="setFormControlSize()" maxlength="2" size="3" placeholder="MM"
               [value]="formatMinSec(model?.minute)" (change)="updateMinute($event.target.value)"
               [readonly]="readonlyInputs" [disabled]="disabled">
           </td>
           <template [ngIf]="seconds">
             <td>&nbsp;:&nbsp;</td>
             <td>
-              <input type="text" class="form-control" [ngClass]="setFormControlSize()" maxlength="2" size="2" placeholder="SS"
+              <input type="text" class="form-control" [ngClass]="setFormControlSize()" maxlength="2" size="3" placeholder="SS"
                 [value]="formatMinSec(model?.second)" (change)="updateSecond($event.target.value)"
                 [readonly]="readonlyInputs" [disabled]="disabled">
             </td>


### PR DESCRIPTION
Widened the inputs to `size=“3”` because at 2 they were too narrow for
the minutes placeholder `MM` as well as some digit values.

Tested on my local machine after changes were made. Please see
screenshots ~

Current:
![screen shot 2017-02-01 at 4 20 15 pm](https://cloud.githubusercontent.com/assets/5892147/22529250/5794ed9a-e89c-11e6-9b20-790264719067.png)

New:
![screen shot 2017-02-01 at 4 21 05 pm](https://cloud.githubusercontent.com/assets/5892147/22529251/579e3e4a-e89c-11e6-8e85-40be774cd0ca.png)

