### PR TITLE
chore(docs): add ability to configure port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ npm-debug.log
 .publish
 .sw*
 .idea
+.vscode
 coverage
 demo/src/api-docs.ts
 demo/src/public/**/plnkr.html
+local.docs.json

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,6 +30,8 @@ var PATHS = {
   coverageJson: 'coverage/json/coverage-final.json'
 };
 
+const docsConfig = Object.assign({port: 9090}, getLocalConfig());
+
 function platformPath(path) {
   return /^win/.test(os.platform()) ? `${path}.cmd` : path;
 }
@@ -258,7 +260,7 @@ gulp.task('clean:demo-cache', function() { return del('.publish/'); });
 
 gulp.task(
     'demo-server', ['generate-docs', 'generate-plunks'],
-    shell.task(['webpack-dev-server --port 9090 --config webpack.demo.js --inline --progress']));
+    shell.task([`webpack-dev-server --port ${docsConfig.port} --config webpack.demo.js --inline --progress`]));
 
 gulp.task(
     'build:demo', ['clean:demo', 'generate-docs', 'generate-plunks'],
@@ -267,7 +269,8 @@ gulp.task(
 gulp.task(
     'demo-server:aot', ['generate-docs', 'generate-plunks'],
     shell.task(
-        ['webpack-dev-server --port 9090 --config webpack.demo.js --inline --progress'], {env: {MODE: 'build'}}));
+        [`webpack-dev-server --port ${docsConfig.port} --config webpack.demo.js --inline --progress`],
+        {env: {MODE: 'build'}}));
 
 gulp.task('demo-push', function() {
   return gulp.src(PATHS.demoDist)
@@ -287,3 +290,13 @@ gulp.task(
 gulp.task('default', function(done) { runSequence('lint', 'enforce-format', 'ddescribe-iit', 'test', done); });
 
 gulp.task('ci', function(done) { runSequence('default', 'build:demo', done); });
+
+function getLocalConfig() {
+  try {
+    require.resolve('./local.docs.json');
+  } catch (e) {
+    return {};
+  }
+
+  return require('./local.docs.json');
+}


### PR DESCRIPTION
- Add ability to configure port used for demo server

This allows users to override the configuration locally in the event the user already uses the default port for other servers (i.e. using webpack-dev-server for local development of their angular application).