### PR TITLE
fix(docs): template to ng-template

### DIFF
--- a/demo/src/app/components/popover/demos/tplcontent/popover-tplcontent.html
+++ b/demo/src/app/components/popover/demos/tplcontent/popover-tplcontent.html
@@ -1,6 +1,6 @@
 <p>
   Popovers can contain any arbitrary HTML, Angular bindings and even directives!
-  Simply enclose desired content in a <code>&lt;template&gt;</code> element.
+  Simply enclose desired content in a <code>&lt;ng-template&gt;</code> element.
 </p>
 
 <ng-template #popContent>Hello, <b>{{name}}</b>!</ng-template>

--- a/demo/src/app/components/tooltip/demos/tplcontent/tooltip-tplcontent.html
+++ b/demo/src/app/components/tooltip/demos/tplcontent/tooltip-tplcontent.html
@@ -1,6 +1,6 @@
 <p>
   Tooltips can contain any arbitrary HTML, Angular bindings and even directives!
-  Simply enclose desired content in a <code>&lt;template&gt;</code> element.
+  Simply enclose desired content in a <code>&lt;ng-template&gt;</code> element.
 </p>
 
 <ng-template #tipContent>Hello, <b>{{name}}</b>!</ng-template>


### PR DESCRIPTION
Since **template** has been deprecated, use in the documentation **ng-template** like the code example does.

Thanks!
