### PR TITLE
added addional modal size supported by Bootstrap

### DIFF
--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -21,7 +21,7 @@ export interface NgbModalOptions {
   /**
    * Size of a new modal window.
    */
-  size?: 'sm' | 'lg' | 'md';
+  size?: 'sm' | 'md' | 'lg';
 
   /**
    * Custom class to append to the modal window

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -21,7 +21,7 @@ export interface NgbModalOptions {
   /**
    * Size of a new modal window.
    */
-  size?: 'sm' | 'lg';
+  size?: 'sm' | 'lg' | 'md';
 
   /**
    * Custom class to append to the modal window


### PR DESCRIPTION
added the 'md' modal size supported by Bootstrap

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests. => not tests found for size check
 - [] added/updated any applicable API documentation. => can't find where you add it to the documentation
 - [] added/updated any applicable demos. => there are no size demos
