### PR TITLE
demo: improve accessibility and keyboard navigation

### DIFF
--- a/demo/src/app/components/shared/example-box/example-box.component.html
+++ b/demo/src/app/components/shared/example-box/example-box.component.html
@@ -5,7 +5,9 @@
         {{ demoTitle }}
       </span>
       <div class="float-right">
-        <img role="button" src="img/code-icon.png" (click)="toggleCode()" title="Show source code"/>
+        <button class="btn-link" (click)="toggleCode()" title="{{showCode ? 'Hide' : 'Show'}} source code">
+          <img src="img/code-icon.png" height="24" width="24"/>
+        </button>
         <a target="_blank" href="app/components/{{component}}/demos/{{demo}}/plnkr.html" title="Edit in Plnkr" >
           <img src="img/plunker-icon.png" height="24" width="24"/>
         </a>


### PR DESCRIPTION
Previously the show / hide source code icon was not
focusable and was always announced as 'Show source code'
even if the code was already shown.