### PR TITLE
chore: reactivate vendor bundle

### DIFF
--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -1,6 +1,3 @@
-import 'prismjs/themes/prism.css';
-import 'bootstrap/dist/css/bootstrap.css';
-
 import {enableProdMode} from '@angular/core';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 

--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -1,3 +1,6 @@
+import 'prismjs/themes/prism.css';
+import 'bootstrap/dist/css/bootstrap.css';
+
 import {enableProdMode} from '@angular/core';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 

--- a/demo/src/vendor.ts
+++ b/demo/src/vendor.ts
@@ -1,5 +1,0 @@
-// Other vendors for example jQuery, Lodash or Bootstrap
-// You can import js, ts, css, sass, ...
-
-import 'prismjs/themes/prism.css';
-import 'bootstrap/dist/css/bootstrap.css';

--- a/webpack.demo.js
+++ b/webpack.demo.js
@@ -13,7 +13,6 @@ var aotplugin = require('@ngtools/webpack');
  * Env
  * Get npm lifecycle event to identify the environment
  */
-var entryPoints = ['polyfills', 'vendor', 'main'];
 var ENV = process.env.MODE;
 var isProd = ENV === 'build';
 var nodeModules = path.join(process.cwd(), 'node_modules');
@@ -43,6 +42,10 @@ module.exports = function makeWebpackConfig() {
    */
   config.entry = {
     'polyfills': './demo/src/polyfills.ts',
+    'vendorStyles': [
+      './node_modules/prismjs/themes/prism.css',
+      './node_modules/bootstrap/dist/css/bootstrap.css'
+    ],
     'main': './demo/src/main.ts'
   };
 
@@ -148,23 +151,15 @@ module.exports = function makeWebpackConfig() {
         ]
     }),
 
+    new CommonsChunkPlugin({
+      names: ['vendor', 'polyfills', 'inline']
+    }),
+
     // Inject script and link tags into html files
     // Reference: https://github.com/ampedandwired/html-webpack-plugin
     new HtmlWebpackPlugin({
       template: './demo/src/public/index.html',
-      chunksSortMode: function sort(left, right) {
-        let leftIndex = entryPoints.indexOf(left.names[0]);
-        let rightindex = entryPoints.indexOf(right.names[0]);
-        if (leftIndex > rightindex) {
-          return 1;
-        }
-        else if (leftIndex < rightindex) {
-          return -1;
-        }
-        else {
-          return 0;
-        }
-      }
+      chunksSortMode: 'dependency'
     }),
 
     // Extract css files


### PR DESCRIPTION
This change makes it possible to load more JS
code in parallel and shave off few hundreds ms
from the first full pain on mobile.

It is also closer to the angular-cli way of
doing things.
