### PR TITLE
fix(pagination): swapped out disabled anchor for span

### DIFF
--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -19,24 +19,23 @@ function expectPages(nativeEl: HTMLElement, pagesDef: string[]): void {
     let pageDef = pagesDef[i];
     let classIndicator = pageDef.charAt(0);
 
-    if (classIndicator === '+') {
+    if (classIndicator === '+') {  // active
       expect(pages[i]).toHaveCssClass('active');
       expect(pages[i]).not.toHaveCssClass('disabled');
-      expect(normalizeText(pages[i].textContent)).toEqual(pageDef.substr(1) + ' (current)');
-    } else if (classIndicator === '-') {
+      expect(pages[i].querySelectorAll('span')[0].textContent.trim().replace(/\s\s+/g, ' '))
+          .toEqual(pageDef.substr(1) + ' Page ' + pageDef.substr(1) + ' (current)');
+    } else if (classIndicator === '-') {  // disabled
       expect(pages[i]).not.toHaveCssClass('active');
       expect(pages[i]).toHaveCssClass('disabled');
-      expect(normalizeText(pages[i].textContent)).toEqual(pageDef.substr(1));
-      if (normalizeText(pages[i].textContent) !== '...') {
-        expect(pages[i].querySelector('a').getAttribute('tabindex')).toEqual('-1');
-      }
+      expect(pages[i].querySelectorAll('span')[0].textContent.trim().replace(/\s\s+/g, ' ')).toEqual(pageDef.substr(1));
+    } else if (classIndicator === '*') {  // disabled active
+      expect(pages[i]).toHaveCssClass('active');
+      expect(pages[i]).toHaveCssClass('disabled');
+      expect(pages[i].querySelectorAll('span')[0].textContent.trim().replace(/\s\s+/g, ' ')).toEqual(pageDef.substr(1));
     } else {
       expect(pages[i]).not.toHaveCssClass('active');
       expect(pages[i]).not.toHaveCssClass('disabled');
-      expect(normalizeText(pages[i].textContent)).toEqual(pageDef);
-      if (normalizeText(pages[i].textContent) !== '...') {
-        expect(pages[i].querySelector('a').hasAttribute('tabindex')).toBeFalsy();
-      }
+      expect(pages[i].querySelector('a').textContent.trim().replace(/\s\s+/g, ' ')).toEqual(pageDef);
     }
   }
 }
@@ -218,17 +217,9 @@ describe('ngb-pagination', () => {
       fixture.detectChanges();
       expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
 
-      getLink(fixture.nativeElement, 0).click();
-      fixture.detectChanges();
-      expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
-
       getLink(fixture.nativeElement, 4).click();
       fixture.detectChanges();
       expectPages(fixture.nativeElement, ['« Previous', '1', '+2', '3', '» Next']);
-
-      getLink(fixture.nativeElement, 4).click();
-      fixture.detectChanges();
-      expectPages(fixture.nativeElement, ['« Previous', '1', '2', '+3', '-» Next']);
 
       getLink(fixture.nativeElement, 4).click();
       fixture.detectChanges();
@@ -245,10 +236,6 @@ describe('ngb-pagination', () => {
       expectPages(fixture.nativeElement, ['-« Previous', '+1', '2', '3', '» Next']);
 
       fixture.componentInstance.boundaryLinks = true;
-      fixture.detectChanges();
-      expectPages(fixture.nativeElement, ['-«« First', '-« Previous', '+1', '2', '3', '» Next', '»» Last']);
-
-      getLink(fixture.nativeElement, 0).click();
       fixture.detectChanges();
       expectPages(fixture.nativeElement, ['-«« First', '-« Previous', '+1', '2', '3', '» Next', '»» Last']);
 
@@ -565,8 +552,7 @@ describe('ngb-pagination', () => {
          expect(fixture.componentInstance.onPageChange).not.toHaveBeenCalled();
        }));
     it('should set classes correctly for disabled state', fakeAsync(() => {
-         const html = `<ngb-pagination [collectionSize]="collectionSize" [pageSize]="pageSize" [maxSize]="maxSize"
-         [disabled]=true></ngb-pagination>`;
+         const html = `<ngb-pagination [pageSize]="10" [disabled]=true></ngb-pagination>`;
          const fixture = createTestComponent(html);
          tick();
 
@@ -575,6 +561,7 @@ describe('ngb-pagination', () => {
            expect(buttons[i]).toHaveCssClass('disabled');
          }
        }));
+
   });
 
   describe('Custom config', () => {
@@ -639,6 +626,7 @@ class TestComponent {
   maxSize = 0;
   ellipses = true;
   rotate = false;
+  disabled = false;
 
   onPageChange = () => {};
 }

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -11,41 +11,59 @@ import {NgbPaginationConfig} from './pagination-config';
   host: {'role': 'navigation'},
   template: `
     <ul [class]="'pagination' + (size ? ' pagination-' + size : '')">
-      <li *ngIf="boundaryLinks" class="page-item"
-        [class.disabled]="!hasPrevious() || disabled">
-        <a aria-label="First" class="page-link" href (click)="!!selectPage(1)" [attr.tabindex]="hasPrevious() ? null : '-1'">
+      <li *ngIf="boundaryLinks" class="page-item" [class.disabled]="!hasPrevious() || disabled">
+        <a *ngIf="hasPrevious() && !disabled" class="page-link" aria-label="First"  href (click)="!!selectPage(1)">
           <span aria-hidden="true">&laquo;&laquo;</span>
           <span class="sr-only">First</span>
         </a>
+        <span *ngIf="!hasPrevious() || disabled" class="page-link">
+          <span aria-hidden="true">&laquo;&laquo;</span>
+          <span class="sr-only">First</span>
+        </span>
       </li>
-
-      <li *ngIf="directionLinks" class="page-item"
-        [class.disabled]="!hasPrevious() || disabled">
-        <a aria-label="Previous" class="page-link" href (click)="!!selectPage(page-1)" [attr.tabindex]="hasPrevious() ? null : '-1'">
+      <li *ngIf="directionLinks" class="page-item" [class.disabled]="!hasPrevious() || disabled">
+        <a *ngIf="hasPrevious() && !disabled" class="page-link" aria-label="Previous" href (click)="!!selectPage(page-1)">
           <span aria-hidden="true">&laquo;</span>
           <span class="sr-only">Previous</span>
         </a>
+        <span *ngIf="!hasPrevious() || disabled" class="page-link">
+          <span aria-hidden="true">&laquo;</span>
+          <span class="sr-only">Previous</span>
+        </span>
       </li>
       <li *ngFor="let pageNumber of pages" class="page-item" [class.active]="pageNumber === page"
         [class.disabled]="isEllipsis(pageNumber) || disabled">
-        <a *ngIf="isEllipsis(pageNumber)" class="page-link">...</a>
-        <a *ngIf="!isEllipsis(pageNumber)" class="page-link" href (click)="!!selectPage(pageNumber)">
-          {{pageNumber}}
-          <span *ngIf="pageNumber === page" class="sr-only">(current)</span>
-        </a>
+        <span *ngIf="isEllipsis(pageNumber)" class="page-link">...</span>
+        <ng-container *ngIf="!isEllipsis(pageNumber)">
+          <a *ngIf="pageNumber!==page && !disabled" class="page-link" href (click)="!!selectPage(pageNumber)"
+            [attr.aria-label]="'Page '+pageNumber">
+            {{pageNumber}}
+          </a>
+          <span *ngIf="pageNumber === page || disabled" class="page-link">
+            <span aria-hidden="true">{{pageNumber}}</span>
+            <span class="sr-only">Page {{pageNumber}} {{pageNumber === page ? '(current)' : ''}}</span>
+          </span>
+        </ng-container>
       </li>
       <li *ngIf="directionLinks" class="page-item" [class.disabled]="!hasNext() || disabled">
-        <a aria-label="Next" class="page-link" href (click)="!!selectPage(page+1)" [attr.tabindex]="hasNext() ? null : '-1'">
+        <a *ngIf="hasNext() && !disabled" class="page-link" aria-label="Next" href (click)="!!selectPage(page+1)">
           <span aria-hidden="true">&raquo;</span>
           <span class="sr-only">Next</span>
         </a>
+        <span *ngIf="!hasNext() || disabled" class="page-link">
+          <span aria-hidden="true">&raquo;</span>
+          <span class="sr-only">Next</span>
+        </span>
       </li>
-
       <li *ngIf="boundaryLinks" class="page-item" [class.disabled]="!hasNext() || disabled">
-        <a aria-label="Last" class="page-link" href (click)="!!selectPage(pageCount)" [attr.tabindex]="hasNext() ? null : '-1'">
+        <a *ngIf="hasNext() && !disabled" class="page-link" aria-label="Last" href (click)="!!selectPage(pageCount)">
           <span aria-hidden="true">&raquo;&raquo;</span>
           <span class="sr-only">Last</span>
         </a>
+        <span *ngIf="!hasNext() || disabled" class="page-link">
+          <span aria-hidden="true">&raquo;&raquo;</span>
+          <span class="sr-only">Last</span>
+        </span>
       </li>
     </ul>
   `
@@ -126,7 +144,11 @@ export class NgbPagination implements OnChanges {
 
   hasNext(): boolean { return this.page < this.pageCount; }
 
-  selectPage(pageNumber: number): void { this._updatePages(pageNumber); }
+  selectPage(pageNumber: number): void {
+    if (!this.disabled) {
+      this._updatePages(pageNumber);
+    }
+  }
 
   ngOnChanges(changes: SimpleChanges): void { this._updatePages(this.page); }
 


### PR DESCRIPTION
disabled pagination is not focusable by tab anymore
fix a bug where it would be possible to select a page when the pagination was disabled
improve accessibility 

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
