### PR TITLE
Support node preservation for accordion and tabset

### DIFF
--- a/src/accordion/accordion.spec.ts
+++ b/src/accordion/accordion.spec.ts
@@ -253,6 +253,26 @@ describe('ngb-accordion', () => {
     expect(getPanelsContent(fixture.nativeElement).length).toBe(1);
   });
 
+  it('should not remove collapsed panels content from DOM with `preserveNodes` flag', () => {
+    const testHtml = `
+    <ngb-accordion #acc="ngbAccordion" [preserveNodes]="true">
+     <ngb-panel *ngFor="let panel of panels" [id]="panel.id">
+       <template ngbPanelTitle>{{panel.title}}</template>
+       <template ngbPanelContent>{{panel.content}}</template>
+     </ngb-panel>
+    </ngb-accordion>
+    <button *ngFor="let panel of panels" (click)="acc.toggle(panel.id)">Toggle the panel {{ panel.id }}</button>
+    `;
+    const fixture = createTestComponent(testHtml);
+
+    fixture.detectChanges();
+
+    getButton(fixture.nativeElement, 0).click();
+    let panelContents = getPanelsContent(fixture.nativeElement);
+    expect(panelContents[0].hasAttribute('hidden')).toBe(true);
+    expect(panelContents.length).toBe(3);
+  });
+
   it('should emit panel change event when toggling panels', () => {
     const fixture = TestBed.createComponent(TestComponent);
     fixture.detectChanges();

--- a/src/accordion/accordion.ts
+++ b/src/accordion/accordion.ts
@@ -104,18 +104,21 @@ export interface NgbPanelChangeEvent {
     <template ngFor let-panel [ngForOf]="panels">
       <div role="tab" id="{{panel.id}}-header" [attr.aria-selected]="panel.focused"
         [class]="'card-header ' + (panel.type ? 'card-'+panel.type: type ? 'card-'+type : '')" [class.active]="isOpen(panel.id)">
-        <a href (click)="!!toggle(panel.id)" (focus)="panel.focused = true" 
-          (blur)="panel.focused = false" [class.text-muted]="panel.disabled" 
+        <a href (click)="!!toggle(panel.id)" (focus)="panel.focused = true"
+          (blur)="panel.focused = false" [class.text-muted]="panel.disabled"
           [attr.aria-expanded]="isOpen(panel.id)" [attr.aria-controls]="panel.id">
           {{panel.title}}<template [ngTemplateOutlet]="panel.titleTpl?.templateRef"></template>
         </a>
       </div>
-      <div id="{{panel.id}}" role="tabpanel" [attr.aria-labelledby]="panel.id + '-header'" class="card-block" *ngIf="isOpen(panel.id)">
+      <div id="{{panel.id}}" role="tabpanel"
+        [attr.aria-labelledby]="panel.id + '-header'" class="card-block"
+        *ngIf="preserveNodes || isOpen(panel.id)"
+        [hidden]="preserveNodes ? !isOpen(panel.id) : null" >
         <template [ngTemplateOutlet]="panel.contentTpl.templateRef"></template>
       </div>
     </template>
   </div>
-`
+  `
 })
 export class NgbAccordion implements AfterContentChecked {
   /**
@@ -139,6 +142,11 @@ export class NgbAccordion implements AfterContentChecked {
    *  Whether the other panels should be closed when a panel is opened
    */
   @Input('closeOthers') closeOtherPanels: boolean;
+
+  /**
+   * Whether the closed panels should be hidden without destroying them
+   */
+  @Input() preserveNodes: boolean;
 
   /**
    *  Accordion's types of panels to be applied globally.

--- a/src/accordion/accordion.ts
+++ b/src/accordion/accordion.ts
@@ -113,7 +113,7 @@ export interface NgbPanelChangeEvent {
       <div id="{{panel.id}}" role="tabpanel"
         [attr.aria-labelledby]="panel.id + '-header'" class="card-block"
         *ngIf="preserveNodes || isOpen(panel.id)"
-        [hidden]="preserveNodes ? !isOpen(panel.id) : null" >
+        [attr.hidden]="isHidden(panel.id)" >
         <template [ngTemplateOutlet]="panel.contentTpl.templateRef"></template>
       </div>
     </template>
@@ -206,6 +206,14 @@ export class NgbAccordion implements AfterContentChecked {
    * @internal
    */
   isOpen(panelId: string): boolean { return this._states.get(panelId); }
+
+  /**
+   * @internal
+   */
+  isHidden(panelId: string): boolean {
+    // Return `null` to avoid attribute insertion into the DOM
+    return this.preserveNodes && !this.isOpen(panelId) ? true : null;
+  }
 
   private _closeOthers(panelId: string) {
     this._states.forEach((state, id) => {

--- a/src/tabset/tabset.spec.ts
+++ b/src/tabset/tabset.spec.ts
@@ -325,6 +325,25 @@ describe('ngb-tabset', () => {
     expectTabs(fixture.nativeElement, [true, false], [false, true]);
   });
 
+  it('should not remove inactive tabs content from DOM with `preserveNodes` flag', () => {
+    const fixture = createTestComponent(`
+          <ngb-tabset #myTabSet="ngbTabset" [preserveNodes]="true">
+            <ngb-tab id="myFirstTab" title="foo"><template ngbTabContent>Foo</template></ngb-tab>
+            <ngb-tab id="mySecondTab" title="bar"><template ngbTabContent>Bar</template></ngb-tab>
+          </ngb-tabset>
+          <button (click)="myTabSet.select('mySecondTab')">Select the second Tab</button>
+        `);
+
+    const button = getButton(fixture.nativeElement);
+
+    // Click on a button to select the second tab
+    (<HTMLElement>button[0]).click();
+    fixture.detectChanges();
+    let tabContents = getTabContent(fixture.nativeElement);
+    expect(tabContents.length).toBe(2);
+    expect(tabContents[0].hasAttribute('hidden')).toBe(true);
+  });
+
 
   it('should emit tab change event when switching tabs', () => {
     const fixture = createTestComponent(`

--- a/src/tabset/tabset.ts
+++ b/src/tabset/tabset.ts
@@ -90,7 +90,10 @@ export interface NgbTabChangeEvent {
     </ul>
     <div class="tab-content">
       <template ngFor let-tab [ngForOf]="tabs">
-        <div class="tab-pane active" *ngIf="tab.id === activeId" role="tabpanel"
+        <div class="tab-pane active"
+          *ngIf="preserveNodes || tab.id === activeId"
+          [hidden]="preserveNodes ? tab.id !== activeId : null"
+          role="tabpanel"
           [attr.aria-labelledby]="tab.id" id="{{tab.id}}-panel"
           [attr.aria-expanded]="tab.id === activeId">
           <template [ngTemplateOutlet]="tab.contentTpl.templateRef"></template>
@@ -111,6 +114,11 @@ export class NgbTabset implements AfterContentChecked {
    * The horizontal alignment of the nav with flexbox utilities. Can be one of 'start', 'center' or 'end'
    */
   @Input() justify: 'start' | 'center' | 'end';
+
+  /**
+   * Whether the closed tabs should be hidden without destroying them
+   */
+  @Input() preserveNodes: boolean;
 
   /**
    * Type of navigation to be used for tabs. Can be one of 'tabs' or 'pills'.

--- a/src/tabset/tabset.ts
+++ b/src/tabset/tabset.ts
@@ -92,7 +92,7 @@ export interface NgbTabChangeEvent {
       <template ngFor let-tab [ngForOf]="tabs">
         <div class="tab-pane active"
           *ngIf="preserveNodes || tab.id === activeId"
-          [hidden]="preserveNodes ? tab.id !== activeId : null"
+          [attr.hidden]="isHidden(tab.id)"
           role="tabpanel"
           [attr.aria-labelledby]="tab.id" id="{{tab.id}}-panel"
           [attr.aria-expanded]="tab.id === activeId">
@@ -157,6 +157,14 @@ export class NgbTabset implements AfterContentChecked {
     // auto-correct activeId that might have been set incorrectly as input
     let activeTab = this._getTabById(this.activeId);
     this.activeId = activeTab ? activeTab.id : (this.tabs.length ? this.tabs.first.id : null);
+  }
+
+  /**
+   * @internal
+   */
+  isHidden(tabId: string): boolean {
+    // Return `null` to avoid attribute insertion into the DOM
+    return this.preserveNodes && tabId !== this.activeId ? true : null;
   }
 
   private _getTabById(id: string): NgbTab {


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.

This resolves https://github.com/ng-bootstrap/ng-bootstrap/issues/1161 and https://github.com/ng-bootstrap/ng-bootstrap/issues/1167 with an optional Input `preserveNodes` which uses `hidden` property if `true` for content hiding.
