### PR TITLE
fix(demo): add labels to typeahead inputs

### DIFF
--- a/demo/src/app/components/typeahead/demos/basic/typeahead-basic.html
+++ b/demo/src/app/components/typeahead/demos/basic/typeahead-basic.html
@@ -5,6 +5,7 @@ A typeahead example that gets values from a static <code>string[]</code>
   <li>limits to 10 results</li>
 </ul>
 
-<input type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search" />
+<label for="typeahead-basic">Search for a state:</label>
+<input id="typeahead-basic" type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search"/>
 <hr>
 <pre>Model: {{ model | json }}</pre>

--- a/demo/src/app/components/typeahead/demos/config/typeahead-config.html
+++ b/demo/src/app/components/typeahead/demos/config/typeahead-config.html
@@ -1,4 +1,5 @@
 <p>This typeahead shows a hint when the input matches because the default values have been customized.</p>
 
-<input type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search" />
+<label for="typeahead-config">Search for a state:</label>
+<input id="typeahead-config" type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search" />
 

--- a/demo/src/app/components/typeahead/demos/format/typeahead-format.html
+++ b/demo/src/app/components/typeahead/demos/format/typeahead-format.html
@@ -1,5 +1,6 @@
 <p>A typeahead example that uses a formatter function for string results</p>
 
-<input type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search" [resultFormatter]="formatter" />
+<label for="typeahead-format">Search for a state:</label>
+<input id="typeahead-format" type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search" [resultFormatter]="formatter" />
 <hr>
 <pre>Model: {{ model | json }}</pre>

--- a/demo/src/app/components/typeahead/demos/http/typeahead-http.html
+++ b/demo/src/app/components/typeahead/demos/http/typeahead-http.html
@@ -9,7 +9,8 @@ A typeahead example that gets values from the <code>WikipediaService</code>
 </ul>
 
 <div class="form-group" [class.has-danger]="searchFailed">
-  <input type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search" placeholder="Wikipedia search" />
+  <label for="typeahead-http">Search for a wiki page:</label>
+  <input id="typeahead-http" type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search" placeholder="Wikipedia search" />
   <span *ngIf="searching">searching...</span>
   <div class="form-control-feedback" *ngIf="searchFailed">Sorry, suggestions could not be loaded.</div>
 </div>

--- a/demo/src/app/components/typeahead/demos/template/typeahead-template.html
+++ b/demo/src/app/components/typeahead/demos/template/typeahead-template.html
@@ -5,6 +5,8 @@
   {{ r.name}}
 </template>
 
-<input type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search" [resultTemplate]="rt" [inputFormatter]="formatter" />
+<label for="typeahead-template">Search for a state:</label>
+<input id="typeahead-template" type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search" [resultTemplate]="rt"
+  [inputFormatter]="formatter" />
 <hr>
 <pre>Model: {{ model | json }}</pre>


### PR DESCRIPTION
I can also use `aria-label` attributes instead of `label` element, tell me what you prefer

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
