### PR TITLE
fix(demo): change name of showvalue progressbar demo component

### DIFF
--- a/demo/src/app/components/progressbar/demos/index.ts
+++ b/demo/src/app/components/progressbar/demos/index.ts
@@ -1,12 +1,12 @@
 import {NgbdProgressbarBasic} from './basic/progressbar-basic';
-import {NgbdProgressbarShowValue} from './showvalue/progressbar-showvalue';
+import {NgbdProgressbarShowvalue} from './showvalue/progressbar-showvalue';
 import {NgbdProgressbarStriped} from './striped/progressbar-striped';
 import {NgbdProgressbarConfig} from './config/progressbar-config';
 import {NgbdProgressbarLabels} from './labels/progressbar-labels';
 
 export const DEMO_DIRECTIVES = [
   NgbdProgressbarBasic,
-  NgbdProgressbarShowValue,
+  NgbdProgressbarShowvalue,
   NgbdProgressbarStriped,
   NgbdProgressbarConfig,
   NgbdProgressbarLabels

--- a/demo/src/app/components/progressbar/demos/showvalue/progressbar-showvalue.ts
+++ b/demo/src/app/components/progressbar/demos/showvalue/progressbar-showvalue.ts
@@ -9,5 +9,5 @@ import {Component} from '@angular/core';
     }
   `]
 })
-export class NgbdProgressbarShowValue {
+export class NgbdProgressbarShowvalue {
 }


### PR DESCRIPTION
The demo worked fine on the site, but not in plnkr, because the generated app component only capitalizes the first letter (Showvalue instead of ShowValue)

closes #1422
