### PR TITLE
feat(carousel): add support for trigger on mouseenter

### DIFF
--- a/src/carousel/carousel.spec.ts
+++ b/src/carousel/carousel.spec.ts
@@ -255,6 +255,39 @@ describe('ngb-carousel', () => {
        discardPeriodicTasks();
      }));
 
+  it('should pause / resume slide change with time passage on mouse enter / leave', fakeAsync(() => {
+       const html = `
+      <ngb-carousel [playOnMouseenter]="true">
+        <ng-template ngbSlide>foo</ng-template>
+        <ng-template ngbSlide>bar</ng-template>
+      </ngb-carousel>
+    `;
+
+       const fixture = createTestComponent(html);
+
+       const carouselDebugEl = fixture.debugElement.query(By.directive(NgbCarousel));
+
+       expectActiveSlides(fixture.nativeElement, [true, false]);
+
+       carouselDebugEl.triggerEventHandler('mouseenter', {});
+       fixture.detectChanges();
+       expectActiveSlides(fixture.nativeElement, [true, false]);
+
+       tick(6000);
+       fixture.detectChanges();
+       expectActiveSlides(fixture.nativeElement, [false, true]);
+
+       carouselDebugEl.triggerEventHandler('mouseleave', {});
+       fixture.detectChanges();
+       expectActiveSlides(fixture.nativeElement, [false, true]);
+
+       tick(6000);
+       fixture.detectChanges();
+       expectActiveSlides(fixture.nativeElement, [true, false]);
+
+       discardPeriodicTasks();
+     }));
+
   it('should wrap slide changes by default', fakeAsync(() => {
        const html = `
       <ngb-carousel>

--- a/src/carousel/carousel.ts
+++ b/src/carousel/carousel.ts
@@ -36,7 +36,7 @@ export class NgbSlide {
     'class': 'carousel slide',
     '[style.display]': '"block"',
     'tabIndex': '0',
-    '(mouseenter)': 'pause()',
+    '(mouseenter)': 'cycleOrPause()',
     '(mouseleave)': 'cycle()',
     '(keydown.arrowLeft)': 'keyPrev()',
     '(keydown.arrowRight)': 'keyNext()'
@@ -84,6 +84,11 @@ export class NgbCarousel implements AfterContentChecked,
    * The active slide id.
    */
   @Input() activeId: string;
+
+  /**
+   * Whether to cycle slides when mouseenter is triggered
+   */
+  @Input() playOnMouseenter: boolean;
 
   constructor(config: NgbCarouselConfig) {
     this.interval = config.interval;
@@ -134,6 +139,14 @@ export class NgbCarousel implements AfterContentChecked,
    */
   cycle() { this._startTimer(); }
 
+  cycleOrPause() {
+    if (this.playOnMouseenter) {
+      this.cycle();
+    } else {
+      this.pause();
+    }
+  }
+
   cycleToNext() { this.cycleToSelected(this._getNextSlide(this.activeId)); }
 
   cycleToPrev() { this.cycleToSelected(this._getPrevSlide(this.activeId)); }
@@ -163,12 +176,15 @@ export class NgbCarousel implements AfterContentChecked,
   }
 
   private _startTimer() {
-    if (this.interval > 0) {
+    if (this.interval > 0 && !this._slideChangeInterval) {
       this._slideChangeInterval = setInterval(() => { this.cycleToNext(); }, this.interval);
     }
   }
 
-  private _stopTimer() { clearInterval(this._slideChangeInterval); }
+  private _stopTimer() {
+    clearInterval(this._slideChangeInterval);
+    this._slideChangeInterval = null;
+  }
 
   private _getSlideById(slideId: string): NgbSlide {
     let slideWithId: NgbSlide[] = this.slides.filter(slide => slide.id === slideId);


### PR DESCRIPTION
- Add optional support for triggering the carousel slide cycling on `mouseenter` via `playOnMouseenter` binding

This should address #1163.

Let me know if there is a better name for this binding @pkozlowski-opensource - I picked it only for lack of imagination.
