### PR TITLE
feat(datepicker): add keyboard navigation

### DIFF
--- a/demo/src/app/components/datepicker/demos/customday/datepicker-customday.html
+++ b/demo/src/app/components/datepicker/demos/customday/datepicker-customday.html
@@ -12,8 +12,8 @@
   </div>
 </form>
 
-<ng-template #customDay let-date="date" let-currentMonth="currentMonth" let-selected="selected" let-disabled="disabled">
-  <span class="custom-day" [class.weekend]="isWeekend(date)"
+<ng-template #customDay let-date="date" let-currentMonth="currentMonth" let-selected="selected" let-disabled="disabled" let-focused="focused">
+  <span class="custom-day" [class.weekend]="isWeekend(date)" [class.focused]="focused"
         [class.bg-primary]="selected" [class.hidden]="date.month !== currentMonth" [class.text-muted]="disabled">
     {{ date.day }}
   </span>

--- a/demo/src/app/components/datepicker/demos/customday/datepicker-customday.ts
+++ b/demo/src/app/components/datepicker/demos/customday/datepicker-customday.ts
@@ -12,7 +12,7 @@ import {NgbDateStruct} from '@ng-bootstrap/ng-bootstrap';
       display: inline-block;
       width: 2rem;
     }
-    .custom-day:hover {
+    .custom-day:hover, .custom-day.focused {
       background-color: #e6e6e6;
     }
     .weekend {

--- a/src/datepicker/datepicker-day-template-context.ts
+++ b/src/datepicker/datepicker-day-template-context.ts
@@ -19,6 +19,11 @@ export interface DayTemplateContext {
   disabled: boolean;
 
   /**
+   * True if current date is focused
+   */
+  focused: boolean;
+
+  /**
    * True if current date is selected
    */
   selected: boolean;

--- a/src/datepicker/datepicker-day-view.ts
+++ b/src/datepicker/datepicker-day-view.ts
@@ -20,7 +20,8 @@ import {NgbDateStruct} from './ngb-date-struct';
     '[class.text-white]': 'selected',
     '[class.text-muted]': 'isMuted()',
     '[class.outside]': 'isMuted()',
-    '[class.btn-secondary]': '!disabled'
+    '[class.btn-secondary]': 'true',
+    '[class.active]': 'focused'
   },
   template: `{{ date.day }}`
 })
@@ -28,6 +29,7 @@ export class NgbDatepickerDayView {
   @Input() currentMonth: number;
   @Input() date: NgbDateStruct;
   @Input() disabled: boolean;
+  @Input() focused: boolean;
   @Input() selected: boolean;
 
   isMuted() { return !this.selected && (this.date.month !== this.currentMonth || this.disabled); }

--- a/src/datepicker/datepicker-day-view.ts
+++ b/src/datepicker/datepicker-day-view.ts
@@ -1,14 +1,15 @@
-import {Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {NgbDateStruct} from './ngb-date-struct';
 
 @Component({
   selector: '[ngbDatepickerDayView]',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [`
     :host {
       text-align: center;
       width: 2rem;
       height: 2rem;
-      line-height: 2rem;      
+      line-height: 2rem;
       border-radius: 0.25rem;
     }
     :host.outside {
@@ -16,11 +17,11 @@ import {NgbDateStruct} from './ngb-date-struct';
     }
   `],
   host: {
+    'class': 'btn-secondary',
     '[class.bg-primary]': 'selected',
     '[class.text-white]': 'selected',
     '[class.text-muted]': 'isMuted()',
     '[class.outside]': 'isMuted()',
-    '[class.btn-secondary]': 'true',
     '[class.active]': 'focused'
   },
   template: `{{ date.day }}`

--- a/src/datepicker/datepicker-keymap-service.spec.ts
+++ b/src/datepicker/datepicker-keymap-service.spec.ts
@@ -1,0 +1,144 @@
+import {NgbDatepickerKeyMapService} from './datepicker-keymap-service';
+import {NgbCalendar, NgbCalendarGregorian} from './ngb-calendar';
+import {NgbDatepickerService} from './datepicker-service';
+import {TestBed} from '@angular/core/testing';
+import {Subject} from 'rxjs/Subject';
+import {NgbDate} from './ngb-date';
+
+enum Key {
+  Enter = 13,
+  Space = 32,
+  PageUp = 33,
+  PageDown = 34,
+  End = 35,
+  Home = 36,
+  ArrowLeft = 37,
+  ArrowUp = 38,
+  ArrowRight = 39,
+  ArrowDown = 40
+}
+
+const event = (keyCode: number, shift = false) =>
+    <any>({which: keyCode, shiftKey: shift, preventDefault: () => {}, stopPropagation: () => {}});
+
+describe('ngb-datepicker-keymap-service', () => {
+
+  let service: NgbDatepickerKeyMapService;
+  let calendar: NgbCalendar;
+  let mock: {focus, focusMove, focusSelect, model$};
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        NgbDatepickerKeyMapService, {provide: NgbCalendar, useClass: NgbCalendarGregorian}, {
+          provide: NgbDatepickerService,
+          useValue: {focus: () => {}, focusMove: () => {}, focusSelect: () => {}, model$: new Subject()}
+        }
+      ]
+    });
+
+    calendar = TestBed.get(NgbCalendar);
+    service = TestBed.get(NgbDatepickerKeyMapService);
+    mock = TestBed.get(NgbDatepickerService);
+
+    spyOn(mock, 'focus');
+    spyOn(mock, 'focusMove');
+    spyOn(mock, 'focusSelect');
+  });
+
+  it('should be instantiated', () => { expect(service).toBeTruthy(); });
+
+  it('should move focus by 1 day or 1 week with "Arrow" keys', () => {
+    service.processKey(event(Key.ArrowUp));
+    expect(mock.focusMove).toHaveBeenCalledWith('d', -7);
+
+    service.processKey(event(Key.ArrowDown));
+    expect(mock.focusMove).toHaveBeenCalledWith('d', 7);
+
+    service.processKey(event(Key.ArrowLeft));
+    expect(mock.focusMove).toHaveBeenCalledWith('d', -1);
+
+    service.processKey(event(Key.ArrowRight));
+    expect(mock.focusMove).toHaveBeenCalledWith('d', 1);
+
+    expect(mock.focusMove).toHaveBeenCalledTimes(4);
+  });
+
+  it('should move focus by 1 month or year "PgUp" and "PageDown"', () => {
+    service.processKey(event(Key.PageUp));
+    expect(mock.focusMove).toHaveBeenCalledWith('m', -1);
+
+    service.processKey(event(Key.PageDown));
+    expect(mock.focusMove).toHaveBeenCalledWith('m', 1);
+
+    service.processKey(event(Key.PageUp, true));
+    expect(mock.focusMove).toHaveBeenCalledWith('y', -1);
+
+    service.processKey(event(Key.PageDown, true));
+    expect(mock.focusMove).toHaveBeenCalledWith('y', 1);
+
+    expect(mock.focusMove).toHaveBeenCalledTimes(4);
+  });
+
+  it('should select focused date with "Space" and "Enter"', () => {
+    service.processKey(event(Key.Enter));
+    service.processKey(event(Key.Space));
+    expect(mock.focusSelect).toHaveBeenCalledTimes(2);
+  });
+
+  it('should move focus to the first and last days in the view with "Home" and "End"', () => {
+    service.processKey(event(Key.Home));
+    expect(mock.focus).toHaveBeenCalledWith(undefined);
+
+    service.processKey(event(Key.End));
+    expect(mock.focus).toHaveBeenCalledWith(undefined);
+
+    mock.model$.next({firstDate: new NgbDate(2017, 1, 1), lastDate: new NgbDate(2017, 12, 1)});
+
+    service.processKey(event(Key.Home));
+    expect(mock.focus).toHaveBeenCalledWith(new NgbDate(2017, 1, 1));
+
+    service.processKey(event(Key.End));
+    expect(mock.focus).toHaveBeenCalledWith(new NgbDate(2017, 12, 1));
+
+    expect(mock.focus).toHaveBeenCalledTimes(4);
+  });
+
+  it('should move focus to the "min" and "max" dates with "Home" and "End"', () => {
+    service.processKey(event(Key.Home, true));
+    expect(mock.focus).toHaveBeenCalledWith(undefined);
+
+    service.processKey(event(Key.End, true));
+    expect(mock.focus).toHaveBeenCalledWith(undefined);
+
+    mock.model$.next({minDate: new NgbDate(2017, 1, 1), maxDate: new NgbDate(2017, 12, 1), months: []});
+
+    service.processKey(event(Key.Home, true));
+    expect(mock.focus).toHaveBeenCalledWith(new NgbDate(2017, 1, 1));
+
+    service.processKey(event(Key.End, true));
+    expect(mock.focus).toHaveBeenCalledWith(new NgbDate(2017, 12, 1));
+
+    expect(mock.focus).toHaveBeenCalledTimes(4);
+  });
+
+  it('should prevent default and stop propagation of the known key', () => {
+    let e = event(Key.ArrowUp);
+    spyOn(e, 'preventDefault');
+    spyOn(e, 'stopPropagation');
+
+    service.processKey(e);
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(e.stopPropagation).toHaveBeenCalled();
+
+    // unknown key
+    e = event(23);
+    spyOn(e, 'preventDefault');
+    spyOn(e, 'stopPropagation');
+
+    service.processKey(e);
+    expect(e.preventDefault).not.toHaveBeenCalled();
+    expect(e.stopPropagation).not.toHaveBeenCalled();
+  });
+
+});

--- a/src/datepicker/datepicker-keymap-service.ts
+++ b/src/datepicker/datepicker-keymap-service.ts
@@ -1,0 +1,75 @@
+import {Injectable} from '@angular/core';
+import {NgbDatepickerService} from './datepicker-service';
+import {NgbCalendar} from './ngb-calendar';
+import {toString} from '../util/util';
+import {NgbDate} from './ngb-date';
+
+enum Key {
+  Enter = 13,
+  Space = 32,
+  PageUp = 33,
+  PageDown = 34,
+  End = 35,
+  Home = 36,
+  ArrowLeft = 37,
+  ArrowUp = 38,
+  ArrowRight = 39,
+  ArrowDown = 40
+}
+
+@Injectable()
+export class NgbDatepickerKeyMapService {
+  private _minDate: NgbDate;
+  private _maxDate: NgbDate;
+  private _firstViewDate: NgbDate;
+  private _lastViewDate: NgbDate;
+
+  constructor(private _service: NgbDatepickerService, private _calendar: NgbCalendar) {
+    _service.model$.subscribe(model => {
+      this._minDate = model.minDate;
+      this._maxDate = model.maxDate;
+      this._firstViewDate = model.firstDate;
+      this._lastViewDate = model.lastDate;
+    });
+  }
+
+  processKey(event: KeyboardEvent) {
+    if (Key[toString(event.which)]) {
+      switch (event.which) {
+        case Key.PageUp:
+          this._service.focusMove(event.shiftKey ? 'y' : 'm', -1);
+          break;
+        case Key.PageDown:
+          this._service.focusMove(event.shiftKey ? 'y' : 'm', 1);
+          break;
+        case Key.End:
+          this._service.focus(event.shiftKey ? this._maxDate : this._lastViewDate);
+          break;
+        case Key.Home:
+          this._service.focus(event.shiftKey ? this._minDate : this._firstViewDate);
+          break;
+        case Key.ArrowLeft:
+          this._service.focusMove('d', -1);
+          break;
+        case Key.ArrowUp:
+          this._service.focusMove('d', -this._calendar.getDaysPerWeek());
+          break;
+        case Key.ArrowRight:
+          this._service.focusMove('d', 1);
+          break;
+        case Key.ArrowDown:
+          this._service.focusMove('d', this._calendar.getDaysPerWeek());
+          break;
+        case Key.Enter:
+        case Key.Space:
+          this._service.focusSelect();
+          break;
+        default:
+          return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }
+}

--- a/src/datepicker/datepicker-month-view.spec.ts
+++ b/src/datepicker/datepicker-month-view.spec.ts
@@ -96,24 +96,7 @@ describe('ngb-datepicker-month-view', () => {
         <ngb-datepicker-month-view [month]="month" [dayTemplate]="tpl" (select)="onClick($event)"></ngb-datepicker-month-view>
       `);
 
-    fixture.componentInstance.month.weeks[0].days[0].disabled = true;
-    fixture.detectChanges();
-
-    spyOn(fixture.componentInstance, 'onClick');
-
-    const dates = getDates(fixture.nativeElement);
-    dates[0].click();
-
-    expect(fixture.componentInstance.onClick).not.toHaveBeenCalled();
-  });
-
-  it('should not send date selection events if disabled', () => {
-    const fixture = createTestComponent(`
-        <ng-template #tpl let-date="date">{{ date.day }}</ng-template>
-        <ngb-datepicker-month-view [month]="month" [dayTemplate]="tpl" [disabled]="true" (select)="onClick($event)">        
-        </ngb-datepicker-month-view>
-      `);
-
+    fixture.componentInstance.month.weeks[0].days[0].context.disabled = true;
     fixture.detectChanges();
 
     spyOn(fixture.componentInstance, 'onClick');
@@ -143,24 +126,13 @@ describe('ngb-datepicker-month-view', () => {
         <ngb-datepicker-month-view [month]="month" [dayTemplate]="tpl" (change)="onClick($event)"></ngb-datepicker-month-view>
       `);
 
-      fixture.componentInstance.month.weeks[0].days[0].disabled = true;
+      const newMonth = Object.assign({}, fixture.componentInstance.month);
+      newMonth.weeks[0].days[0].context.disabled = true;
+      fixture.componentInstance.month = newMonth;
       fixture.detectChanges();
 
       const dates = getDates(fixture.nativeElement);
       expect(window.getComputedStyle(dates[0]).getPropertyValue('cursor')).toBe('default');
-    });
-
-    it('should set default cursor for all dates if disabled', () => {
-      const fixture = createTestComponent(`
-        <ng-template #tpl let-date="date">{{ date.day }}</ng-template>
-        <ngb-datepicker-month-view [month]="month" [dayTemplate]="tpl" (change)="onClick($event)" [disabled]="true">        
-        </ngb-datepicker-month-view>
-      `);
-
-      fixture.detectChanges();
-
-      const dates = getDates(fixture.nativeElement);
-      dates.forEach((date) => expect(window.getComputedStyle(date).getPropertyValue('cursor')).toBe('default'));
     });
 
     it('should set default cursor for other months days', () => {
@@ -207,7 +179,7 @@ describe('ngb-datepicker-month-view', () => {
   it('should collapse weeks outside of current month', () => {
     const fixture = createTestComponent(`
         <ng-template #tpl let-date="date">{{ date.day }}</ng-template>
-        <ngb-datepicker-month-view [month]="monthCollapsedWeeks" [outsideDays]="outsideDays" [dayTemplate]="tpl">        
+        <ngb-datepicker-month-view [month]="monthCollapsedWeeks" [outsideDays]="outsideDays" [dayTemplate]="tpl">
         </ngb-datepicker-month-view>
     `);
 
@@ -225,7 +197,7 @@ describe('ngb-datepicker-month-view', () => {
   it('should collapse weeks regardless of "showWeekNumbers" value', () => {
     const fixture = createTestComponent(`
         <ng-template #tpl let-date="date">{{ date.day }}</ng-template>
-        <ngb-datepicker-month-view [month]="monthCollapsedWeeks" outsideDays="collapsed" [dayTemplate]="tpl">        
+        <ngb-datepicker-month-view [month]="monthCollapsedWeeks" outsideDays="collapsed" [dayTemplate]="tpl">
         </ngb-datepicker-month-view>
     `);
 
@@ -242,17 +214,40 @@ describe('ngb-datepicker-month-view', () => {
 class TestComponent {
   month: MonthViewModel = {
     firstDate: new NgbDate(2016, 7, 22),
+    lastDate: new NgbDate(2016, 7, 23),
     year: 2016,
     number: 7,
     weekdays: [1],
     weeks: [{
       number: 2,
-      days: [{date: new NgbDate(2016, 7, 22), disabled: false}, {date: new NgbDate(2016, 8, 23), disabled: false}]
+      days: [
+        {
+          date: new NgbDate(2016, 7, 22),
+          context: {
+            currentMonth: 7,
+            date: {year: 2016, month: 7, day: 22},
+            disabled: false,
+            focused: false,
+            selected: false
+          }
+        },
+        {
+          date: new NgbDate(2016, 8, 23),
+          context: {
+            currentMonth: 7,
+            date: {year: 2016, month: 8, day: 23},
+            disabled: false,
+            focused: false,
+            selected: false
+          }
+        }
+      ]
     }]
   };
 
   monthCollapsedWeeks: MonthViewModel = {
     firstDate: new NgbDate(2016, 8, 1),
+    lastDate: new NgbDate(2016, 8, 31),
     year: 2016,
     number: 8,
     weekdays: [1, 2],
@@ -260,22 +255,106 @@ class TestComponent {
       // month: 7, 8
       {
         number: 2,
-        days: [{date: new NgbDate(2016, 7, 4), disabled: false}, {date: new NgbDate(2016, 8, 1), disabled: false}]
+        days: [
+          {
+            date: new NgbDate(2016, 7, 4),
+            context: {
+              currentMonth: 8,
+              date: {year: 2016, month: 7, day: 4},
+              disabled: false,
+              focused: false,
+              selected: false
+            }
+          },
+          {
+            date: new NgbDate(2016, 8, 1),
+            context: {
+              currentMonth: 8,
+              date: {year: 2016, month: 8, day: 1},
+              disabled: false,
+              focused: false,
+              selected: false
+            }
+          }
+        ]
       },
       // month: 8, 8
       {
         number: 3,
-        days: [{date: new NgbDate(2016, 8, 2), disabled: false}, {date: new NgbDate(2016, 8, 3), disabled: false}]
+        days: [
+          {
+            date: new NgbDate(2016, 8, 2),
+            context: {
+              currentMonth: 8,
+              date: {year: 2016, month: 8, day: 2},
+              disabled: false,
+              focused: false,
+              selected: false
+            }
+          },
+          {
+            date: new NgbDate(2016, 8, 3),
+            context: {
+              currentMonth: 8,
+              date: {year: 2016, month: 8, day: 3},
+              disabled: false,
+              focused: false,
+              selected: false
+            }
+          }
+        ]
       },
       // month: 8, 9
       {
         number: 3,
-        days: [{date: new NgbDate(2016, 8, 4), disabled: false}, {date: new NgbDate(2016, 9, 1), disabled: false}]
+        days: [
+          {
+            date: new NgbDate(2016, 8, 4),
+            context: {
+              currentMonth: 8,
+              date: {year: 2016, month: 8, day: 4},
+              disabled: false,
+              focused: false,
+              selected: false
+            }
+          },
+          {
+            date: new NgbDate(2016, 9, 1),
+            context: {
+              currentMonth: 8,
+              date: {year: 2016, month: 9, day: 1},
+              disabled: false,
+              focused: false,
+              selected: false
+            }
+          }
+        ]
       },
       // month: 9, 9 -> to collapse
       {
         number: 4,
-        days: [{date: new NgbDate(2016, 9, 2), disabled: false}, {date: new NgbDate(2016, 9, 3), disabled: false}]
+        days: [
+          {
+            date: new NgbDate(2016, 9, 2),
+            context: {
+              currentMonth: 8,
+              date: {year: 2016, month: 9, day: 2},
+              disabled: false,
+              focused: false,
+              selected: false
+            }
+          },
+          {
+            date: new NgbDate(2016, 9, 3),
+            context: {
+              currentMonth: 8,
+              date: {year: 2016, month: 9, day: 3},
+              disabled: false,
+              focused: false,
+              selected: false
+            }
+          }
+        ]
       }
     ]
   };

--- a/src/datepicker/datepicker-month-view.ts
+++ b/src/datepicker/datepicker-month-view.ts
@@ -13,7 +13,7 @@ import {DayTemplateContext} from './datepicker-day-template-context';
     }
     .ngb-dp-day, .ngb-dp-weekday, .ngb-dp-week-number {
       width: 2rem;
-      height: 2rem;      
+      height: 2rem;
     }
     .ngb-dp-day {
       cursor: pointer;
@@ -37,6 +37,10 @@ import {DayTemplateContext} from './datepicker-day-template-context';
           <ng-template [ngIf]="!isHidden(day)">
             <ng-template [ngTemplateOutlet]="dayTemplate"
             [ngOutletContext]="_getDayContext(day, month)">
+              currentMonth: month.number,
+              disabled: isDisabled(day),
+              focused: isFocused(day.date),
+              selected: isSelected(day.date)}">
             </ng-template>
           </ng-template>
         </div>
@@ -47,6 +51,7 @@ import {DayTemplateContext} from './datepicker-day-template-context';
 export class NgbDatepickerMonthView {
   @Input() dayTemplate: TemplateRef<DayTemplateContext>;
   @Input() disabled: boolean;
+  @Input() focusedDate: NgbDate;
   @Input() month: MonthViewModel;
   @Input() outsideDays: 'visible' | 'hidden' | 'collapsed';
   @Input() selectedDate: NgbDate;
@@ -72,16 +77,20 @@ export class NgbDatepickerMonthView {
     };
   }
 
-  isDisabled(day: DayViewModel) { return this.disabled || day.disabled; }
-
-  isSelected(date: NgbDate) { return this.selectedDate && this.selectedDate.equals(date); }
-
   isCollapsed(week: WeekViewModel) {
     return this.outsideDays === 'collapsed' && week.days[0].date.month !== this.month.number &&
         week.days[week.days.length - 1].date.month !== this.month.number;
   }
 
+  isDisabled(day: DayViewModel) { return this.disabled || day.disabled; }
+
+  isFocused(date: NgbDate) {
+    return !!(this.focusedDate && this.focusedDate.equals(date) && this.month.number === date.month);
+  }
+
   isHidden(day: DayViewModel) {
     return (this.outsideDays === 'hidden' || this.outsideDays === 'collapsed') && this.month.number !== day.date.month;
   }
+
+  isSelected(date: NgbDate) { return !!(this.selectedDate && this.selectedDate.equals(date)); }
 }

--- a/src/datepicker/datepicker-month-view.ts
+++ b/src/datepicker/datepicker-month-view.ts
@@ -32,16 +32,10 @@ import {DayTemplateContext} from './datepicker-day-template-context';
     <ng-template ngFor let-week [ngForOf]="month.weeks">
       <div *ngIf="!isCollapsed(week)" class="ngb-dp-week d-flex">
         <div *ngIf="showWeekNumbers" class="ngb-dp-week-number small text-center font-italic text-muted">{{ week.number }}</div>
-        <div *ngFor="let day of week.days" (click)="doSelect(day)" class="ngb-dp-day" [class.disabled]="isDisabled(day)"
+        <div *ngFor="let day of week.days" (click)="doSelect(day)" class="ngb-dp-day" [class.disabled]="day.context.disabled"
          [class.hidden]="isHidden(day)">
           <ng-template [ngIf]="!isHidden(day)">
-            <ng-template [ngTemplateOutlet]="dayTemplate"
-            [ngOutletContext]="_getDayContext(day, month)">
-              currentMonth: month.number,
-              disabled: isDisabled(day),
-              focused: isFocused(day.date),
-              selected: isSelected(day.date)}">
-            </ng-template>
+            <ng-template [ngTemplateOutlet]="dayTemplate" [ngOutletContext]="day.context"></ng-template>
           </ng-template>
         </div>
       </div>
@@ -50,11 +44,8 @@ import {DayTemplateContext} from './datepicker-day-template-context';
 })
 export class NgbDatepickerMonthView {
   @Input() dayTemplate: TemplateRef<DayTemplateContext>;
-  @Input() disabled: boolean;
-  @Input() focusedDate: NgbDate;
   @Input() month: MonthViewModel;
   @Input() outsideDays: 'visible' | 'hidden' | 'collapsed';
-  @Input() selectedDate: NgbDate;
   @Input() showWeekdays;
   @Input() showWeekNumbers;
 
@@ -63,18 +54,9 @@ export class NgbDatepickerMonthView {
   constructor(public i18n: NgbDatepickerI18n) {}
 
   doSelect(day: DayViewModel) {
-    if (!this.isDisabled(day) && !this.isHidden(day)) {
+    if (!day.context.disabled && !this.isHidden(day)) {
       this.select.emit(NgbDate.from(day.date));
     }
-  }
-
-  _getDayContext(day: any, month: any) {
-    return {
-      date: {year: day.date.year, month: day.date.month, day: day.date.day},
-      currentMonth: month.number,
-      disabled: this.isDisabled(day),
-      selected: this.isSelected(day.date)
-    };
   }
 
   isCollapsed(week: WeekViewModel) {
@@ -82,15 +64,7 @@ export class NgbDatepickerMonthView {
         week.days[week.days.length - 1].date.month !== this.month.number;
   }
 
-  isDisabled(day: DayViewModel) { return this.disabled || day.disabled; }
-
-  isFocused(date: NgbDate) {
-    return !!(this.focusedDate && this.focusedDate.equals(date) && this.month.number === date.month);
-  }
-
   isHidden(day: DayViewModel) {
     return (this.outsideDays === 'hidden' || this.outsideDays === 'collapsed') && this.month.number !== day.date.month;
   }
-
-  isSelected(date: NgbDate) { return !!(this.selectedDate && this.selectedDate.equals(date)); }
 }

--- a/src/datepicker/datepicker-navigation-select.ts
+++ b/src/datepicker/datepicker-navigation-select.ts
@@ -18,11 +18,20 @@ import {NgbCalendar} from './ngb-calendar';
     }
   `],
   template: `
-    <select [disabled]="disabled" class="custom-select d-inline-block" [value]="date?.month" (change)="changeMonth($event.target.value)">
-      <option *ngFor="let m of months" [value]="m">{{ i18n.getMonthShortName(m) }}</option>
-    </select>` +
-      `<select [disabled]="disabled" class="custom-select d-inline-block" [value]="date?.year" (change)="changeYear($event.target.value)">
-      <option *ngFor="let y of years" [value]="y">{{ y }}</option>
+    <select
+      [disabled]="disabled"
+      class="custom-select d-inline-block"
+      [value]="date?.month"
+      (change)="changeMonth($event.target.value)"
+      tabindex="-1">
+        <option *ngFor="let m of months" [value]="m">{{ i18n.getMonthShortName(m) }}</option>
+    </select><select
+      [disabled]="disabled"
+      class="custom-select d-inline-block"
+      [value]="date?.year"
+      (change)="changeYear($event.target.value)"
+      tabindex="-1">
+        <option *ngFor="let y of years" [value]="y">{{ y }}</option>
     </select> 
   `  // template needs to be formatted in a certain way so we don't add empty text nodes
 })

--- a/src/datepicker/datepicker-navigation-select.ts
+++ b/src/datepicker/datepicker-navigation-select.ts
@@ -1,4 +1,4 @@
-import {Component, Input, Output, EventEmitter, OnChanges, SimpleChanges} from '@angular/core';
+import {Component, Input, Output, EventEmitter, OnChanges, SimpleChanges, ChangeDetectionStrategy} from '@angular/core';
 import {NgbDate} from './ngb-date';
 import {toInteger} from '../util/util';
 import {NgbDatepickerI18n} from './datepicker-i18n';
@@ -6,6 +6,7 @@ import {NgbCalendar} from './ngb-calendar';
 
 @Component({
   selector: 'ngb-datepicker-navigation-select',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [`
     select {
       /* to align with btn-sm */
@@ -33,7 +34,7 @@ import {NgbCalendar} from './ngb-calendar';
       tabindex="-1">
         <option *ngFor="let y of years" [value]="y">{{ y }}</option>
     </select> 
-  `  // template needs to be formatted in a certain way so we don't add empty text nodes
+  `
 })
 export class NgbDatepickerNavigationSelect implements OnChanges {
   months: number[];

--- a/src/datepicker/datepicker-navigation.ts
+++ b/src/datepicker/datepicker-navigation.ts
@@ -1,4 +1,4 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
+import {Component, Input, Output, EventEmitter, ChangeDetectionStrategy} from '@angular/core';
 import {NavigationEvent} from './datepicker-view-model';
 import {NgbDate} from './ngb-date';
 import {NgbDatepickerI18n} from './datepicker-i18n';
@@ -6,6 +6,7 @@ import {NgbCalendar} from './ngb-calendar';
 
 @Component({
   selector: 'ngb-datepicker-navigation',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {'class': 'd-flex justify-content-between', '[class.collapsed]': '!showSelect'},
   styles: [`
     :host {

--- a/src/datepicker/datepicker-navigation.ts
+++ b/src/datepicker/datepicker-navigation.ts
@@ -43,7 +43,7 @@ import {NgbCalendar} from './ngb-calendar';
     }    
   `],
   template: `
-    <button type="button" class="btn-link" (click)="!!doNavigate(navigation.PREV)" [disabled]="prevDisabled()">
+    <button type="button" class="btn-link" (click)="!!doNavigate(navigation.PREV)" [disabled]="prevDisabled()" tabindex="-1">
       <span class="ngb-dp-navigation-chevron"></span>    
     </button>
     
@@ -55,7 +55,7 @@ import {NgbCalendar} from './ngb-calendar';
       (select)="selectDate($event)">
     </ngb-datepicker-navigation-select>
     
-    <button type="button" class="btn-link" (click)="!!doNavigate(navigation.NEXT)" [disabled]="nextDisabled()">
+    <button type="button" class="btn-link" (click)="!!doNavigate(navigation.NEXT)" [disabled]="nextDisabled()" tabindex="-1">
       <span class="ngb-dp-navigation-chevron right"></span>
     </button>
   `

--- a/src/datepicker/datepicker-service.spec.ts
+++ b/src/datepicker/datepicker-service.spec.ts
@@ -1,142 +1,772 @@
-import {TestBed, inject} from '@angular/core/testing';
-
+import {TestBed} from '@angular/core/testing';
+import {NgbDatepickerService} from './datepicker-service';
 import {NgbCalendar, NgbCalendarGregorian} from './ngb-calendar';
 import {NgbDate} from './ngb-date';
-import {NgbDatepickerI18n} from './datepicker-i18n';
-import {NgbDatepickerService} from './datepicker-service';
-
-class MockCalendar extends NgbCalendarGregorian {
-  getDaysPerWeek(): number { return 1; }
-
-  getWeeksPerMonth(): number { return 1; }
-
-  getWeekday(date: NgbDate): number { return 1; }
-
-  getWeekNumber(week: NgbDate[], firstDayOfWeek: number): number { return 1; }
-
-  getNext(date: NgbDate, period = 'd'): NgbDate { return new NgbDate(2000, 0, 1); }
-
-  getPrev(date: NgbDate, period = 'd'): NgbDate { return new NgbDate(2000, 2, 1); }
-
-  getToday(): NgbDate { return new NgbDate(2000, 1, 1); }
-
-  isValid(date: NgbDate): boolean { return true; }
-}
+import {Subscription} from 'rxjs/Subscription';
+import {DatepickerViewModel} from './datepicker-view-model';
 
 describe('ngb-datepicker-service', () => {
 
+  let service: NgbDatepickerService;
+  let calendar: NgbCalendar;
+  let model: DatepickerViewModel;
+  let mock: {onNext};
+
+  let subscriptions: Subscription[];
+
+  const getDay = (n: number) => model.months[0].weeks[0].days[n];
+  const getDayCtx = (n: number) => getDay(n).context;
+
   beforeEach(() => {
     TestBed.configureTestingModule(
-        {providers: [NgbDatepickerI18n, NgbDatepickerService, {provide: NgbCalendar, useClass: MockCalendar}]});
+        {providers: [NgbDatepickerService, {provide: NgbCalendar, useClass: NgbCalendarGregorian}]});
+
+    calendar = TestBed.get(NgbCalendar);
+    service = TestBed.get(NgbDatepickerService);
+    subscriptions = [];
+    model = undefined;
+
+    mock = {onNext: () => {}};
+    spyOn(mock, 'onNext');
+
+    // subscribing
+    subscriptions.push(service.model$.subscribe(mock.onNext), service.model$.subscribe(m => model = m));
   });
 
-  it('should generate month view model', inject([NgbDatepickerService, NgbCalendar], (service, calendar) => {
-       const monthViewModel = service.generateMonthViewModel(
-           calendar.getToday(), new NgbDate(2000, 0, 1), new NgbDate(2000, 2, 1), 1, null);
-       expect(monthViewModel).toEqual({
-         number: 1,
-         year: 2000,
-         firstDate: new NgbDate(2000, 1, 1),
-         weeks: [{number: 1, days: [{date: new NgbDate(2000, 1, 1), disabled: false}]}],
-         weekdays: [1]
-       });
-     }));
+  afterEach(() => { subscriptions.forEach(s => s.unsubscribe()); });
 
-  it('should mark dates out of min/max bounds as disabled',
-     inject([NgbDatepickerService, NgbCalendar], (service, calendar) => {
-       let monthViewModel = service.generateMonthViewModel(
-           calendar.getToday(), new NgbDate(2000, 2, 1), new NgbDate(2000, 2, 10), 1, null);
-       expect(monthViewModel).toEqual({
-         number: 1,
-         year: 2000,
-         firstDate: new NgbDate(2000, 1, 1),
-         weeks: [{number: 1, days: [{date: new NgbDate(2000, 1, 1), disabled: true}]}],
-         weekdays: [1]
-       });
+  it(`should be possible to instantiate`, () => { expect(service).toBeTruthy(); });
 
-       monthViewModel = service.generateMonthViewModel(
-           calendar.getToday(), new NgbDate(2000, 0, 1), new NgbDate(2000, 0, 10), 1, null);
-       expect(monthViewModel).toEqual({
-         number: 1,
-         year: 2000,
-         firstDate: new NgbDate(2000, 1, 1),
-         weeks: [{number: 1, days: [{date: new NgbDate(2000, 1, 1), disabled: true}]}],
-         weekdays: [1]
-       });
-     }));
+  it(`should not return anything upon subscription`, () => {
+    expect(model).toBeUndefined();
+    expect(mock.onNext).not.toHaveBeenCalled();
+  });
 
-  it('should mark dates out of min/max bounds as disabled',
-     inject([NgbDatepickerService, NgbCalendar], (service, calendar) => {
-       let monthViewModel = service.generateMonthViewModel(
-           calendar.getToday(), new NgbDate(2000, 0, 1), new NgbDate(2000, 1, 10), 1, () => true);
-       expect(monthViewModel).toEqual({
-         number: 1,
-         year: 2000,
-         firstDate: new NgbDate(2000, 1, 1),
-         weeks: [{number: 1, days: [{date: new NgbDate(2000, 1, 1), disabled: true}]}],
-         weekdays: [1]
-       });
-     }));
+  describe(`min/max dates`, () => {
 
-  it('markDisabled callback should not override date bounds',
-     inject([NgbDatepickerService, NgbCalendar], (service, calendar) => {
-       let monthViewModel = service.generateMonthViewModel(
-           calendar.getToday(), new NgbDate(2000, 0, 1), new NgbDate(2000, 0, 10), 1, () => false);
-       expect(monthViewModel).toEqual({
-         number: 1,
-         year: 2000,
-         firstDate: new NgbDate(2000, 1, 1),
-         weeks: [{number: 1, days: [{date: new NgbDate(2000, 1, 1), disabled: true}]}],
-         weekdays: [1]
-       });
-     }));
+    it(`should emit only undefined and valid 'minDate' values`, () => {
+      // valid
+      const minDate = new NgbDate(2017, 5, 1);
+      service.minDate = minDate;
+      service.focus(new NgbDate(2017, 5, 1));
+      expect(model.minDate).toEqual(minDate);
 
-  it('markDisabled should pass the correct year and month',
-     inject([NgbDatepickerService, NgbCalendar], (service, calendar) => {
+      // undefined
+      service.minDate = undefined;
+      expect(model.minDate).toBeUndefined();
 
-       let result;
+      // null -> ignore
+      service.minDate = null;
+      expect(model.minDate).toBeUndefined();
 
-       const markDisabled = (date, current) => {
-         result = current;
-         return false;
-       };
+      // invalid -> ignore
+      service.minDate = new NgbDate(-2, 0, null);
+      expect(model.minDate).toBeUndefined();
 
-       service.generateMonthViewModel(
-           new NgbDate(2016, 10, 10), new NgbDate(2000, 0, 1), new NgbDate(2020, 0, 10), 1, markDisabled);
-       expect(result).toEqual({month: 10, year: 2016});
-     }));
-
-  describe('toValidDate() for Gregorian Calendar', () => {
-
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        providers: [NgbDatepickerI18n, NgbDatepickerService, {provide: NgbCalendar, useClass: NgbCalendarGregorian}]
-      });
+      expect(mock.onNext).toHaveBeenCalledTimes(2);
     });
 
-    it('should convert a valid NgbDate', inject([NgbDatepickerService], (service) => {
-         expect(service.toValidDate(new NgbDate(2016, 10, 5))).toEqual(new NgbDate(2016, 10, 5));
-         expect(service.toValidDate({year: 2016, month: 10, day: 5})).toEqual(new NgbDate(2016, 10, 5));
-       }));
+    it(`should emit only undefined and valid 'maxDate' values`, () => {
+      // valid
+      const maxDate = new NgbDate(2017, 5, 1);
+      service.maxDate = maxDate;
+      service.focus(new NgbDate(2017, 5, 1));
+      expect(model.maxDate).toEqual(maxDate);
 
-    it('should return today for an invalid NgbDate',
-       inject([NgbDatepickerService, NgbCalendar], (service, calendar) => {
-         const today = calendar.getToday();
-         expect(service.toValidDate(null)).toEqual(today);
-         expect(service.toValidDate({})).toEqual(today);
-         expect(service.toValidDate(undefined)).toEqual(today);
-         expect(service.toValidDate(new Date())).toEqual(today);
-       }));
+      // undefined
+      service.maxDate = undefined;
+      expect(model.maxDate).toBeUndefined();
 
-    it('should return today if default value is undefined',
-       inject([NgbDatepickerService, NgbCalendar], (service, calendar) => {
-         expect(service.toValidDate(null, undefined)).toEqual(calendar.getToday());
-       }));
+      // null -> ignore
+      service.maxDate = null;
+      expect(model.maxDate).toBeUndefined();
 
-    it('should return default value for an invalid NgbDate if provided', inject([NgbDatepickerService], (service) => {
-         expect(service.toValidDate(null, new NgbDate(1066, 6, 6))).toEqual(new NgbDate(1066, 6, 6));
-         expect(service.toValidDate(null, null)).toEqual(null);
-       }));
+      // invalid -> ignore
+      service.maxDate = new NgbDate(-2, 0, null);
+      expect(model.maxDate).toBeUndefined();
+
+      expect(mock.onNext).toHaveBeenCalledTimes(2);
+    });
+
+    it(`should not emit the same 'minDate' value twice`, () => {
+      service.minDate = new NgbDate(2017, 5, 1);
+      service.focus(new NgbDate(2015, 5, 1));
+
+      service.minDate = new NgbDate(2017, 5, 1);
+
+      expect(mock.onNext).toHaveBeenCalledTimes(1);
+    });
+
+    it(`should not emit the same 'maxDate' value twice`, () => {
+      service.maxDate = new NgbDate(2017, 5, 1);
+      service.focus(new NgbDate(2015, 5, 1));
+
+      service.maxDate = new NgbDate(2017, 5, 1);
+
+      expect(mock.onNext).toHaveBeenCalledTimes(1);
+    });
+
+    it(`should throw if 'min' date is after 'max' date`, () => {
+      const minDate = new NgbDate(2017, 5, 1);
+      service.focus(new NgbDate(2015, 5, 1));
+
+      expect(() => {
+        service.minDate = minDate;
+        service.maxDate = new NgbDate(2017, 4, 1);
+      }).toThrowError();
+    });
+
+    it(`should align 'date' with 'maxDate'`, () => {
+      service.maxDate = new NgbDate(2017, 5, 1);
+      service.focus(new NgbDate(2017, 5, 5));
+      expect(model.focusDate).toEqual(new NgbDate(2017, 5, 1));
+    });
+
+    it(`should align 'date' with 'minDate'`, () => {
+      service.minDate = new NgbDate(2017, 5, 10);
+      service.focus(new NgbDate(2017, 5, 5));
+      expect(model.focusDate).toEqual(new NgbDate(2017, 5, 10));
+    });
+
+    it(`should mark dates outside 'min/maxDates' as disabled`, () => {
+      // MAY 2017
+      service.focus(new NgbDate(2017, 5, 1));
+      expect(model.minDate).toBeUndefined();
+      expect(model.maxDate).toBeUndefined();
+      expect(getDayCtx(0).disabled).toBe(false);  // 1 MAY
+      expect(getDayCtx(5).disabled).toBe(false);  // 6 MAY
+
+      service.minDate = new NgbDate(2017, 5, 2);
+      service.maxDate = new NgbDate(2017, 5, 5);
+      expect(getDayCtx(0).disabled).toBe(true);  // 1 MAY
+      expect(getDayCtx(5).disabled).toBe(true);  // 6 MAY
+    });
+
+    it(`should rebuild month when 'min/maxDates' change and visible`, () => {
+      // MAY 2017
+      service.focus(new NgbDate(2017, 5, 5));
+      expect(model.months.length).toBe(1);
+      expect(model.minDate).toBeUndefined();
+      expect(model.maxDate).toBeUndefined();
+
+      const month = model.months[0];
+      const date = month.weeks[0].days[0].date;
+
+      // MIN -> 5 MAY, 2017
+      service.minDate = new NgbDate(2017, 5, 5);
+      expect(model.months.length).toBe(1);
+      expect(model.months[0]).not.toBe(month);
+      expect(getDayCtx(0).disabled).toBe(true);
+      expect(getDay(0).date).not.toBe(date);
+
+      // MAX -> 10 MAY, 2017
+      service.maxDate = new NgbDate(2017, 5, 10);
+      expect(model.months.length).toBe(1);
+      expect(model.months[0]).not.toBe(month);
+      expect(model.months[0].weeks[4].days[0].context.disabled).toBe(true);
+      expect(model.months[0].weeks[0].days[0].date).not.toBe(date);
+    });
   });
 
+  describe(`firstDayOfWeek`, () => {
+
+    it(`should emit only positive numeric 'firstDayOfWeek' values`, () => {
+      // valid
+      service.firstDayOfWeek = 2;
+      service.focus(new NgbDate(2015, 5, 1));
+      expect(model.firstDayOfWeek).toEqual(2);
+
+      // -1 -> ignore
+      service.firstDayOfWeek = -1;
+      expect(model.firstDayOfWeek).toEqual(2);
+
+      // null -> ignore
+      service.firstDayOfWeek = null;
+      expect(model.firstDayOfWeek).toEqual(2);
+
+      // undefined -> ignore
+      service.firstDayOfWeek = null;
+      expect(model.firstDayOfWeek).toEqual(2);
+
+      expect(mock.onNext).toHaveBeenCalledTimes(1);
+    });
+
+    it(`should not emit the same 'firstDayOfWeek' value twice`, () => {
+      service.firstDayOfWeek = 2;
+      service.focus(new NgbDate(2015, 5, 1));
+
+      service.firstDayOfWeek = 2;
+
+      expect(mock.onNext).toHaveBeenCalledTimes(1);
+    });
+
+    it(`should generate a month with firstDayOfWeek=1 by default`, () => {
+      service.focus(new NgbDate(2017, 5, 5));
+      expect(model.months.length).toBe(1);
+      expect(model.months[0].weekdays[0]).toBe(1);
+    });
+
+    it(`should generate weeks starting with 'firstDayOfWeek'`, () => {
+      service.firstDayOfWeek = 2;
+      service.focus(new NgbDate(2017, 5, 5));
+      expect(model.months.length).toBe(1);
+      expect(model.months[0].weekdays[0]).toBe(2);
+
+      service.firstDayOfWeek = 4;
+      expect(model.months.length).toBe(1);
+      expect(model.months[0].weekdays[0]).toBe(4);
+    });
+
+    it(`should rebuild months when 'firstDayOfWeek' changes`, () => {
+      service.focus(new NgbDate(2017, 5, 5));
+      expect(model.months.length).toBe(1);
+      expect(model.firstDayOfWeek).toBe(1);
+
+      const month = model.months[0];
+      const date = month.weeks[0].days[0].date;
+
+      service.firstDayOfWeek = 3;
+      expect(model.months.length).toBe(1);
+      expect(model.months[0]).not.toBe(month);
+      expect(getDay(0).date).not.toBe(date);
+    });
+  });
+
+  describe(`displayMonths`, () => {
+
+    it(`should emit only positive numeric 'displayMonths' values`, () => {
+      // valid
+      service.displayMonths = 2;
+      service.focus(new NgbDate(2017, 5, 1));
+      expect(model.displayMonths).toEqual(2);
+
+      // -1 -> ignore
+      service.displayMonths = -1;
+      expect(model.displayMonths).toEqual(2);
+
+      // null -> ignore
+      service.displayMonths = null;
+      expect(model.displayMonths).toEqual(2);
+
+      // undefined -> ignore
+      service.displayMonths = null;
+      expect(model.displayMonths).toEqual(2);
+
+      expect(mock.onNext).toHaveBeenCalledTimes(1);
+    });
+
+    it(`should not emit the same 'displayMonths' value twice`, () => {
+      service.displayMonths = 2;
+      service.focus(new NgbDate(2017, 5, 1));
+
+      service.displayMonths = 2;
+
+      expect(mock.onNext).toHaveBeenCalledTimes(1);
+    });
+
+    it(`should generate 'displayMonths' number of months`, () => {
+      service.displayMonths = 2;
+      service.focus(new NgbDate(2017, 5, 5));
+      expect(model.months.length).toBe(2);
+
+      service.displayMonths = 4;
+      expect(model.months.length).toBe(4);
+    });
+
+    it(`should reuse existing months when 'displayMonths' changes`, () => {
+      service.focus(new NgbDate(2017, 5, 5));
+
+      // 1 month
+      expect(model.months.length).toBe(1);
+      const month = model.months[0];
+      const date = month.weeks[0].days[0].date;
+      expect(date).toEqual(new NgbDate(2017, 5, 1));
+
+      // 2 months
+      service.displayMonths = 2;
+      expect(model.months.length).toBe(2);
+      expect(model.months[0]).toBe(month);
+      expect(getDay(0).date).toBe(date);
+
+      // back to 1 month
+      service.displayMonths = 1;
+      expect(model.months.length).toBe(1);
+      expect(model.months[0]).toBe(month);
+      expect(getDay(0).date).toBe(date);
+    });
+  });
+
+  describe(`disabled`, () => {
+
+    it(`should emit 'disabled' values`, () => {
+      service.focus(new NgbDate(2017, 5, 1));
+      expect(model.disabled).toEqual(false);
+
+      service.disabled = true;
+      expect(model.disabled).toEqual(true);
+    });
+
+    it(`should not emit the same 'disabled' value twice`, () => {
+      service.focus(new NgbDate(2017, 5, 1));  // 1
+      service.disabled = true;                 // 2
+
+      service.disabled = true;  // ignored
+
+      expect(mock.onNext).toHaveBeenCalledTimes(2);
+    });
+
+    it(`should not allow focusing when disabled`, () => {
+      const today = new NgbDate(2017, 5, 2);
+      service.focus(today);     // 1
+      service.disabled = true;  // 2
+
+      // focus
+      service.focus(new NgbDate(2017, 5, 1));  // nope
+      expect(model.focusDate).toEqual(today);
+
+      // focusMove
+      service.focusMove('d', 1);  // nope
+      expect(model.focusDate).toEqual(today);
+
+      expect(mock.onNext).toHaveBeenCalledTimes(2);
+    });
+
+    it(`should not allow selecting when disabled`, () => {
+      const today = new NgbDate(2017, 5, 2);
+      service.focus(today);     // 1
+      service.disabled = true;  // 2
+
+      // select
+      service.select(new NgbDate(2017, 5, 2));  // nope
+      expect(model.selectedDate).toBeNull();
+
+      // focus select
+      service.focusSelect();  // nope
+      expect(model.selectedDate).toBeNull();
+
+      expect(mock.onNext).toHaveBeenCalledTimes(2);
+    });
+
+    it(`should not allow opening when disabled`, () => {
+      service.focus(new NgbDate(2017, 5, 2));  // 1
+      service.disabled = true;                 // 2
+
+      // open
+      service.open(new NgbDate(2016, 5, 1));  // nope
+      expect(model.firstDate).toEqual(new NgbDate(2017, 5, 1));
+
+      expect(mock.onNext).toHaveBeenCalledTimes(2);
+    });
+
+    it(`should turn focus off when disabled`, () => {
+      service.focus(new NgbDate(2017, 5, 2));
+      service.focusVisible = true;
+      expect(model.focusVisible).toBeTruthy();
+
+      service.disabled = true;
+      expect(model.focusVisible).toBeFalsy();
+    });
+
+    it(`should not turn focus on when disabled`, () => {
+      service.focus(new NgbDate(2017, 5, 2));
+      service.disabled = true;
+      expect(model.focusVisible).toBeFalsy();
+
+      service.focusVisible = true;
+      expect(model.focusVisible).toBeFalsy();
+    });
+
+  });
+
+  describe(`focusVisible`, () => {
+
+    it(`should set focus visible or not`, () => {
+      service.focus(new NgbDate(2017, 5, 1));
+      expect(model.focusVisible).toEqual(false);
+
+      service.focusVisible = true;
+      expect(model.focusVisible).toEqual(true);
+    });
+
+    it(`should not emit the same 'focusVisible' value twice`, () => {
+      service.focusVisible = true;
+      service.focus(new NgbDate(2017, 5, 1));
+
+      service.focusVisible = true;  // ignored
+
+      expect(mock.onNext).toHaveBeenCalledTimes(1);
+    });
+
+  });
+
+  describe(`markDisabled`, () => {
+
+    it(`should mark dates as disabled by passing 'markDisabled'`, () => {
+      // marking 5th day of each month as disabled
+      service.markDisabled = (date) => date && date.day === 5;
+
+      // MAY 2017
+      service.focus(new NgbDate(2017, 5, 1));
+
+      const day = getDay(4);  // 5th day;
+      expect(day.date).toEqual(new NgbDate(2017, 5, 5));
+      expect(day.context.disabled).toBe(true);
+    });
+
+    it(`should rebuild months when 'markDisabled changes'`, () => {
+      // MAY 2017
+      service.markDisabled = (_) => true;
+      service.focus(new NgbDate(2017, 5, 1));
+
+      const month = model.months[0];
+      const date = month.weeks[0].days[0].date;
+
+      service.markDisabled = (_) => true;
+      expect(model.months[0]).not.toBe(month);
+      expect(getDay(0).date).not.toBe(date);
+    });
+  });
+
+  describe(`focus handling`, () => {
+
+    it(`should generate 1 month on 'focus()' by default`, () => {
+      expect(model).toBeUndefined();
+
+      service.focus(new NgbDate(2017, 5, 5));
+      expect(model.months).toBeTruthy();
+      expect(model.months.length).toBe(1);
+    });
+
+    it(`should emit new date on 'focus()'`, () => {
+      const today = new NgbDate(2017, 5, 2);
+      service.focus(today);
+      expect(model.focusDate).toEqual(today);
+
+      expect(mock.onNext).toHaveBeenCalledTimes(1);
+    });
+
+    it(`should ignore invalid 'focus()' values`, () => {
+      service.focus(null);
+      service.focus(undefined);
+      service.focus(new NgbDate(-2, 0, null));
+
+      expect(mock.onNext).not.toHaveBeenCalled();
+    });
+
+    it(`should not emit the same date twice on 'focus()'`, () => {
+      service.focus(new NgbDate(2017, 5, 2));
+      service.focus(new NgbDate(2017, 5, 2));
+
+      expect(mock.onNext).toHaveBeenCalledTimes(1);
+    });
+
+    it(`should update months when focused date updates`, () => {
+      service.focus(new NgbDate(2017, 5, 5));
+
+      expect(model.months.length).toBe(1);
+      expect(model.months[0].firstDate).toEqual(new NgbDate(2017, 5, 1));
+
+      // next month
+      service.focus(new NgbDate(2017, 6, 10));
+
+      expect(model.months.length).toBe(1);
+      expect(model.months[0].firstDate).toEqual(new NgbDate(2017, 6, 1));
+
+      // next year
+      service.focus(new NgbDate(2018, 6, 10));
+
+      expect(model.months.length).toBe(1);
+      expect(model.months[0].firstDate).toEqual(new NgbDate(2018, 6, 1));
+
+      expect(mock.onNext).toHaveBeenCalledTimes(3);
+    });
+
+    it(`should move focus with 'focusMove()'`, () => {
+      const date = new NgbDate(2017, 5, 5);
+
+      // days
+      service.focus(date);
+      service.focusMove('d', 1);
+      expect(model.focusDate).toEqual(new NgbDate(2017, 5, 6));
+
+      service.focus(date);
+      service.focusMove('d', -1);
+      expect(model.focusDate).toEqual(new NgbDate(2017, 5, 4));
+
+      // months
+      service.focus(date);
+      service.focusMove('m', 1);
+      expect(model.focusDate).toEqual(new NgbDate(2017, 6, 1));
+
+      service.focus(date);
+      service.focusMove('m', -1);
+      expect(model.focusDate).toEqual(new NgbDate(2017, 4, 1));
+
+      // years
+      service.focus(date);
+      service.focusMove('y', 1);
+      expect(model.focusDate).toEqual(new NgbDate(2018, 1, 1));
+
+      service.focus(date);
+      service.focusMove('y', -1);
+      expect(model.focusDate).toEqual(new NgbDate(2016, 1, 1));
+    });
+
+    it(`should move focus when 'minDate' changes`, () => {
+      service.focus(new NgbDate(2017, 5, 5));
+      service.maxDate = new NgbDate(2017, 5, 1);
+      expect(model.focusDate).toEqual(new NgbDate(2017, 5, 1));
+    });
+
+    it(`should move focus when 'maxDate' changes`, () => {
+      service.focus(new NgbDate(2017, 5, 5));
+      service.minDate = new NgbDate(2017, 5, 10);
+      expect(model.focusDate).toEqual(new NgbDate(2017, 5, 10));
+    });
+
+    it(`should not rebuild a single month if newly focused date is visible`, () => {
+      service.focus(new NgbDate(2017, 5, 5));
+
+      expect(model.months.length).toBe(1);
+      const month = model.months[0];
+      const date = month.weeks[0].days[0].date;
+      expect(date).toEqual(new NgbDate(2017, 5, 1));
+
+      service.focus(new NgbDate(2017, 5, 10));
+      expect(model.months[0]).toBe(month);
+      expect(getDay(0).date).toBe(date);
+    });
+
+    it(`should not rebuild multiple months if newly focused date is visible`, () => {
+      service.displayMonths = 2;
+      service.focus(new NgbDate(2017, 5, 5));
+
+      expect(model.months.length).toBe(2);
+      const months = model.months;
+      expect(months[0].firstDate).toEqual(new NgbDate(2017, 5, 1));
+      expect(months[1].lastDate).toEqual(new NgbDate(2017, 6, 30));
+
+      service.focus(new NgbDate(2017, 6, 10));
+      expect(model.months.length).toBe(2);
+      expect(model.months[0]).toBe(months[0]);
+      expect(model.months[1]).toBe(months[1]);
+    });
+  });
+
+  describe(`view change handling`, () => {
+
+    it(`should open month and set up focus correctly`, () => {
+      service.open(new NgbDate(2017, 5, 5));
+      expect(model.months.length).toBe(1);
+      expect(model.firstDate).toEqual(new NgbDate(2017, 5, 1));
+      expect(model.focusDate).toEqual(new NgbDate(2017, 5, 5));
+    });
+
+    it(`should open month and move the focus with it`, () => {
+      service.focus(new NgbDate(2017, 5, 5));
+      expect(model.months.length).toBe(1);
+      expect(model.focusDate).toEqual(new NgbDate(2017, 5, 5));
+
+      // same month, same focus
+      service.open(new NgbDate(2017, 5, 1));
+      expect(model.focusDate).toEqual(new NgbDate(2017, 5, 5));
+
+      // different month, moving focus along
+      service.open(new NgbDate(2017, 10, 10));
+      expect(model.focusDate).toEqual(new NgbDate(2017, 10, 10));
+    });
+
+    it(`should open multiple months and move focus with them`, () => {
+      // MAY-JUN
+      service.displayMonths = 2;
+      service.focus(new NgbDate(2017, 5, 5));
+      expect(model.months.length).toBe(2);
+      expect(model.firstDate).toEqual(new NgbDate(2017, 5, 1));
+      expect(model.focusDate).toEqual(new NgbDate(2017, 5, 5));
+
+      // moving view to JUL-AUG
+      service.open(new NgbDate(2017, 7, 10));
+      expect(model.firstDate).toEqual(new NgbDate(2017, 7, 1));
+      expect(model.focusDate).toEqual(new NgbDate(2017, 7, 10));
+
+      // moving view to MAY-JUN
+      service.open(new NgbDate(2017, 5, 10));
+      expect(model.firstDate).toEqual(new NgbDate(2017, 5, 1));
+      expect(model.focusDate).toEqual(new NgbDate(2017, 5, 10));
+    });
+
+    it(`should open multiple months and do not touch focus if it is visible`, () => {
+      // MAY-JUN
+      service.displayMonths = 2;
+      service.focus(new NgbDate(2017, 5, 5));
+      expect(model.months.length).toBe(2);
+      expect(model.firstDate).toEqual(new NgbDate(2017, 5, 1));
+      expect(model.focusDate).toEqual(new NgbDate(2017, 5, 5));
+
+      // moving focus to JUN
+      service.focus(new NgbDate(2017, 6, 5));
+      expect(model.focusDate).toEqual(new NgbDate(2017, 6, 5));
+
+      // moving view to JUN-JUL
+      service.open(new NgbDate(2017, 6, 10));
+      expect(model.firstDate).toEqual(new NgbDate(2017, 6, 1));
+      expect(model.focusDate).toEqual(new NgbDate(2017, 6, 5));
+
+      // moving view to MAY-JUN
+      service.open(new NgbDate(2017, 5, 10));
+      expect(model.firstDate).toEqual(new NgbDate(2017, 5, 1));
+      expect(model.focusDate).toEqual(new NgbDate(2017, 6, 5));
+    });
+
+    it(`should reuse existing months when opening`, () => {
+      service.focus(new NgbDate(2017, 5, 5));
+      expect(model.months.length).toBe(1);
+      const month = model.months[0];
+      const date = month.weeks[0].days[0].date;
+      expect(date).toEqual(new NgbDate(2017, 5, 1));
+
+      service.open(new NgbDate(2017, 5, 10));
+      expect(model.months.length).toBe(1);
+      expect(model.months[0]).toBe(month);
+      expect(getDay(0).date).toBe(date);
+    });
+  });
+
+  describe(`selection handling`, () => {
+
+    it(`should select currently focused date with 'focusSelect()'`, () => {
+      const date = new NgbDate(2017, 5, 5);
+      service.focus(date);
+      expect(model.selectedDate).toBeNull();
+
+      service.focusSelect();
+      expect(model.selectedDate).toEqual(date);
+    });
+
+    it(`should not select disabled dates with 'focusSelect()'`, () => {
+      // marking 5th day of each month as disabled
+      service.markDisabled = (date) => date && date.day === 5;
+
+      // focusing MAY, 5
+      const date = new NgbDate(2017, 5, 5);
+      service.focus(date);
+      expect(model.focusDate).toEqual(date);
+      expect(model.selectedDate).toBeNull();
+
+      service.focusSelect();
+      expect(model.selectedDate).toBeNull();
+    });
+  });
+
+  describe(`template context`, () => {
+
+    it(`should generate 'date' for day template`, () => {
+      service.focus(new NgbDate(2017, 5, 1));
+      expect(getDayCtx(0).date).toEqual({year: 2017, month: 5, day: 1});
+      expect(getDayCtx(1).date).toEqual({year: 2017, month: 5, day: 2});
+
+      service.focus(new NgbDate(2017, 10, 1));
+      expect(getDayCtx(0).date).toEqual({year: 2017, month: 9, day: 25});
+      expect(getDayCtx(1).date).toEqual({year: 2017, month: 9, day: 26});
+    });
+
+    it(`should generate 'currentMonth' for day template`, () => {
+      service.focus(new NgbDate(2017, 5, 1));
+      expect(getDayCtx(0).currentMonth).toBe(5);
+
+      service.focus(new NgbDate(2017, 10, 1));
+      expect(getDayCtx(0).currentMonth).toBe(10);
+    });
+
+    it(`should update 'focused' flag for day template`, () => {
+      // off
+      service.focus(new NgbDate(2017, 5, 1));
+      expect(getDayCtx(0).focused).toBeFalsy();
+      expect(getDayCtx(1).focused).toBeFalsy();
+
+      // on
+      service.focusVisible = true;
+      expect(getDayCtx(0).focused).toBeTruthy();
+      expect(getDayCtx(1).focused).toBeFalsy();
+
+      // move
+      service.focusMove('d', 1);
+      expect(getDayCtx(0).focused).toBeFalsy();
+      expect(getDayCtx(1).focused).toBeTruthy();
+
+      // off
+      service.focusVisible = false;
+      expect(getDayCtx(0).focused).toBeFalsy();
+      expect(getDayCtx(1).focused).toBeFalsy();
+    });
+
+    it(`should update 'selected' flag for day template`, () => {
+      // off
+      service.focus(new NgbDate(2017, 5, 1));
+      expect(getDayCtx(0).selected).toBeFalsy();
+      expect(getDayCtx(1).selected).toBeFalsy();
+
+      // select
+      service.focusSelect();
+      expect(getDayCtx(0).selected).toBeTruthy();
+      expect(getDayCtx(1).selected).toBeFalsy();
+
+      // move
+      service.select(new NgbDate(2017, 5, 2));
+      expect(getDayCtx(0).selected).toBeFalsy();
+      expect(getDayCtx(1).selected).toBeTruthy();
+
+      // off
+      service.select(null);
+      expect(getDayCtx(0).selected).toBeFalsy();
+      expect(getDayCtx(1).selected).toBeFalsy();
+    });
+
+    it(`should update 'disabled' flag for day template`, () => {
+      // off
+      service.focus(new NgbDate(2017, 5, 1));
+      expect(getDayCtx(0).disabled).toBeFalsy();
+      expect(getDayCtx(1).disabled).toBeFalsy();
+
+      // marking 2nd day of each month as disabled
+      service.markDisabled = (date) => date && date.day === 2;
+      expect(getDayCtx(0).disabled).toBeFalsy();
+      expect(getDayCtx(1).disabled).toBeTruthy();
+
+      // global disabled on
+      service.disabled = true;
+      expect(getDayCtx(0).disabled).toBeTruthy();
+      expect(getDayCtx(1).disabled).toBeTruthy();
+
+      // global disabled on
+      service.disabled = false;
+      expect(getDayCtx(0).disabled).toBeFalsy();
+      expect(getDayCtx(1).disabled).toBeTruthy();
+    });
+  });
+
+  describe('toValidDate()', () => {
+
+    it('should convert a valid NgbDate', () => {
+      expect(service.toValidDate(new NgbDate(2016, 10, 5))).toEqual(new NgbDate(2016, 10, 5));
+      expect(service.toValidDate({year: 2016, month: 10, day: 5})).toEqual(new NgbDate(2016, 10, 5));
+    });
+
+    it('should return today for an invalid NgbDate', () => {
+      const today = calendar.getToday();
+      expect(service.toValidDate(null)).toEqual(today);
+      expect(service.toValidDate(<any>{})).toEqual(today);
+      expect(service.toValidDate(undefined)).toEqual(today);
+      expect(service.toValidDate(<any>new Date())).toEqual(today);
+      expect(service.toValidDate(new NgbDate(275760, 9, 14))).toEqual(today);
+    });
+
+    it('should return today if default value is undefined',
+       () => { expect(service.toValidDate(null, undefined)).toEqual(calendar.getToday()); });
+
+    it('should return default value for an invalid NgbDate if provided', () => {
+      expect(service.toValidDate(null, new NgbDate(1066, 6, 6))).toEqual(new NgbDate(1066, 6, 6));
+      expect(service.toValidDate(null, null)).toEqual(null);
+    });
+  });
 });

--- a/src/datepicker/datepicker-tools.spec.ts
+++ b/src/datepicker/datepicker-tools.spec.ts
@@ -1,0 +1,334 @@
+import {buildMonth, buildMonths, checkDateInRange, dateComparator, getFirstViewDate} from './datepicker-tools';
+import {NgbDate} from './ngb-date';
+import {NgbCalendar, NgbCalendarGregorian} from './ngb-calendar';
+import {TestBed} from '@angular/core/testing';
+import {NgbMarkDisabled} from './datepicker-view-model';
+
+describe(`datepicker-tools`, () => {
+
+  describe(`dateComparator()`, () => {
+
+    it(`should compare valid dates`, () => {
+      expect(dateComparator(new NgbDate(2017, 5, 2), new NgbDate(2017, 5, 2))).toBe(true);
+
+      expect(dateComparator(new NgbDate(2017, 5, 2), new NgbDate(2017, 5, 1))).toBe(false);
+      expect(dateComparator(new NgbDate(2017, 5, 2), new NgbDate(2017, 1, 2))).toBe(false);
+      expect(dateComparator(new NgbDate(2017, 5, 2), new NgbDate(2001, 5, 2))).toBe(false);
+    });
+
+    it(`should compare invalid dates`, () => {
+      expect(dateComparator(undefined, undefined)).toBe(true);
+      expect(dateComparator(null, null)).toBe(true);
+
+      expect(dateComparator(new NgbDate(2017, 5, 2), null)).toBe(false);
+      expect(dateComparator(new NgbDate(2017, 5, 2), undefined)).toBe(false);
+      expect(dateComparator(null, new NgbDate(2017, 5, 2))).toBe(false);
+      expect(dateComparator(undefined, new NgbDate(2017, 5, 2))).toBe(false);
+    });
+  });
+
+  describe(`checkDateInRange()`, () => {
+
+    it(`should throw adjust date to be in between of min and max dates`, () => {
+      const minDate = new NgbDate(2015, 5, 1);
+      const maxDate = new NgbDate(2015, 5, 10);
+
+      expect(checkDateInRange(new NgbDate(2015, 5, 5), minDate, maxDate)).toEqual(new NgbDate(2015, 5, 5));
+      expect(checkDateInRange(new NgbDate(2015, 4, 5), minDate, maxDate)).toEqual(minDate);
+      expect(checkDateInRange(new NgbDate(2015, 6, 5), minDate, maxDate)).toEqual(maxDate);
+    });
+
+    it(`should allow for undefined max and min dates`, () => {
+      const minDate = new NgbDate(2015, 5, 1);
+      const maxDate = new NgbDate(2015, 5, 10);
+
+      expect(checkDateInRange(new NgbDate(2015, 5, 5), undefined, undefined)).toEqual(new NgbDate(2015, 5, 5));
+      expect(checkDateInRange(new NgbDate(2015, 5, 5), minDate, undefined)).toEqual(new NgbDate(2015, 5, 5));
+      expect(checkDateInRange(new NgbDate(2015, 5, 5), undefined, maxDate)).toEqual(new NgbDate(2015, 5, 5));
+
+      expect(checkDateInRange(new NgbDate(2015, 4, 5), minDate, undefined)).toEqual(minDate);
+      expect(checkDateInRange(new NgbDate(2015, 6, 5), undefined, maxDate)).toEqual(maxDate);
+    });
+
+    it(`should bypass invalid date values`, () => {
+      expect(checkDateInRange(undefined, undefined, undefined)).toBeUndefined();
+      expect(checkDateInRange(null, undefined, undefined)).toBeNull();
+      expect(checkDateInRange(new NgbDate(-2, 0, 0), undefined, undefined)).toEqual(new NgbDate(-2, 0, 0));
+    });
+
+    it(`should not alter date object`, () => {
+      const date = new NgbDate(2017, 5, 1);
+      expect(checkDateInRange(date, undefined, undefined)).toBe(date);
+    });
+  });
+
+  describe(`buildMonth()`, () => {
+
+    let calendar: NgbCalendar;
+
+    beforeAll(() => {
+      TestBed.configureTestingModule({providers: [{provide: NgbCalendar, useClass: NgbCalendarGregorian}]});
+      calendar = TestBed.get(NgbCalendar);
+    });
+
+    // TODO: this should be automated somehow, ex. generate next 10 years or something
+    const months = [
+      {
+        // MAY 2017
+        date: new NgbDate(2017, 5, 5),
+        lastDay: 31,
+        firstWeek: {number: 18, date: new NgbDate(2017, 5, 1)},
+        lastWeek: {number: 23, date: new NgbDate(2017, 6, 11)}
+      },
+      {
+        // JUN 2017
+        date: new NgbDate(2017, 6, 5),
+        lastDay: 30,
+        firstWeek: {number: 22, date: new NgbDate(2017, 5, 29)},
+        lastWeek: {number: 27, date: new NgbDate(2017, 7, 9)}
+      },
+      {
+        // FEB 2017
+        date: new NgbDate(2017, 2, 1),
+        lastDay: 28,
+        firstWeek: {number: 5, date: new NgbDate(2017, 1, 30)},
+        lastWeek: {number: 10, date: new NgbDate(2017, 3, 12)}
+      },
+      {
+        // FEB 2016
+        date: new NgbDate(2016, 2, 10),
+        lastDay: 29,
+        firstWeek: {number: 5, date: new NgbDate(2016, 2, 1)},
+        lastWeek: {number: 10, date: new NgbDate(2016, 3, 13)}
+      }
+    ];
+
+    months.forEach(refMonth => {
+      it(`should build month (${refMonth.date.year} - ${refMonth.date.month}) correctly`, () => {
+
+        let month = buildMonth(calendar, refMonth.date, undefined, undefined, 1, undefined);
+
+        expect(month).toBeTruthy();
+        expect(month.year).toEqual(refMonth.date.year);
+        expect(month.number).toEqual(refMonth.date.month);
+        expect(month.firstDate).toEqual(new NgbDate(refMonth.date.year, refMonth.date.month, 1));
+        expect(month.lastDate).toEqual(new NgbDate(refMonth.date.year, refMonth.date.month, refMonth.lastDay));
+        expect(month.weekdays).toEqual([1, 2, 3, 4, 5, 6, 7]);
+        expect(month.weeks.length).toBe(6);
+
+        // First week, first day
+        expect(month.weeks[0].number).toEqual(refMonth.firstWeek.number);
+        expect(month.weeks[0].days.length).toEqual(7);
+        expect(month.weeks[0].days[0].date).toEqual(refMonth.firstWeek.date);
+        expect(month.weeks[0].days[0].context.disabled).toBe(false);
+
+        // Last week, last day
+        expect(month.weeks[5].number).toEqual(refMonth.lastWeek.number);
+        expect(month.weeks[5].days.length).toEqual(7);
+        expect(month.weeks[5].days[6].date).toEqual(refMonth.lastWeek.date);
+        expect(month.weeks[5].days[6].context.disabled).toBe(false);
+      });
+    });
+
+    it(`should mark dates as disabled`, () => {
+      // disable the second day
+      const markDisabled: NgbMarkDisabled = (date) => date.day === 2;
+
+      // MAY 2017
+      let month = buildMonth(calendar, new NgbDate(2017, 5, 5), undefined, undefined, 1, markDisabled);
+
+      // 2 MAY - disabled
+      expect(month.weeks[0].days[0].context.disabled).toBe(false);
+      expect(month.weeks[0].days[1].context.disabled).toBe(true);
+      expect(month.weeks[0].days[2].context.disabled).toBe(false);
+    });
+
+
+    it(`should call 'markDisabled' with correct arguments`, () => {
+      const mock = {markDisabled: () => false};
+      spyOn(mock, 'markDisabled').and.returnValue(false);
+
+      // MAY 2017
+      const minDate = new NgbDate(2017, 5, 10);
+      const maxDate = new NgbDate(2017, 5, 10);
+      buildMonth(calendar, new NgbDate(2017, 5, 5), minDate, maxDate, 1, mock.markDisabled);
+
+      // called one time, because it should be used only inside min-max range
+      expect(mock.markDisabled).toHaveBeenCalledWith(new NgbDate(2017, 5, 10), {year: 2017, month: 5});
+      expect(mock.markDisabled).toHaveBeenCalledTimes(1);
+    });
+
+    it(`should mark dates before 'minDate' as disabled and ignore 'markDisabled'`, () => {
+      const markDisabled: NgbMarkDisabled = (date) => date.day === 1;
+
+      // MAY 2017
+      const minDate = new NgbDate(2017, 5, 3);
+      const month = buildMonth(calendar, new NgbDate(2017, 5, 5), minDate, undefined, 1, markDisabled);
+
+      // MIN = 2, so 1-2 MAY - disabled
+      expect(month.weeks[0].days[0].context.disabled).toBe(true);
+      expect(month.weeks[0].days[1].context.disabled).toBe(true);
+      expect(month.weeks[0].days[2].context.disabled).toBe(false);
+      expect(month.weeks[0].days[3].context.disabled).toBe(false);
+    });
+
+    it(`should mark dates after 'maxDate' as disabled and ignore 'markDisabled`, () => {
+      const markDisabled: NgbMarkDisabled = (date) => date.day === 3;
+
+      // MAY 2017
+      const maxDate = new NgbDate(2017, 5, 2);
+      const month = buildMonth(calendar, new NgbDate(2017, 5, 5), undefined, maxDate, 1, markDisabled);
+
+      // MAX = 2, so 3-4 MAY - disabled
+      expect(month.weeks[0].days[0].context.disabled).toBe(false);
+      expect(month.weeks[0].days[1].context.disabled).toBe(false);
+      expect(month.weeks[0].days[2].context.disabled).toBe(true);
+      expect(month.weeks[0].days[3].context.disabled).toBe(true);
+    });
+
+    it(`should rotate days of the week`, () => {
+      // SUN = 7
+      let month = buildMonth(calendar, new NgbDate(2017, 5, 5), undefined, undefined, 7, undefined);
+      expect(month.weekdays).toEqual([7, 1, 2, 3, 4, 5, 6]);
+      expect(month.weeks[0].days[0].date).toEqual(new NgbDate(2017, 4, 30));
+
+      // WED = 3
+      month = buildMonth(calendar, new NgbDate(2017, 5, 5), undefined, undefined, 3, undefined);
+      expect(month.weekdays).toEqual([3, 4, 5, 6, 7, 1, 2]);
+      expect(month.weeks[0].days[0].date).toEqual(new NgbDate(2017, 4, 26));
+    });
+  });
+
+  describe(`buildMonths()`, () => {
+
+    let calendar: NgbCalendar;
+
+    beforeAll(() => {
+      TestBed.configureTestingModule({providers: [{provide: NgbCalendar, useClass: NgbCalendarGregorian}]});
+      calendar = TestBed.get(NgbCalendar);
+    });
+
+    it(`should generate 'displayMonths' number of months`, () => {
+      let displayMonths = 1;
+      let months =
+          buildMonths(calendar, [], new NgbDate(2017, 5, 5), undefined, undefined, displayMonths, 1, undefined, false);
+      expect(months.length).toBe(1);
+
+      displayMonths = 2;
+      months =
+          buildMonths(calendar, [], new NgbDate(2017, 5, 5), undefined, undefined, displayMonths, 1, undefined, false);
+      expect(months.length).toBe(2);
+    });
+
+    it(`should not rebuild existing months by default`, () => {
+      const may = new NgbDate(2017, 5, 5);
+      const june = new NgbDate(2017, 6, 5);
+
+      // one same month
+      let months = buildMonths(calendar, [], may, undefined, undefined, 1, 1, undefined, false);
+      let newMonths = buildMonths(calendar, months, may, undefined, undefined, 1, 1, undefined, false);
+
+      expect(months.length).toBe(1);
+      expect(newMonths.length).toBe(1);
+      expect(months[0]).toBe(newMonths[0]);
+
+      // one new month
+      months = buildMonths(calendar, [], may, undefined, undefined, 1, 1, undefined, false);
+      newMonths = buildMonths(calendar, months, june, undefined, undefined, 1, 1, undefined, false);
+
+      expect(months.length).toBe(1);
+      expect(newMonths.length).toBe(1);
+      expect(months[0]).not.toBe(newMonths[0]);
+
+      // two same months
+      months = buildMonths(calendar, [], may, undefined, undefined, 2, 1, undefined, false);
+      newMonths = buildMonths(calendar, months, may, undefined, undefined, 2, 1, undefined, false);
+
+      expect(months.length).toBe(2);
+      expect(newMonths.length).toBe(2);
+      expect(months[0]).toBe(newMonths[0]);
+      expect(months[1]).toBe(newMonths[1]);
+
+      // two months, one overlaps
+      months = buildMonths(calendar, [], may, undefined, undefined, 2, 1, undefined, false);
+      newMonths = buildMonths(calendar, months, june, undefined, undefined, 2, 1, undefined, false);
+
+      expect(months.length).toBe(2);
+      expect(newMonths.length).toBe(2);
+      expect(months[0]).not.toBe(newMonths[0]);
+      expect(months[1]).not.toBe(newMonths[1]);
+      expect(months[1]).toBe(newMonths[0]);  // june reused
+    });
+
+    it(`should rebuild existing months with 'rebuild=false'`, () => {
+      const may = new NgbDate(2017, 5, 5);
+      const june = new NgbDate(2017, 6, 5);
+
+      // one same month
+      let months = buildMonths(calendar, [], may, undefined, undefined, 1, 1, undefined, true);
+      let newMonths = buildMonths(calendar, months, may, undefined, undefined, 1, 1, undefined, true);
+
+      expect(months.length).toBe(1);
+      expect(newMonths.length).toBe(1);
+      expect(months[0]).not.toBe(newMonths[0]);
+
+      // one new month
+      months = buildMonths(calendar, [], may, undefined, undefined, 1, 1, undefined, true);
+      newMonths = buildMonths(calendar, months, june, undefined, undefined, 1, 1, undefined, true);
+
+      expect(months.length).toBe(1);
+      expect(newMonths.length).toBe(1);
+      expect(months[0]).not.toBe(newMonths[0]);
+
+      // two same months
+      months = buildMonths(calendar, [], may, undefined, undefined, 2, 1, undefined, true);
+      newMonths = buildMonths(calendar, months, may, undefined, undefined, 2, 1, undefined, true);
+
+      expect(months.length).toBe(2);
+      expect(newMonths.length).toBe(2);
+      expect(months[0]).not.toBe(newMonths[0]);
+      expect(months[1]).not.toBe(newMonths[1]);
+
+      // two months, one overlaps
+      months = buildMonths(calendar, [], may, undefined, undefined, 2, 1, undefined, true);
+      newMonths = buildMonths(calendar, months, june, undefined, undefined, 2, 1, undefined, true);
+
+      expect(months.length).toBe(2);
+      expect(newMonths.length).toBe(2);
+      expect(months[0]).not.toBe(newMonths[0]);
+      expect(months[1]).not.toBe(newMonths[1]);
+      expect(months[1]).not.toBe(newMonths[0]);
+    });
+  });
+
+  describe(`getFirstViewDate()`, () => {
+
+    let calendar: NgbCalendar;
+
+    beforeAll(() => {
+      TestBed.configureTestingModule({providers: [{provide: NgbCalendar, useClass: NgbCalendarGregorian}]});
+      calendar = TestBed.get(NgbCalendar);
+    });
+
+    const months = [
+      {date: new NgbDate(2017, 1, 10), first: new NgbDate(2016, 12, 26)},
+      {date: new NgbDate(2017, 2, 10), first: new NgbDate(2017, 1, 30)},
+      {date: new NgbDate(2017, 3, 10), first: new NgbDate(2017, 2, 27)},
+      {date: new NgbDate(2017, 4, 10), first: new NgbDate(2017, 3, 27)},
+      {date: new NgbDate(2017, 5, 10), first: new NgbDate(2017, 5, 1)},
+      {date: new NgbDate(2017, 6, 10), first: new NgbDate(2017, 5, 29)},
+      {date: new NgbDate(2017, 7, 10), first: new NgbDate(2017, 6, 26)},
+      {date: new NgbDate(2017, 8, 10), first: new NgbDate(2017, 7, 31)},
+      {date: new NgbDate(2017, 9, 10), first: new NgbDate(2017, 8, 28)},
+      {date: new NgbDate(2017, 10, 10), first: new NgbDate(2017, 9, 25)},
+      {date: new NgbDate(2017, 11, 10), first: new NgbDate(2017, 10, 30)},
+      {date: new NgbDate(2017, 12, 10), first: new NgbDate(2017, 11, 27)}
+    ];
+
+    months.forEach(month => {
+      it(`should return the correct first view date`,
+         () => { expect(getFirstViewDate(calendar, month.date, 1)).toEqual(month.first); });
+    });
+  });
+
+});

--- a/src/datepicker/datepicker-tools.ts
+++ b/src/datepicker/datepicker-tools.ts
@@ -1,0 +1,140 @@
+import {NgbDate} from './ngb-date';
+import {DayViewModel, MonthViewModel, NgbMarkDisabled} from './datepicker-view-model';
+import {NgbCalendar} from './ngb-calendar';
+
+export function isChangedDate(prev: NgbDate, next: NgbDate) {
+  return !dateComparator(prev, next);
+}
+
+export function dateComparator(prev: NgbDate, next: NgbDate) {
+  return (!prev && !next) || (!!prev && !!next && prev.equals(next));
+}
+
+export function checkMinBeforeMax(minDate: NgbDate, maxDate: NgbDate) {
+  if (maxDate && minDate && maxDate.before(minDate)) {
+    throw new Error(`'maxDate' ${maxDate} should be greater than 'minDate' ${minDate}`);
+  }
+}
+
+export function checkDateInRange(date: NgbDate, minDate: NgbDate, maxDate: NgbDate): NgbDate {
+  if (date && minDate && date.before(minDate)) {
+    return NgbDate.from(minDate);
+  }
+  if (date && maxDate && date.after(maxDate)) {
+    return NgbDate.from(maxDate);
+  }
+
+  return date;
+}
+
+export function isDateSelectable(months: MonthViewModel[], date: NgbDate) {
+  let selectable = false;
+  const month = months.find(curMonth => curMonth.year === date.year && curMonth.number === date.month);
+  if (month) {
+    month.weeks.find(week => {
+      const day = week.days.find(day => date.equals(day.date));
+      if (day && !day.context.disabled) {
+        selectable = true;
+      }
+      return !!day;
+    });
+  }
+
+  return selectable;
+}
+
+export function buildMonths(
+    calendar: NgbCalendar, months: MonthViewModel[], date: NgbDate, minDate: NgbDate, maxDate: NgbDate,
+    displayMonths: number, firstDayOfWeek: number, markDisabled: NgbMarkDisabled, force: boolean): MonthViewModel[] {
+  const newMonths = [];
+  for (let i = 0; i < displayMonths; i++) {
+    const newDate = calendar.getNext(date, 'm', i);
+    const index = months.findIndex(month => month.firstDate.equals(newDate));
+
+    if (force || index === -1) {
+      newMonths.push(buildMonth(calendar, newDate, minDate, maxDate, firstDayOfWeek, markDisabled));
+    } else {
+      newMonths.push(months[index]);
+    }
+  }
+
+  return newMonths;
+}
+
+export function buildMonth(
+    calendar: NgbCalendar, date: NgbDate, minDate: NgbDate, maxDate: NgbDate, firstDayOfWeek: number,
+    markDisabled: NgbMarkDisabled): MonthViewModel {
+  const month:
+      MonthViewModel = {firstDate: null, lastDate: null, number: date.month, year: date.year, weeks: [], weekdays: []};
+
+  date = getFirstViewDate(calendar, date, firstDayOfWeek);
+
+  // month has weeks
+  for (let week = 0; week < calendar.getWeeksPerMonth(); week++) {
+    const days: DayViewModel[] = [];
+
+    // week has days
+    for (let day = 0; day < calendar.getDaysPerWeek(); day++) {
+      if (week === 0) {
+        month.weekdays.push(calendar.getWeekday(date));
+      }
+
+      const newDate = new NgbDate(date.year, date.month, date.day);
+      const nextDate = calendar.getNext(newDate);
+
+      // marking date as disabled
+      let disabled = !!((minDate && newDate.before(minDate)) || (maxDate && newDate.after(maxDate)));
+      if (!disabled && markDisabled) {
+        disabled = markDisabled(newDate, {month: month.number, year: month.year});
+      }
+
+      // saving first date of the month
+      if (month.firstDate === null && newDate.month === month.number) {
+        month.firstDate = newDate;
+      }
+
+      // saving last date of the month
+      if (newDate.month === month.number && nextDate.month !== month.number) {
+        month.lastDate = newDate;
+      }
+
+      days.push({
+        date: newDate,
+        context: {
+          date: {year: newDate.year, month: newDate.month, day: newDate.day},
+          currentMonth: month.number,
+          disabled: disabled,
+          focused: false,
+          selected: false
+        }
+      });
+
+      date = nextDate;
+    }
+
+    month.weeks.push(
+        {number: calendar.getWeekNumber(days.map(day => NgbDate.from(day.date)), firstDayOfWeek), days: days});
+  }
+
+  return month;
+}
+
+export function getFirstViewDate(calendar: NgbCalendar, date: NgbDate, firstDayOfWeek: number): NgbDate {
+  const currentMonth = date.month;
+  let today = new NgbDate(date.year, date.month, date.day);
+  let yesterday = calendar.getPrev(today);
+
+  const firstDayOfCurrentMonthIsAlsoFirstDayOfWeek =
+      () => { return today.month !== yesterday.month && firstDayOfWeek === calendar.getWeekday(today); };
+
+  const reachedTheFirstDayOfTheLastWeekOfPreviousMonth =
+      () => { return today.month !== currentMonth && firstDayOfWeek === calendar.getWeekday(today); };
+
+  // going back in time
+  while (!reachedTheFirstDayOfTheLastWeekOfPreviousMonth() && !firstDayOfCurrentMonthIsAlsoFirstDayOfWeek()) {
+    today = new NgbDate(yesterday.year, yesterday.month, yesterday.day);
+    yesterday = calendar.getPrev(yesterday);
+  }
+
+  return today;
+}

--- a/src/datepicker/datepicker-view-model.ts
+++ b/src/datepicker/datepicker-view-model.ts
@@ -1,8 +1,12 @@
 import {NgbDate} from './ngb-date';
+import {NgbDateStruct} from './ngb-date-struct';
+import {DayTemplateContext} from './datepicker-day-template-context';
+
+export type NgbMarkDisabled = (date: NgbDateStruct, current: {year: number, month: number}) => boolean;
 
 export type DayViewModel = {
   date: NgbDate,
-  disabled: boolean
+  context: DayTemplateContext
 }
 
 export type WeekViewModel = {
@@ -12,11 +16,29 @@ export type WeekViewModel = {
 
 export type MonthViewModel = {
   firstDate: NgbDate,
+  lastDate: NgbDate,
   number: number,
   year: number,
   weeks: WeekViewModel[],
   weekdays: number[]
 };
+
+// clang-format off
+export type DatepickerViewModel = {
+  disabled: boolean,
+  displayMonths: number,
+  firstDate?: NgbDate,
+  firstDayOfWeek: number,
+  focusDate?: NgbDate,
+  focusVisible: boolean,
+  lastDate?: NgbDate,
+  markDisabled?: NgbMarkDisabled,
+  maxDate?: NgbDate,
+  minDate?: NgbDate,
+  months: MonthViewModel[],
+  selectedDate: NgbDate
+}
+// clang-format on
 
 export enum NavigationEvent {
   PREV,

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -34,7 +34,7 @@ function getDatepicker(element: HTMLElement): HTMLElement {
 
 function triggerKeyDown(element: DebugElement, keyCode: number, shiftKey = false) {
   let event = {
-    keyCode: keyCode,
+    which: keyCode,
     shiftKey: shiftKey,
     defaultPrevented: false,
     propagationStopped: false,
@@ -67,13 +67,13 @@ function expectSameValues(datepicker: NgbDatepicker, config: NgbDatepickerConfig
   expect(datepicker.displayMonths).toBe(config.displayMonths);
   expect(datepicker.firstDayOfWeek).toBe(config.firstDayOfWeek);
   expect(datepicker.markDisabled).toBe(config.markDisabled);
-  expect(datepicker.minDate).toBe(config.minDate);
-  expect(datepicker.maxDate).toBe(config.maxDate);
+  expect(datepicker.minDate).toEqual(config.minDate);
+  expect(datepicker.maxDate).toEqual(config.maxDate);
   expect(datepicker.navigation).toBe(config.navigation);
   expect(datepicker.outsideDays).toBe(config.outsideDays);
   expect(datepicker.showWeekdays).toBe(config.showWeekdays);
   expect(datepicker.showWeekNumbers).toBe(config.showWeekNumbers);
-  expect(datepicker.startDate).toBe(config.startDate);
+  expect(datepicker.startDate).toEqual(config.startDate);
 }
 
 function customizeConfig(config: NgbDatepickerConfig) {
@@ -436,17 +436,17 @@ describe('ngb-datepicker', () => {
 
   describe('ngModel', () => {
 
-    it('should update model based on calendar clicks', () => {
-      const fixture = createTestComponent(
-          `<ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="model"></ngb-datepicker>`);
+    it('should update model based on calendar clicks', async(() => {
+         const fixture = createTestComponent(
+             `<ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="model"></ngb-datepicker>`);
 
-      const dates = getDates(fixture.nativeElement);
-      dates[0].click();  // 1 AUG 2016
-      expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 1});
+         const dates = getDates(fixture.nativeElement);
+         dates[0].click();  // 1 AUG 2016
+         expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 1});
 
-      dates[1].click();
-      expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 2});
-    });
+         dates[1].click();
+         expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 2});
+       }));
 
     it('should not update model based on calendar clicks when disabled', async(() => {
          const fixture = createTestComponent(
@@ -516,47 +516,47 @@ describe('ngb-datepicker', () => {
          });
        }));
 
-    it('should switch month on prev/next navigation click', () => {
-      const fixture = createTestComponent(
-          `<ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="model"></ngb-datepicker>`);
+    it('should switch month on prev/next navigation click', async(() => {
+         const fixture = createTestComponent(
+             `<ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="model"></ngb-datepicker>`);
 
-      let dates = getDates(fixture.nativeElement);
-      const navigation = getNavigationLinks(fixture.nativeElement);
+         let dates = getDates(fixture.nativeElement);
+         const navigation = getNavigationLinks(fixture.nativeElement);
 
-      dates[0].click();  // 1 AUG 2016
-      expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 1});
+         dates[0].click();  // 1 AUG 2016
+         expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 1});
 
-      // PREV
-      navigation[0].click();
-      fixture.detectChanges();
-      dates = getDates(fixture.nativeElement);
-      dates[4].click();  // 1 JUL 2016
-      expect(fixture.componentInstance.model).toEqual({year: 2016, month: 7, day: 1});
+         // PREV
+         navigation[0].click();
+         fixture.detectChanges();
+         dates = getDates(fixture.nativeElement);
+         dates[4].click();  // 1 JUL 2016
+         expect(fixture.componentInstance.model).toEqual({year: 2016, month: 7, day: 1});
 
-      // NEXT
-      navigation[1].click();
-      fixture.detectChanges();
-      dates = getDates(fixture.nativeElement);
-      dates[0].click();  // 1 AUG 2016
-      expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 1});
-    });
+         // NEXT
+         navigation[1].click();
+         fixture.detectChanges();
+         dates = getDates(fixture.nativeElement);
+         dates[0].click();  // 1 AUG 2016
+         expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 1});
+       }));
 
-    it('should switch month using navigateTo({date})', () => {
-      const fixture = createTestComponent(
-          `<ngb-datepicker #dp [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="model"></ngb-datepicker>
+    it('should switch month using navigateTo({date})', async(() => {
+         const fixture = createTestComponent(
+             `<ngb-datepicker #dp [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="model"></ngb-datepicker>
        <button id="btn"(click)="dp.navigateTo({year: 2015, month: 6})"></button>`);
 
-      const button = fixture.nativeElement.querySelector('button#btn');
-      button.click();
+         const button = fixture.nativeElement.querySelector('button#btn');
+         button.click();
 
-      fixture.detectChanges();
-      expect(getMonthSelect(fixture.nativeElement).value).toBe('6');
-      expect(getYearSelect(fixture.nativeElement).value).toBe('2015');
+         fixture.detectChanges();
+         expect(getMonthSelect(fixture.nativeElement).value).toBe('6');
+         expect(getYearSelect(fixture.nativeElement).value).toBe('2015');
 
-      const dates = getDates(fixture.nativeElement);
-      dates[0].click();  // 1 JUN 2015
-      expect(fixture.componentInstance.model).toEqual({year: 2015, month: 6, day: 1});
-    });
+         const dates = getDates(fixture.nativeElement);
+         dates[0].click();  // 1 JUN 2015
+         expect(fixture.componentInstance.model).toEqual({year: 2015, month: 6, day: 1});
+       }));
 
     it('should switch to current month using navigateTo() without arguments', () => {
       const fixture = createTestComponent(
@@ -570,143 +570,6 @@ describe('ngb-datepicker', () => {
       const today = new Date();
       expect(getMonthSelect(fixture.nativeElement).value).toBe(`${today.getMonth() + 1}`);
       expect(getYearSelect(fixture.nativeElement).value).toBe(`${today.getFullYear()}`);
-    });
-
-    it('should correctly navigate with keyboard', () => {
-      const fixture = createTestComponent(`<ngb-datepicker #dp
-        [startDate]="date" [minDate]="minDate"
-        [maxDate]="maxDate" [displayMonths]="2"
-        [markDisabled]="markDisabled"></ngb-datepicker>`);
-
-      const datepicker = fixture.debugElement.query(By.directive(NgbDatepicker));
-      expectFocusedDate(datepicker, null);
-      expectSelectedDate(datepicker, null);
-
-      datepicker.triggerEventHandler('focus', {});
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2016, 8, 1));
-      expectSelectedDate(datepicker, null);
-
-      triggerKeyDown(datepicker, 40 /* down arrow */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2016, 8, 8));
-      expectSelectedDate(datepicker, null);
-
-      triggerKeyDown(datepicker, 32 /* space */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2016, 8, 8));
-      expectSelectedDate(datepicker, new NgbDate(2016, 8, 8));
-
-      triggerKeyDown(datepicker, 39 /* right arrow */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2016, 8, 9));
-      expectSelectedDate(datepicker, new NgbDate(2016, 8, 8));
-
-      triggerKeyDown(datepicker, 38 /* up arrow */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2016, 8, 2));
-      expectSelectedDate(datepicker, new NgbDate(2016, 8, 8));
-
-      triggerKeyDown(datepicker, 37 /* left arrow */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2016, 8, 1));
-      expectSelectedDate(datepicker, new NgbDate(2016, 8, 8));
-
-      triggerKeyDown(datepicker, 33 /* page up */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2016, 7, 1));
-      expectSelectedDate(datepicker, new NgbDate(2016, 8, 8));
-
-      triggerKeyDown(datepicker, 35 /* end */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2016, 8, 31));
-      expectSelectedDate(datepicker, new NgbDate(2016, 8, 8));
-
-      triggerKeyDown(datepicker, 13 /* enter */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2016, 8, 31));
-      expectSelectedDate(datepicker, new NgbDate(2016, 8, 31));
-
-      triggerKeyDown(datepicker, 36 /* home */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2016, 7, 1));
-      expectSelectedDate(datepicker, new NgbDate(2016, 8, 31));
-
-      triggerKeyDown(datepicker, 33 /* page up */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2016, 6, 1));
-      expectSelectedDate(datepicker, null);  // selection is no longer visible
-
-      triggerKeyDown(datepicker, 34 /* page down */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2016, 7, 1));
-      expectSelectedDate(datepicker, null);  // selection is still no longer visible
-
-      triggerKeyDown(datepicker, 35 /* end */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2016, 7, 31));
-      expectSelectedDate(datepicker, null);  // selection is still no longer visible
-
-      triggerKeyDown(datepicker, 39 /* right arrow */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2016, 8, 1));
-      expectSelectedDate(datepicker, new NgbDate(2016, 8, 31));  // selection is visible again
-
-      triggerKeyDown(datepicker, 40 /* down arrow */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2016, 8, 8));
-      expectSelectedDate(datepicker, new NgbDate(2016, 8, 31));
-
-      triggerKeyDown(datepicker, 40 /* down arrow */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2016, 8, 15));
-      expectSelectedDate(datepicker, new NgbDate(2016, 8, 31));
-
-      triggerKeyDown(datepicker, 40 /* down arrow */);
-      fixture.detectChanges();
-      // we can reach the disabled date
-      expectFocusedDate(datepicker, new NgbDate(2016, 8, 22));
-      expectSelectedDate(datepicker, new NgbDate(2016, 8, 31));
-
-      triggerKeyDown(datepicker, 32 /* space */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2016, 8, 22));
-      expectSelectedDate(datepicker, new NgbDate(2016, 8, 31));  // space on a disabled date does not select it
-
-      triggerKeyDown(datepicker, 13 /* enter */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2016, 8, 22));
-      expectSelectedDate(datepicker, new NgbDate(2016, 8, 31));  // enter on a disabled date does not select it
-
-      triggerKeyDown(datepicker, 35 /* end */, true /* with shift */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2020, 12, 31));  // maximum date
-      expectSelectedDate(datepicker, null);                      // selection is again no longer visible
-
-      triggerKeyDown(datepicker, 39 /* right arrow */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2020, 12, 31));  // stays at the maximum date
-
-      triggerKeyDown(datepicker, 36 /* home */, true /* with shift */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2010, 1, 1));  // minimum date
-
-      triggerKeyDown(datepicker, 37 /* left arrow */);
-      fixture.detectChanges();
-      expectFocusedDate(datepicker, new NgbDate(2010, 1, 1));  // stays at the minimum date
-
-      triggerKeyDown(datepicker, 34 /* page down */, true /* with shift */);
-      fixture.detectChanges();
-
-      expectFocusedDate(datepicker, new NgbDate(2011, 1, 1));
-      triggerKeyDown(datepicker, 33 /* page up */, true /* with shift */);
-      fixture.detectChanges();
-
-      expectFocusedDate(datepicker, new NgbDate(2010, 1, 1));
-      datepicker.triggerEventHandler('blur', {});
-      fixture.detectChanges();
-
-      expectFocusedDate(datepicker, null);
     });
 
     it('should support disabling all dates and navigation via the disabled attribute', async(() => {
@@ -730,6 +593,187 @@ describe('ngb-datepicker', () => {
                expect(getMonthSelect(fixture.nativeElement).disabled).toBeTruthy();
              });
        }));
+  });
+
+  describe('keyboard navigation', () => {
+
+    const template = `<ngb-datepicker #dp
+        [startDate]="date" [minDate]="minDate"
+        [maxDate]="maxDate" [displayMonths]="2"
+        [markDisabled]="markDisabled"></ngb-datepicker>`;
+
+    it('should move focus with arrow keys', () => {
+      const fixture = createTestComponent(template);
+
+      const datepicker = fixture.debugElement.query(By.directive(NgbDatepicker));
+      expectFocusedDate(datepicker, null);
+      expectSelectedDate(datepicker, null);
+
+      datepicker.triggerEventHandler('focus', {});
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 1));
+      expectSelectedDate(datepicker, null);
+
+      triggerKeyDown(datepicker, 40 /* down arrow */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 8));
+      expectSelectedDate(datepicker, null);
+
+      triggerKeyDown(datepicker, 39 /* right arrow */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 9));
+      expectSelectedDate(datepicker, null);
+
+      triggerKeyDown(datepicker, 38 /* up arrow */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 2));
+      expectSelectedDate(datepicker, null);
+
+      triggerKeyDown(datepicker, 37 /* left arrow */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 1));
+      expectSelectedDate(datepicker, null);
+
+      datepicker.triggerEventHandler('blur', {});
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, null);
+    });
+
+    it('should select focused date with enter or space', () => {
+      const fixture = createTestComponent(template);
+
+      const datepicker = fixture.debugElement.query(By.directive(NgbDatepicker));
+      expectFocusedDate(datepicker, null);
+      expectSelectedDate(datepicker, null);
+
+      datepicker.triggerEventHandler('focus', {});
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 1));
+      expectSelectedDate(datepicker, null);
+
+      triggerKeyDown(datepicker, 32 /* space */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 1));
+      expectSelectedDate(datepicker, new NgbDate(2016, 8, 1));
+
+      triggerKeyDown(datepicker, 40 /* down arrow */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 8));
+      expectSelectedDate(datepicker, new NgbDate(2016, 8, 1));
+
+      triggerKeyDown(datepicker, 13 /* enter */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 8));
+      expectSelectedDate(datepicker, new NgbDate(2016, 8, 8));
+    });
+
+    it('should select first and last dates of the view with home/end', () => {
+      const fixture = createTestComponent(template);
+
+      const datepicker = fixture.debugElement.query(By.directive(NgbDatepicker));
+      expectFocusedDate(datepicker, null);
+      expectSelectedDate(datepicker, null);
+
+      datepicker.triggerEventHandler('focus', {});
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 1));
+      expectSelectedDate(datepicker, null);
+
+      triggerKeyDown(datepicker, 35 /* end */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 9, 30));
+      expectSelectedDate(datepicker, null);
+
+      triggerKeyDown(datepicker, 36 /* home */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 1));
+      expectSelectedDate(datepicker, null);
+    });
+
+    it('should select min and max dates with shift+home/end', () => {
+      const fixture = createTestComponent(template);
+
+      const datepicker = fixture.debugElement.query(By.directive(NgbDatepicker));
+      expectFocusedDate(datepicker, null);
+      expectSelectedDate(datepicker, null);
+
+      datepicker.triggerEventHandler('focus', {});
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 1));
+      expectSelectedDate(datepicker, null);
+
+      triggerKeyDown(datepicker, 35 /* end */, true /* shift */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2020, 12, 31));
+      expectSelectedDate(datepicker, null);
+
+      triggerKeyDown(datepicker, 40 /* down arrow */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2020, 12, 31));
+      expectSelectedDate(datepicker, null);
+
+      triggerKeyDown(datepicker, 36 /* home */, true /* shift */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2010, 1, 1));
+      expectSelectedDate(datepicker, null);
+
+      triggerKeyDown(datepicker, 38 /* up arrow */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2010, 1, 1));
+      expectSelectedDate(datepicker, null);
+    });
+
+    it('should navigate between months with pageUp/Down', () => {
+      const fixture = createTestComponent(template);
+
+      const datepicker = fixture.debugElement.query(By.directive(NgbDatepicker));
+      expectFocusedDate(datepicker, null);
+      expectSelectedDate(datepicker, null);
+
+      datepicker.triggerEventHandler('focus', {});
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 1));
+      expectSelectedDate(datepicker, null);
+
+      triggerKeyDown(datepicker, 39 /* right arrow */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 2));
+      expectSelectedDate(datepicker, null);
+
+      triggerKeyDown(datepicker, 33 /* page up */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 7, 1));
+      expectSelectedDate(datepicker, null);
+
+      triggerKeyDown(datepicker, 34 /* page down */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 1));
+      expectSelectedDate(datepicker, null);
+    });
+
+    it('should navigate between years with shift+pageUp/Down', () => {
+      const fixture = createTestComponent(template);
+
+      const datepicker = fixture.debugElement.query(By.directive(NgbDatepicker));
+      expectFocusedDate(datepicker, null);
+      expectSelectedDate(datepicker, null);
+
+      datepicker.triggerEventHandler('focus', {});
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 8, 1));
+      expectSelectedDate(datepicker, null);
+
+      triggerKeyDown(datepicker, 33 /* page up */, true /* shift */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2015, 1, 1));
+      expectSelectedDate(datepicker, null);
+
+      triggerKeyDown(datepicker, 34 /* page down */, true /* shift */);
+      fixture.detectChanges();
+      expectFocusedDate(datepicker, new NgbDate(2016, 1, 1));
+      expectSelectedDate(datepicker, null);
+    });
+
   });
 
   describe('forms', () => {

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -1,4 +1,7 @@
+import {Subscription} from 'rxjs/Subscription';
 import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   Input,
   OnChanges,
@@ -8,19 +11,20 @@ import {
   SimpleChanges,
   EventEmitter,
   Output,
-  ElementRef,
-  HostListener
+  OnDestroy
 } from '@angular/core';
 import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
-import {NgbCalendar, NgbPeriod} from './ngb-calendar';
+import {NgbCalendar} from './ngb-calendar';
 import {NgbDate} from './ngb-date';
 import {NgbDatepickerService} from './datepicker-service';
-import {MonthViewModel, NavigationEvent} from './datepicker-view-model';
+import {NgbDatepickerKeyMapService} from './datepicker-keymap-service';
+import {DatepickerViewModel, NavigationEvent} from './datepicker-view-model';
 import {toInteger} from '../util/util';
 import {DayTemplateContext} from './datepicker-day-template-context';
 import {NgbDatepickerConfig} from './datepicker-config';
 import {NgbDateStruct} from './ngb-date-struct';
 import {NgbDatepickerI18n} from './datepicker-i18n';
+import {isChangedDate} from './datepicker-tools';
 
 const NGB_DATEPICKER_VALUE_ACCESSOR = {
   provide: NG_VALUE_ACCESSOR,
@@ -49,13 +53,13 @@ export interface NgbDatepickerNavigateEvent {
 @Component({
   exportAs: 'ngbDatepicker',
   selector: 'ngb-datepicker',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     'class': 'd-inline-block rounded',
     '[attr.tabindex]': 'disabled ? undefined : "0"',
-    '(blur)': 'focusedDate = null',
-    '(focus)': 'onFocus($event)',
-    '(keydown)': 'onKeyDown($event)',
-    '(mousedown)': 'onMouseDown($event)'
+    '(blur)': 'showFocus(false)',
+    '(focus)': 'showFocus(true)',
+    '(keydown)': 'onKeyDown($event)'
   },
   styles: [`
     :host {
@@ -91,13 +95,13 @@ export interface NgbDatepickerNavigateEvent {
     </ng-template>
 
     <div class="ngb-dp-header bg-faded pt-1 rounded-top" [style.height.rem]="getHeaderHeight()"
-      [style.marginBottom.rem]="-getHeaderMargin()">
+         [style.marginBottom.rem]="-getHeaderMargin()">
       <ngb-datepicker-navigation *ngIf="navigation !== 'none'"
-        [date]="months[0]?.firstDate"
-        [minDate]="_minDate"
-        [maxDate]="_maxDate"
-        [months]="months.length"
-        [disabled]="disabled"
+        [date]="model.firstDate"
+        [minDate]="model.minDate"
+        [maxDate]="model.maxDate"
+        [months]="model.months.length"
+        [disabled]="model.disabled"
         [showWeekNumbers]="showWeekNumbers"
         [showSelect]="navigation === 'select'"
         (navigate)="onNavigateEvent($event)"
@@ -106,38 +110,30 @@ export interface NgbDatepickerNavigateEvent {
     </div>
 
     <div class="ngb-dp-months d-flex px-1 pb-1">
-      <ng-template ngFor let-month [ngForOf]="months" let-i="index">
+      <ng-template ngFor let-month [ngForOf]="model.months" let-i="index">
         <div class="ngb-dp-month d-block ml-3">
           <div *ngIf="navigation !== 'select' || displayMonths > 1" class="ngb-dp-month-name text-center">
             {{ i18n.getMonthFullName(month.number) }} {{ month.year }}
           </div>
           <ngb-datepicker-month-view
             [month]="month"
-            [selectedDate]="model"
-            [focusedDate]="focusedDate"
             [dayTemplate]="dayTemplate || dt"
             [showWeekdays]="showWeekdays"
             [showWeekNumbers]="showWeekNumbers"
-            [disabled]="disabled"
-            [outsideDays]="displayMonths === 1 ? outsideDays : 'hidden'"
+            [outsideDays]="(displayMonths === 1 ? outsideDays : 'hidden')"
             (select)="onDateSelect($event)">
           </ngb-datepicker-month-view>
         </div>
       </ng-template>
     </div>
   `,
-  providers: [NGB_DATEPICKER_VALUE_ACCESSOR, NgbDatepickerService]
+  providers: [NGB_DATEPICKER_VALUE_ACCESSOR, NgbDatepickerService, NgbDatepickerKeyMapService]
 })
-export class NgbDatepicker implements OnChanges,
-    OnInit, ControlValueAccessor {
-  _date: NgbDate;
-  _maxDate: NgbDate;
-  _minDate: NgbDate;
+export class NgbDatepicker implements OnDestroy,
+    OnChanges, OnInit, ControlValueAccessor {
+  model: DatepickerViewModel;
 
-  focusedDate: NgbDate;
-  model: NgbDate;
-  months: MonthViewModel[] = [];
-
+  private _subscription: Subscription;
   /**
    * Reference for the custom template for the day display
    */
@@ -205,14 +201,13 @@ export class NgbDatepicker implements OnChanges,
    */
   @Output() navigate = new EventEmitter<NgbDatepickerNavigateEvent>();
 
-  disabled = false;
-
   onChange = (_: any) => {};
   onTouched = () => {};
 
   constructor(
-      private _service: NgbDatepickerService, private _calendar: NgbCalendar, public i18n: NgbDatepickerI18n,
-      config: NgbDatepickerConfig, private _elementRef: ElementRef) {
+      private _keyMapService: NgbDatepickerKeyMapService, public _service: NgbDatepickerService,
+      private _calendar: NgbCalendar, public i18n: NgbDatepickerI18n, config: NgbDatepickerConfig,
+      private _cd: ChangeDetectorRef) {
     this.dayTemplate = config.dayTemplate;
     this.displayMonths = config.displayMonths;
     this.firstDayOfWeek = config.firstDayOfWeek;
@@ -224,6 +219,32 @@ export class NgbDatepicker implements OnChanges,
     this.showWeekdays = config.showWeekdays;
     this.showWeekNumbers = config.showWeekNumbers;
     this.startDate = config.startDate;
+
+    this._subscription = _service.model$.subscribe(model => {
+      const newDate = model.firstDate;
+      const oldDate = this.model ? this.model.firstDate : null;
+      const newSelectedDate = model.selectedDate;
+      const oldSelectedDate = this.model ? this.model.selectedDate : null;
+
+      this.model = model;
+
+      // handling selection change
+      if (isChangedDate(newSelectedDate, oldSelectedDate)) {
+        this.onTouched();
+        this.onChange(
+            newSelectedDate ? {year: newSelectedDate.year, month: newSelectedDate.month, day: newSelectedDate.day} :
+                              null);
+      }
+
+      // emitting navigation event if the first month changes
+      if (!newDate.equals(oldDate)) {
+        this.navigate.emit({
+          current: oldDate ? {year: oldDate.year, month: oldDate.month} : null,
+          next: {year: newDate.year, month: newDate.month}
+        });
+      }
+      _cd.markForCheck();
+    });
   }
 
   getHeaderHeight() {
@@ -243,260 +264,74 @@ export class NgbDatepicker implements OnChanges,
    * Use 'startDate' input as an alternative
    */
   navigateTo(date?: {year: number, month: number}) {
-    this._setViewWithinLimits(this._service.toValidDate(date));
-    this._updateData();
+    this._service.open(date ? new NgbDate(date.year, date.month, 1) : this._calendar.getToday());
   }
 
+  ngOnDestroy() { this._subscription.unsubscribe(); }
+
   ngOnInit() {
-    this._setDates();
-    this.navigateTo(this._date);
+    if (this.model === undefined) {
+      this._service.displayMonths = toInteger(this.displayMonths);
+      this._service.markDisabled = this.markDisabled;
+      this._service.firstDayOfWeek = this.firstDayOfWeek;
+      this._setDates();
+    }
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    this._setDates();
-    this._setViewWithinLimits(this._date);
-
     if (changes['displayMonths']) {
-      this.displayMonths = toInteger(this.displayMonths);
+      this._service.displayMonths = toInteger(this.displayMonths);
     }
-
-    // we have to force rebuild all months only if any of these inputs changes
-    if (['startDate', 'minDate', 'maxDate', 'navigation', 'firstDayOfWeek', 'markDisabled', 'displayMonths'].some(
-            input => !!changes[input])) {
-      this._updateData(true);
+    if (changes['markDisabled']) {
+      this._service.markDisabled = this.markDisabled;
     }
+    if (changes['firstDayOfWeek']) {
+      this._service.firstDayOfWeek = this.firstDayOfWeek;
+    }
+    this._setDates();
   }
 
   onDateSelect(date: NgbDate) {
-    this._setFocusedDateWithinLimits(date);
-    this.onTouched();
+    this._service.focus(date);
     this.writeValue(date);
-    this.onChange({year: date.year, month: date.month, day: date.day});
   }
 
-  onFocus(event: FocusEvent) {
-    const firstDate = this._getFirstDisplayedDate();
-    const lastDate = this._getLastDisplayedDate();
-    const model = this.model;
-    this.focusedDate = (!model || model.before(firstDate) || model.after(lastDate)) ? firstDate : model;
-  }
+  onKeyDown(event: KeyboardEvent) { this._keyMapService.processKey(event); }
 
-  onKeyDown(event: KeyboardEvent) {
-    if (!this.focusedDate) {
-      return;
-    }
-    switch (event.keyCode) {
-      case 33 /* page up */:
-        if (event.shiftKey) {
-          this._setRelativeFocusedDate('y', -1);
-        } else {
-          this._setRelativeFocusedDate('m', -1);
-        }
-        break;
-      case 34 /* page down */:
-        if (event.shiftKey) {
-          this._setRelativeFocusedDate('y', 1);
-        } else {
-          this._setRelativeFocusedDate('m', 1);
-        }
-        break;
-      case 35 /* end */:
-        if (event.shiftKey) {
-          this._setFocusedDateWithinLimits(this._maxDate);
-        } else {
-          this._setFocusedDateWithinLimits(this._getLastDisplayedDate());
-        }
-        break;
-      case 36 /* home */:
-        if (event.shiftKey) {
-          this._setFocusedDateWithinLimits(this._minDate);
-        } else {
-          this._setFocusedDateWithinLimits(this._getFirstDisplayedDate());
-        }
-        break;
-      case 37 /* left arrow */:
-        this._setRelativeFocusedDate('d', -1);
-        break;
-      case 38 /* up arrow */:
-        this._setRelativeFocusedDate('d', -this._calendar.getDaysPerWeek());
-        break;
-      case 39 /* right arrow */:
-        this._setRelativeFocusedDate('d', 1);
-        break;
-      case 40 /* down arrow */:
-        this._setRelativeFocusedDate('d', this._calendar.getDaysPerWeek());
-        break;
-      case 13 /* enter */:
-      case 32 /* space */:
-        if (this._isDisplayedDateSelectable(this.focusedDate)) {
-          this.onDateSelect(NgbDate.from(this.focusedDate));
-        }
-        break;
-      default:
-        return;
-    }
-    event.preventDefault();
-    event.stopPropagation();
-  }
-
-  onMouseDown(event: MouseEvent) {
-    // Internet Explorer has some issues to give focus to the right element when clicking
-    // so this method is here to make IE behave correctly!
-    const target = <HTMLElement>event.target;
-    const tagName = target.tagName.toLowerCase();
-    if (tagName !== 'select' && tagName !== 'input' && tagName !== 'option') {
-      if (!this.focusedDate) {
-        this._elementRef.nativeElement.focus();
-      }
-      event.preventDefault();
-    }
-  }
-
-  onNavigateDateSelect(date: NgbDate) {
-    this._setViewWithinLimits(date);
-    this._updateData();
-  }
+  onNavigateDateSelect(date: NgbDate) { this._service.open(date); }
 
   onNavigateEvent(event: NavigationEvent) {
     switch (event) {
       case NavigationEvent.PREV:
-        this._setViewWithinLimits(this._calendar.getPrev(this._getFirstDisplayedDate(), 'm'));
+        this._service.open(this._calendar.getPrev(this.model.firstDate, 'm', 1));
         break;
       case NavigationEvent.NEXT:
-        this._setViewWithinLimits(this._calendar.getNext(this._getFirstDisplayedDate(), 'm'));
+        this._service.open(this._calendar.getNext(this.model.firstDate, 'm', 1));
         break;
     }
-
-    this._updateData();
   }
 
   registerOnChange(fn: (value: any) => any): void { this.onChange = fn; }
 
   registerOnTouched(fn: () => any): void { this.onTouched = fn; }
 
-  setDisabledState(isDisabled: boolean) { this.disabled = isDisabled; }
+  setDisabledState(isDisabled: boolean) { this._service.disabled = isDisabled; }
 
-  writeValue(value) { this.model = this._service.toValidDate(value, null); }
+  showFocus(focusVisible: boolean) { this._service.focusVisible = focusVisible; }
 
-  private _checkFocusedDateVisible() {
-    const focusedDate = this.focusedDate;
-    if (focusedDate) {
-      const firstDisplayedDate = this._getFirstDisplayedDate();
-      const lastDisplayedDate = this._getLastDisplayedDate();
-      if (focusedDate.before(firstDisplayedDate)) {
-        this.focusedDate = firstDisplayedDate;
-      } else if (focusedDate.after(lastDisplayedDate)) {
-        this.focusedDate = lastDisplayedDate;
-      }
-    }
-  }
-
-  private _getFirstDisplayedDate() { return this.months[0].firstDate; }
-
-  private _getLastDisplayedDate() {
-    return this._calendar.getPrev(
-        this._calendar.getNext(this.months[this.months.length - 1].firstDate, 'm', 1), 'd', 1);
-  }
-
-  private _isDisplayedDateSelectable(date: NgbDate) {
-    let selectable = false;
-    const month = this.months.find(curMonth => curMonth.year === date.year && curMonth.number === date.month);
-    if (month) {
-      month.weeks.find(week => {
-        const day = week.days.find(day => date.equals(day.date));
-        if (day && !day.disabled) {
-          selectable = true;
-        }
-        return !!day;
-      });
-    }
-    return selectable;
-  }
+  writeValue(value) { this._service.select(value); }
 
   private _setDates() {
-    this._maxDate = NgbDate.from(this.maxDate);
-    this._minDate = NgbDate.from(this.minDate);
-    this._date = this._service.toValidDate(this.startDate);
+    const startDate = this._service.toValidDate(this.startDate, this._calendar.getToday());
+    const minDate = this._service.toValidDate(this.minDate, this._calendar.getPrev(startDate, 'y', 10));
+    const maxDate =
+        this._service.toValidDate(this.maxDate, this._calendar.getPrev(this._calendar.getNext(startDate, 'y', 11)));
 
-    if (!this._calendar.isValid(this._minDate)) {
-      this._minDate = this._calendar.getPrev(this._date, 'y', 10);
-      this.minDate = {year: this._minDate.year, month: this._minDate.month, day: this._minDate.day};
-    }
+    this.minDate = {year: minDate.year, month: minDate.month, day: minDate.day};
+    this.maxDate = {year: maxDate.year, month: maxDate.month, day: maxDate.day};
 
-    if (!this._calendar.isValid(this._maxDate)) {
-      this._maxDate = this._calendar.getNext(this._date, 'y', 11);
-      this._maxDate = this._calendar.getPrev(this._maxDate);
-      this.maxDate = {year: this._maxDate.year, month: this._maxDate.month, day: this._maxDate.day};
-    }
-
-    if (this._minDate && this._maxDate && this._maxDate.before(this._minDate)) {
-      throw new Error(`'maxDate' ${this._maxDate} should be greater than 'minDate' ${this._minDate}`);
-    }
-  }
-
-  private _setFocusedDateWithinLimits(date: NgbDate) {
-    if (this._minDate && date.before(this._minDate)) {
-      date = this._minDate;
-    } else if (this._maxDate && date.after(this._maxDate)) {
-      date = this._maxDate;
-    }
-    const firstDate = this._getFirstDisplayedDate();
-    const lastDate = this._getLastDisplayedDate();
-    let newViewDate;
-    if (date.before(firstDate)) {
-      newViewDate = date;
-    } else if (date.after(lastDate)) {
-      newViewDate = this._calendar.getPrev(date, 'm', this.displayMonths - 1);
-    }
-    this.focusedDate = date;
-    if (newViewDate) {
-      this._setViewWithinLimits(newViewDate);
-      this._updateData();
-    }
-  }
-
-  private _setRelativeFocusedDate(period?: NgbPeriod, number?: number) {
-    this._setFocusedDateWithinLimits(this._calendar.getNext(this.focusedDate, period, number));
-  }
-
-  private _setViewWithinLimits(date: NgbDate) {
-    if (this._minDate && date.before(this._minDate)) {
-      this._date = new NgbDate(this._minDate.year, this._minDate.month, 1);
-    } else if (this._maxDate && date.after(this._maxDate)) {
-      this._date = new NgbDate(this._maxDate.year, this._maxDate.month, 1);
-    } else {
-      this._date = new NgbDate(date.year, date.month, 1);
-    }
-  }
-
-  private _updateData(force = false) {
-    const newMonths = [];
-    for (let i = 0; i < this.displayMonths; i++) {
-      const newDate = this._calendar.getNext(this._date, 'm', i);
-      const index = this.months.findIndex(month => month.firstDate.equals(newDate));
-
-      if (force || index === -1) {
-        newMonths.push(
-            this._service.generateMonthViewModel(
-                newDate, this._minDate, this._maxDate, toInteger(this.firstDayOfWeek), this.markDisabled));
-      } else {
-        newMonths.push(this.months[index]);
-      }
-    }
-
-    const newDate = newMonths[0].firstDate;
-    const oldDate = this.months[0] ? this.months[0].firstDate : null;
-
-    this.months = newMonths;
-
-    // emitting navigation event if the first month changes
-    if (!newDate.equals(oldDate)) {
-      this._checkFocusedDateVisible();
-
-      this.navigate.emit({
-        current: oldDate ? {year: oldDate.year, month: oldDate.month} : null,
-        next: {year: newDate.year, month: newDate.month}
-      });
-    }
+    this._service.minDate = minDate;
+    this._service.maxDate = maxDate;
+    this.navigateTo(startDate);
   }
 }


### PR DESCRIPTION
This essentially contains two things:
- All the work @divdavem has done for adding keyboard navigation (#1273)
- Complete refactoring or the datepicker internals

Problems with the datepicker before refactoring:
- All the logic is inside of the `NgbDatepicker` component - became a huge mess after adding of the keyboard handling
- Very little unit tests for the logic because of the above

Refactoring:
- Public API unchanged
- `NgbDatepicker` component is as dumb as possible, just displays `DatepickerViewModel` and propagates `@Inputs` to the service
- `NgbDatepickerService` generates the `DatepickerViewModel` with a very simple API
- `NgbDatepickerKeyMappingService` handles key event mapping to actions 
- Many more unit tests for the `service`
- `OnPush` everywhere for the datepicker components

So now it looks something like this:
![dp design](https://cloud.githubusercontent.com/assets/8074436/26060542/b6783e40-3985-11e7-8a67-e110f339862c.png)

P.S. It might seem a lot, but 2/3 of the PR are unit tests
P.P.S. Tried lots of different solutions based on observables, but for now they add only boilerplate code...