### PR TITLE
fix(positioning): top-right, right-bottom, bottom-right, left-bottom

### DIFF
--- a/src/util/positioning.spec.ts
+++ b/src/util/positioning.spec.ts
@@ -115,7 +115,7 @@ describe('Positioning', () => {
     let position = positioning.positionElements(element, targetElement, 'top-right');
 
     expect(position.top).toBe(50);
-    expect(position.left).toBe(450);
+    expect(position.left).toBe(350);
   });
 
   it('should position the element bottom-left', () => {
@@ -136,7 +136,7 @@ describe('Positioning', () => {
     let position = positioning.positionElements(element, targetElement, 'bottom-right');
 
     expect(position.top).toBe(300);
-    expect(position.left).toBe(450);
+    expect(position.left).toBe(350);
   });
 
   it('should position the element left-top', () => {
@@ -156,7 +156,7 @@ describe('Positioning', () => {
   it('should position the element left-bottom', () => {
     let position = positioning.positionElements(element, targetElement, 'left-bottom');
 
-    expect(position.top).toBe(300);
+    expect(position.top).toBe(250);
     expect(position.left).toBe(50);
   });
 
@@ -177,7 +177,7 @@ describe('Positioning', () => {
   it('should position the element right-bottom', () => {
     let position = positioning.positionElements(element, targetElement, 'right-bottom');
 
-    expect(position.top).toBe(300);
+    expect(position.top).toBe(250);
     expect(position.left).toBe(450);
   });
 

--- a/src/util/positioning.ts
+++ b/src/util/positioning.ts
@@ -82,16 +82,6 @@ export class Positioning {
   positionElements(hostElement: HTMLElement, targetElement: HTMLElement, placement: string, appendToBody?: boolean):
       ClientRect {
     const hostElPosition = appendToBody ? this.offset(hostElement, false) : this.position(hostElement, false);
-    const shiftWidth: any = {
-      left: hostElPosition.left,
-      center: hostElPosition.left + hostElPosition.width / 2 - targetElement.offsetWidth / 2,
-      right: hostElPosition.left + hostElPosition.width
-    };
-    const shiftHeight: any = {
-      top: hostElPosition.top,
-      center: hostElPosition.top + hostElPosition.height / 2 - targetElement.offsetHeight / 2,
-      bottom: hostElPosition.top + hostElPosition.height
-    };
     const targetElBCR = targetElement.getBoundingClientRect();
     const placementPrimary = placement.split('-')[0] || 'top';
     const placementSecondary = placement.split('-')[1] || 'center';
@@ -108,27 +98,37 @@ export class Positioning {
     switch (placementPrimary) {
       case 'top':
         targetElPosition.top = hostElPosition.top - targetElement.offsetHeight;
-        targetElPosition.bottom += hostElPosition.top - targetElement.offsetHeight;
-        targetElPosition.left = shiftWidth[placementSecondary];
-        targetElPosition.right += shiftWidth[placementSecondary];
         break;
       case 'bottom':
-        targetElPosition.top = shiftHeight[placementPrimary];
-        targetElPosition.bottom += shiftHeight[placementPrimary];
-        targetElPosition.left = shiftWidth[placementSecondary];
-        targetElPosition.right += shiftWidth[placementSecondary];
+        targetElPosition.top = hostElPosition.top + hostElPosition.height;
         break;
       case 'left':
-        targetElPosition.top = shiftHeight[placementSecondary];
-        targetElPosition.bottom += shiftHeight[placementSecondary];
         targetElPosition.left = hostElPosition.left - targetElement.offsetWidth;
-        targetElPosition.right += hostElPosition.left - targetElement.offsetWidth;
         break;
       case 'right':
-        targetElPosition.top = shiftHeight[placementSecondary];
-        targetElPosition.bottom += shiftHeight[placementSecondary];
-        targetElPosition.left = shiftWidth[placementPrimary];
-        targetElPosition.right += shiftWidth[placementPrimary];
+        targetElPosition.left = hostElPosition.left + hostElPosition.width;
+        break;
+    }
+
+    switch (placementSecondary) {
+      case 'top':
+        targetElPosition.top = hostElPosition.top;
+        break;
+      case 'bottom':
+        targetElPosition.top = hostElPosition.top + hostElPosition.height - targetElement.offsetHeight;
+        break;
+      case 'left':
+        targetElPosition.left = hostElPosition.left;
+        break;
+      case 'right':
+        targetElPosition.left = hostElPosition.left + hostElPosition.width - targetElement.offsetWidth;
+        break;
+      case 'center':
+        if (placementPrimary === 'top' || placementPrimary === 'bottom') {
+          targetElPosition.left = hostElPosition.left + hostElPosition.width / 2 - targetElement.offsetWidth / 2;
+        } else {
+          targetElPosition.top = hostElPosition.top + hostElPosition.height / 2 - targetElement.offsetHeight / 2;
+        }
         break;
     }
 


### PR DESCRIPTION
The following positions were incorrect. I've fixed them by copying logic from ui-bootstrap and updating the tests:
- top-right
- right-bottom
- bottom-right
- left-bottom

Related: https://github.com/ng-bootstrap/ng-bootstrap/issues/857

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
