### PR TITLE
refactor(rating): simplify markup and reuse star contexts

### DIFF
--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -36,12 +36,12 @@ function getStar(compiled, num: number) {
   return getStars(compiled)[num - 1];
 }
 
-function getStars(element, selector = 'span > span:not(.sr-only)') {
+function getStars(element, selector = 'span:not(.sr-only)') {
   return <HTMLElement[]>Array.from(element.querySelectorAll(selector));
 }
 
 function getDbgStar(element, num: number) {
-  return element.queryAll(By.css('span > span:not(.sr-only)'))[num - 1];
+  return element.queryAll(By.css('span:not(.sr-only)'))[num - 1];
 }
 
 function getState(element: DebugElement | HTMLElement) {
@@ -175,7 +175,7 @@ describe('ngb-rating', () => {
   it('handles correctly the mouse enter/leave', () => {
     const fixture = createTestComponent('<ngb-rating [(rate)]="rate" max="5"></ngb-rating>');
     const el = fixture.debugElement;
-    const rating = el.query(By.directive(NgbRating)).children[0];
+    const rating = el.query(By.directive(NgbRating));
 
     // 3/5
     expect(getState(el)).toEqual([true, true, true, false, false]);
@@ -318,9 +318,9 @@ describe('ngb-rating', () => {
     it('contains aria-valuemax with the number of stars', () => {
       const fixture = createTestComponent('<ngb-rating [max]="max"></ngb-rating>');
 
-      const compiled = fixture.nativeElement;
+      const rating = fixture.debugElement.query(By.directive(NgbRating));
 
-      expect(compiled.querySelector('span').getAttribute('aria-valuemax')).toBe('10');
+      expect(rating.attributes['aria-valuemax']).toBe('10');
     });
 
     it('contains a hidden span for each star for screenreaders', () => {
@@ -336,38 +336,37 @@ describe('ngb-rating', () => {
       const fixture = createTestComponent('<ngb-rating rate="3" max="5"></ngb-rating>');
 
       const compiled = fixture.nativeElement;
-
       expect(getAriaState(compiled)).toEqual([true, true, true, false, false]);
     });
 
     it('contains aria-valuenow with the current rate', () => {
       const fixture = createTestComponent('<ngb-rating [max]="max" rate="3"></ngb-rating>');
 
-      const compiled = fixture.nativeElement;
+      const rating = fixture.debugElement.query(By.directive(NgbRating));
 
-      expect(compiled.querySelector('span').getAttribute('aria-valuenow')).toBe('3');
+      expect(rating.attributes['aria-valuenow']).toBe('3');
     });
 
     it('updates aria-valuenow when the rate changes', () => {
       const fixture = createTestComponent('<ngb-rating [max]="max" rate="3"></ngb-rating>');
 
-      const compiled = fixture.nativeElement;
+      const rating = fixture.debugElement.query(By.directive(NgbRating));
 
-      getStar(compiled, 7).click();
+      getStar(rating.nativeElement, 7).click();
       fixture.detectChanges();
 
-      expect(compiled.querySelector('span').getAttribute('aria-valuenow')).toBe('7');
+      expect(rating.attributes['aria-valuenow']).toBe('7');
     });
 
     it('updates aria-valuetext when the rate changes', () => {
       const fixture = createTestComponent('<ngb-rating [max]="max" rate="3"></ngb-rating>');
 
-      const compiled = fixture.nativeElement;
+      const rating = fixture.debugElement.query(By.directive(NgbRating));
 
-      getStar(compiled, 7).click();
+      getStar(rating.nativeElement, 7).click();
       fixture.detectChanges();
 
-      expect(compiled.querySelector('span').getAttribute('aria-valuetext')).toBe('7 out of 10');
+      expect(rating.attributes['aria-valuetext']).toBe('7 out of 10');
     });
   });
 

--- a/src/rating/rating.ts
+++ b/src/rating/rating.ts
@@ -47,26 +47,32 @@ const NGB_RATING_VALUE_ACCESSOR = {
 @Component({
   selector: 'ngb-rating',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  host: {'(keydown)': 'handleKeyDown($event)'},
+  host: {
+    'class': 'd-inline-flex',
+    'tabindex': '0',
+    'role': 'slider',
+    'attr.aria-valuemin': '0',
+    '[attr.aria-valuemax]': 'max',
+    '[attr.aria-valuenow]': 'nextRate',
+    '[attr.aria-valuetext]': 'ariaValueText()',
+    '(mouseleave)': 'reset()',
+    '(keydown)': 'handleKeyDown($event)'
+  },
   template: `
     <template #t let-fill="fill">{{ fill === 100 ? '&#9733;' : '&#9734;' }}</template>
-    <span tabindex="0" (mouseleave)="reset()" role="slider" aria-valuemin="0"
-      [attr.aria-valuemax]="max" [attr.aria-valuenow]="nextRate" [attr.aria-valuetext]="ariaValueText()">
-      <template ngFor [ngForOf]="range" let-index="index">
-        <span class="sr-only">({{ index < nextRate ? '*' : ' ' }})</span>
-        <span (mouseenter)="enter(index + 1)" (click)="update(index + 1)" 
-        [style.cursor]="readonly ? 'default' : 'pointer'">
-          <template [ngTemplateOutlet]="starTemplate || t" [ngOutletContext]="{fill: getFillValue(index)}"></template>
-        </span>
-      </template>
-    </span>
+    <template ngFor [ngForOf]="contexts" let-index="index">
+      <span class="sr-only">({{ index < nextRate ? '*' : ' ' }})</span>
+      <span (mouseenter)="enter(index + 1)" (click)="update(index + 1)" [style.cursor]="readonly ? 'default' : 'pointer'">
+        <template [ngTemplateOutlet]="starTemplate || t" [ngOutletContext]="contexts[index]"></template>
+      </span>
+    </template>
   `,
   providers: [NGB_RATING_VALUE_ACCESSOR]
 })
 export class NgbRating implements ControlValueAccessor,
     OnInit, OnChanges {
+  contexts: StarTemplateContext[] = [];
   nextRate: number;
-  range: number[] = [];
 
   /**
    * Maximal rating that can be given using this widget.
@@ -119,7 +125,7 @@ export class NgbRating implements ControlValueAccessor,
 
   enter(value: number): void {
     if (!this.readonly) {
-      this.nextRate = value;
+      this._updateState(value);
     }
     this.hover.emit(value);
   }
@@ -147,7 +153,44 @@ export class NgbRating implements ControlValueAccessor,
     }
   }
 
-  getFillValue(index: number): number {
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['rate']) {
+      this.update(this.rate);
+    }
+  }
+
+  ngOnInit(): void {
+    this.contexts = Array.from({length: this.max}, () => ({fill: 0}));
+    this._updateState(this.rate);
+  }
+
+  registerOnChange(fn: (value: any) => any): void { this.onChange = fn; }
+
+  registerOnTouched(fn: () => any): void { this.onTouched = fn; }
+
+  reset(): void {
+    this.leave.emit(this.nextRate);
+    this._updateState(this.rate);
+  }
+
+  update(value: number, internalChange = true): void {
+    const newRate = getValueInRange(value, this.max, 0);
+    if (!this.readonly && this.rate !== newRate) {
+      this.rate = newRate;
+      this.rateChange.emit(this.rate);
+    }
+    if (internalChange) {
+      this.onChange(this.rate);
+    }
+    this._updateState(this.rate);
+  }
+
+  writeValue(value) {
+    this.update(value, false);
+    this._changeDetectorRef.markForCheck();
+  }
+
+  private _getFillValue(index: number): number {
     const diff = this.nextRate - index;
 
     if (diff >= 1) {
@@ -160,40 +203,8 @@ export class NgbRating implements ControlValueAccessor,
     return 0;
   }
 
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes['rate']) {
-      this.update(this.rate);
-    }
-  }
-
-  ngOnInit(): void {
-    this.range = Array.from({length: this.max}, (v, k) => k + 1);
-    this.nextRate = this.rate;
-  }
-
-  registerOnChange(fn: (value: any) => any): void { this.onChange = fn; }
-
-  registerOnTouched(fn: () => any): void { this.onTouched = fn; }
-
-  reset(): void {
-    this.leave.emit(this.nextRate);
-    this.nextRate = this.rate;
-  }
-
-  update(value: number, internalChange = true): void {
-    const newRate = getValueInRange(value, this.max, 0);
-    if (!this.readonly && this.rate !== newRate) {
-      this.rate = newRate;
-      this.rateChange.emit(this.rate);
-    }
-    if (internalChange) {
-      this.onChange(this.rate);
-    }
-    this.nextRate = this.rate;
-  }
-
-  writeValue(value) {
-    this.update(value, false);
-    this._changeDetectorRef.markForCheck();
+  private _updateState(nextValue: number) {
+    this.nextRate = nextValue;
+    this.contexts.forEach((context, index) => context.fill = this._getFillValue(index));
   }
 }


### PR DESCRIPTION
Several rating updates as a result of trying to fix #1204 

- Simplified markup → removed intermediate parent `span`, sticking everything onto host directly
- Display changed to `inline-flex`
- Reusing template contexts:

Before: `[ngOutletContext]="{fill: getFillValue(index)}"`
Now: `[ngOutletContext]="contexts[index]"`

This was triggering star template element recreation that was giving 2 `mouseenter` events instead of 1 and most likely the cause of missing `mouseleave` on the parent

Fixes #1204 