### PR TITLE
feat(allowInsideClick): Add 'closeFromInsideClick' to dropdown

### DIFF
--- a/src/dropdown/dropdown-config.spec.ts
+++ b/src/dropdown/dropdown-config.spec.ts
@@ -6,5 +6,6 @@ describe('ngb-dropdown-config', () => {
 
     expect(config.up).toBe(false);
     expect(config.autoClose).toBe(true);
+    expect(config.closeFromInsideClick).toBe(true);
   });
 });

--- a/src/dropdown/dropdown-config.ts
+++ b/src/dropdown/dropdown-config.ts
@@ -9,4 +9,5 @@ import {Injectable, TemplateRef} from '@angular/core';
 export class NgbDropdownConfig {
   up = false;
   autoClose = true;
+  closeFromInsideClick = true;
 }

--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -22,7 +22,7 @@ describe('ngb-dropdown', () => {
 
   it('should initialize inputs with provided config', () => {
     const defaultConfig = new NgbDropdownConfig();
-    const dropdown = new NgbDropdown(defaultConfig);
+    const dropdown = new NgbDropdown(defaultConfig, createTestComponent('<div></div>'));
     expect(dropdown.up).toBe(defaultConfig.up);
     expect(dropdown.autoClose).toBe(defaultConfig.autoClose);
   });
@@ -387,6 +387,28 @@ describe('ngb-dropdown-toggle', () => {
     fixture.detectChanges();
     expect(dropdownEls[0]).not.toHaveCssClass('show');
     expect(dropdownEls[1]).toHaveCssClass('show');
+  });
+
+  it('should not close on item click if closeFromInsideClick is set to false', () => {
+    const html = `
+      <div ngbDropdown [open]="true" [closeFromInsideClick]="false">
+          <button ngbDropdownToggle>Toggle dropdown</button>
+          <div class="dropdown-menu" aria-labelledby="dropdownMenu1">
+            <a class="dropdown-item">Action</a>
+          </div>
+      </div>`;
+
+    const fixture = createTestComponent(html);
+    const compiled = fixture.nativeElement;
+    let dropdownEl = getDropdownEl(compiled);
+    let linkEl = compiled.querySelector('a');
+
+    fixture.detectChanges();
+    expect(dropdownEl).toHaveCssClass('show');
+
+    linkEl.click();
+    fixture.detectChanges();
+    expect(dropdownEl).toHaveCssClass('show');
   });
 
   describe('Custom config', () => {

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -29,6 +29,12 @@ export class NgbDropdown {
   @Input() autoClose: boolean;
 
   /**
+   * Indicates that dropdown should be closed from a click within the dropdown. If autoClose is false, then this is not
+   * taken into account.
+   */
+  @Input() closeFromInsideClick: boolean;
+
+  /**
    *  Defines whether or not the dropdown-menu is open initially.
    */
   @Input('open') _open = false;
@@ -39,9 +45,10 @@ export class NgbDropdown {
    */
   @Output() openChange = new EventEmitter();
 
-  constructor(config: NgbDropdownConfig) {
+  constructor(config: NgbDropdownConfig, private elementRef: ElementRef) {
     this.up = config.up;
     this.autoClose = config.autoClose;
+    this.closeFromInsideClick = config.closeFromInsideClick;
   }
 
 
@@ -82,7 +89,8 @@ export class NgbDropdown {
   }
 
   closeFromOutsideClick($event) {
-    if (this.autoClose && $event.button !== 2 && !this._isEventFromToggle($event)) {
+    if (this.autoClose && this._shouldcloseFromInsideClick($event) && $event.button !== 2 &&
+        !this._isEventFromToggle($event)) {
       this.close();
     }
   }
@@ -99,6 +107,10 @@ export class NgbDropdown {
   set toggleElement(toggleElement: any) { this._toggleElement = toggleElement; }
 
   private _isEventFromToggle($event) { return !!this._toggleElement && this._toggleElement.contains($event.target); }
+
+  private _shouldcloseFromInsideClick($event) {
+    return this.closeFromInsideClick || !this.elementRef.nativeElement.contains($event.target);
+  }
 }
 
 /**


### PR DESCRIPTION
This adds an option so that `closeFromOutsideClick` ignores clicks inside the dropdown. This option will be ignored when `autoClose` is set to `false`.

Closes #1022 