### PR TITLE
feat(typeahead): expose the NgbHighlight component

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,8 @@ export {
   NgbTypeaheadModule,
   NgbTypeaheadConfig,
   NgbTypeaheadSelectItemEvent,
-  NgbTypeahead
+  NgbTypeahead,
+  NgbHighlight
 } from './typeahead/typeahead.module';
 
 const NGB_MODULES = [

--- a/src/typeahead/typeahead.module.ts
+++ b/src/typeahead/typeahead.module.ts
@@ -13,7 +13,7 @@ export {NgbTypeahead, NgbTypeaheadSelectItemEvent} from './typeahead';
 
 @NgModule({
   declarations: [NgbTypeahead, NgbHighlight, NgbTypeaheadWindow],
-  exports: [NgbTypeahead],
+  exports: [NgbTypeahead, NgbHighlight],
   imports: [CommonModule],
   entryComponents: [NgbTypeaheadWindow]
 })


### PR DESCRIPTION
Enables users to reuse the same highlight behavior as the default one when using custom result templates.

Closes #1553
Follows #1555 that was closed a few days ago