### PR TITLE
Tag name fix for documentation

### DIFF
--- a/demo/src/app/components/datepicker/demos/i18n/datepicker-i18n.html
+++ b/demo/src/app/components/datepicker/demos/i18n/datepicker-i18n.html
@@ -7,5 +7,5 @@
   </label>
 </div>
 <hr>
-<ngb-datepicker [(ngModel)]="model"></ngb-datepicker>
+<ngbd-datepicker-i18n [(ngModel)]="model"></ngbd-datepicker-i18n>
 


### PR DESCRIPTION
The 'ngb-datepicker' tag changed to 'ngbd-datepicker-i18n' for the translation example. 
For this example, we need to use the selector defined in the example, not the default selector.

I read the contributors guide at: [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md). But couldn't find information about documentation change request guidelines.

Before submitting a pull request, please make sure you have at least performed the following:

 - [] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [] built and tested the changes locally.
 - [] added/updated any applicable tests.
 - [] added/updated any applicable API documentation.
 - [] added/updated any applicable demos.
