### PR TITLE
fix(datepicker): allow datepicker calendar override

### DIFF
--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -38,7 +38,7 @@ const NGB_DATEPICKER_VALUE_ACCESSOR = {
   selector: 'input[ngbDatepicker]',
   exportAs: 'ngbDatepicker',
   host: {'(change)': 'manualDateChange($event.target.value)', '(keyup.esc)': 'close()', '(blur)': 'onBlur()'},
-  providers: [NGB_DATEPICKER_VALUE_ACCESSOR]
+  providers: [NGB_DATEPICKER_VALUE_ACCESSOR, NgbDatepickerService]
 })
 export class NgbInputDatepicker implements ControlValueAccessor {
   private _cRef: ComponentRef<NgbDatepicker> = null;

--- a/src/datepicker/datepicker-integration.spec.ts
+++ b/src/datepicker/datepicker-integration.spec.ts
@@ -1,0 +1,60 @@
+import {TestBed} from '@angular/core/testing';
+import {Component} from '@angular/core';
+import {NgbDatepickerModule} from './datepicker.module';
+import {NgbCalendar, NgbCalendarGregorian} from './ngb-calendar';
+import {NgbDate} from './ngb-date';
+import {getMonthSelect, getYearSelect} from '../test/datepicker/common';
+import {NgbDatepickerI18n, NgbDatepickerI18nDefault} from './datepicker-i18n';
+
+describe('ngb-datepicker integration', () => {
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot()]});
+  });
+
+  it('should allow overriding datepicker calendar', () => {
+
+    class FixedTodayCalendar extends NgbCalendarGregorian {
+      getToday() { return new NgbDate(2000, 7, 1); }
+    }
+
+    TestBed.overrideComponent(TestComponent, {
+      set: {
+        template: `<ngb-datepicker></ngb-datepicker>`,
+        providers: [{provide: NgbCalendar, useClass: FixedTodayCalendar}]
+      }
+    });
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    expect(getMonthSelect(fixture.nativeElement).value).toBe('7');
+    expect(getYearSelect(fixture.nativeElement).value).toBe('2000');
+  });
+
+  it('should allow overriding datepicker i18n', () => {
+
+    const MONTHS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L'];
+
+    class AlphabetMonthsI18n extends NgbDatepickerI18nDefault {
+      getMonthShortName(month: number) { return MONTHS[month - 1]; }
+    }
+
+    TestBed.overrideComponent(TestComponent, {
+      set: {
+        template: `<ngb-datepicker></ngb-datepicker>`,
+        providers: [{provide: NgbDatepickerI18n, useClass: AlphabetMonthsI18n}]
+      }
+    });
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    const monthOptionsText =
+        Array.from(getMonthSelect(fixture.nativeElement).querySelectorAll('option')).map(o => o.innerHTML);
+
+    expect(monthOptionsText).toEqual(MONTHS);
+  });
+});
+
+@Component({selector: 'test-cmp', template: ''})
+class TestComponent {
+}

--- a/src/datepicker/datepicker.module.ts
+++ b/src/datepicker/datepicker.module.ts
@@ -9,12 +9,12 @@ import {NgbDatepickerDayView} from './datepicker-day-view';
 import {NgbDatepickerI18n, NgbDatepickerI18nDefault} from './datepicker-i18n';
 import {NgbCalendar, NgbCalendarGregorian} from './ngb-calendar';
 import {NgbDateParserFormatter, NgbDateISOParserFormatter} from './ngb-date-parser-formatter';
-import {NgbDatepickerService} from './datepicker-service';
 import {NgbDatepickerNavigationSelect} from './datepicker-navigation-select';
 import {NgbDatepickerConfig} from './datepicker-config';
 
 export {NgbDatepicker, NgbDatepickerNavigateEvent} from './datepicker';
 export {NgbInputDatepicker} from './datepicker-input';
+export {NgbCalendar} from './ngb-calendar';
 export {NgbDatepickerMonthView} from './datepicker-month-view';
 export {NgbDatepickerDayView} from './datepicker-day-view';
 export {NgbDatepickerNavigation} from './datepicker-navigation';
@@ -40,8 +40,7 @@ export class NgbDatepickerModule {
       providers: [
         {provide: NgbCalendar, useClass: NgbCalendarGregorian},
         {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nDefault},
-        {provide: NgbDateParserFormatter, useClass: NgbDateISOParserFormatter}, NgbDatepickerService,
-        NgbDatepickerConfig
+        {provide: NgbDateParserFormatter, useClass: NgbDateISOParserFormatter}, NgbDatepickerConfig
       ]
     };
   }

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -110,7 +110,7 @@ export interface NgbDatepickerNavigateEvent {
       </template>
     </div>
   `,
-  providers: [NGB_DATEPICKER_VALUE_ACCESSOR]
+  providers: [NGB_DATEPICKER_VALUE_ACCESSOR, NgbDatepickerService]
 })
 export class NgbDatepicker implements OnChanges,
     OnInit, ControlValueAccessor {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export {NgbButtonsModule, NgbRadioGroup} from './buttons/radio.module';
 export {NgbCarouselModule, NgbCarouselConfig, NgbCarousel, NgbSlide} from './carousel/carousel.module';
 export {NgbCollapseModule, NgbCollapse} from './collapse/collapse.module';
 export {
+  NgbCalendar,
   NgbDatepickerModule,
   NgbDatepickerI18n,
   NgbDatepickerConfig,


### PR DESCRIPTION
- `NgbCalendar` export was missing
- `NgbDatepickerService` should not be global, but per-datepicker as it is using `NgbCalendar` itself
