### PR TITLE
fix(accordion): remove aria-controls when panel is not in DOM

### DIFF
--- a/src/accordion/accordion.spec.ts
+++ b/src/accordion/accordion.spec.ts
@@ -252,6 +252,23 @@ describe('ngb-accordion', () => {
     expect(disabledPanelLink.getAttribute('tabindex')).toBe('-1');
   });
 
+  it('should remove aria-controls attribute when closed', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    const tc = fixture.componentInstance;
+
+    fixture.detectChanges();
+    const headingLinks = fixture.nativeElement.querySelectorAll('.card-header a');
+
+    expectOpenPanels(fixture.nativeElement, [false, false, false]);
+    expect(headingLinks[0].getAttribute('aria-controls')).toBeNull();
+
+    tc.activeIds = ['one'];
+    fixture.detectChanges();
+    const panelsContent = getPanelsContent(fixture.nativeElement);
+    expectOpenPanels(fixture.nativeElement, [true, false, false]);
+    expect(headingLinks[0].getAttribute('aria-controls')).toBe(panelsContent[0].id);
+  });
+
 
   it('should remove collapsed panels content from DOM', () => {
     const fixture = TestBed.createComponent(TestComponent);

--- a/src/accordion/accordion.ts
+++ b/src/accordion/accordion.ts
@@ -100,7 +100,8 @@ export interface NgbPanelChangeEvent {
       <div role="tab" id="{{panel.id}}-header"
         [class]="'card-header ' + (panel.type ? 'card-'+panel.type: type ? 'card-'+type : '')" [class.active]="isOpen(panel.id)">
         <a href (click)="!!toggle(panel.id)" [class.text-muted]="panel.disabled" [attr.tabindex]="(panel.disabled ? '-1' : null)"
-          [attr.aria-expanded]="isOpen(panel.id)" [attr.aria-controls]="panel.id" [attr.aria-disabled]="panel.disabled">
+          [attr.aria-expanded]="isOpen(panel.id)" [attr.aria-controls]="(isOpen(panel.id) ? panel.id : null)"
+          [attr.aria-disabled]="panel.disabled">
           {{panel.title}}<template [ngTemplateOutlet]="panel.titleTpl?.templateRef"></template>
         </a>
       </div>


### PR DESCRIPTION
This changes will have to be reflected in #1370: aria-controls should be kept when accordion panel is only hidden

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
