### PR TITLE
fix(dropdown): fixed zone for closeFromOutsideClick

### DIFF
--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -22,7 +22,7 @@ describe('ngb-dropdown', () => {
 
   it('should initialize inputs with provided config', () => {
     const defaultConfig = new NgbDropdownConfig();
-    const dropdown = new NgbDropdown(defaultConfig);
+    const dropdown = new NgbDropdown((<any>window).Zone.current, defaultConfig);
     expect(dropdown.up).toBe(defaultConfig.up);
     expect(dropdown.autoClose).toBe(defaultConfig.autoClose);
   });

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -1,4 +1,4 @@
-import {Directive, Input, Output, EventEmitter, ElementRef} from '@angular/core';
+import {Directive, Input, Output, EventEmitter, ElementRef, NgZone} from '@angular/core';
 import {NgbDropdownConfig} from './dropdown-config';
 
 /**
@@ -39,7 +39,7 @@ export class NgbDropdown {
    */
   @Output() openChange = new EventEmitter();
 
-  constructor(config: NgbDropdownConfig) {
+  constructor(private _zone: NgZone, config: NgbDropdownConfig) {
     this.up = config.up;
     this.autoClose = config.autoClose;
   }
@@ -82,9 +82,11 @@ export class NgbDropdown {
   }
 
   closeFromOutsideClick($event) {
-    if (this.autoClose && $event.button !== 2 && !this._isEventFromToggle($event)) {
-      this.close();
-    }
+    this._zone.run(() => {
+      if (this.autoClose && $event.button !== 2 && !this._isEventFromToggle($event)) {
+        this.close();
+      }
+    });
   }
 
   closeFromOutsideEsc() {


### PR DESCRIPTION
The `document:` listener runs in the root zone.

This fixes #1506
