### PR TITLE
docs(README): Add instructions for modular builds to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,48 @@ export class OtherModule {
 }
 ```
 
+### Including only what you need
+For production scenarios, you will likely only want to include the parts of ng-bootstrap that you are using in your application.
+To do so, you can import only the specific modules that you need. For example:
+
+ ```js
+ import {NgbModalModule, NgbDropdownModule, NgbRatingModule} from '@ng-bootstrap/ng-bootstrap';
+ 
+ @NgModule({
+   declarations: [...],
+   imports: [
+      NgbModalModule.forRoot(),
+      NgbDropdownModule.forRoot(),
+      NgbRatingModule.forRoot(),
+      ...
+    ], 
+ })
+ export class AppModule {
+ }
+ ```
+ 
+ Any ng-bootstrap modules that you import in lazily loaded feature modules must also be imported in your main "AppModule" using the `.forRoot()` method.
+ Also note that components in your lazily loaded modules should use deep imports to avoid bringing in unused code. For example,
+ one common way to open ng-bootstrap modals is by doing the following:
+ 
+ ```js
+ constructor(private modalService: NgbModal) {
+    
+ }
+ 
+   
+ 
+ openModal() {
+   this.modalService.open(SomeModalComponent);
+ }
+ ```
+ 
+ If this were a component in a lazily loaded module, you would want to import `NgbModal` in the following way:
+  
+  `import { NgbModal } from '@ng-bootstrap/ng-bootstrap/modal/modal';` 
+
+
+
 ### SystemJS
 If you are using SystemJS, you should also adjust your configuration to point to the UMD bundle.
 

--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ For production scenarios, you will likely only want to include the parts of ng-b
 To do so, you can import only the specific modules that you need. For example:
 
  ```js
- import {NgbModalModule, NgbDropdownModule, NgbRatingModule} from '@ng-bootstrap/ng-bootstrap';
- 
+ import { NgbModalModule } from '@ng-bootstrap/ng-bootstrap/modal/modal.module';
+ import { NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap/dropdown/dropdown.module';
+ import { NgbRatingModule } from '@ng-bootstrap/ng-bootstrap/rating/rating.module';
+   
  @NgModule({
    declarations: [...],
    imports: [
@@ -94,8 +96,10 @@ To do so, you can import only the specific modules that you need. For example:
  ```
  
  If this were a component in a lazily loaded module, you would want to import `NgbModal` in the following way:
-  
-  `import { NgbModal } from '@ng-bootstrap/ng-bootstrap/modal/modal';` 
+
+ ```js
+  import { NgbModal } from '@ng-bootstrap/ng-bootstrap/modal/modal';
+ ``` 
 
 
 


### PR DESCRIPTION
I spent a ton of time trying to figure this out for myself, so I figured I'd save others some time by adding this information to the README. 

This [stack overflow link](http://stackoverflow.com/questions/43429897/webpack2-angular2-ng-bootstrap-tree-shaking/) appears to be the only information online that mention "tree shaking" or modular builds in relation to ng-bootstrap. It would be good to document this information in the README, which this PR accomplishes.  
