### PR TITLE
Demo AoT build fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   - ./scripts/sauce_connect_setup.sh
 
 script:
-  - gulp
+  - gulp ci
   - ./scripts/sauce_connect_block.sh
   - gulp saucelabs
 

--- a/demo/src/app/components/datepicker/demos/calendars/datepicker-calendars.ts
+++ b/demo/src/app/components/datepicker/demos/calendars/datepicker-calendars.ts
@@ -9,7 +9,7 @@ const MONTHS_FULL = [
 ];
 
 @Injectable()
-class IslamicCivilI18n extends NgbDatepickerI18n {
+export class IslamicCivilI18n extends NgbDatepickerI18n {
 
 
   getWeekdayShortName(weekday: number) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,4 @@
+var asyncDone = require('async-done');
 var gulp = require('gulp');
 var gutil = require('gulp-util');
 var ddescribeIit = require('gulp-ddescribe-iit');
@@ -162,9 +163,10 @@ gulp.task('build:tests', ['clean:tests'], (cb) => {
 gulp.task(
     'ddescribe-iit', function() { return gulp.src(PATHS.specs).pipe(ddescribeIit({allowDisabledTests: false})); });
 
-gulp.task('test', ['build:tests'], function() {
+gulp.task('test', ['build:tests'], function(done) {
   startKarmaServer(false, false, () => {
-    return gulp.src(PATHS.coverageJson).pipe(remapIstanbul({reports: {'html': 'coverage/html'}}));
+    asyncDone(
+        () => { return gulp.src(PATHS.coverageJson).pipe(remapIstanbul({reports: {'html': 'coverage/html'}})); }, done);
   });
 });
 
@@ -283,3 +285,5 @@ gulp.task(
     'deploy-demo', function(done) { runSequence('clean:demo', 'build:demo', 'demo-push', 'clean:demo-cache', done); });
 
 gulp.task('default', function(done) { runSequence('lint', 'enforce-format', 'ddescribe-iit', 'test', done); });
+
+gulp.task('ci', function(done) { runSequence('default', 'build:demo', done); });

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/jasmine": "2.5.41",
     "@types/node": "^6.0.46",
     "angular2-template-loader": "^0.6.0",
+    "async-done": "^1.2.2",
     "autoprefixer": "^6.5.1",
     "bootstrap": "4.0.0-alpha.6",
     "clang-format": "1.0.35",


### PR DESCRIPTION
While releasing alpha.21 I've bumped into AoT errors with the freshly added datepicker calendar demo. After the investigation it turned out to be a missing `export` and it was easy to fix. The real problem, thought, was that there was nothing that warned us about the fact that our demo page was broken in the AoT mode.

This PR fixes the AoT issue and adds demo build process to our CI so we can catch those errors as early as possible. Additionally it fixes an issue where the `test` task was exiting process too early without waiting for test coverage reports to be generated. This was causing issue with any tasks executed after `test` - those tasks were executed too early, while tests were still running.

@maxokorokov since you've added the datepicker demo _and_ were playing with Karma setup, could you please review this one? Ping me if you've got any questions.