### PR TITLE
fix(typeahead): clear input text on blur when editable is false

### DIFF
--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -197,7 +197,14 @@ export class NgbTypeahead implements ControlValueAccessor,
 
   isPopupOpen() { return this._windowRef != null; }
 
-  handleBlur() { this._onTouched(); }
+  handleBlur() {
+    if (!this.editable) {
+      this._userInput = null;
+      this._onChange(undefined);
+      this.writeValue(undefined);
+    }
+    this._onTouched();
+  }
 
   handleKeyDown(event: KeyboardEvent) {
     if (!this.isPopupOpen()) {


### PR DESCRIPTION
Fixes #1276

I am putting this up for discussion purposes on #1276 and #1467.

I will add unit tests after deciding on the correct approach.
