### PR TITLE
Add note about making ng-bootstrap work with Bootstrap 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ As with Bootstrap 4, this library is a work in progress. Please check out our li
 [issues](https://github.com/ng-bootstrap/ng-bootstrap/issues) to see all the things we are implementing.
 Feel free to make comments there.
 
+*If you need to make ng-bootstrap work with legacy Bootstrap v3.3.7 code, you can try an unofficial, work-in-progress, [CSS compatibility patch](https://github.com/ngTrumbitta/ng-bootstrap-to-bootstrap-3).*
+
 ## Demo
 
 View all the directives in action at https://ng-bootstrap.github.io


### PR DESCRIPTION
I'm working on a CSS-based compatibility patch to make ng-bootstrap work with Bootstrap 3, because I need it at work.

I figured I could possibly not be the only one needing it, so I published it on NPM and will update it as I go on and find myself in need of more components.

This pull-request is really just a way to let you guys know about it.

## Current status:

- [x] Accordion *(BS4 structure with BS3 colors and spacing)*
- [ ] Alert
- [ ] Buttons
- [ ] Carousel
- [x] Collapse
- [ ] Datepicker
- [x] Dropdown
- [x] Modal
- [ ] Pagination
- [x] Popover
- [x] Progressbar
- [x] Rating *(It just works, no need for a patch)*
- [ ] Scrollspy *(Planned feature of ng-bootstrap)*
- [x] Tabs
- [ ] Timepicker
- [ ] Tooltip
- [x] Typeahead