### PR TITLE
fix(datepicker): add stricter checks on dates validity

### DIFF
--- a/src/datepicker/datepicker-service.spec.ts
+++ b/src/datepicker/datepicker-service.spec.ts
@@ -117,7 +117,6 @@ describe('ngb-datepicker-service', () => {
     it('should convert a valid NgbDate', inject([NgbDatepickerService], (service) => {
          expect(service.toValidDate(new NgbDate(2016, 10, 5))).toEqual(new NgbDate(2016, 10, 5));
          expect(service.toValidDate({year: 2016, month: 10, day: 5})).toEqual(new NgbDate(2016, 10, 5));
-         expect(service.toValidDate(new NgbDate(999, 999, 999))).toEqual(new NgbDate(999, 999, 999));
        }));
 
     it('should return today for an invalid NgbDate',

--- a/src/datepicker/ngb-calendar.spec.ts
+++ b/src/datepicker/ngb-calendar.spec.ts
@@ -64,9 +64,7 @@ describe('ngb-calendar-gregorian', () => {
     expect(calendar.getPrev(new NgbDate(2017, 1, 22), 'y')).toEqual(new NgbDate(2016, 1, 1));
   });
 
-  it('should check that NgbDate is a valid javascript date', () => {
-
-    // invalid values
+  it('should properly recognize invalid javascript date', () => {
     expect(calendar.isValid(null)).toBeFalsy();
     expect(calendar.isValid(undefined)).toBeFalsy();
     expect(calendar.isValid(<any>NaN)).toBeFalsy();
@@ -75,16 +73,23 @@ describe('ngb-calendar-gregorian', () => {
     expect(calendar.isValid(new NgbDate(undefined, undefined, undefined))).toBeFalsy();
     expect(calendar.isValid(new NgbDate(NaN, NaN, NaN))).toBeFalsy();
     expect(calendar.isValid(new NgbDate(<any>'2017', <any>'03', <any>'10'))).toBeFalsy();
+  });
 
-    // min/max dates
-    expect(calendar.isValid(new NgbDate(275760, 9, 12))).toBeTruthy();
+  it('should recognize dates outside of JS range as invalid', () => {
     expect(calendar.isValid(new NgbDate(275760, 9, 14))).toBeFalsy();
     expect(calendar.isValid(new NgbDate(-271821, 4, 19))).toBeFalsy();
-    expect(calendar.isValid(new NgbDate(-271821, 4, 21))).toBeTruthy();
-
-    // valid dates
-    expect(calendar.isValid(new NgbDate(2016, 8, 8))).toBeTruthy();
-    expect(calendar.isValid(new NgbDate(0, 0, 0))).toBeTruthy();
-    expect(calendar.isValid(new NgbDate(-1, -1, -1))).toBeTruthy();
   });
+
+  it('should recognize dates outside of calendar range as invalid', () => {
+    expect(calendar.isValid(new NgbDate(0, 0, 0))).toBeFalsy();
+    expect(calendar.isValid(new NgbDate(-1, -1, -1))).toBeFalsy();
+    expect(calendar.isValid(new NgbDate(2016, 17, 1))).toBeFalsy();
+    expect(calendar.isValid(new NgbDate(2017, 5, 35))).toBeFalsy();
+  });
+
+  it('should mark valid JS dates as valid', () => {
+    expect(calendar.isValid(new NgbDate(275760, 9, 12))).toBeTruthy();
+    expect(calendar.isValid(new NgbDate(2016, 8, 8))).toBeTruthy();
+  });
+
 });

--- a/src/datepicker/ngb-calendar.ts
+++ b/src/datepicker/ngb-calendar.ts
@@ -89,7 +89,13 @@ export class NgbCalendarGregorian extends NgbCalendar {
   getToday(): NgbDate { return fromJSDate(new Date()); }
 
   isValid(date: NgbDate): boolean {
-    return date && isInteger(date.year) && isInteger(date.month) && isInteger(date.day) &&
-        !isNaN(toJSDate(date).getTime());
+    if (!date || !isInteger(date.year) || !isInteger(date.month) || !isInteger(date.day)) {
+      return false;
+    }
+
+    const jsDate = toJSDate(date);
+
+    return !isNaN(jsDate.getTime()) && jsDate.getFullYear() === date.year && jsDate.getMonth() + 1 === date.month &&
+        jsDate.getDate() === date.day;
   }
 }


### PR DESCRIPTION
Fixes #1230

BREAKING CHANGE:

Datepickers in popups are much stricter about valid dates
now and won't try to auto-correct invalid dates any more.
For example 2017-99-99 was considered valid previously and
auto-corrected. This is not the case any more. Please check
control's validity to detect invalid dates entered by users.
