### PR TITLE
fix(datepicker): change trigger event for NgbInputDatepicker

### DIFF
--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -74,7 +74,7 @@ describe('NgbInputDatepicker', () => {
       const fixture = createTestCmpt(`<input ngbDatepicker [(ngModel)]="date">`);
       const inputDebugEl = fixture.debugElement.query(By.css('input'));
 
-      inputDebugEl.triggerEventHandler('change', {target: {value: '2016-09-10'}});
+      inputDebugEl.triggerEventHandler('input', {target: {value: '2016-09-10'}});
       expect(fixture.componentInstance.date).toEqual({year: 2016, month: 9, day: 10});
     });
 
@@ -299,12 +299,12 @@ describe('NgbInputDatepicker', () => {
            const inputDebugEl = fixture.debugElement.query(By.css('input'));
            const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
 
-           inputDebugEl.triggerEventHandler('change', {target: {value: '2016-09-10'}});
+           inputDebugEl.triggerEventHandler('input', {target: {value: '2016-09-10'}});
            fixture.detectChanges();
            tick();
            expect(form.control.valid).toBeTruthy();
 
-           inputDebugEl.triggerEventHandler('change', {target: {value: 'invalid'}});
+           inputDebugEl.triggerEventHandler('input', {target: {value: 'invalid'}});
            fixture.detectChanges();
            tick();
            expect(form.control.invalid).toBeTruthy();

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -46,7 +46,12 @@ const NGB_DATEPICKER_VALIDATOR = {
 @Directive({
   selector: 'input[ngbDatepicker]',
   exportAs: 'ngbDatepicker',
-  host: {'(input)': 'manualDateChange($event.target.value)', '(keyup.esc)': 'close()', '(blur)': 'onBlur()'},
+  host: {
+    '(input)': 'manualDateChange($event.target.value)',
+    '(change)': 'manualDateChange($event.target.value, true)',
+    '(keyup.esc)': 'close()',
+    '(blur)': 'onBlur()'
+  },
   providers: [NGB_DATEPICKER_VALUE_ACCESSOR, NGB_DATEPICKER_VALIDATOR, NgbDatepickerService]
 })
 export class NgbInputDatepicker implements OnChanges,
@@ -184,10 +189,13 @@ export class NgbInputDatepicker implements OnChanges,
     this._writeModelValue(this._model);
   }
 
-  manualDateChange(value: string) {
+  manualDateChange(value: string, updateView = false) {
     this._model = this._service.toValidDate(this._parserFormatter.parse(value), null);
     this._onChange(this._model ? {year: this._model.year, month: this._model.month, day: this._model.day} : value);
-    this._writeModelValue(this._model);
+
+    if (updateView) {
+      this._writeModelValue(this._model);
+    }
   }
 
   isOpen() { return !!this._cRef; }

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -46,7 +46,7 @@ const NGB_DATEPICKER_VALIDATOR = {
 @Directive({
   selector: 'input[ngbDatepicker]',
   exportAs: 'ngbDatepicker',
-  host: {'(change)': 'manualDateChange($event.target.value)', '(keyup.esc)': 'close()', '(blur)': 'onBlur()'},
+  host: {'(input)': 'manualDateChange($event.target.value)', '(keyup.esc)': 'close()', '(blur)': 'onBlur()'},
   providers: [NGB_DATEPICKER_VALUE_ACCESSOR, NGB_DATEPICKER_VALIDATOR, NgbDatepickerService]
 })
 export class NgbInputDatepicker implements OnChanges,


### PR DESCRIPTION
Changes the trigger event in NgbInputDatepicker for manual date change from `change` to `input`as discussed in #1225.