### PR TITLE
refactor(carousel): remove `template[ngbSlide]` (ng4 deprecated) in favor of `ngb-slide`

### DIFF
--- a/demo/src/app/components/carousel/demos/basic/carousel-basic.html
+++ b/demo/src/app/components/carousel/demos/basic/carousel-basic.html
@@ -1,23 +1,23 @@
 <ngb-carousel>
-  <template ngbSlide>
-    <img src="http://lorempixel.com/900/500?r=1" alt="Random first slide">
+  <ngb-slide>
+    <img src="http://lorempixel.com/900/500?r=1" alt="Random first ngb-slide">
     <div class="carousel-caption">
-      <h3>First slide label</h3>
+      <h3>First ngb-slide label</h3>
       <p>Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
     </div>
-  </template>
-  <template ngbSlide>
-    <img src="http://lorempixel.com/900/500?r=2" alt="Random second slide">
+  </ngb-slide>
+  <ngb-slide>
+    <img src="http://lorempixel.com/900/500?r=2" alt="Random second ngb-slide">
     <div class="carousel-caption">
-      <h3>Second slide label</h3>
+      <h3>Second ngb-slide label</h3>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
     </div>
-  </template>
-  <template ngbSlide>
-    <img src="http://lorempixel.com/900/500?r=3" alt="Random third slide">
+  </ngb-slide>
+  <ngb-slide>
+    <img src="http://lorempixel.com/900/500?r=3" alt="Random third ngb-slide">
     <div class="carousel-caption">
-      <h3>Third slide label</h3>
+      <h3>Third ngb-slide label</h3>
       <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur.</p>
     </div>
-  </template>
+  </ngb-slide>
 </ngb-carousel>

--- a/demo/src/app/components/carousel/demos/config/carousel-config.html
+++ b/demo/src/app/components/carousel/demos/config/carousel-config.html
@@ -1,23 +1,23 @@
 <ngb-carousel>
-  <template ngbSlide>
+  <ngb-slide>
     <img src="http://lorempixel.com/900/500?r=4" alt="Random first slide">
     <div class="carousel-caption">
       <h3>10 seconds between slides...</h3>
       <p>This carousel uses customized default values.</p>
     </div>
-  </template>
-  <template ngbSlide>
+  </ngb-slide>
+  <ngb-slide>
     <img src="http://lorempixel.com/900/500?r=5"  alt="Random second slide">
     <div class="carousel-caption">
       <h3>No keyboard...</h3>
       <p>This carousel uses customized default values.</p>
     </div>
-  </template>
-  <template ngbSlide>
+  </ngb-slide>
+  <ngb-slide>
     <img src="http://lorempixel.com/900/500?r=6" alt="Random third slide">
     <div class="carousel-caption">
       <h3>And no wrap after last slide.</h3>
       <p>This carousel uses customized default values.</p>
     </div>
-  </template>
+  </ngb-slide>
 </ngb-carousel>

--- a/src/carousel/carousel.spec.ts
+++ b/src/carousel/carousel.spec.ts
@@ -46,8 +46,8 @@ describe('ngb-carousel', () => {
   it('should render slides and navigation indicators', fakeAsync(() => {
        const html = `
       <ngb-carousel>
-        <template ngbSlide>foo</template>
-        <template ngbSlide>bar</template>
+        <ngb-slide>foo</ngb-slide>
+        <ngb-slide>bar</ngb-slide>
       </ngb-carousel>
     `;
        const fixture = createTestComponent(html);
@@ -66,8 +66,8 @@ describe('ngb-carousel', () => {
   it('should mark the first slide as active by default', fakeAsync(() => {
        const html = `
       <ngb-carousel>
-        <template ngbSlide>foo</template>
-        <template ngbSlide>bar</template>
+        <ngb-slide>foo</ngb-slide>
+        <ngb-slide>bar</ngb-slide>
       </ngb-carousel>
     `;
 
@@ -81,8 +81,8 @@ describe('ngb-carousel', () => {
   it('should mark the requested slide as active', fakeAsync(() => {
        const html = `
        <ngb-carousel [activeId]="activeSlideId">
-         <template ngbSlide id="1">foo</template>
-         <template ngbSlide id="2">bar</template>
+         <ngb-slide id="1">foo</ngb-slide>
+         <ngb-slide id="2">bar</ngb-slide>
        </ngb-carousel>
      `;
 
@@ -98,8 +98,8 @@ describe('ngb-carousel', () => {
   it('should auto-correct when slide index is undefined', fakeAsync(() => {
        const html = `
             <ngb-carousel [activeId]="doesntExist">
-              <template ngbSlide>foo</template>
-              <template ngbSlide>bar</template>
+              <ngb-slide>foo</ngb-slide>
+              <ngb-slide>bar</ngb-slide>
             </ngb-carousel>
           `;
 
@@ -113,8 +113,8 @@ describe('ngb-carousel', () => {
   it('should change slide on indicator click', fakeAsync(() => {
        const html = `
       <ngb-carousel>
-        <template ngbSlide>foo</template>
-        <template ngbSlide>bar</template>
+        <ngb-slide>foo</ngb-slide>
+        <ngb-slide>bar</ngb-slide>
       </ngb-carousel>
     `;
 
@@ -134,8 +134,8 @@ describe('ngb-carousel', () => {
   it('should change slide on carousel control click', fakeAsync(() => {
        const html = `
       <ngb-carousel>
-        <template ngbSlide>foo</template>
-        <template ngbSlide>bar</template>
+        <ngb-slide>foo</ngb-slide>
+        <ngb-slide>bar</ngb-slide>
       </ngb-carousel>
     `;
 
@@ -160,8 +160,8 @@ describe('ngb-carousel', () => {
   it('should change slide on time passage (default interval value)', fakeAsync(() => {
        const html = `
       <ngb-carousel>
-        <template ngbSlide>foo</template>
-        <template ngbSlide>bar</template>
+        <ngb-slide>foo</ngb-slide>
+        <ngb-slide>bar</ngb-slide>
       </ngb-carousel>
     `;
 
@@ -179,8 +179,8 @@ describe('ngb-carousel', () => {
   it('should change slide on time passage (custom interval value)', fakeAsync(() => {
        const html = `
       <ngb-carousel [interval]="2000">
-        <template ngbSlide>foo</template>
-        <template ngbSlide>bar</template>
+        <ngb-slide>foo</ngb-slide>
+        <ngb-slide>bar</ngb-slide>
       </ngb-carousel>
     `;
 
@@ -202,8 +202,8 @@ describe('ngb-carousel', () => {
   it('should not change slide on time passage (custom interval value is zero)', fakeAsync(() => {
        const html = `
       <ngb-carousel [interval]="0">
-        <template ngbSlide>foo</template>
-        <template ngbSlide>bar</template>
+        <ngb-slide>foo</ngb-slide>
+        <ngb-slide>bar</ngb-slide>
       </ngb-carousel>
     `;
 
@@ -225,8 +225,8 @@ describe('ngb-carousel', () => {
   it('should pause / resume slide change with time passage on mouse enter / leave', fakeAsync(() => {
        const html = `
       <ngb-carousel>
-        <template ngbSlide>foo</template>
-        <template ngbSlide>bar</template>
+        <ngb-slide>foo</ngb-slide>
+        <ngb-slide>bar</ngb-slide>
       </ngb-carousel>
     `;
 
@@ -258,8 +258,8 @@ describe('ngb-carousel', () => {
   it('should wrap slide changes by default', fakeAsync(() => {
        const html = `
       <ngb-carousel>
-        <template ngbSlide>foo</template>
-        <template ngbSlide>bar</template>
+        <ngb-slide>foo</ngb-slide>
+        <ngb-slide>bar</ngb-slide>
       </ngb-carousel>
     `;
 
@@ -288,8 +288,8 @@ describe('ngb-carousel', () => {
   it('should not wrap slide changes by when requested', fakeAsync(() => {
        const html = `
       <ngb-carousel [wrap]="false">
-        <template ngbSlide>foo</template>
-        <template ngbSlide>bar</template>
+        <ngb-slide>foo</ngb-slide>
+        <ngb-slide>bar</ngb-slide>
       </ngb-carousel>
     `;
 
@@ -318,8 +318,8 @@ describe('ngb-carousel', () => {
   it('should change on key arrowRight and arrowLeft', fakeAsync(() => {
        const html = `
             <ngb-carousel [keyboard]="keyboard" [wrap]="false">
-              <template ngbSlide>foo</template>
-              <template ngbSlide>bar</template>
+              <ngb-slide>foo</ngb-slide>
+              <ngb-slide>bar</ngb-slide>
             </ngb-carousel>
           `;
 
@@ -348,8 +348,8 @@ describe('ngb-carousel', () => {
   it('should listen to keyevents based on keyboard attribute', fakeAsync(() => {
        const html = `
                <ngb-carousel [keyboard]="keyboard" >
-                 <template ngbSlide>foo</template>
-                 <template ngbSlide>bar</template>
+                 <ngb-slide>foo</ngb-slide>
+                 <ngb-slide>bar</ngb-slide>
                </ngb-carousel>
              `;
 


### PR DESCRIPTION
Refer to Issue https://github.com/ng-bootstrap/ng-bootstrap/issues/1344

In the above spirit, I have put together a refactor of the carousel component with the above things in mind. I've removed `<template ngbSlide>` in favor of  `<ngb-slide>`  and gotten rid of the `template` throughout the carousel code. 

It is working (demo looks fine and gulp tests have passed)

Since it is refactored in a way that works with both angular 2 and 4, my hope is that (even though this is a breaking change) we may discuss considering this (or a revised version) for PR without having to wait for stable angular 4 to go live. 

I thought I'd try PR with just the carousel component before trying to potentially contribute code for refactoring some of the other components (removing `<template>`).

I'm open to all suggestions.
What do y'all think?
Thanks!
