### PR TITLE
feat(accordion): support nodes preservation

### DIFF
--- a/src/accordion/accordion.spec.ts
+++ b/src/accordion/accordion.spec.ts
@@ -253,6 +253,27 @@ describe('ngb-accordion', () => {
     expect(getPanelsContent(fixture.nativeElement).length).toBe(1);
   });
 
+  it('should not remove collapsed panels content from DOM with `destroyOnHide` flag', () => {
+    const testHtml = `
+    <ngb-accordion #acc="ngbAccordion" [closeOthers]="true" [destroyOnHide]="false">
+     <ngb-panel *ngFor="let panel of panels" [id]="panel.id">
+       <template ngbPanelTitle>{{panel.title}}</template>
+       <template ngbPanelContent>{{panel.content}}</template>
+     </ngb-panel>
+    </ngb-accordion>
+    <button *ngFor="let panel of panels" (click)="acc.toggle(panel.id)">Toggle the panel {{ panel.id }}</button>
+    `;
+    const fixture = createTestComponent(testHtml);
+
+    fixture.detectChanges();
+
+    getButton(fixture.nativeElement, 1).click();
+    fixture.detectChanges();
+    let panelContents = getPanelsContent(fixture.nativeElement);
+    expect(panelContents[1]).toHaveCssClass('show');
+    expect(panelContents.length).toBe(3);
+  });
+
   it('should emit panel change event when toggling panels', () => {
     const fixture = TestBed.createComponent(TestComponent);
     fixture.detectChanges();

--- a/src/accordion/accordion.ts
+++ b/src/accordion/accordion.ts
@@ -104,18 +104,22 @@ export interface NgbPanelChangeEvent {
     <template ngFor let-panel [ngForOf]="panels">
       <div role="tab" id="{{panel.id}}-header" [attr.aria-selected]="panel.focused"
         [class]="'card-header ' + (panel.type ? 'card-'+panel.type: type ? 'card-'+type : '')" [class.active]="isOpen(panel.id)">
-        <a href (click)="!!toggle(panel.id)" (focus)="panel.focused = true" 
-          (blur)="panel.focused = false" [class.text-muted]="panel.disabled" 
+        <a href (click)="!!toggle(panel.id)" (focus)="panel.focused = true"
+          (blur)="panel.focused = false" [class.text-muted]="panel.disabled"
           [attr.aria-expanded]="isOpen(panel.id)" [attr.aria-controls]="panel.id">
           {{panel.title}}<template [ngTemplateOutlet]="panel.titleTpl?.templateRef"></template>
         </a>
       </div>
-      <div id="{{panel.id}}" role="tabpanel" [attr.aria-labelledby]="panel.id + '-header'" class="card-block" *ngIf="isOpen(panel.id)">
+      <div id="{{panel.id}}" role="tabpanel"
+        *ngIf="!destroyOnHide || isOpen(panel.id)"
+        [attr.aria-labelledby]="panel.id + '-header'"
+        class="card-block {{isOpen(panel.id) ? 'show' : null}}"
+      >
         <template [ngTemplateOutlet]="panel.contentTpl.templateRef"></template>
       </div>
     </template>
   </div>
-`
+  `
 })
 export class NgbAccordion implements AfterContentChecked {
   /**
@@ -139,6 +143,11 @@ export class NgbAccordion implements AfterContentChecked {
    *  Whether the other panels should be closed when a panel is opened
    */
   @Input('closeOthers') closeOtherPanels: boolean;
+
+  /**
+   * Whether the closed panels should be hidden without destroying them
+   */
+  @Input() destroyOnHide: boolean = true;
 
   /**
    *  Accordion's types of panels to be applied globally.


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.

Fixes https://github.com/ng-bootstrap/ng-bootstrap/issues/1161 and https://github.com/ng-bootstrap/ng-bootstrap/issues/1167 
In this case I left `hidden` because there are no examples of `accordion` component in Bootstrap 4 examples for `Card` and `active` would require writing custom CSS to hide the panel 