### PR TITLE
chore: fix tests for the docs extraction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   - ./scripts/sauce_connect_setup.sh
 
 script:
-  - gulp ci
+  - gulp ci && npm run api-doc-test
   - ./scripts/sauce_connect_block.sh
   - gulp saucelabs
 

--- a/misc/api-doc.js
+++ b/misc/api-doc.js
@@ -32,7 +32,7 @@ function isPrivateOrInternal(member) {
 
 class APIDocVisitor {
   constructor(fileNames) {
-    this.program = ts.createProgram(fileNames, {});
+    this.program = ts.createProgram(fileNames, {lib: ["lib.es6.d.ts"]});
     this.typeChecker = this.program.getTypeChecker(true);
   }
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "install": "node misc/validate-commit.install.js",
     "test": "karma start karma.conf.js",
-    "api-doc-tdd": "jasmine-node misc/api-doc.spec.js --autotest --watch misc/api-doc-test-cases/*.ts misc/api-doc.js"
+    "api-doc-tdd": "jasmine-node misc/api-doc.spec.js --autotest --watch misc/api-doc-test-cases/*.ts misc/api-doc.js",
+    "api-doc-test": "jasmine-node misc/api-doc.spec.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We had a regression in the docs extraction introduced
by df30bbd030fc7f4f20100490e65c986c7eb4be83 but the
breakage went unnoticed since we don't run doc extraction
test on CI. This commit fixes extraction logic and adds
docs extraction logic to the CI run.