### PR TITLE
Pagination: Boundary and Direction CSS Classes and Custom Text 

### DIFF
--- a/demo/src/app/components/pagination/demos/advanced/pagination-advanced.html
+++ b/demo/src/app/components/pagination/demos/advanced/pagination-advanced.html
@@ -5,7 +5,7 @@
 <ngb-pagination [collectionSize]="120" [(page)]="page" [maxSize]="5" [rotate]="true" [boundaryLinks]="true"></ngb-pagination>
 
 <div>maxSize = 5, rotate = true, ellipses = false</div>
-<ngb-pagination [collectionSize]="120" [(page)]="page" [maxSize]="5" [rotate]="true" [ellipses]="false" [boundaryLinks]="true"></ngb-pagination>
+<ngb-pagination [collectionSize]="120" [(page)]="page" [maxSize]="5" [rotate]="true" [ellipses]="false" [boundaryLinks]="true" boundaryLinksFirst="&lt;&lt;" boundaryLinksLast="&gt;&gt;" directionLinksPrev="&lt;" directionLinksNext="&gt;" ></ngb-pagination>
 
 <hr>
 

--- a/demo/src/app/components/pagination/demos/controls-text/pagination-controls-text.html
+++ b/demo/src/app/components/pagination/demos/controls-text/pagination-controls-text.html
@@ -1,0 +1,6 @@
+<div>boundaryLinksFirst = &lt;&lt;,  boundaryLinksLast = &gt;&gt;,  directionLinksPrevious = &lt;, directionLinksNext = &gt;</div>
+<ngb-pagination  [collectionSize]="70" [(page)]="page" [boundaryLinks]="true" boundaryLinksFirst="&lt;&lt;" boundaryLinksLast="&gt;&gt;" directionLinksPrevious="&lt;" directionLinksNext="&gt;" ></ngb-pagination>
+
+<hr>
+
+<pre>Current page: {{page}}</pre>

--- a/demo/src/app/components/pagination/demos/controls-text/pagination-controls-text.ts
+++ b/demo/src/app/components/pagination/demos/controls-text/pagination-controls-text.ts
@@ -1,0 +1,9 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'ngbd-pagination-controls-text',
+  templateUrl: './pagination-controls-text.html'
+})
+export class NgbdPaginationControlsText {
+  page = 1;
+}

--- a/demo/src/app/components/pagination/demos/index.ts
+++ b/demo/src/app/components/pagination/demos/index.ts
@@ -3,9 +3,10 @@ import {NgbdPaginationBasic} from './basic/pagination-basic';
 import {NgbdPaginationSize} from './size/pagination-size';
 import {NgbdPaginationConfig} from './config/pagination-config';
 import {NgbdPaginationDisabled} from './disabled/pagination-disabled';
+import {NgbdPaginationControlsText} from './controls-text/pagination-controls-text';
 
 export const DEMO_DIRECTIVES = [
-  NgbdPaginationAdvanced, NgbdPaginationBasic, NgbdPaginationSize, NgbdPaginationConfig, NgbdPaginationDisabled
+  NgbdPaginationAdvanced, NgbdPaginationBasic, NgbdPaginationSize, NgbdPaginationConfig, NgbdPaginationDisabled, NgbdPaginationControlsText
 ];
 
 export const DEMO_SNIPPETS = {
@@ -28,5 +29,9 @@ export const DEMO_SNIPPETS = {
   config: {
     code: require('!!prismjs-loader?lang=typescript!./config/pagination-config'),
     markup: require('!!prismjs-loader?lang=markup!./config/pagination-config.html')
+  },
+  controlsText: {
+    code: require('!!prismjs-loader?lang=typescript!./controls-text/pagination-controls-text'),
+    markup: require('!!prismjs-loader?lang=markup!./controls-text/pagination-controls-text.html')
   }
 };

--- a/demo/src/app/components/pagination/pagination.component.ts
+++ b/demo/src/app/components/pagination/pagination.component.ts
@@ -19,6 +19,9 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Disabled pagination" [snippets]="snippets" component="pagination" demo="disabled">
         <ngbd-pagination-disabled></ngbd-pagination-disabled>
       </ngbd-example-box>
+      <ngbd-example-box demoTitle="Custom controls text" [snippets]="snippets" component="pagination" demo="controlsText">
+        <ngbd-pagination-controls-text></ngbd-pagination-controls-text>
+      </ngbd-example-box>
       <ngbd-example-box demoTitle="Global configuration" [snippets]="snippets" component="pagination" demo="config">
         <ngbd-pagination-config></ngbd-pagination-config>
       </ngbd-example-box>

--- a/src/pagination/pagination-config.ts
+++ b/src/pagination/pagination-config.ts
@@ -9,7 +9,11 @@ import {Injectable} from '@angular/core';
 export class NgbPaginationConfig {
   disabled = false;
   boundaryLinks = false;
+  boundaryLinksFirst = '««';
+  boundaryLinksLast = '»»';
   directionLinks = true;
+  directionLinksPrevious = '«';
+  directionLinksNext = '»';
   ellipses = true;
   maxSize = 0;
   pageSize = 10;

--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -539,7 +539,7 @@ describe('ngb-pagination', () => {
     });
 
     it('should not emit "pageChange" for incorrect input values', fakeAsync(() => {
-         const html = `<ngb-pagination [collectionSize]="collectionSize" [pageSize]="pageSize" [maxSize]="maxSize" 
+         const html = `<ngb-pagination [collectionSize]="collectionSize" [pageSize]="pageSize" [maxSize]="maxSize"
         (pageChange)="onPageChange($event)"></ngb-pagination>`;
          const fixture = createTestComponent(html);
          tick();
@@ -560,9 +560,10 @@ describe('ngb-pagination', () => {
 
          expect(fixture.componentInstance.onPageChange).not.toHaveBeenCalled();
        }));
+
     it('should set classes correctly for disabled state', fakeAsync(() => {
-         const html = `<ngb-pagination [collectionSize]="collectionSize" [pageSize]="pageSize" [maxSize]="maxSize" 
-         [disabled]=true></ngb-pagination>`;
+         const html = `<ngb-pagination [collectionSize]="collectionSize" [pageSize]="pageSize" [maxSize]="maxSize"
+      [disabled]=true></ngb-pagination>`;
          const fixture = createTestComponent(html);
          tick();
 
@@ -570,6 +571,24 @@ describe('ngb-pagination', () => {
          for (let i = 0; i < buttons.length; i++) {
            expect(buttons[i]).toHaveCssClass('disabled');
          }
+       }));
+
+    it('should show custom text in direction and boundary links', fakeAsync(() => {
+         const html = `<ngb-pagination [collectionSize]="collectionSize" [page]="page" [maxSize]="maxSize"
+              [boundaryLinks]="boundaryLinks" [boundaryLinksFirst]="boundaryLinksFirst"
+              [boundaryLinksLast]="boundaryLinksLast" [directionLinksPrevious]="directionLinksPrevious"
+              [directionLinksNext]="directionLinksNext"></ngb-pagination>`;
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.collectionSize = 30;
+         fixture.componentInstance.boundaryLinks = true;
+         fixture.componentInstance.boundaryLinksFirst = 'first';
+         fixture.componentInstance.boundaryLinksLast = 'last';
+         fixture.componentInstance.directionLinksPrevious = 'previous';
+         fixture.componentInstance.directionLinksNext = 'next';
+
+         fixture.detectChanges();
+         expectPages(
+             fixture.nativeElement, ['-first First', '-previous Previous', '+1', '2', '3', 'next Next', 'last Last']);
        }));
   });
 
@@ -581,7 +600,11 @@ describe('ngb-pagination', () => {
     beforeEach(inject([NgbPaginationConfig], (c: NgbPaginationConfig) => {
       config = c;
       config.boundaryLinks = true;
+      config.boundaryLinksFirst = 'first';
+      config.boundaryLinksLast = 'last';
       config.directionLinks = false;
+      config.directionLinksPrevious = 'previous';
+      config.directionLinksNext = 'next';
       config.ellipses = false;
       config.maxSize = 42;
       config.pageSize = 7;
@@ -602,7 +625,11 @@ describe('ngb-pagination', () => {
     let config = new NgbPaginationConfig();
     config.disabled = true;
     config.boundaryLinks = true;
+    config.boundaryLinksFirst = 'first';
+    config.boundaryLinksLast = 'last';
     config.directionLinks = false;
+    config.directionLinksPrevious = 'previous';
+    config.directionLinksNext = 'next';
     config.ellipses = false;
     config.maxSize = 42;
     config.pageSize = 7;
@@ -630,7 +657,11 @@ class TestComponent {
   collectionSize = 100;
   page = 1;
   boundaryLinks = false;
+  boundaryLinksFirst = '««';
+  boundaryLinksLast = '»»';
   directionLinks = false;
+  directionLinksPrevious = '«';
+  directionLinksNext = '»';
   size = '';
   maxSize = 0;
   ellipses = true;

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -14,7 +14,7 @@ import {NgbPaginationConfig} from './pagination-config';
         <li *ngIf="boundaryLinks" class="page-item boundary-link first"
           [class.disabled]="!hasPrevious() || disabled">
           <a aria-label="First" class="page-link" href (click)="!!selectPage(1)" [attr.tabindex]="hasPrevious() ? null : '-1'">
-            <span aria-hidden="true">&laquo;&laquo;</span>
+            <span aria-hidden="true">{{boundaryLinksFirst}}</span>
             <span class="sr-only">First</span>
           </a>
         </li>
@@ -22,7 +22,7 @@ import {NgbPaginationConfig} from './pagination-config';
         <li *ngIf="directionLinks" class="page-item direction-link previous"
           [class.disabled]="!hasPrevious() || disabled">
           <a aria-label="Previous" class="page-link" href (click)="!!selectPage(page-1)" [attr.tabindex]="hasPrevious() ? null : '-1'">
-            <span aria-hidden="true">&laquo;</span>
+            <span aria-hidden="true">{{directionLinksPrevious}}</span>
             <span class="sr-only">Previous</span>
           </a>
         </li>
@@ -33,14 +33,14 @@ import {NgbPaginationConfig} from './pagination-config';
         </li>
         <li *ngIf="directionLinks" class="page-item direction-link next" [class.disabled]="!hasNext() || disabled">
           <a aria-label="Next" class="page-link" href (click)="!!selectPage(page+1)" [attr.tabindex]="hasNext() ? null : '-1'">
-            <span aria-hidden="true">&raquo;</span>
+            <span aria-hidden="true">{{directionLinksNext}}</span>
             <span class="sr-only">Next</span>
           </a>
         </li>
 
         <li *ngIf="boundaryLinks" class="page-item boundary-link last" [class.disabled]="!hasNext() || disabled">
           <a aria-label="Last" class="page-link" href (click)="!!selectPage(pageCount)" [attr.tabindex]="hasNext() ? null : '-1'">
-            <span aria-hidden="true">&raquo;&raquo;</span>
+            <span aria-hidden="true">{{boundaryLinksLast}}</span>
             <span class="sr-only">Last</span>
           </a>
         </li>
@@ -63,9 +63,29 @@ export class NgbPagination implements OnChanges {
   @Input() boundaryLinks: boolean;
 
   /**
+   *  Text to display in the First boundary link
+   */
+  @Input() boundaryLinksFirst: string;
+
+  /**
+   *  Text to display in the Last boundary link
+   */
+  @Input() boundaryLinksLast: string;
+
+  /**
    *  Whether to show the "Next" and "Previous" page links
    */
   @Input() directionLinks: boolean;
+
+  /**
+   *  Text to display in the Previous direction link
+   */
+  @Input() directionLinksPrevious: string;
+
+  /**
+   *  Text to display in the Next direction link
+   */
+  @Input() directionLinksNext: string;
 
   /**
    *  Whether to show ellipsis symbols and first/last page numbers when maxSize > number of pages
@@ -112,7 +132,11 @@ export class NgbPagination implements OnChanges {
   constructor(config: NgbPaginationConfig) {
     this.disabled = config.disabled;
     this.boundaryLinks = config.boundaryLinks;
+    this.boundaryLinksFirst = config.boundaryLinksFirst;
+    this.boundaryLinksLast = config.boundaryLinksLast;
     this.directionLinks = config.directionLinks;
+    this.directionLinksPrevious = config.directionLinksPrevious;
+    this.directionLinksNext = config.directionLinksNext;
     this.ellipses = config.ellipses;
     this.maxSize = config.maxSize;
     this.pageSize = config.pageSize;

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -11,39 +11,39 @@ import {NgbPaginationConfig} from './pagination-config';
   template: `
     <nav>
       <ul [class]="'pagination' + (size ? ' pagination-' + size : '')">
-        <li *ngIf="boundaryLinks" class="page-item" 
+        <li *ngIf="boundaryLinks" class="page-item boundary-link first"
           [class.disabled]="!hasPrevious() || disabled">
           <a aria-label="First" class="page-link" href (click)="!!selectPage(1)" [attr.tabindex]="hasPrevious() ? null : '-1'">
             <span aria-hidden="true">&laquo;&laquo;</span>
             <span class="sr-only">First</span>
-          </a>                
+          </a>
         </li>
-      
-        <li *ngIf="directionLinks" class="page-item" 
+
+        <li *ngIf="directionLinks" class="page-item direction-link previous"
           [class.disabled]="!hasPrevious() || disabled">
           <a aria-label="Previous" class="page-link" href (click)="!!selectPage(page-1)" [attr.tabindex]="hasPrevious() ? null : '-1'">
             <span aria-hidden="true">&laquo;</span>
             <span class="sr-only">Previous</span>
           </a>
         </li>
-        <li *ngFor="let pageNumber of pages" class="page-item" [class.active]="pageNumber === page" 
+        <li *ngFor="let pageNumber of pages" class="page-item" [class.active]="pageNumber === page"
           [class.disabled]="isEllipsis(pageNumber) || disabled">
           <a *ngIf="isEllipsis(pageNumber)" class="page-link">...</a>
           <a *ngIf="!isEllipsis(pageNumber)" class="page-link" href (click)="!!selectPage(pageNumber)">{{pageNumber}}</a>
         </li>
-        <li *ngIf="directionLinks" class="page-item" [class.disabled]="!hasNext() || disabled">
+        <li *ngIf="directionLinks" class="page-item direction-link next" [class.disabled]="!hasNext() || disabled">
           <a aria-label="Next" class="page-link" href (click)="!!selectPage(page+1)" [attr.tabindex]="hasNext() ? null : '-1'">
             <span aria-hidden="true">&raquo;</span>
             <span class="sr-only">Next</span>
           </a>
         </li>
-        
-        <li *ngIf="boundaryLinks" class="page-item" [class.disabled]="!hasNext() || disabled">
+
+        <li *ngIf="boundaryLinks" class="page-item boundary-link last" [class.disabled]="!hasNext() || disabled">
           <a aria-label="Last" class="page-link" href (click)="!!selectPage(pageCount)" [attr.tabindex]="hasNext() ? null : '-1'">
             <span aria-hidden="true">&raquo;&raquo;</span>
             <span class="sr-only">Last</span>
-          </a>                
-        </li>        
+          </a>
+        </li>
       </ul>
     </nav>
   `


### PR DESCRIPTION
I ran into an issue on a project where I needed to replace the text and style the boundary and direction controls separately from the page links, so I made a few modifications to the ngbPagination component. I've tried to adhere to the guidelines as far as I understand them. I hope this is useful, let me know if I should make any changes to get this merged. 

This PR expands on the existing markup adding additional classes to help select the direction and boundary controls from CSS. 

* .boundary-link, . first, .last
* .direction-link, .previous, .next

in addition it adds inputs to override the default text displayed for boundary and direction links.

* boundaryLinksFirst
* boundaryLinksLast
* directionLinksFirst
* directionLinksLast


Before submitting a pull request, please make sure you have at least performed the following:

 - [*] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [*] built and tested the changes locally.
 - [*] added/updated any applicable tests.
 - [*] added/updated any applicable API documentation.
 - [*] added/updated any applicable demos.
