### PR TITLE
refactor(modal): setting NgbModalRef as a generic type

### DIFF
--- a/src/modal/modal-ref.ts
+++ b/src/modal/modal-ref.ts
@@ -1,4 +1,4 @@
-import {Injectable, ComponentRef} from '@angular/core';
+﻿import {Injectable, ComponentRef} from '@angular/core';
 
 import {NgbModalBackdrop} from './modal-backdrop';
 import {NgbModalWindow} from './modal-window';
@@ -26,7 +26,7 @@ export class NgbActiveModal {
  * A reference to a newly opened modal.
  */
 @Injectable()
-export class NgbModalRef {
+export class NgbModalRef<T> {
   private _resolve: (result?: any) => void;
   private _reject: (reason?: any) => void;
 
@@ -34,14 +34,14 @@ export class NgbModalRef {
    * The instance of component used as modal's content.
    * Undefined when a TemplateRef is used as modal's content.
    */
-  get componentInstance(): any {
+  get componentInstance(): T {
     if (this._contentRef.componentRef) {
       return this._contentRef.componentRef.instance;
     }
   }
 
   // only needed to keep TS1.8 compatibility
-  set componentInstance(instance: any) {}
+  set componentInstance(instance: T) {}
 
   /**
    * A promise that is resolved when a modal is closed and rejected when a modal is dismissed.

--- a/src/modal/modal-stack.ts
+++ b/src/modal/modal-stack.ts
@@ -1,4 +1,4 @@
-import {
+﻿import {
   ApplicationRef,
   Injectable,
   Injector,
@@ -28,7 +28,7 @@ export class NgbModalStack {
     this._windowFactory = _componentFactoryResolver.resolveComponentFactory(NgbModalWindow);
   }
 
-  open(moduleCFR: ComponentFactoryResolver, contentInjector: Injector, content: any, options): NgbModalRef {
+  open<T>(moduleCFR: ComponentFactoryResolver, contentInjector: Injector, content: T, options): NgbModalRef<T> {
     const containerSelector = options.container || 'body';
     const containerEl = document.querySelector(containerSelector);
 
@@ -41,7 +41,7 @@ export class NgbModalStack {
 
     let windowCmptRef: ComponentRef<NgbModalWindow>;
     let backdropCmptRef: ComponentRef<NgbModalBackdrop>;
-    let ngbModalRef: NgbModalRef;
+    let ngbModalRef: NgbModalRef<T>;
 
 
     if (options.backdrop !== false) {
@@ -53,7 +53,7 @@ export class NgbModalStack {
     this._applicationRef.attachView(windowCmptRef.hostView);
     containerEl.appendChild(windowCmptRef.location.nativeElement);
 
-    ngbModalRef = new NgbModalRef(windowCmptRef, contentRef, backdropCmptRef);
+    ngbModalRef = new NgbModalRef<T>(windowCmptRef, contentRef, backdropCmptRef);
 
     activeModal.close = (result: any) => { ngbModalRef.close(result); };
     activeModal.dismiss = (reason: any) => { ngbModalRef.dismiss(reason); };

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -1,4 +1,4 @@
-import {Component, Injectable, ViewChild, OnDestroy, NgModule, getDebugNode, DebugElement} from '@angular/core';
+﻿import {Component, Injectable, ViewChild, OnDestroy, NgModule, getDebugNode, DebugElement} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {TestBed, ComponentFixture} from '@angular/core/testing';
 
@@ -528,7 +528,7 @@ export class WithActiveModalCmpt {
 })
 class TestComponent {
   name = 'World';
-  openedModal: NgbModalRef;
+  openedModal: NgbModalRef<any>;
   show = true;
   @ViewChild('content') tplContent;
   @ViewChild('destroyableContent') tplDestroyableContent;
@@ -548,7 +548,7 @@ class TestComponent {
     }
   }
   openTpl(options?: Object) { return this.modalService.open(this.tplContent, options); }
-  openCmpt(cmptType: any, options?: Object) { return this.modalService.open(cmptType, options); }
+  openCmpt<T>(cmptType: T, options?: Object) { return this.modalService.open(cmptType, options); }
   openDestroyableTpl(options?: Object) { return this.modalService.open(this.tplDestroyableContent, options); }
   openTplClose(options?: Object) { return this.modalService.open(this.tplContentWithClose, options); }
   openTplDismiss(options?: Object) { return this.modalService.open(this.tplContentWithDismiss, options); }

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -1,4 +1,4 @@
-import {Injectable, Injector, ComponentFactoryResolver} from '@angular/core';
+﻿import {Injectable, Injector, ComponentFactoryResolver} from '@angular/core';
 
 import {NgbModalStack} from './modal-stack';
 import {NgbModalRef} from './modal-ref';
@@ -49,7 +49,7 @@ export class NgbModal {
    * components can be injected with an instance of the NgbActiveModal class. You can use methods on the
    * NgbActiveModal class to close / dismiss modals from "inside" of a component.
    */
-  open(content: any, options: NgbModalOptions = {}): NgbModalRef {
+  open<T>(content: T, options: NgbModalOptions = {}): NgbModalRef<T> {
     return this._modalStack.open(this._moduleCFR, this._injector, content, options);
   }
 }


### PR DESCRIPTION
Modal implementation code goes from:

        let modal = this.modalService.open(MyModalComponent);
        (modal.componentInstance as MyModalComponent).sampleInput= 'Sample Value';

to:

        let modal = this.modalService.open(MyModalComponent);
        modal.componentInstance.sampleInput= 'Sample Value';

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.
