### PR TITLE
feat(timepicker): Added support for keyboard and mouse events

### DIFF
--- a/src/timepicker/timepicker.spec.ts
+++ b/src/timepicker/timepicker.spec.ts
@@ -12,6 +12,19 @@ import {NgbTimepicker} from './timepicker';
 const createTestComponent = (html: string) =>
     createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
+function createKeyDownEvent(key: 'ArrowUp' | 'ArrowDown') {
+  const event = {key: key, preventDefault: () => {}};
+  spyOn(event, 'preventDefault');
+  return event;
+}
+
+function createMouseWheelEvent(detail: number) {
+  const event = {detail: detail, preventDefault: () => {}};
+  spyOn(event, 'preventDefault');
+  return event;
+}
+
+
 function getTimepicker(el: HTMLElement) {
   return el.querySelector('ngb-timepicker');
 }
@@ -382,6 +395,203 @@ describe('ngb-timepicker', () => {
        }));
   });
 
+  describe('model updates in response to mouse events', () => {
+
+    it('should increment / decrement hours on mouse wheel up/down', async(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
+
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+
+               const inputs = fixture.debugElement.queryAll(By.css('input'));
+
+               expectToDisplayTime(fixture.nativeElement, '10:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+
+               const upScroll = createMouseWheelEvent(50);
+               inputs[0].triggerEventHandler('mousewheel', upScroll);  // H+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '11:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
+
+               const downScroll = createMouseWheelEvent(-50);
+               inputs[0].triggerEventHandler('mousewheel', downScroll);  // H-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+             });
+       }));
+
+    it('should increment / decrement minutes on mouse wheel up/down', async(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
+
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+
+               const inputs = fixture.debugElement.queryAll(By.css('input'));
+
+               expectToDisplayTime(fixture.nativeElement, '10:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+
+               const upScroll = createMouseWheelEvent(50);
+               inputs[1].triggerEventHandler('mousewheel', upScroll);  // M+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:31');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 0});
+
+               const downScroll = createMouseWheelEvent(-50);
+               inputs[1].triggerEventHandler('mousewheel', downScroll);  // M-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+             });
+       }));
+
+    it('should increment / decrement seconds on mouse wheel up/down', async(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true"></ngb-timepicker>`;
+
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+
+               const inputs = fixture.debugElement.queryAll(By.css('input'));
+
+               expectToDisplayTime(fixture.nativeElement, '10:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+
+               const upScroll = createMouseWheelEvent(50);
+               inputs[2].triggerEventHandler('mousewheel', upScroll);  // S+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:30:01');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 1});
+
+               const downScroll = createMouseWheelEvent(-50);
+               inputs[2].triggerEventHandler('mousewheel', downScroll);  // S-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+             });
+       }));
+  });
+
+  describe('model updates in response to keyboard events', () => {
+
+    it('should increment / decrement hours on key up/down', async(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
+
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+
+               const inputs = fixture.debugElement.queryAll(By.css('input'));
+
+               expectToDisplayTime(fixture.nativeElement, '10:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+
+               const upEvent = createKeyDownEvent('ArrowUp');
+               inputs[0].triggerEventHandler('keydown.ArrowUp', upEvent);  // H+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '11:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
+
+               const downEvent = createKeyDownEvent('ArrowDown');
+               inputs[0].triggerEventHandler('keydown.ArrowDown', downEvent);  // H-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+             });
+       }));
+
+    it('should increment / decrement minutes on key up/down', async(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
+
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+
+               const inputs = fixture.debugElement.queryAll(By.css('input'));
+
+               expectToDisplayTime(fixture.nativeElement, '10:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+
+               const upEvent = createKeyDownEvent('ArrowUp');
+               inputs[1].triggerEventHandler('keydown.ArrowUp', upEvent);  // M+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:31');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 0});
+
+               const downEvent = createKeyDownEvent('ArrowDown');
+               inputs[1].triggerEventHandler('keydown.ArrowDown', downEvent);  // M-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:30');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+             });
+       }));
+
+    it('should increment / decrement seconds on key up/down', async(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true"></ngb-timepicker>`;
+
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+               const inputs = fixture.debugElement.queryAll(By.css('input'));
+
+               expectToDisplayTime(fixture.nativeElement, '10:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+
+               const upEvent = createKeyDownEvent('ArrowUp');
+               inputs[2].triggerEventHandler('keydown.ArrowUp', upEvent);  // S+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:30:01');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 1});
+
+               const downEvent = createKeyDownEvent('ArrowDown');
+               inputs[2].triggerEventHandler('keydown.ArrowDown', downEvent);  // S-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '10:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+             });
+       }));
+  });
+
   describe('model updates in response to input field changes', () => {
 
     it('should update hours', async(() => {
@@ -740,6 +950,61 @@ describe('ngb-timepicker', () => {
                expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
                (<HTMLButtonElement>buttons[5]).click();  // S-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+             });
+       }));
+
+    it('should not change the value on mousewheel up/down, when it is disabled', async(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [disabled]="disabled"></ngb-timepicker>`;
+
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 13, minute: 30, second: 0};
+         fixture.detectChanges();
+         fixture.whenStable()
+             .then(() => {
+               fixture.detectChanges();
+               return fixture.whenStable();
+             })
+             .then(() => {
+               const inputs = fixture.debugElement.queryAll(By.css('input'));
+
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+
+               const upScroll = createMouseWheelEvent(50);
+               const downScroll = createMouseWheelEvent(-50);
+
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+
+               inputs[0].triggerEventHandler('mousewheel', upScroll);  // H+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+
+               inputs[0].triggerEventHandler('mousewheel', downScroll);  // H-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+
+               inputs[1].triggerEventHandler('mousewheel', upScroll);  // M+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+
+               inputs[1].triggerEventHandler('mousewheel', downScroll);  // M-
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+
+               inputs[2].triggerEventHandler('mousewheel', upScroll);  // S+
+               fixture.detectChanges();
+               expectToDisplayTime(fixture.nativeElement, '13:30:00');
+               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+
+               inputs[2].triggerEventHandler('mousewheel', downScroll);  // S-
                fixture.detectChanges();
                expectToDisplayTime(fixture.nativeElement, '13:30:00');
                expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});

--- a/src/timepicker/timepicker.ts
+++ b/src/timepicker/timepicker.ts
@@ -91,12 +91,14 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
           <td>
             <input type="text" class="form-control" [ngClass]="setFormControlSize()" maxlength="2" size="2" placeholder="HH"
               [value]="formatHour(model?.hour)" (change)="updateHour($event.target.value)"
+              (mousewheel)="mouseHour($event)" (keydown.ArrowDown)="keyDownHour($event)" (keydown.ArrowUp)="keyDownHour($event)"
               [readonly]="readonlyInputs" [disabled]="disabled" aria-label="Hours">
           </td>
           <td>&nbsp;:&nbsp;</td>
           <td>
             <input type="text" class="form-control" [ngClass]="setFormControlSize()" maxlength="2" size="2" placeholder="MM"
               [value]="formatMinSec(model?.minute)" (change)="updateMinute($event.target.value)"
+              (mousewheel)="mouseMinute($event)" (keydown.ArrowDown)="keyDownMinute($event)" (keydown.ArrowUp)="keyDownMinute($event)"
               [readonly]="readonlyInputs" [disabled]="disabled" aria-label="Minutes">
           </td>
           <template [ngIf]="seconds">
@@ -104,6 +106,7 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
             <td>
               <input type="text" class="form-control" [ngClass]="setFormControlSize()" maxlength="2" size="2" placeholder="SS"
                 [value]="formatMinSec(model?.second)" (change)="updateSecond($event.target.value)"
+                (mousewheel)="mouseSecond($event)" (keydown.ArrowDown)="keyDownSecond($event)" (keydown.ArrowUp)="keyDownSecond($event)"
                 [readonly]="readonlyInputs" [disabled]="disabled" aria-label="Seconds">
             </td>
           </template>
@@ -254,6 +257,48 @@ export class NgbTimepicker implements ControlValueAccessor,
     this.propagateModelChange();
   }
 
+  mouseHour(event: MouseWheelEvent) {
+    if (!this.disabled) {
+      let step: number = this.isScrollUp(event) ? this.hourStep : -this.hourStep;
+      this.changeHour(step);
+    }
+    event.preventDefault();
+  }
+
+  mouseMinute(event: MouseWheelEvent) {
+    if (!this.disabled) {
+      let step: number = this.isScrollUp(event) ? this.minuteStep : -this.minuteStep;
+      this.changeMinute(step);
+    }
+    event.preventDefault();
+  }
+
+  mouseSecond(event: MouseWheelEvent) {
+    if (!this.disabled) {
+      let step: number = this.isScrollUp(event) ? this.minuteStep : -this.minuteStep;
+      this.changeSecond(step);
+    }
+    event.preventDefault();
+  }
+
+  keyDownHour(event: KeyboardEvent) {
+    event.key === 'ArrowUp' ? this.changeHour(this.hourStep) : this.changeHour(-this.hourStep);
+    event.preventDefault();
+  }
+
+  keyDownMinute(event: KeyboardEvent) {
+    event.key === 'ArrowUp' ? this.changeMinute(this.minuteStep) : this.changeMinute(-this.minuteStep);
+    event.preventDefault();
+  }
+
+  keyDownSecond(event: KeyboardEvent) {
+    event.key === 'ArrowUp' ? this.changeSecond(this.secondStep) : this.changeSecond(-this.secondStep);
+    event.preventDefault();
+  }
+
+  /**
+   * @internal
+   */
   toggleMeridian() {
     if (this.meridian) {
       this.changeHour(12);
@@ -295,5 +340,10 @@ export class NgbTimepicker implements ControlValueAccessor,
     } else {
       this.onChange(null);
     }
+  }
+
+  private isScrollUp(event: MouseWheelEvent): boolean {
+    let delta: number = event.wheelDelta ? event.wheelDelta : -event.wheelDeltaY;
+    return event.detail > 0 || delta > 0;
   }
 }


### PR DESCRIPTION
fix #459

based on #468, I only merged and added tabindex="-1" since buttons doesnt need to be focusable (and it's even worse for screen readers)

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
