### PR TITLE
fix(buttons): provide constant in forRoot

### DIFF
--- a/src/buttons/radio.module.ts
+++ b/src/buttons/radio.module.ts
@@ -1,5 +1,5 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
-import {NgbRadio, NgbActiveLabel, NgbRadioGroup} from './radio';
+import {NgbRadio, NgbActiveLabel, NgbRadioGroup, NGB_RADIO_VALUE_ACCESSOR} from './radio';
 
 export {NgbRadio, NgbActiveLabel, NgbRadioGroup} from './radio';
 
@@ -7,5 +7,5 @@ const NGB_RADIO_DIRECTIVES = [NgbRadio, NgbActiveLabel, NgbRadioGroup];
 
 @NgModule({declarations: NGB_RADIO_DIRECTIVES, exports: NGB_RADIO_DIRECTIVES})
 export class NgbButtonsModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbButtonsModule, providers: []}; }
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbButtonsModule, providers: [NGB_RADIO_VALUE_ACCESSOR]}; }
 }

--- a/src/buttons/radio.ts
+++ b/src/buttons/radio.ts
@@ -1,7 +1,7 @@
 import {Directive, forwardRef, Optional, Input, Renderer, ElementRef, OnDestroy} from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 
-const NGB_RADIO_VALUE_ACCESSOR = {
+export const NGB_RADIO_VALUE_ACCESSOR = {
   provide: NG_VALUE_ACCESSOR,
   useExisting: forwardRef(() => NgbRadioGroup),
   multi: true


### PR DESCRIPTION
- Provide constant in `module.forRoot` in order for it to be available

See [Plunker](http://plnkr.co/edit/Zk74D6KrgIJVpW48JnCl?p=preview) for fix in action.

This should fix #1125.