### PR TITLE
feat(pagination): improve accessibility

### DIFF
--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -22,10 +22,14 @@ function expectPages(nativeEl: HTMLElement, pagesDef: string[]): void {
     if (classIndicator === '+') {
       expect(pages[i]).toHaveCssClass('active');
       expect(pages[i]).not.toHaveCssClass('disabled');
-      expect(normalizeText(pages[i].textContent)).toEqual(pageDef.substr(1) + ' (current)');
+      expect(pages[i].querySelector('a').getAttribute('aria-label'))
+          .toEqual('Page ' + pageDef.substr(1) + ' (current)');
+      expect(pages[i].querySelector('a').getAttribute('aria-current')).toBeTruthy();
     } else if (classIndicator === '-') {
       expect(pages[i]).not.toHaveCssClass('active');
       expect(pages[i]).toHaveCssClass('disabled');
+      expect(pages[i].querySelector('a').getAttribute('aria-disabled')).toBeTruthy();
+      expect(pages[i].querySelector('a').getAttribute('aria-current')).toBeFalsy();
       expect(normalizeText(pages[i].textContent)).toEqual(pageDef.substr(1));
       if (normalizeText(pages[i].textContent) !== '...') {
         expect(pages[i].querySelector('a').getAttribute('tabindex')).toEqual('-1');
@@ -573,6 +577,8 @@ describe('ngb-pagination', () => {
          const buttons = fixture.nativeElement.querySelectorAll('li');
          for (let i = 0; i < buttons.length; i++) {
            expect(buttons[i]).toHaveCssClass('disabled');
+           expect(buttons[i].querySelector('a').getAttribute('aria-disabled')).toBeTruthy();
+           expect(buttons[i].querySelector('a').getAttribute('tabindex')).toEqual('-1');
          }
        }));
   });

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -13,36 +13,42 @@ import {NgbPaginationConfig} from './pagination-config';
     <ul [class]="'pagination' + (size ? ' pagination-' + size : '')">
       <li *ngIf="boundaryLinks" class="page-item"
         [class.disabled]="!hasPrevious() || disabled">
-        <a aria-label="First" class="page-link" href (click)="!!selectPage(1)" [attr.tabindex]="hasPrevious() ? null : '-1'">
+        <a aria-label="First" class="page-link" href (click)="!!selectPage(1)"
+          [attr.tabindex]="(!hasPrevious() || disabled ? '-1' : undefined)" [attr.aria-disabled]="!hasPrevious() || disabled">
           <span aria-hidden="true">&laquo;&laquo;</span>
           <span class="sr-only">First</span>
         </a>
       </li>
-
       <li *ngIf="directionLinks" class="page-item"
         [class.disabled]="!hasPrevious() || disabled">
-        <a aria-label="Previous" class="page-link" href (click)="!!selectPage(page-1)" [attr.tabindex]="hasPrevious() ? null : '-1'">
+        <a aria-label="Previous" class="page-link" href (click)="!!selectPage(page-1)"
+          [attr.tabindex]="(!hasPrevious() || disabled ? '-1' : undefined)"  [attr.aria-disabled]="!hasPrevious() || disabled">
           <span aria-hidden="true">&laquo;</span>
           <span class="sr-only">Previous</span>
         </a>
       </li>
       <li *ngFor="let pageNumber of pages" class="page-item" [class.active]="pageNumber === page"
         [class.disabled]="isEllipsis(pageNumber) || disabled">
-        <a *ngIf="isEllipsis(pageNumber)" class="page-link">...</a>
-        <a *ngIf="!isEllipsis(pageNumber)" class="page-link" href (click)="!!selectPage(pageNumber)">
+        <a *ngIf="isEllipsis(pageNumber)" class="page-link"
+          [attr.tabindex]="(disabled ? '-1' : undefined)" [attr.aria-disabled]="disabled">
+          ...
+        </a>
+        <a *ngIf="!isEllipsis(pageNumber)" class="page-link" href (click)="!!selectPage(pageNumber)"
+          [attr.aria-current]="pageNumber === page" [attr.tabindex]="(disabled ? '-1' : undefined)" [attr.aria-disabled]="disabled"
+          [attr.aria-label]="'Page ' + pageNumber + (pageNumber === page ? ' (current)' : '')">
           {{pageNumber}}
-          <span *ngIf="pageNumber === page" class="sr-only">(current)</span>
         </a>
       </li>
       <li *ngIf="directionLinks" class="page-item" [class.disabled]="!hasNext() || disabled">
-        <a aria-label="Next" class="page-link" href (click)="!!selectPage(page+1)" [attr.tabindex]="hasNext() ? null : '-1'">
+        <a aria-label="Next" class="page-link" href (click)="!!selectPage(page+1)"
+          [attr.tabindex]="(!hasNext() || disabled ? '-1' : undefined)" [attr.aria-disabled]="!hasNext() || disabled">
           <span aria-hidden="true">&raquo;</span>
           <span class="sr-only">Next</span>
         </a>
       </li>
-
       <li *ngIf="boundaryLinks" class="page-item" [class.disabled]="!hasNext() || disabled">
-        <a aria-label="Last" class="page-link" href (click)="!!selectPage(pageCount)" [attr.tabindex]="hasNext() ? null : '-1'">
+        <a aria-label="Last" class="page-link" href (click)="!!selectPage(pageCount)"
+          [attr.tabindex]="(!hasNext() || disabled ? '-1' : undefined)" [attr.aria-disabled]="!hasNext() || disabled">
           <span aria-hidden="true">&raquo;&raquo;</span>
           <span class="sr-only">Last</span>
         </a>
@@ -126,7 +132,11 @@ export class NgbPagination implements OnChanges {
 
   hasNext(): boolean { return this.page < this.pageCount; }
 
-  selectPage(pageNumber: number): void { this._updatePages(pageNumber); }
+  selectPage(pageNumber: number): void {
+    if (!this.disabled) {
+      this._updatePages(pageNumber);
+    }
+  }
 
   ngOnChanges(changes: SimpleChanges): void { this._updatePages(this.page); }
 

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -34,8 +34,8 @@ import {NgbPaginationConfig} from './pagination-config';
           ...
         </a>
         <a *ngIf="!isEllipsis(pageNumber)" class="page-link" href (click)="!!selectPage(pageNumber)"
-          [attr.aria-current]="pageNumber === page" [attr.tabindex]="(disabled ? '-1' : undefined)" [attr.aria-disabled]="disabled"
-          [attr.aria-label]="'Page ' + pageNumber + (pageNumber === page ? ' (current)' : '')">
+          [attr.aria-current]="(pageNumber === page ? true : undefined)" [attr.aria-disabled]="disabled"
+          [attr.aria-label]="'Page '+pageNumber+(pageNumber===page?' (current)':'')" [attr.tabindex]="(disabled ? '-1' : undefined)">
           {{pageNumber}}
         </a>
       </li>


### PR DESCRIPTION
disabled pagination is not focusable by tab
fix a bug where it would be possible to select a page when the pagination was disabled
add `tabindex=-1` on all links when the pagination is disabled (this is debatable)

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
