### PR TITLE
feat(modal): add a11y module and apply focus trap to modal dialog

### DIFF
--- a/src/a11y/a11y.module.ts
+++ b/src/a11y/a11y.module.ts
@@ -1,0 +1,16 @@
+import {NgModule, ModuleWithProviders} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {NgbPlatform} from './platform';
+import {NgbInteractivityChecker} from './interactivity-checker';
+import {NgbFocusTrapFactory, NgbFocusTrapDirective} from './focus-trap';
+
+export {NgbPlatform} from './platform';
+export {NgbInteractivityChecker} from './interactivity-checker';
+export {NgbFocusTrapFactory, NgbFocusTrapDirective, NgbFocusTrap} from './focus-trap';
+
+@NgModule({declarations: [NgbFocusTrapDirective], exports: [NgbFocusTrapDirective], imports: [CommonModule]})
+export class NgbA11yModule {
+  static forRoot(): ModuleWithProviders {
+    return {ngModule: NgbA11yModule, providers: [NgbFocusTrapFactory, NgbInteractivityChecker, NgbPlatform]};
+  }
+}

--- a/src/a11y/focus-trap.spec.ts
+++ b/src/a11y/focus-trap.spec.ts
@@ -1,0 +1,191 @@
+import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {Component, ViewChild} from '@angular/core';
+import {NgbFocusTrapFactory, NgbFocusTrapDirective, NgbFocusTrap} from './focus-trap';
+import {NgbInteractivityChecker} from './interactivity-checker';
+import {NgbPlatform} from './platform';
+
+
+describe('ngb-focus-trap', () => {
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [NgbFocusTrapDirective, FocusTrapWithBindings, SimpleFocusTrap, FocusTrapTargets, FocusTrapWithSvg],
+      providers: [NgbInteractivityChecker, NgbPlatform, NgbFocusTrapFactory]
+    });
+
+    TestBed.compileComponents();
+  }));
+
+  describe('with default element', () => {
+    let fixture: ComponentFixture<SimpleFocusTrap>;
+    let focusTrapInstance: NgbFocusTrap;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(SimpleFocusTrap);
+      fixture.detectChanges();
+      focusTrapInstance = fixture.componentInstance.focusTrapDirective.focusTrap;
+    });
+
+    it('wrap focus from end to start', () => {
+      // Because we can't mimic a real tab press focus change in a unit test, just call the
+      // focus event handler directly.
+      focusTrapInstance.focusFirstTabbableElement();
+
+      expect(document.activeElement.nodeName.toLowerCase()).toBe('input', 'Expected input element to be focused');
+    });
+
+    it('should wrap focus from start to end', () => {
+      // Because we can't mimic a real tab press focus change in a unit test, just call the
+      // focus event handler directly.
+      focusTrapInstance.focusLastTabbableElement();
+
+      // In iOS button elements are never tabbable, so the last element will be the input.
+      let lastElement = new NgbPlatform().IOS ? 'input' : 'button';
+
+      expect(document.activeElement.nodeName.toLowerCase())
+          .toBe(lastElement, `Expected ${lastElement} element to be focused`);
+    });
+
+    it('should be enabled by default', () => { expect(focusTrapInstance.enabled).toBe(true); });
+
+  });
+
+  describe('with bindings', () => {
+    let fixture: ComponentFixture<FocusTrapWithBindings>;
+    let focusTrapInstance: NgbFocusTrap;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(FocusTrapWithBindings);
+      fixture.detectChanges();
+      focusTrapInstance = fixture.componentInstance.focusTrapDirective.focusTrap;
+    });
+
+    it('should clean up its anchor sibling elements on destroy', () => {
+      const rootElement = fixture.debugElement.nativeElement as HTMLElement;
+
+      expect(rootElement.querySelectorAll('div.sr-only').length).toBe(2);
+
+      fixture.componentInstance.renderFocusTrap = false;
+      fixture.detectChanges();
+
+      expect(rootElement.querySelectorAll('div.sr-only').length).toBe(0);
+    });
+
+    it('should set the appropriate tabindex on the anchors, based on the disabled state', () => {
+      const anchors = Array.from(fixture.debugElement.nativeElement.querySelectorAll('div.sr-only')) as HTMLElement[];
+
+      expect(anchors.every(current => current.getAttribute('tabindex') === '0')).toBe(true);
+
+      fixture.componentInstance.isFocusTrapEnabled = false;
+      fixture.detectChanges();
+
+      expect(anchors.every(current => current.getAttribute('tabindex') === '-1')).toBe(true);
+    });
+  });
+
+  describe('with focus targets', () => {
+    let fixture: ComponentFixture<FocusTrapTargets>;
+    let focusTrapInstance: NgbFocusTrap;
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(FocusTrapTargets);
+      fixture.detectChanges();
+      focusTrapInstance = fixture.componentInstance.focusTrapDirective.focusTrap;
+    });
+
+    it('should be able to set initial focus target', () => {
+      // Because we can't mimic a real tab press focus change in a unit test, just call the
+      // focus event handler directly.
+      focusTrapInstance.focusInitialElement();
+      expect(document.activeElement.id).toBe('middle');
+    });
+
+    it('should be able to prioritize the first focus target', () => {
+      // Because we can't mimic a real tab press focus change in a unit test, just call the
+      // focus event handler directly.
+      focusTrapInstance.focusFirstTabbableElement();
+      expect(document.activeElement.id).toBe('first');
+    });
+
+    it('should be able to prioritize the last focus target', () => {
+      // Because we can't mimic a real tab press focus change in a unit test, just call the
+      // focus event handler directly.
+      focusTrapInstance.focusLastTabbableElement();
+      expect(document.activeElement.id).toBe('last');
+    });
+  });
+
+  describe('special cases', () => {
+    it('should not throw when it has a SVG child', () => {
+      let fixture = TestBed.createComponent(FocusTrapWithSvg);
+
+      fixture.detectChanges();
+
+      let focusTrapInstance = fixture.componentInstance.focusTrapDirective.focusTrap;
+
+      expect(() => focusTrapInstance.focusFirstTabbableElement()).not.toThrow();
+      expect(() => focusTrapInstance.focusLastTabbableElement()).not.toThrow();
+    });
+  });
+
+});
+
+
+@Component({
+  template: `
+    <div ngbTrapFocus>
+      <input>
+      <button>SAVE</button>
+    </div>
+    `
+})
+class SimpleFocusTrap {
+  @ViewChild(NgbFocusTrapDirective) focusTrapDirective: NgbFocusTrapDirective;
+}
+
+
+@Component({
+  template: `
+    <div *ngIf="renderFocusTrap" [ngbTrapFocus]="isFocusTrapEnabled">
+      <input>
+      <button>SAVE</button>
+    </div>
+    `
+})
+class FocusTrapWithBindings {
+  @ViewChild(NgbFocusTrapDirective) focusTrapDirective: NgbFocusTrapDirective;
+  renderFocusTrap = true;
+  isFocusTrapEnabled = true;
+}
+
+
+@Component({
+  template: `
+    <div ngbTrapFocus>
+      <input>
+      <button>before</button>
+      <button id="first" ngb-focus-region-start></button>
+      <button id="middle" ngb-focus-initial></button>
+      <button id="last" ngb-focus-region-end></button>
+      <button>after</button>
+      <input>
+    </div>
+    `
+})
+class FocusTrapTargets {
+  @ViewChild(NgbFocusTrapDirective) focusTrapDirective: NgbFocusTrapDirective;
+}
+
+
+@Component({
+  template: `
+    <div ngbTrapFocus>
+      <svg xmlns="http://www.w3.org/2000/svg">
+        <circle cx="100" cy="100" r="100"/>
+      </svg>
+    </div>
+    `
+})
+class FocusTrapWithSvg {
+  @ViewChild(NgbFocusTrapDirective) focusTrapDirective: NgbFocusTrapDirective;
+}

--- a/src/a11y/focus-trap.ts
+++ b/src/a11y/focus-trap.ts
@@ -1,0 +1,235 @@
+import {
+  Directive,
+  ElementRef,
+  Input,
+  NgZone,
+  OnDestroy,
+  AfterContentInit,
+  Injectable,
+} from '@angular/core';
+import 'rxjs/add/operator/first';
+import {NgbInteractivityChecker} from './interactivity-checker';
+import {toBoolean} from '../util/util';
+
+
+/**
+ * Class that allows for trapping focus within a DOM element.
+ *
+ * NOTE: This class currently uses a very simple (naive) approach to focus trapping.
+ * It assumes that the tab order is the same as DOM order, which is not necessarily true.
+ * Things like tabIndex > 0, flex `order`, and shadow roots can cause to two to misalign.
+ * This will be replaced with a more intelligent solution before the library is considered stable.
+ */
+export class NgbFocusTrap {
+  private _startAnchor: HTMLElement;
+  private _endAnchor: HTMLElement;
+
+  /** Whether the focus trap is active. */
+  get enabled(): boolean { return this._enabled; }
+  set enabled(val: boolean) {
+    this._enabled = val;
+
+    if (this._startAnchor && this._endAnchor) {
+      this._startAnchor.tabIndex = this._endAnchor.tabIndex = this._enabled ? 0 : -1;
+    }
+  }
+  private _enabled: boolean = true;
+
+  constructor(
+      private _element: HTMLElement, private _checker: NgbInteractivityChecker, private _ngZone: NgZone,
+      deferAnchors = false) {
+    if (!deferAnchors) {
+      this.attachAnchors();
+    }
+  }
+
+  /** Destroys the focus trap by cleaning up the anchors. */
+  destroy() {
+    if (this._startAnchor && this._startAnchor.parentNode) {
+      this._startAnchor.parentNode.removeChild(this._startAnchor);
+    }
+
+    if (this._endAnchor && this._endAnchor.parentNode) {
+      this._endAnchor.parentNode.removeChild(this._endAnchor);
+    }
+
+    this._startAnchor = this._endAnchor = null;
+  }
+
+  /**
+   * Inserts the anchors into the DOM. This is usually done automatically
+   * in the constructor, but can be deferred for cases like directives with `*ngIf`.
+   */
+  attachAnchors(): void {
+    if (!this._startAnchor) {
+      this._startAnchor = this._createAnchor();
+    }
+
+    if (!this._endAnchor) {
+      this._endAnchor = this._createAnchor();
+    }
+
+    this._ngZone.runOutsideAngular(() => {
+      this._startAnchor.addEventListener('focus', () => this.focusLastTabbableElement());
+      this._endAnchor.addEventListener('focus', () => this.focusFirstTabbableElement());
+
+      this._element.parentNode.insertBefore(this._startAnchor, this._element);
+      this._element.parentNode.insertBefore(this._endAnchor, this._element.nextSibling);
+    });
+  }
+
+  focusInitialElementWhenReady() { this._ngZone.onMicrotaskEmpty.first().subscribe(() => this.focusInitialElement()); }
+
+  /**
+   * Waits for microtask queue to empty, then focuses
+   * the first tabbable element within the focus trap region.
+   */
+  focusFirstTabbableElementWhenReady() {
+    this._ngZone.onMicrotaskEmpty.first().subscribe(() => this.focusFirstTabbableElement());
+  }
+
+  /**
+   * Waits for microtask queue to empty, then focuses
+   * the last tabbable element within the focus trap region.
+   */
+  focusLastTabbableElementWhenReady() {
+    this._ngZone.onMicrotaskEmpty.first().subscribe(() => this.focusLastTabbableElement());
+  }
+
+  /**
+   * Get the specified boundary element of the trapped region.
+   * @param bound The boundary to get (start or end of trapped region).
+   * @returns The boundary element.
+   */
+  private _getRegionBoundary(bound: 'start' | 'end'): HTMLElement | null {
+    let markers = [
+      ...Array.prototype.slice.call(this._element.querySelectorAll(`[ngb-focus-region-${bound}]`)),
+      // Deprecated version of selector, for temporary backwards comparability:
+      ...Array.prototype.slice.call(this._element.querySelectorAll(`[ngb-focus-${bound}]`)),
+    ];
+
+    markers.forEach((el: HTMLElement) => {
+      if (el.hasAttribute(`ngb-focus-${bound}`)) {
+        console.warn(
+            `Found use of deprecated attribute 'ngb-focus-${bound}',` + ` use 'ngb-focus-region-${bound}' instead.`,
+            el);
+      }
+    });
+
+    if (bound === 'start') {
+      return markers.length ? markers[0] : this._getFirstTabbableElement(this._element);
+    }
+    return markers.length ? markers[markers.length - 1] : this._getLastTabbableElement(this._element);
+  }
+
+  /** Focuses the element that should be focused when the focus trap is initialized. */
+  focusInitialElement() {
+    let redirectToElement = this._element.querySelector('[ngb-focus-initial]') as HTMLElement;
+    if (redirectToElement) {
+      redirectToElement.focus();
+    } else {
+      this.focusFirstTabbableElement();
+    }
+  }
+
+  /** Focuses the first tabbable element within the focus trap region. */
+  focusFirstTabbableElement() {
+    let redirectToElement = this._getRegionBoundary('start');
+    if (redirectToElement) {
+      redirectToElement.focus();
+    }
+  }
+
+  /** Focuses the last tabbable element within the focus trap region. */
+  focusLastTabbableElement() {
+    let redirectToElement = this._getRegionBoundary('end');
+    if (redirectToElement) {
+      redirectToElement.focus();
+    }
+  }
+
+  /** Get the first tabbable element from a DOM subtree (inclusive). */
+  private _getFirstTabbableElement(root: HTMLElement): HTMLElement {
+    if (this._checker.isFocusable(root) && this._checker.isTabbable(root)) {
+      return root;
+    }
+
+    // Iterate in DOM order. Note that IE doesn't have `children` for SVG so we fall
+    // back to `childNodes` which includes text nodes, comments etc.
+    let children = root.children || root.childNodes;
+
+    for (let i = 0; i < children.length; i++) {
+      let tabbableChild =
+          children[i].nodeType === Node.ELEMENT_NODE ? this._getFirstTabbableElement(children[i] as HTMLElement) : null;
+
+      if (tabbableChild) {
+        return tabbableChild;
+      }
+    }
+
+    return null;
+  }
+
+  /** Get the last tabbable element from a DOM subtree (inclusive). */
+  private _getLastTabbableElement(root: HTMLElement): HTMLElement {
+    if (this._checker.isFocusable(root) && this._checker.isTabbable(root)) {
+      return root;
+    }
+
+    // Iterate in reverse DOM order.
+    let children = root.children || root.childNodes;
+
+    for (let i = children.length - 1; i >= 0; i--) {
+      let tabbableChild =
+          children[i].nodeType === Node.ELEMENT_NODE ? this._getLastTabbableElement(children[i] as HTMLElement) : null;
+
+      if (tabbableChild) {
+        return tabbableChild;
+      }
+    }
+
+    return null;
+  }
+
+  /** Creates an anchor element. */
+  private _createAnchor(): HTMLElement {
+    let anchor = document.createElement('div');
+    anchor.tabIndex = this._enabled ? 0 : -1;
+    anchor.classList.add('sr-only');
+    anchor.classList.add('ngb-focus-trap-anchor');
+    return anchor;
+  }
+}
+
+
+/** Factory that allows easy instantiation of focus traps. */
+@Injectable()
+export class NgbFocusTrapFactory {
+  constructor(private _checker: NgbInteractivityChecker, private _ngZone: NgZone) {}
+
+  create(element: HTMLElement, deferAnchors = false): NgbFocusTrap {
+    return new NgbFocusTrap(element, this._checker, this._ngZone, deferAnchors);
+  }
+}
+
+
+/** Directive for trapping focus within a region. */
+@Directive({selector: '[ngbTrapFocus]', exportAs: 'cdkTrapFocus'})
+export class NgbFocusTrapDirective implements OnDestroy, AfterContentInit {
+  focusTrap: NgbFocusTrap;
+
+  /** Whether the focus trap is active. */
+  @Input('ngbTrapFocus')
+  get enabled(): boolean {
+    return this.focusTrap.enabled;
+  }
+  set enabled(value: boolean) { this.focusTrap.enabled = toBoolean(value); }
+
+  constructor(private _elementRef: ElementRef, private _focusTrapFactory: NgbFocusTrapFactory) {
+    this.focusTrap = this._focusTrapFactory.create(this._elementRef.nativeElement, true);
+  }
+
+  ngOnDestroy() { this.focusTrap.destroy(); }
+
+  ngAfterContentInit() { this.focusTrap.attachAnchors(); }
+}

--- a/src/a11y/interactivity-checker.spec.ts
+++ b/src/a11y/interactivity-checker.spec.ts
@@ -1,0 +1,477 @@
+import {NgbInteractivityChecker} from './interactivity-checker';
+import {NgbPlatform} from './platform';
+
+describe('ngb-interactivity-checker', () => {
+  let testContainerElement: HTMLElement;
+  let checker: NgbInteractivityChecker;
+  let platform: NgbPlatform = new NgbPlatform();
+
+  beforeEach(() => {
+    testContainerElement = document.createElement('div');
+    document.body.appendChild(testContainerElement);
+
+    checker = new NgbInteractivityChecker(platform);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(testContainerElement);
+    testContainerElement.innerHTML = '';
+  });
+
+  describe('isDisabled', () => {
+    it('should return true for disabled elements', () => {
+      let elements = createElements('input', 'textarea', 'select', 'button', 'md-checkbox');
+      elements.forEach(el => el.setAttribute('disabled', ''));
+      appendElements(elements);
+
+      elements.forEach(
+          el => { expect(checker.isDisabled(el)).toBe(true, `Expected <${el.nodeName} disabled> to be disabled`); });
+    });
+
+    it('should return false for elements without disabled', () => {
+      let elements = createElements('input', 'textarea', 'select', 'button', 'md-checkbox');
+      appendElements(elements);
+
+      elements.forEach(
+          el => { expect(checker.isDisabled(el)).toBe(false, `Expected <${el.nodeName}> not to be disabled`); });
+    });
+  });
+
+  describe('isVisible', () => {
+    it('should return false for a `display: none` element', () => {
+      testContainerElement.innerHTML = `<input style="display: none;">`;
+      let input = testContainerElement.querySelector('input') as HTMLElement;
+
+      expect(checker.isVisible(input)).toBe(false, 'Expected element with `display: none` to not be visible');
+    });
+
+    it('should return false for the child of a `display: none` element', () => {
+      testContainerElement.innerHTML = `<div style="display: none;">
+           <input>
+         </div>`;
+      let input = testContainerElement.querySelector('input') as HTMLElement;
+
+      expect(checker.isVisible(input)).toBe(false, 'Expected element with `display: none` parent to not be visible');
+    });
+
+    it('should return false for a `visibility: hidden` element', () => {
+      testContainerElement.innerHTML = `<input style="visibility: hidden;">`;
+      let input = testContainerElement.querySelector('input') as HTMLElement;
+
+      expect(checker.isVisible(input)).toBe(false, 'Expected element with `visibility: hidden` to not be visible');
+    });
+
+    it('should return false for the child of a `visibility: hidden` element', () => {
+      testContainerElement.innerHTML = `<div style="visibility: hidden;">
+           <input>
+         </div>`;
+      let input = testContainerElement.querySelector('input') as HTMLElement;
+
+      expect(checker.isVisible(input))
+          .toBe(false, 'Expected element with `visibility: hidden` parent to not be visible');
+    });
+
+    it('should return true for an element with `visibility: hidden` ancestor and *closer* ' +
+           '`visibility: visible` ancestor',
+       () => {
+         testContainerElement.innerHTML = `<div style="visibility: hidden;">
+           <div style="visibility: visible;">
+             <input>
+           </div>
+         </div>`;
+         let input = testContainerElement.querySelector('input') as HTMLElement;
+
+         expect(checker.isVisible(input))
+             .toBe(
+                 true, 'Expected element with `visibility: hidden` ancestor and closer ' +
+                     '`visibility: visible` ancestor to be visible');
+       });
+
+    it('should return true for an element without visibility modifiers', () => {
+      let input = document.createElement('input');
+      testContainerElement.appendChild(input);
+
+      expect(checker.isVisible(input)).toBe(true, 'Expected element without visibility modifiers to be visible');
+    });
+  });
+
+  describe('isFocusable', () => {
+    it('should return true for native form controls', () => {
+      let elements = createElements('input', 'textarea', 'select', 'button');
+      appendElements(elements);
+
+      elements.forEach(
+          el => { expect(checker.isFocusable(el)).toBe(true, `Expected <${el.nodeName}> to be focusable`); });
+    });
+
+    it('should return true for an anchor with an href', () => {
+      let anchor = document.createElement('a');
+      anchor.href = 'google.com';
+      testContainerElement.appendChild(anchor);
+
+      expect(checker.isFocusable(anchor)).toBe(true, `Expected <a> with href to be focusable`);
+    });
+
+    it('should return false for an anchor without an href', () => {
+      let anchor = document.createElement('a');
+      testContainerElement.appendChild(anchor);
+
+      expect(checker.isFocusable(anchor)).toBe(false, `Expected <a> without href not to be focusable`);
+    });
+
+    it('should return false for disabled form controls', () => {
+      let elements = createElements('input', 'textarea', 'select', 'button');
+      elements.forEach(el => el.setAttribute('disabled', ''));
+      appendElements(elements);
+
+      elements.forEach(el => {
+        expect(checker.isFocusable(el)).toBe(false, `Expected <${el.nodeName} disabled> not to be focusable`);
+      });
+    });
+
+    it('should return false for a `display: none` element', () => {
+      testContainerElement.innerHTML = `<input style="display: none;">`;
+      let input = testContainerElement.querySelector('input') as HTMLElement;
+
+      expect(checker.isFocusable(input)).toBe(false, 'Expected element with `display: none` to not be visible');
+    });
+
+    it('should return false for the child of a `display: none` element', () => {
+      testContainerElement.innerHTML = `<div style="display: none;">
+           <input>
+         </div>`;
+      let input = testContainerElement.querySelector('input') as HTMLElement;
+
+      expect(checker.isFocusable(input)).toBe(false, 'Expected element with `display: none` parent to not be visible');
+    });
+
+    it('should return false for a `visibility: hidden` element', () => {
+      testContainerElement.innerHTML = `<input style="visibility: hidden;">`;
+      let input = testContainerElement.querySelector('input') as HTMLElement;
+
+      expect(checker.isFocusable(input)).toBe(false, 'Expected element with `visibility: hidden` not to be focusable');
+    });
+
+    it('should return false for the child of a `visibility: hidden` element', () => {
+      testContainerElement.innerHTML = `<div style="visibility: hidden;">
+           <input>
+         </div>`;
+      let input = testContainerElement.querySelector('input') as HTMLElement;
+
+      expect(checker.isFocusable(input))
+          .toBe(false, 'Expected element with `visibility: hidden` parent not to be focusable');
+    });
+
+    it('should return true for an element with `visibility: hidden` ancestor and *closer* ' +
+           '`visibility: visible` ancestor',
+       () => {
+         testContainerElement.innerHTML = `<div style="visibility: hidden;">
+           <div style="visibility: visible;">
+             <input>
+           </div>
+         </div>`;
+         let input = testContainerElement.querySelector('input') as HTMLElement;
+
+         expect(checker.isFocusable(input))
+             .toBe(
+                 true, 'Expected element with `visibility: hidden` ancestor and closer ' +
+                     '`visibility: visible` ancestor to be focusable');
+       });
+
+    it('should return false for an element with an empty tabindex', () => {
+      let element = document.createElement('div');
+      element.setAttribute('tabindex', '');
+      testContainerElement.appendChild(element);
+
+      expect(checker.isFocusable(element)).toBe(false, `Expected element with tabindex="" not to be focusable`);
+    });
+
+    it('should return false for an element with a non-numeric tabindex', () => {
+      let element = document.createElement('div');
+      element.setAttribute('tabindex', 'abba');
+      testContainerElement.appendChild(element);
+
+      expect(checker.isFocusable(element))
+          .toBe(false, `Expected element with non-numeric tabindex not to be focusable`);
+    });
+
+    it('should return true for an element with contenteditable', () => {
+      let element = document.createElement('div');
+      element.setAttribute('contenteditable', '');
+      testContainerElement.appendChild(element);
+
+      expect(checker.isFocusable(element)).toBe(true, `Expected element with contenteditable to be focusable`);
+    });
+
+
+    it('should return false for inert div and span', () => {
+      let elements = createElements('div', 'span');
+      appendElements(elements);
+
+      elements.forEach(
+          el => { expect(checker.isFocusable(el)).toBe(false, `Expected <${el.nodeName}> not to be focusable`); });
+    });
+
+
+  });
+
+  describe('isTabbable', () => {
+
+    it('should respect the tabindex for video elements with controls',
+       // Do not run for Blink, Firefox and iOS because those treat video elements
+       // with controls different and are covered in other tests.
+       runIf(!platform.BLINK && !platform.FIREFOX && !platform.IOS, () => {
+         let video = createFromTemplate('<video controls>', true);
+
+         expect(checker.isTabbable(video)).toBe(true);
+
+         video.tabIndex = -1;
+
+         expect(checker.isTabbable(video)).toBe(false);
+       }));
+
+    it('should always mark video elements with controls as tabbable (BLINK & FIREFOX)',
+       // Only run this spec for Blink and Firefox, because those always treat video
+       // elements with controls as tabbable.
+       runIf(platform.BLINK || platform.FIREFOX, () => {
+         let video = createFromTemplate('<video controls>', true);
+
+         expect(checker.isTabbable(video)).toBe(true);
+
+         video.tabIndex = -1;
+
+         expect(checker.isTabbable(video)).toBe(true);
+       }));
+
+    // Some tests should not run inside of iOS browsers, because those only allow specific
+    // elements to be tabbable and cause the tests to always fail.
+    describe(
+        'for non-iOS browsers', runIf(!platform.IOS, () => {
+
+          it('should mark form controls and anchors without tabindex attribute as tabbable', () => {
+            let elements = createElements('input', 'textarea', 'select', 'button', 'a');
+            appendElements(elements);
+
+            elements.forEach(
+                el => { expect(checker.isTabbable(el)).toBe(true, `Expected <${el.nodeName}> to be tabbable`); });
+          });
+
+          it('should return true for div and span with tabindex == 0', () => {
+            let elements = createElements('div', 'span');
+
+            elements.forEach(el => el.setAttribute('tabindex', '0'));
+            appendElements(elements);
+
+            elements.forEach(el => {
+              expect(checker.isFocusable(el)).toBe(true, `Expected <${el.nodeName} tabindex="0"> to be focusable`);
+            });
+          });
+
+          it('should return false for native form controls and anchor with tabindex == -1', () => {
+            let elements = createElements('input', 'textarea', 'select', 'button', 'a');
+
+            elements.forEach(el => el.setAttribute('tabindex', '-1'));
+            appendElements(elements);
+
+            elements.forEach(el => {
+              expect(checker.isTabbable(el)).toBe(false, `Expected <${el.nodeName} tabindex="-1"> not to be tabbable`);
+            });
+          });
+
+          it('should return true for div and span with tabindex == 0', () => {
+            let elements = createElements('div', 'span');
+
+            elements.forEach(el => el.setAttribute('tabindex', '0'));
+            appendElements(elements);
+
+            elements.forEach(el => {
+              expect(checker.isTabbable(el)).toBe(true, `Expected <${el.nodeName} tabindex="0"> to be tabbable`);
+            });
+          });
+
+          it('should respect the inherited tabindex inside of frame elements', () => {
+            let iframe = createFromTemplate('<iframe>', true) as HTMLFrameElement;
+            let button = createFromTemplate('<button tabindex="0">Not Tabbable</button>');
+
+            appendElements([iframe]);
+
+            iframe.tabIndex = -1;
+            const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
+            iframeDoc.open();
+            iframeDoc.write('<html><body></body></html>');
+            iframeDoc.close();
+            iframeDoc.body.appendChild(button);
+
+            expect(checker.isTabbable(iframe)).toBe(false);
+            expect(checker.isTabbable(button)).toBe(false);
+
+            iframe.tabIndex = null;
+
+            expect(checker.isTabbable(iframe)).toBe(false);
+            expect(checker.isTabbable(button)).toBe(true);
+          });
+
+          it('should mark elements which are contentEditable as tabbable', () => {
+            let editableEl = createFromTemplate('<div contenteditable="true">', true);
+
+            expect(checker.isTabbable(editableEl)).toBe(true);
+
+            editableEl.tabIndex = -1;
+
+            expect(checker.isTabbable(editableEl)).toBe(false);
+          });
+
+          it('should never mark iframe elements as tabbable', () => {
+            let iframe = createFromTemplate('<iframe>', true);
+
+            // iFrame elements will be never marked as tabbable, because it depends on the content
+            // which is mostly not detectable due to CORS and also the checks will be not reliable.
+            expect(checker.isTabbable(iframe)).toBe(false);
+          });
+
+          it('should always mark audio elements without controls as not tabbable', () => {
+            let audio = createFromTemplate('<audio>', true);
+
+            expect(checker.isTabbable(audio)).toBe(false);
+          });
+
+        }));
+
+    describe('for Blink and Webkit browsers', runIf(platform.BLINK || platform.WEBKIT, () => {
+
+               it('should not mark elements inside of object frames as tabbable', () => {
+                 let objectEl = createFromTemplate('<object>', true) as HTMLObjectElement;
+                 let button = createFromTemplate('<button tabindex="0">Not Tabbable</button>');
+
+                 appendElements([objectEl]);
+
+                 // This is a hack to create an empty contentDocument for the frame element.
+                 objectEl.type = 'text/html';
+                 objectEl.contentDocument.body.appendChild(button);
+
+                 expect(checker.isTabbable(objectEl)).toBe(false);
+                 expect(checker.isTabbable(button)).toBe(false);
+               });
+
+               it('should not mark elements inside of invisible frames as tabbable', () => {
+                 let iframe = createFromTemplate('<iframe>', true) as HTMLFrameElement;
+                 let button = createFromTemplate('<button tabindex="0">Not Tabbable</button>');
+
+                 appendElements([iframe]);
+
+                 iframe.style.display = 'none';
+                 const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
+                 iframeDoc.open();
+                 iframeDoc.write('<html><body></body></html>');
+                 iframeDoc.close();
+                 iframeDoc.body.appendChild(button);
+
+                 expect(checker.isTabbable(iframe)).toBe(false);
+                 expect(checker.isTabbable(button)).toBe(false);
+               });
+
+               it('should never mark object frame elements as tabbable', () => {
+                 let objectEl = createFromTemplate('<object>', true);
+
+                 expect(checker.isTabbable(objectEl)).toBe(false);
+               });
+
+             }));
+
+    describe('for Blink browsers', runIf(platform.BLINK, () => {
+
+               it('should always mark audio elements with controls as tabbable', () => {
+                 let audio = createFromTemplate('<audio controls>', true);
+
+                 expect(checker.isTabbable(audio)).toBe(true);
+
+                 audio.tabIndex = -1;
+
+                 // The audio element will be still tabbable because Blink always
+                 // considers them as tabbable.
+                 expect(checker.isTabbable(audio)).toBe(true);
+               });
+
+             }));
+
+    describe('for Internet Explorer', runIf(platform.TRIDENT, () => {
+
+               it('should never mark video elements without controls as tabbable', () => {
+                 // In Internet Explorer video elements without controls are never tabbable.
+                 let video = createFromTemplate('<video>', true);
+
+                 expect(checker.isTabbable(video)).toBe(false);
+
+                 video.tabIndex = 0;
+
+                 expect(checker.isTabbable(video)).toBe(false);
+
+               });
+
+             }));
+
+    describe('for iOS browsers', runIf(platform.IOS && platform.WEBKIT, () => {
+
+               it('should never allow div elements to be tabbable', () => {
+                 let divEl = createFromTemplate('<div tabindex="0">', true);
+
+                 expect(checker.isTabbable(divEl)).toBe(false);
+               });
+
+               it('should never allow span elements to be tabbable', () => {
+                 let spanEl = createFromTemplate('<span tabindex="0">Text</span>', true);
+
+                 expect(checker.isTabbable(spanEl)).toBe(false);
+               });
+
+               it('should never allow button elements to be tabbable', () => {
+                 let buttonEl = createFromTemplate('<button tabindex="0">', true);
+
+                 expect(checker.isTabbable(buttonEl)).toBe(false);
+               });
+
+               it('should never allow anchor elements to be tabbable', () => {
+                 let anchorEl = createFromTemplate('<a tabindex="0">Link</a>', true);
+
+                 expect(checker.isTabbable(anchorEl)).toBe(false);
+               });
+
+             }));
+
+
+  });
+
+  /** Creates an array of elements with the given node names. */
+  function createElements(...nodeNames: string[]) { return nodeNames.map(name => document.createElement(name)); }
+
+  function createFromTemplate(template: string, append = false) {
+    let tmpRoot = document.createElement('div');
+    tmpRoot.innerHTML = template;
+
+    let element = tmpRoot.firstElementChild;
+
+    tmpRoot.removeChild(element);
+
+    if (append) {
+      appendElements([element]);
+    }
+
+    return element as HTMLElement;
+  }
+
+  /** Appends elements to the testContainerElement. */
+  function appendElements(elements: Element[]) {
+    for (let e of elements) {
+      testContainerElement.appendChild(e);
+    }
+  }
+
+  function runIf(condition: boolean, runFn: Function): () => void {
+    return (...args: any[]) => {
+      if (condition) {
+        runFn.apply(this, args);
+      }
+    };
+  }
+
+});

--- a/src/a11y/interactivity-checker.ts
+++ b/src/a11y/interactivity-checker.ts
@@ -1,0 +1,219 @@
+import {Injectable} from '@angular/core';
+import {NgbPlatform} from './platform';
+
+/**
+ * The InteractivityChecker leans heavily on the ally.js accessibility utilities.
+ * Methods like `isTabbable` are only covering specific edge-cases for the browsers which are
+ * supported.
+ */
+
+/**
+ * Utility for checking the interactivity of an element, such as whether is is focusable or
+ * tabbable.
+ */
+@Injectable()
+export class NgbInteractivityChecker {
+  constructor(private _platform: NgbPlatform) {}
+
+  /**
+   * Gets whether an element is disabled.
+   *
+   * @param element Element to be checked.
+   * @returns Whether the element is disabled.
+   */
+  isDisabled(element: HTMLElement): boolean {
+    // This does not capture some cases, such as a non-form control with a disabled attribute or
+    // a form control inside of a disabled form, but should capture the most common cases.
+    return element.hasAttribute('disabled');
+  }
+
+  /**
+   * Gets whether an element is visible for the purposes of interactivity.
+   *
+   * This will capture states like `display: none` and `visibility: hidden`, but not things like
+   * being clipped by an `overflow: hidden` parent or being outside the viewport.
+   *
+   * @returns Whether the element is visible.
+   */
+  isVisible(element: HTMLElement): boolean {
+    return hasGeometry(element) && getComputedStyle(element).visibility === 'visible';
+  }
+
+  /**
+   * Gets whether an element can be reached via Tab key.
+   * Assumes that the element has already been checked with isFocusable.
+   *
+   * @param element Element to be checked.
+   * @returns Whether the element is tabbable.
+   */
+  isTabbable(element: HTMLElement): boolean {
+    let frameElement = getWindow(element).frameElement as HTMLElement;
+
+    if (frameElement) {
+      let frameType = frameElement && frameElement.nodeName.toLowerCase();
+
+      // Frame elements inherit their tabindex onto all child elements.
+      if (getTabIndexValue(frameElement) === -1) {
+        return false;
+      }
+
+      // Webkit and Blink consider anything inside of an <object> element as non-tabbable.
+      if ((this._platform.BLINK || this._platform.WEBKIT) && frameType === 'object') {
+        return false;
+      }
+
+      // Webkit and Blink disable tabbing to an element inside of an invisible frame.
+      if ((this._platform.BLINK || this._platform.WEBKIT) && !this.isVisible(frameElement)) {
+        return false;
+      }
+    }
+
+    let nodeName = element.nodeName.toLowerCase();
+    let tabIndexValue = getTabIndexValue(element);
+
+    if (element.hasAttribute('contenteditable')) {
+      return tabIndexValue !== -1;
+    }
+
+    if (nodeName === 'iframe') {
+      // The frames may be tabbable depending on content, but it's not possibly to reliably
+      // investigate the content of the frames.
+      return false;
+    }
+
+    if (nodeName === 'audio') {
+      if (!element.hasAttribute('controls')) {
+        // By default an <audio> element without the controls enabled is not tabbable.
+        return false;
+      } else if (this._platform.BLINK) {
+        // In Blink <audio controls> elements are always tabbable.
+        return true;
+      }
+    }
+
+    if (nodeName === 'video') {
+      if (!element.hasAttribute('controls') && this._platform.TRIDENT) {
+        // In Trident a <video> element without the controls enabled is not tabbable.
+        return false;
+      } else if (this._platform.BLINK || this._platform.FIREFOX) {
+        // In Chrome and Firefox <video controls> elements are always tabbable.
+        return true;
+      }
+    }
+
+    if (nodeName === 'object' && (this._platform.BLINK || this._platform.WEBKIT)) {
+      // In all Blink and WebKit based browsers <object> elements are never tabbable.
+      return false;
+    }
+
+    // In iOS the browser only considers some specific elements as tabbable.
+    if (this._platform.WEBKIT && this._platform.IOS && !isPotentiallyTabbableIOS(element)) {
+      return false;
+    }
+
+    return element.tabIndex >= 0;
+  }
+
+  /**
+   * Gets whether an element can be focused by the user.
+   *
+   * @param element Element to be checked.
+   * @returns Whether the element is focusable.
+   */
+  isFocusable(element: HTMLElement): boolean {
+    // Perform checks in order of left to most expensive.
+    // Again, naive approach that does not capture many edge cases and browser quirks.
+    return isPotentiallyFocusable(element) && !this.isDisabled(element) && this.isVisible(element);
+  }
+}
+
+/** Checks whether the specified element has any geometry / rectangles. */
+function hasGeometry(element: HTMLElement): boolean {
+  // Use logic from jQuery to check for an invisible element.
+  // See https://github.com/jquery/jquery/blob/master/src/css/hiddenVisibleSelectors.js#L12
+  return !!(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
+}
+
+/** Gets whether an element's  */
+function isNativeFormElement(element: Node) {
+  let nodeName = element.nodeName.toLowerCase();
+  return nodeName === 'input' || nodeName === 'select' || nodeName === 'button' || nodeName === 'textarea';
+}
+
+/** Gets whether an element is an <input type="hidden">. */
+function isHiddenInput(element: HTMLElement): boolean {
+  return isInputElement(element) && element.type === 'hidden';
+}
+
+/** Gets whether an element is an anchor that has an href attribute. */
+function isAnchorWithHref(element: HTMLElement): boolean {
+  return isAnchorElement(element) && element.hasAttribute('href');
+}
+
+/** Gets whether an element is an input element. */
+function isInputElement(element: HTMLElement): element is HTMLInputElement {
+  return element.nodeName.toLowerCase() === 'input';
+}
+
+/** Gets whether an element is an anchor element. */
+function isAnchorElement(element: HTMLElement): element is HTMLAnchorElement {
+  return element.nodeName.toLowerCase() === 'a';
+}
+
+/** Gets whether an element has a valid tabindex. */
+function hasValidTabIndex(element: HTMLElement): boolean {
+  if (!element.hasAttribute('tabindex') || element.tabIndex === undefined) {
+    return false;
+  }
+
+  let tabIndex = element.getAttribute('tabindex');
+
+  // IE11 parses tabindex="" as the value "-32768"
+  if (tabIndex === '-32768') {
+    return false;
+  }
+
+  return !!(tabIndex && !isNaN(parseInt(tabIndex, 10)));
+}
+
+/**
+ * Returns the parsed tabindex from the element attributes instead of returning the
+ * evaluated tabindex from the browsers defaults.
+ */
+function getTabIndexValue(element: HTMLElement): number {
+  if (!hasValidTabIndex(element)) {
+    return null;
+  }
+
+  // See browser issue in Gecko https://bugzilla.mozilla.org/show_bug.cgi?id=1128054
+  const tabIndex = parseInt(element.getAttribute('tabindex'), 10);
+
+  return isNaN(tabIndex) ? -1 : tabIndex;
+}
+
+/** Checks whether the specified element is potentially tabbable on iOS */
+function isPotentiallyTabbableIOS(element: HTMLElement): boolean {
+  let nodeName = element.nodeName.toLowerCase();
+  let inputType = nodeName === 'input' && (element as HTMLInputElement).type;
+
+  return inputType === 'text' || inputType === 'password' || nodeName === 'select' || nodeName === 'textarea';
+}
+
+/**
+ * Gets whether an element is potentially focusable without taking current visible/disabled state
+ * into account.
+ */
+function isPotentiallyFocusable(element: HTMLElement): boolean {
+  // Inputs are potentially focusable *unless* they're type="hidden".
+  if (isHiddenInput(element)) {
+    return false;
+  }
+
+  return isNativeFormElement(element) || isAnchorWithHref(element) || element.hasAttribute('contenteditable') ||
+      hasValidTabIndex(element);
+}
+
+/** Gets the parent window of a DOM node with regards of being inside of an iframe. */
+function getWindow(node: HTMLElement): Window {
+  return node.ownerDocument.defaultView || window;
+}

--- a/src/a11y/platform.ts
+++ b/src/a11y/platform.ts
@@ -1,0 +1,38 @@
+import {Injectable} from '@angular/core';
+
+// Whether the current platform supports the V8 Break Iterator. The V8 check
+// is necessary to detect all Blink based browsers.
+const hasV8BreakIterator = (typeof(Intl) !== 'undefined' && (Intl as any).v8BreakIterator);
+
+/**
+ * Service to detect the current platform by comparing the userAgent strings and
+ * checking browser-specific global properties.
+ * @docs-private
+ */
+@Injectable()
+export class NgbPlatform {
+  isBrowser: boolean = typeof document === 'object' && !!document;
+
+  /** Layout Engines */
+  EDGE = this.isBrowser && /(edge)/i.test(navigator.userAgent);
+  TRIDENT = this.isBrowser && /(msie|trident)/i.test(navigator.userAgent);
+
+  // EdgeHTML and Trident mock Blink specific things and need to be excluded from this check.
+  BLINK = this.isBrowser && (!!((window as any).chrome || hasV8BreakIterator) && !!CSS && !this.EDGE && !this.TRIDENT);
+
+  // Webkit is part of the userAgent in EdgeHTML, Blink and Trident. Therefore we need to
+  // ensure that Webkit runs standalone and is not used as another engine's base.
+  WEBKIT = this.isBrowser && /AppleWebKit/i.test(navigator.userAgent) && !this.BLINK && !this.EDGE && !this.TRIDENT;
+
+  /** Browsers and Platform Types */
+  IOS = this.isBrowser && /iPad|iPhone|iPod/.test(navigator.userAgent) && !(window as any).MSStream;
+
+  // It's difficult to detect the plain Gecko engine, because most of the browsers identify
+  // them self as Gecko-like browsers and modify the userAgent's according to that.
+  // Since we only cover one explicit Firefox case, we can simply check for Firefox
+  // instead of having an unstable check for Gecko.
+  FIREFOX = /(firefox|minefield)/i.test(navigator.userAgent);
+
+  // Trident on mobile adds the android platform to the userAgent to trick detections.
+  ANDROID = /android/i.test(navigator.userAgent) && !this.TRIDENT;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 
+import {NgbA11yModule} from './a11y/a11y.module';
 import {NgbAccordionModule, NgbPanelChangeEvent} from './accordion/accordion.module';
 import {NgbAlertModule} from './alert/alert.module';
 import {NgbButtonsModule} from './buttons/radio.module';
@@ -17,6 +18,13 @@ import {NgbTimepickerModule} from './timepicker/timepicker.module';
 import {NgbTooltipModule} from './tooltip/tooltip.module';
 import {NgbTypeaheadModule, NgbTypeaheadSelectItemEvent} from './typeahead/typeahead.module';
 
+export {
+  NgbPlatform,
+  NgbInteractivityChecker,
+  NgbFocusTrapFactory,
+  NgbFocusTrapDirective,
+  NgbFocusTrap,
+} from './a11y/a11y.module';
 export {
   NgbAccordionModule,
   NgbPanelChangeEvent,
@@ -76,7 +84,7 @@ export {
 const NGB_MODULES = [
   NgbAccordionModule, NgbAlertModule, NgbButtonsModule, NgbCarouselModule, NgbCollapseModule, NgbDatepickerModule,
   NgbDropdownModule, NgbModalModule, NgbPaginationModule, NgbPopoverModule, NgbProgressbarModule, NgbRatingModule,
-  NgbTabsetModule, NgbTimepickerModule, NgbTooltipModule, NgbTypeaheadModule
+  NgbTabsetModule, NgbTimepickerModule, NgbTooltipModule, NgbTypeaheadModule, NgbA11yModule
 ];
 
 @NgModule({
@@ -85,7 +93,7 @@ const NGB_MODULES = [
     NgbTooltipModule.forRoot(), NgbTypeaheadModule.forRoot(), NgbAccordionModule.forRoot(), NgbCarouselModule.forRoot(),
     NgbDatepickerModule.forRoot(), NgbDropdownModule.forRoot(), NgbModalModule.forRoot(), NgbPaginationModule.forRoot(),
     NgbPopoverModule.forRoot(), NgbProgressbarModule.forRoot(), NgbRatingModule.forRoot(), NgbTabsetModule.forRoot(),
-    NgbTimepickerModule.forRoot(), NgbTooltipModule.forRoot()
+    NgbTimepickerModule.forRoot(), NgbTooltipModule.forRoot(), NgbA11yModule.forRoot()
   ],
   exports: NGB_MODULES
 })

--- a/src/modal/modal-window.ts
+++ b/src/modal/modal-window.ts
@@ -23,7 +23,7 @@ import {ModalDismissReasons} from './modal-dismiss-reasons';
     '(click)': 'backdropClick($event)'
   },
   template: `
-    <div [class]="'modal-dialog' + (size ? ' modal-' + size : '')" role="document">
+    <div ngbTrapFocus [class]="'modal-dialog' + (size ? ' modal-' + size : '')" role="document">
         <div class="modal-content"><ng-content></ng-content></div>
     </div>
     `

--- a/src/modal/modal.module.ts
+++ b/src/modal/modal.module.ts
@@ -1,5 +1,6 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 
+import {NgbA11yModule} from './../a11y/a11y.module';
 import {NgbModalBackdrop} from './modal-backdrop';
 import {NgbModalWindow} from './modal-window';
 import {NgbModalStack} from './modal-stack';
@@ -10,6 +11,7 @@ export {NgbModalRef, NgbActiveModal} from './modal-ref';
 export {ModalDismissReasons} from './modal-dismiss-reasons';
 
 @NgModule({
+  imports: [NgbA11yModule.forRoot()],
   declarations: [NgbModalBackdrop, NgbModalWindow],
   entryComponents: [NgbModalBackdrop, NgbModalWindow],
   providers: [NgbModal]

--- a/src/util/util.spec.ts
+++ b/src/util/util.spec.ts
@@ -1,4 +1,4 @@
-import {toInteger, toString, getValueInRange, isInteger, isString} from './util';
+import {toInteger, toString, toBoolean, getValueInRange, isInteger, isString} from './util';
 
 describe('util', () => {
 
@@ -19,6 +19,20 @@ describe('util', () => {
       expect(toInteger('10')).toBe(10);
       expect(toInteger('10.1')).toBe(10);
       expect(toInteger('10.9')).toBe(10);
+    });
+
+  });
+
+  describe('toBoolean', () => {
+
+    it('should be noop for booleans', () => {
+      expect(toBoolean(true)).toBe(true);
+      expect(toBoolean(false)).toBe(false);
+    });
+
+    it('should parse strings', () => {
+      expect(toBoolean('true')).toBe(true);
+      expect(toBoolean('false')).toBe(false);
     });
 
   });

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -6,6 +6,10 @@ export function toString(value: any): string {
   return (value !== undefined && value !== null) ? `${value}` : '';
 }
 
+export function toBoolean(value: any): boolean {
+  return value != null && `${value}` !== 'false';
+}
+
 export function getValueInRange(value: number, max: number, min = 0): number {
   return Math.max(Math.min(value, max), min);
 }


### PR DESCRIPTION
Add a11y module which includes: 
1. Focus trap
2. Interactivity checker
3. Platform detection

Most codes are from material 2:
https://github.com/angular/material2/tree/master/src/lib/core/a11y

Apply focus trap to modal dialog to prevent focus "escape" the opened modal

fix:
https://github.com/ng-bootstrap/ng-bootstrap/issues/1363
https://github.com/ng-bootstrap/ng-bootstrap/issues/642
