### PR TITLE
feat(datepicker): add 'dateFormat' option

### DIFF
--- a/demo/src/app/components/datepicker/datepicker.component.ts
+++ b/demo/src/app/components/datepicker/datepicker.component.ts
@@ -31,6 +31,9 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Custom day view" [snippets]="snippets" component="datepicker" demo="customday">
         <ngbd-datepicker-customday></ngbd-datepicker-customday>
       </ngbd-example-box>
+      <ngbd-example-box demoTitle="Custom date format" [snippets]="snippets" component="datepicker" demo="customformat">
+        <ngbd-datepicker-customformat></ngbd-datepicker-customformat>
+      </ngbd-example-box>
       <ngbd-example-box demoTitle="Global configuration of datepickers" [snippets]="snippets" component="datepicker" demo="config">
         <ngbd-datepicker-config></ngbd-datepicker-config>
       </ngbd-example-box>
@@ -38,5 +41,5 @@ import {DEMO_SNIPPETS} from './demos';
   `
 })
 export class NgbdDatepicker {
-   snippets = DEMO_SNIPPETS;
+  snippets = DEMO_SNIPPETS;
 }

--- a/demo/src/app/components/datepicker/demos/customformat/datepicker-customformat.html
+++ b/demo/src/app/components/datepicker/demos/customformat/datepicker-customformat.html
@@ -1,0 +1,26 @@
+<p>This datepicker uses a custom date format. Use: </p>
+<ul>
+  <li>'dd' for day</li>
+  <li>'mm' for month</li>
+  <li>'yyyy' for year</li>
+  <li>'/' or '-' for delimiting</li>
+</ul>
+<p>
+  You can choose order of date parts and the delimiter.
+  Some examples: 'dd-mm-yyyy', 'mm-dd-yyyy', 'yyyy-mm-dd', 'yyyy/mm/dd', 'dd/mm/yyyy'
+</p>
+
+<form class="form-inline">
+  <div class="form-group">
+    <div class="input-group">
+      <input class="form-control" placeholder="dd/mm/yyyy"
+             name="dp" ngbDatepicker [dateFormat]="dateFormat"  #d="ngbDatepicker">
+      <div class="input-group-addon" (click)="d.toggle()" >
+        <img src="img/calendar-icon.svg" style="width: 1.2rem; height: 1rem; cursor: pointer;"/>
+      </div>
+    </div>
+  </div>
+</form>
+
+<hr/>
+<pre>Format: {{dateFormat}}</pre>

--- a/demo/src/app/components/datepicker/demos/customformat/datepicker-customformat.ts
+++ b/demo/src/app/components/datepicker/demos/customformat/datepicker-customformat.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+@Component({
+  selector: 'ngbd-datepicker-customformat',
+  templateUrl: './datepicker-customformat.html'
+})
+export class NgbdDatepickerCustomformat {
+  dateFormat = 'dd/mm/yyyy';
+}

--- a/demo/src/app/components/datepicker/demos/index.ts
+++ b/demo/src/app/components/datepicker/demos/index.ts
@@ -4,11 +4,12 @@ import {NgbdDatepickerI18n} from './i18n/datepicker-i18n';
 import {NgbdDatepickerDisabled} from './disabled/datepicker-disabled';
 import {NgbdDatepickerPopup} from './popup/datepicker-popup';
 import {NgbdDatepickerCustomday} from './customday/datepicker-customday';
+import {NgbdDatepickerCustomformat} from './customformat/datepicker-customformat';
 import {NgbdDatepickerMultiple} from './multiple/datepicker-multiple';
 
 export const DEMO_DIRECTIVES = [
   NgbdDatepickerBasic, NgbdDatepickerPopup, NgbdDatepickerDisabled, NgbdDatepickerI18n,
-  NgbdDatepickerCustomday, NgbdDatepickerConfig, NgbdDatepickerMultiple
+  NgbdDatepickerCustomday, NgbdDatepickerConfig, NgbdDatepickerMultiple, NgbdDatepickerCustomformat
 ];
 
 export const DEMO_SNIPPETS = {

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -107,6 +107,12 @@ export class NgbInputDatepicker implements ControlValueAccessor {
   @Input() startDate: {year: number, month: number};
 
   /**
+   * Date format for the input.
+   * With default we use ISO 8601: yyyy-mm-dd.
+   */
+  @Input() dateFormat: string = 'yyyy-mm-dd';
+
+  /**
    * An event fired when navigation happens and currently displayed month changes.
    * See NgbDatepickerNavigateEvent for the payload info.
    */
@@ -145,7 +151,7 @@ export class NgbInputDatepicker implements ControlValueAccessor {
   }
 
   manualDateChange(value: string) {
-    this._model = this._service.toValidDate(this._parserFormatter.parse(value), null);
+    this._model = this._service.toValidDate(this._parserFormatter.parse(value, this.dateFormat), null);
     this._onChange(this._model ? {year: this._model.year, month: this._model.month, day: this._model.day} : null);
     this._writeModelValue(this._model);
   }
@@ -231,7 +237,8 @@ export class NgbInputDatepicker implements ControlValueAccessor {
   }
 
   private _writeModelValue(model: NgbDate) {
-    this._renderer.setElementProperty(this._elRef.nativeElement, 'value', this._parserFormatter.format(model));
+    this._renderer.setElementProperty(
+        this._elRef.nativeElement, 'value', this._parserFormatter.format(model, this.dateFormat));
     if (this.isOpen()) {
       this._cRef.instance.writeValue(model);
       this._onTouched();

--- a/src/datepicker/datepicker.module.ts
+++ b/src/datepicker/datepicker.module.ts
@@ -8,7 +8,7 @@ import {FormsModule} from '@angular/forms';
 import {NgbDatepickerDayView} from './datepicker-day-view';
 import {NgbDatepickerI18n, NgbDatepickerI18nDefault} from './datepicker-i18n';
 import {NgbCalendar, NgbCalendarGregorian} from './ngb-calendar';
-import {NgbDateParserFormatter, NgbDateISOParserFormatter} from './ngb-date-parser-formatter';
+import {NgbDateParserFormatter, NgbDateDefaultParserFormatter} from './ngb-date-parser-formatter';
 import {NgbDatepickerService} from './datepicker-service';
 import {NgbDatepickerNavigationSelect} from './datepicker-navigation-select';
 import {NgbDatepickerConfig} from './datepicker-config';
@@ -40,7 +40,7 @@ export class NgbDatepickerModule {
       providers: [
         {provide: NgbCalendar, useClass: NgbCalendarGregorian},
         {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nDefault},
-        {provide: NgbDateParserFormatter, useClass: NgbDateISOParserFormatter}, NgbDatepickerService,
+        {provide: NgbDateParserFormatter, useClass: NgbDateDefaultParserFormatter}, NgbDatepickerService,
         NgbDatepickerConfig
       ]
     };

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -63,19 +63,19 @@ export interface NgbDatepickerNavigateEvent {
     }
     .ngb-dp-month:first-child {
       margin-left: 0 !important;
-    }    
+    }
     .ngb-dp-month-name {
       font-size: larger;
       height: 2rem;
       line-height: 2rem;
-    }    
+    }
   `],
   template: `
     <template #dt let-date="date" let-currentMonth="currentMonth" let-selected="selected" let-disabled="disabled">
        <div ngbDatepickerDayView [date]="date" [currentMonth]="currentMonth" [selected]="selected" [disabled]="disabled"></div>
     </template>
-    
-    <div class="ngb-dp-header bg-faded pt-1 rounded-top" [style.height.rem]="getHeaderHeight()" 
+
+    <div class="ngb-dp-header bg-faded pt-1 rounded-top" [style.height.rem]="getHeaderHeight()"
       [style.marginBottom.rem]="-getHeaderMargin()">
       <ngb-datepicker-navigation *ngIf="navigation !== 'none'"
         [date]="months[0]?.firstDate"
@@ -92,7 +92,7 @@ export interface NgbDatepickerNavigateEvent {
 
     <div class="ngb-dp-months d-flex px-1 pb-1">
       <template ngFor let-month [ngForOf]="months" let-i="index">
-        <div class="ngb-dp-month d-block ml-3">            
+        <div class="ngb-dp-month d-block ml-3">
           <div *ngIf="navigation !== 'select' || displayMonths > 1" class="ngb-dp-month-name text-center">
             {{ i18n.getMonthFullName(month.number) }} {{ month.year }}
           </div>

--- a/src/datepicker/ngb-date-parser-formatter.spec.ts
+++ b/src/datepicker/ngb-date-parser-formatter.spec.ts
@@ -1,46 +1,73 @@
-import {NgbDateISOParserFormatter} from './ngb-date-parser-formatter';
+import {NgbDateDefaultParserFormatter} from './ngb-date-parser-formatter';
 
 describe('ngb-date parsing and formatting', () => {
-  let pf: NgbDateISOParserFormatter;
+  let pf: NgbDateDefaultParserFormatter;
 
-  beforeEach(() => { pf = new NgbDateISOParserFormatter(); });
+  beforeEach(() => { pf = new NgbDateDefaultParserFormatter(); });
 
   describe('parsing', () => {
 
     it('should parse null undefined and empty string as null', () => {
-      expect(pf.parse(null)).toBeNull();
-      expect(pf.parse(undefined)).toBeNull();
-      expect(pf.parse('')).toBeNull();
-      expect(pf.parse('   ')).toBeNull();
+      expect(pf.parse(null, 'yyyy-mm-dd')).toBeNull();
+      expect(pf.parse(undefined, 'yyyy-mm-dd')).toBeNull();
+      expect(pf.parse('', 'yyyy-mm-dd')).toBeNull();
+      expect(pf.parse('   ', 'yyyy-mm-dd')).toBeNull();
     });
 
-    it('should parse valid date', () => { expect(pf.parse('2016-05-12')).toEqual({year: 2016, month: 5, day: 12}); });
+    it('should throw an error with invalid date format', () => {
+      expect(pf.parse('2016-03-23', 'yy-mm-dd')).toBeNull();
+      expect(pf.parse('2016-03-23', 'yyyy-md-dd')).toBeNull();
+    });
+
+    it('should parse valid date',
+       () => { expect(pf.parse('2016-05-12', 'yyyy-mm-dd')).toEqual({year: 2016, month: 5, day: 12}); });
 
     it('should parse non-date as null', () => {
-      expect(pf.parse('foo-bar-baz')).toBeNull();
-      expect(pf.parse('2014-bar')).toBeNull();
-      expect(pf.parse('2014-11-12-15')).toBeNull();
+      expect(pf.parse('foo-bar-baz', 'yyyy-mm-dd')).toBeNull();
+      expect(pf.parse('2014-bar', 'yyyy-mm-dd')).toBeNull();
+      expect(pf.parse('2014-11-12-15', 'yyyy-mm-dd')).toBeNull();
     });
 
     it('should do its best parsing incomplete dates',
-       () => { expect(pf.parse('2011-5')).toEqual({year: 2011, month: 5, day: null}); });
+       () => { expect(pf.parse('2011-5', 'yyyy-mm-dd')).toEqual({year: 2011, month: 5, day: null}); });
+  });
+
+  describe('validating', () => {
+    it('should validate correct date format', () => {
+      expect(pf.isValidFormat('yyyy-mm-dd')).toEqual(true);
+      expect(pf.isValidFormat('dd/mm/yyyy')).toEqual(true);
+      expect(pf.isValidFormat('mm/dd/yyyy')).toEqual(true);
+      expect(pf.isValidFormat('yyyy/mm/dd')).toEqual(true);
+    });
+
+    it('should validate incorrect date format', () => {
+      expect(pf.isValidFormat('yyy-mm-dd')).toEqual(false);
+      expect(pf.isValidFormat('dd/mmyyyy')).toEqual(false);
+      expect(pf.isValidFormat('dd/mmyy/yy')).toEqual(false);
+      expect(pf.isValidFormat('ddmmyyyy')).toEqual(false);
+      expect(pf.isValidFormat('yyyymmdd')).toEqual(false);
+      expect(pf.isValidFormat('yyyy--mm--dd')).toEqual(false);
+      expect(pf.isValidFormat('yyyy mm dd')).toEqual(false);
+      expect(pf.isValidFormat('yyyy-md-dd')).toEqual(false);
+    });
   });
 
   describe('formatting', () => {
 
     it('should format null and undefined as an empty string', () => {
-      expect(pf.format(null)).toBe('');
-      expect(pf.format(undefined)).toBe('');
+      expect(pf.format(null, 'yyyy-mm-dd')).toBe('');
+      expect(pf.format(undefined, 'yyyy-mm-dd')).toBe('');
     });
 
-    it('should format a valid date', () => { expect(pf.format({year: 2016, month: 10, day: 15})).toBe('2016-10-15'); });
+    it('should format a valid date',
+       () => { expect(pf.format({year: 2016, month: 10, day: 15}, 'yyyy-mm-dd')).toBe('2016-10-15'); });
 
     it('should format a valid date with padding',
-       () => { expect(pf.format({year: 2016, month: 10, day: 5})).toBe('2016-10-05'); });
+       () => { expect(pf.format({year: 2016, month: 10, day: 5}, 'yyyy-mm-dd')).toBe('2016-10-05'); });
 
     it('should try its best with invalid dates', () => {
-      expect(pf.format({year: 2016, month: NaN, day: undefined})).toBe('2016--');
-      expect(pf.format({year: 2016, month: null, day: 0})).toBe('2016--00');
+      expect(pf.format({year: 2016, month: NaN, day: undefined}, 'yyyy-mm-dd')).toBe('2016--');
+      expect(pf.format({year: 2016, month: null, day: 0}, 'yyyy-mm-dd')).toBe('2016--00');
     });
   });
 

--- a/src/datepicker/ngb-date-parser-formatter.ts
+++ b/src/datepicker/ngb-date-parser-formatter.ts
@@ -12,34 +12,132 @@ export abstract class NgbDateParserFormatter {
    * partial. They must return null if the value can't be parsed.
    * @param value the value to parse
    */
-  abstract parse(value: string): NgbDateStruct;
+  abstract parse(value: string, format: string): NgbDateStruct;
 
   /**
    * Formats the given date to a string. Implementations should return an empty string if the given date is null,
    * and try their best to provide a partial result if the given date is incomplete or invalid.
    * @param date the date to format as a string
    */
-  abstract format(date: NgbDateStruct): string;
+  abstract format(date: NgbDateStruct, format: string): string;
 }
 
-export class NgbDateISOParserFormatter extends NgbDateParserFormatter {
-  parse(value: string): NgbDateStruct {
-    if (value) {
-      const dateParts = value.trim().split('-');
-      if (dateParts.length === 1 && isNumber(dateParts[0])) {
-        return {year: toInteger(dateParts[0]), month: null, day: null};
-      } else if (dateParts.length === 2 && isNumber(dateParts[0]) && isNumber(dateParts[1])) {
-        return {year: toInteger(dateParts[0]), month: toInteger(dateParts[1]), day: null};
-      } else if (dateParts.length === 3 && isNumber(dateParts[0]) && isNumber(dateParts[1]) && isNumber(dateParts[2])) {
-        return {year: toInteger(dateParts[0]), month: toInteger(dateParts[1]), day: toInteger(dateParts[2])};
+export class NgbDateDefaultParserFormatter extends NgbDateParserFormatter {
+  parse(value: string, format: string): NgbDateStruct {
+    if (value && this.isValidFormat(format) && value.trim() && value.length <= format.length) {
+      let result: NgbDateStruct = {day: null, month: null, year: null};
+
+      let dayChars: Array<string> = [];
+      let monthChars: Array<string> = [];
+      let yearChars: Array<string> = [];
+
+      for (let i = 0; i < value.length && i < format.length; i++) {
+        switch (format.charAt(i)) {
+          case 'd':
+            if (isNumber(value.charAt(i))) {
+              dayChars.push(value.charAt(i));
+            } else {
+              return null;
+            }
+            break;
+          case 'm':
+            if (isNumber(value.charAt(i))) {
+              monthChars.push(value.charAt(i));
+            } else {
+              return null;
+            }
+            break;
+          case 'y':
+            if (isNumber(value.charAt(i))) {
+              yearChars.push(value.charAt(i));
+            } else {
+              return null;
+            }
+            break;
+          default:
+            if (format.charAt(i) !== '/' && format.charAt(i) !== '-') {
+              return null;
+            }
+        }
       }
+
+      if (dayChars.length === 2 || dayChars.length === 1 && isNumber(dayChars.join(''))) {
+        result.day = toInteger(dayChars.join(''));
+      }
+      if (monthChars.length === 2 || monthChars.length === 1 && isNumber(monthChars.join(''))) {
+        result.month = toInteger(monthChars.join(''));
+      }
+      if (yearChars.length === 4 && isNumber(yearChars.join(''))) {
+        result.year = toInteger(yearChars.join(''));
+      }
+
+      return result.day || result.month || result.year ? result : null;
     }
+
     return null;
   }
 
-  format(date: NgbDateStruct): string {
-    return date ?
-        `${date.year}-${isNumber(date.month) ? padNumber(date.month) : ''}-${isNumber(date.day) ? padNumber(date.day) : ''}` :
-        '';
+  format(date: NgbDateStruct, format: string): string {
+    let result = '';
+    if (date && format) {
+      let dateString: string[] = [];
+      result = format;
+      result = result.replace('dd', isNumber(date.day) ? padNumber(date.day) : '');
+      result = result.replace('mm', isNumber(date.month) ? padNumber(date.month) : '');
+      result = result.replace('yyyy', isNumber(date.year) ? String(date.year) : '');
+    }
+    return result;
+  }
+
+  isValidFormat(format: string): boolean {
+    if (format && format.length === 10) {
+      let foundNumber = false;
+
+      for (let i = 0; i < format.length; i++) {
+        switch (format.charAt(i)) {
+          case 'd':
+            if (format.charAt(i + 1) === 'd' && !foundNumber) {
+              i++;
+              foundNumber = true;
+            } else {
+              return false;
+            }
+            break;
+          case 'm':
+            if (format.charAt(i + 1) === 'm' && !foundNumber) {
+              i++;
+              foundNumber = true;
+            } else {
+              return false;
+            }
+            break;
+          case 'y':
+            if (format.charAt(i + 1) === 'y' && format.charAt(i + 2) === 'y' && format.charAt(i + 3) === 'y' &&
+                !foundNumber) {
+              foundNumber = true;
+              i = i + 3;
+            } else {
+              return false;
+            }
+            break;
+          case '/':
+            if (!foundNumber) {
+              return false;
+            }
+            foundNumber = false;
+            break;
+          case '-':
+            if (!foundNumber) {
+              return false;
+            }
+            foundNumber = false;
+            break;
+          default:
+            return false;
+        }
+      }
+      return true;
+    }
+    return false;
   }
 }


### PR DESCRIPTION
Now you can use custom format date where:
- 'dd' is day
- 'mm' is month
- 'yyyy' is year
- '/' or '-' is the delimiters allowed
You can change order of the date part and choose the delimiter you want to use.
Ex: yyyy-mm-dd, dd-yyyy-mm, mm-dd-yyyy, dd/mm/yyyy.
