### PR TITLE
fix(tabs): prevent focus of disabled tabs

### DIFF
--- a/src/tabset/tabset.spec.ts
+++ b/src/tabset/tabset.spec.ts
@@ -41,12 +41,12 @@ function expectTabs(nativeEl: HTMLElement, active: boolean[], disabled?: boolean
 
     if (disabled[i]) {
       expect(tabTitles[i]).toHaveCssClass('disabled');
-      expect(tabTitles[i].getAttribute('aria-disabled')).toEqual('true');
-      expect(tabTitles[i].getAttribute('tabindex')).toEqual('-1');
+      expect(tabTitles[i].getAttribute('aria-disabled')).toBe('true');
+      expect(tabTitles[i].getAttribute('tabindex')).toBe('-1');
     } else {
       expect(tabTitles[i]).not.toHaveCssClass('disabled');
-      expect(tabTitles[i].getAttribute('aria-disabled')).toEqual('false');
-      expect(tabTitles[i].getAttribute('tabindex')).toBeFalsy();
+      expect(tabTitles[i].getAttribute('aria-disabled')).toBe('false');
+      expect(tabTitles[i].getAttribute('tabindex')).toBeNull();
     }
   }
 }

--- a/src/tabset/tabset.spec.ts
+++ b/src/tabset/tabset.spec.ts
@@ -41,8 +41,12 @@ function expectTabs(nativeEl: HTMLElement, active: boolean[], disabled?: boolean
 
     if (disabled[i]) {
       expect(tabTitles[i]).toHaveCssClass('disabled');
+      expect(tabTitles[i].getAttribute('aria-disabled')).toEqual('true');
+      expect(tabTitles[i].getAttribute('tabindex')).toEqual('-1');
     } else {
       expect(tabTitles[i]).not.toHaveCssClass('disabled');
+      expect(tabTitles[i].getAttribute('aria-disabled')).toEqual('false');
+      expect(tabTitles[i].getAttribute('tabindex')).toBeFalsy();
     }
   }
 }

--- a/src/tabset/tabset.ts
+++ b/src/tabset/tabset.ts
@@ -82,7 +82,8 @@ export interface NgbTabChangeEvent {
     <ul [class]="'nav nav-' + type + ' justify-content-' + justify" role="tablist">
       <li class="nav-item" *ngFor="let tab of tabs">
         <a [id]="tab.id" class="nav-link" [class.active]="tab.id === activeId" [class.disabled]="tab.disabled"
-          href (click)="!!select(tab.id)" role="tab" [attr.aria-controls]="tab.id + '-panel'" [attr.aria-expanded]="tab.id === activeId">
+          href (click)="!!select(tab.id)" role="tab" [attr.tabindex]="(tab.disabled ? '-1': undefined)"
+          [attr.aria-controls]="tab.id + '-panel'" [attr.aria-expanded]="tab.id === activeId" [attr.aria-disabled]="tab.disabled">
           {{tab.title}}<template [ngTemplateOutlet]="tab.titleTpl?.templateRef"></template>
         </a>
       </li>


### PR DESCRIPTION
add `aria-disabled` attribute to disabled tabs.
fix #1430 

This is just a quick fix while waiting on [twbs/bootstrap#19738](https://github.com/twbs/bootstrap/issues/19738)

Before submitting a pull request, please make sure you have at least performed the following:
 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
