### PR TITLE
fix: support closure-compiler

### DIFF
--- a/demo/src/app/components/accordion/demos/index.ts
+++ b/demo/src/app/components/accordion/demos/index.ts
@@ -8,24 +8,24 @@ export const DEMO_DIRECTIVES =
     [NgbdAccordionBasic, NgbdAccordionPreventchange, NgbdAccordionStatic, NgbdAccordionToggle, NgbdAccordionConfig];
 
 export const DEMO_SNIPPETS = {
-  basic: {
-    code: require('!!prismjs-loader?lang=typescript!./basic/accordion-basic'),
-    markup: require('!!prismjs-loader?lang=markup!./basic/accordion-basic.html')
+  'basic': {
+    'code': require('!!prismjs-loader?lang=typescript!./basic/accordion-basic'),
+    'markup': require('!!prismjs-loader?lang=markup!./basic/accordion-basic.html')
   },
-  preventchange: {
-    code: require('!!prismjs-loader?lang=typescript!./preventchange/accordion-preventchange'),
-    markup: require('!!prismjs-loader?lang=markup!./preventchange/accordion-preventchange.html')
+  'preventchange': {
+    'code': require('!!prismjs-loader?lang=typescript!./preventchange/accordion-preventchange'),
+    'markup': require('!!prismjs-loader?lang=markup!./preventchange/accordion-preventchange.html')
   },
-  static: {
-    code: require('!!prismjs-loader?lang=typescript!./static/accordion-static'),
-    markup: require('!!prismjs-loader?lang=markup!./static/accordion-static.html')
+  'static': {
+    'code': require('!!prismjs-loader?lang=typescript!./static/accordion-static'),
+    'markup': require('!!prismjs-loader?lang=markup!./static/accordion-static.html')
   },
-  toggle: {
-    code: require('!!prismjs-loader?lang=typescript!./toggle/accordion-toggle'),
-    markup: require('!!prismjs-loader?lang=markup!./toggle/accordion-toggle.html')
+  'toggle': {
+    'code': require('!!prismjs-loader?lang=typescript!./toggle/accordion-toggle'),
+    'markup': require('!!prismjs-loader?lang=markup!./toggle/accordion-toggle.html')
   },
-  config: {
-    code: require('!!prismjs-loader?lang=typescript!./config/accordion-config'),
-    markup: require('!!prismjs-loader?lang=markup!./config/accordion-config.html')
+  'config': {
+    'code': require('!!prismjs-loader?lang=typescript!./config/accordion-config'),
+    'markup': require('!!prismjs-loader?lang=markup!./config/accordion-config.html')
   }
 };

--- a/demo/src/app/components/alert/demos/index.ts
+++ b/demo/src/app/components/alert/demos/index.ts
@@ -8,24 +8,24 @@ export const DEMO_DIRECTIVES =
     [NgbdAlertBasic, NgbdAlertCloseable, NgbdAlertCustom, NgbdAlertSelfclosing, NgbdAlertConfig];
 
 export const DEMO_SNIPPETS = {
-  basic: {
-    code: require('!!prismjs-loader?lang=typescript!./basic/alert-basic'),
-    markup: require('!!prismjs-loader?lang=markup!./basic/alert-basic.html')
+  'basic': {
+    'code': require('!!prismjs-loader?lang=typescript!./basic/alert-basic'),
+    'markup': require('!!prismjs-loader?lang=markup!./basic/alert-basic.html')
   },
-  closeable: {
-    code: require('!!prismjs-loader?lang=typescript!./closeable/alert-closeable'),
-    markup: require('!!prismjs-loader?lang=markup!./closeable/alert-closeable.html')
+  'closeable': {
+    'code': require('!!prismjs-loader?lang=typescript!./closeable/alert-closeable'),
+    'markup': require('!!prismjs-loader?lang=markup!./closeable/alert-closeable.html')
   },
-  custom: {
-    code: require('!!prismjs-loader?lang=typescript!./custom/alert-custom'),
-    markup: require('!!prismjs-loader?lang=markup!./custom/alert-custom.html')
+  'custom': {
+    'code': require('!!prismjs-loader?lang=typescript!./custom/alert-custom'),
+    'markup': require('!!prismjs-loader?lang=markup!./custom/alert-custom.html')
   },
-  selfclosing: {
-    code: require('!!prismjs-loader?lang=typescript!./selfclosing/alert-selfclosing'),
-    markup: require('!!prismjs-loader?lang=markup!./selfclosing/alert-selfclosing.html')
+  'selfclosing': {
+    'code': require('!!prismjs-loader?lang=typescript!./selfclosing/alert-selfclosing'),
+    'markup': require('!!prismjs-loader?lang=markup!./selfclosing/alert-selfclosing.html')
   },
-  config: {
-    code: require('!!prismjs-loader?lang=typescript!./config/alert-config'),
-    markup: require('!!prismjs-loader?lang=markup!./config/alert-config.html')
+  'config': {
+    'code': require('!!prismjs-loader?lang=typescript!./config/alert-config'),
+    'markup': require('!!prismjs-loader?lang=markup!./config/alert-config.html')
   }
 };

--- a/demo/src/app/components/alert/demos/selfclosing/alert-selfclosing.ts
+++ b/demo/src/app/components/alert/demos/selfclosing/alert-selfclosing.ts
@@ -1,6 +1,6 @@
 import {Component, OnInit} from '@angular/core';
 import {Subject} from 'rxjs/Subject';
-import 'rxjs/add/operator/debounceTime';
+import {debounceTime} from 'rxjs/operator/debounceTime';
 
 @Component({
   selector: 'ngbd-alert-selfclosing',
@@ -16,7 +16,7 @@ export class NgbdAlertSelfclosing implements OnInit {
     setTimeout(() => this.staticAlertClosed = true, 20000);
 
     this._success.subscribe((message) => this.successMessage = message);
-    this._success.debounceTime(5000).subscribe(() => this.successMessage = null);
+    debounceTime.call(this._success, 5000).subscribe(() => this.successMessage = null);
   }
 
   public changeSuccessMessage() {

--- a/demo/src/app/components/buttons/demos/index.ts
+++ b/demo/src/app/components/buttons/demos/index.ts
@@ -6,16 +6,16 @@ import {NgbdButtonsRadioReactive} from './radio-reactive/buttons-radio-reactive'
 export const DEMO_DIRECTIVES = [NgbdButtonsCheckbox, NgbdButtonsCheckboxReactive, NgbdButtonsRadio, NgbdButtonsRadioReactive];
 
 export const DEMO_SNIPPETS = {
-  checkbox: {
-    code: require('!!prismjs-loader?lang=typescript!./checkbox/buttons-checkbox'),
-    markup: require('!!prismjs-loader?lang=markup!./checkbox/buttons-checkbox.html')},
-  checkboxReactive: {
-    code: require('!!prismjs-loader?lang=typescript!./checkbox-reactive/buttons-checkbox-reactive'),
-    markup: require('!!prismjs-loader?lang=markup!./checkbox-reactive/buttons-checkbox-reactive.html')},
-  radio: {
-    code: require('!!prismjs-loader?lang=typescript!./radio/buttons-radio'),
-    markup: require('!!prismjs-loader?lang=markup!./radio/buttons-radio.html')},
-  radioReactive: {
-    code: require('!!prismjs-loader?lang=typescript!./radio-reactive/buttons-radio-reactive'),
-    markup: require('!!prismjs-loader?lang=markup!./radio-reactive/buttons-radio-reactive.html')}
+  'checkbox': {
+    'code': require('!!prismjs-loader?lang=typescript!./checkbox/buttons-checkbox'),
+    'markup': require('!!prismjs-loader?lang=markup!./checkbox/buttons-checkbox.html')},
+  'checkboxReactive': {
+    'code': require('!!prismjs-loader?lang=typescript!./checkbox-reactive/buttons-checkbox-reactive'),
+      'markup': require('!!prismjs-loader?lang=markup!./checkbox-reactive/buttons-checkbox-reactive.html')},
+  'radio': {
+    'code': require('!!prismjs-loader?lang=typescript!./radio/buttons-radio'),
+    'markup': require('!!prismjs-loader?lang=markup!./radio/buttons-radio.html')},
+  'radioReactive': {
+    'code': require('!!prismjs-loader?lang=typescript!./radio-reactive/buttons-radio-reactive'),
+    'markup': require('!!prismjs-loader?lang=markup!./radio-reactive/buttons-radio-reactive.html')}
 };

--- a/demo/src/app/components/buttons/demos/radio-reactive/buttons-radio-reactive.html
+++ b/demo/src/app/components/buttons/demos/radio-reactive/buttons-radio-reactive.html
@@ -12,4 +12,4 @@
   </div>
 </form>
 <hr>
-<pre>{{radioGroupForm.value.model}}</pre>
+<pre>{{radioGroupForm.value['model']}}</pre>

--- a/demo/src/app/components/buttons/demos/radio-reactive/buttons-radio-reactive.ts
+++ b/demo/src/app/components/buttons/demos/radio-reactive/buttons-radio-reactive.ts
@@ -12,7 +12,7 @@ export class NgbdButtonsRadioReactive implements OnInit {
 
   ngOnInit() {
     this.radioGroupForm = this.formBuilder.group({
-      model: 1
+      'model': 1
     });
   }
 }

--- a/demo/src/app/components/carousel/demos/index.ts
+++ b/demo/src/app/components/carousel/demos/index.ts
@@ -4,12 +4,12 @@ import {NgbdCarouselConfig} from './config/carousel-config';
 export const DEMO_DIRECTIVES = [NgbdCarouselBasic, NgbdCarouselConfig];
 
 export const DEMO_SNIPPETS = {
-  basic: {
-    code: require('!!prismjs-loader?lang=typescript!./basic/carousel-basic'),
-    markup: require('!!prismjs-loader?lang=markup!./basic/carousel-basic.html')
+  'basic': {
+    'code': require('!!prismjs-loader?lang=typescript!./basic/carousel-basic'),
+    'markup': require('!!prismjs-loader?lang=markup!./basic/carousel-basic.html')
   },
-  config: {
-    code: require('!!prismjs-loader?lang=typescript!./config/carousel-config'),
-    markup: require('!!prismjs-loader?lang=markup!./config/carousel-config.html')
+  'config': {
+    'code': require('!!prismjs-loader?lang=typescript!./config/carousel-config'),
+    'markup': require('!!prismjs-loader?lang=markup!./config/carousel-config.html')
   }
 };

--- a/demo/src/app/components/collapse/demos/index.ts
+++ b/demo/src/app/components/collapse/demos/index.ts
@@ -3,7 +3,7 @@ import { NgbdCollapseBasic } from './basic/collapse-basic';
 export const DEMO_DIRECTIVES = [NgbdCollapseBasic];
 
 export const DEMO_SNIPPETS = {
-  basic: {
-    code: require('!!prismjs-loader?lang=typescript!./basic/collapse-basic'),
-    markup: require('!!prismjs-loader?lang=markup!./basic/collapse-basic.html')}
+  'basic': {
+    'code': require('!!prismjs-loader?lang=typescript!./basic/collapse-basic'),
+    'markup': require('!!prismjs-loader?lang=markup!./basic/collapse-basic.html')}
 };

--- a/demo/src/app/components/datepicker/demos/i18n/datepicker-i18n.ts
+++ b/demo/src/app/components/datepicker/demos/i18n/datepicker-i18n.ts
@@ -2,11 +2,11 @@ import {Component, Injectable} from '@angular/core';
 import {NgbDatepickerI18n} from '@ng-bootstrap/ng-bootstrap';
 
 const I18N_VALUES = {
-  en: {
+  'en': {
     weekdays: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'],
     months: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
   },
-  fr: {
+  'fr': {
     weekdays: ['Lu', 'Ma', 'Me', 'Je', 'Ve', 'Sa', 'Di'],
     months: ['Jan', 'Fév', 'Mar', 'Avr', 'Mai', 'Juin', 'Juil', 'Aou', 'Sep', 'Oct', 'Nov', 'Déc'],
   }

--- a/demo/src/app/components/datepicker/demos/index.ts
+++ b/demo/src/app/components/datepicker/demos/index.ts
@@ -13,36 +13,36 @@ export const DEMO_DIRECTIVES = [
 ];
 
 export const DEMO_SNIPPETS = {
-  basic: {
-    code: require('!!prismjs-loader?lang=typescript!./basic/datepicker-basic'),
-    markup: require('!!prismjs-loader?lang=markup!./basic/datepicker-basic.html')
+  'basic': {
+    'code': require('!!prismjs-loader?lang=typescript!./basic/datepicker-basic'),
+    'markup': require('!!prismjs-loader?lang=markup!./basic/datepicker-basic.html')
   },
-  popup: {
-    code: require('!!prismjs-loader?lang=typescript!./popup/datepicker-popup'),
-    markup: require('!!prismjs-loader?lang=markup!./popup/datepicker-popup.html')
+  'popup': {
+    'code': require('!!prismjs-loader?lang=typescript!./popup/datepicker-popup'),
+    'markup': require('!!prismjs-loader?lang=markup!./popup/datepicker-popup.html')
   },
-  disabled: {
-    code: require('!!prismjs-loader?lang=typescript!./disabled/datepicker-disabled'),
-    markup: require('!!prismjs-loader?lang=markup!./disabled/datepicker-disabled.html')
+  'disabled': {
+    'code': require('!!prismjs-loader?lang=typescript!./disabled/datepicker-disabled'),
+    'markup': require('!!prismjs-loader?lang=markup!./disabled/datepicker-disabled.html')
   },
-  i18n: {
-    code: require('!!prismjs-loader?lang=typescript!./i18n/datepicker-i18n'),
-    markup: require('!!prismjs-loader?lang=markup!./i18n/datepicker-i18n.html')
+  'i18n': {
+    'code': require('!!prismjs-loader?lang=typescript!./i18n/datepicker-i18n'),
+    'markup': require('!!prismjs-loader?lang=markup!./i18n/datepicker-i18n.html')
   },
-  customday: {
-    code: require('!!prismjs-loader?lang=typescript!./customday/datepicker-customday'),
-    markup: require('!!prismjs-loader?lang=markup!./customday/datepicker-customday.html')
+  'customday': {
+    'code': require('!!prismjs-loader?lang=typescript!./customday/datepicker-customday'),
+    'markup': require('!!prismjs-loader?lang=markup!./customday/datepicker-customday.html')
   },
-  multiple: {
-    code: require('!!prismjs-loader?lang=typescript!./multiple/datepicker-multiple'),
-    markup: require('!!prismjs-loader?lang=markup!./multiple/datepicker-multiple.html')
+  'multiple': {
+    'code': require('!!prismjs-loader?lang=typescript!./multiple/datepicker-multiple'),
+    'markup': require('!!prismjs-loader?lang=markup!./multiple/datepicker-multiple.html')
   },
-  calendars: {
-    code: require('!!prismjs-loader?lang=typescript!./calendars/datepicker-calendars'),
-    markup: require('!!prismjs-loader?lang=markup!./calendars/datepicker-calendars.html')
+  'calendars': {
+  'code': require('!!prismjs-loader?lang=typescript!./calendars/datepicker-calendars'),
+    'markup': require('!!prismjs-loader?lang=markup!./calendars/datepicker-calendars.html')
   },
-  config: {
-    code: require('!!prismjs-loader?lang=typescript!./config/datepicker-config'),
-    markup: require('!!prismjs-loader?lang=markup!./config/datepicker-config.html')
+  'config': {
+    'code': require('!!prismjs-loader?lang=typescript!./config/datepicker-config'),
+    'markup': require('!!prismjs-loader?lang=markup!./config/datepicker-config.html')
   }
 };

--- a/demo/src/app/components/pagination/demos/index.ts
+++ b/demo/src/app/components/pagination/demos/index.ts
@@ -9,24 +9,24 @@ export const DEMO_DIRECTIVES = [
 ];
 
 export const DEMO_SNIPPETS = {
-  advanced: {
-    code: require('!!prismjs-loader?lang=typescript!./advanced/pagination-advanced'),
-    markup: require('!!prismjs-loader?lang=markup!./advanced/pagination-advanced.html')
+  'advanced': {
+    'code': require('!!prismjs-loader?lang=typescript!./advanced/pagination-advanced'),
+    'markup': require('!!prismjs-loader?lang=markup!./advanced/pagination-advanced.html')
   },
-  basic: {
-    code: require('!!prismjs-loader?lang=typescript!./basic/pagination-basic'),
-    markup: require('!!prismjs-loader?lang=markup!./basic/pagination-basic.html')
+  'basic': {
+    'code': require('!!prismjs-loader?lang=typescript!./basic/pagination-basic'),
+    'markup': require('!!prismjs-loader?lang=markup!./basic/pagination-basic.html')
   },
-  size: {
-    code: require('!!prismjs-loader?lang=typescript!./size/pagination-size'),
-    markup: require('!!prismjs-loader?lang=markup!./size/pagination-size.html')
+  'size': {
+    'code': require('!!prismjs-loader?lang=typescript!./size/pagination-size'),
+    'markup': require('!!prismjs-loader?lang=markup!./size/pagination-size.html')
   },
-  disabled: {
-    code: require('!!prismjs-loader?lang=typescript!./disabled/pagination-disabled'),
-    markup: require('!!prismjs-loader?lang=markup!./disabled/pagination-disabled.html')
+  'disabled': {
+    'code': require('!!prismjs-loader?lang=typescript!./disabled/pagination-disabled'),
+    'markup': require('!!prismjs-loader?lang=markup!./disabled/pagination-disabled.html')
   },
-  config: {
-    code: require('!!prismjs-loader?lang=typescript!./config/pagination-config'),
-    markup: require('!!prismjs-loader?lang=markup!./config/pagination-config.html')
+  'config': {
+    'code': require('!!prismjs-loader?lang=typescript!./config/pagination-config'),
+    'markup': require('!!prismjs-loader?lang=markup!./config/pagination-config.html')
   }
 };

--- a/demo/src/app/components/popover/demos/index.ts
+++ b/demo/src/app/components/popover/demos/index.ts
@@ -17,32 +17,32 @@ export const DEMO_DIRECTIVES = [
 ];
 
 export const DEMO_SNIPPETS = {
-  basic: {
-    code: require('!!prismjs-loader?lang=typescript!./basic/popover-basic'),
-    markup: require('!!prismjs-loader?lang=markup!./basic/popover-basic.html')
+  'basic': {
+    'code': require('!!prismjs-loader?lang=typescript!./basic/popover-basic'),
+    'markup': require('!!prismjs-loader?lang=markup!./basic/popover-basic.html')
   },
-  tplcontent: {
-    code: require('!!prismjs-loader?lang=typescript!./tplcontent/popover-tplcontent'),
-    markup: require('!!prismjs-loader?lang=markup!./tplcontent/popover-tplcontent.html')
+  'tplcontent': {
+    'code': require('!!prismjs-loader?lang=typescript!./tplcontent/popover-tplcontent'),
+    'markup': require('!!prismjs-loader?lang=markup!./tplcontent/popover-tplcontent.html')
   },
-  triggers: {
-    code: require('!!prismjs-loader?lang=typescript!./triggers/popover-triggers'),
-    markup: require('!!prismjs-loader?lang=markup!./triggers/popover-triggers.html')
+  'triggers': {
+    'code': require('!!prismjs-loader?lang=typescript!./triggers/popover-triggers'),
+    'markup': require('!!prismjs-loader?lang=markup!./triggers/popover-triggers.html')
   },
-  tplwithcontext: {
-    code: require('!!prismjs-loader?lang=typescript!./tplwithcontext/popover-tplwithcontext'),
-    markup: require('!!prismjs-loader?lang=markup!./tplwithcontext/popover-tplwithcontext.html')
+  'tplwithcontext': {
+    'code': require('!!prismjs-loader?lang=typescript!./tplwithcontext/popover-tplwithcontext'),
+    'markup': require('!!prismjs-loader?lang=markup!./tplwithcontext/popover-tplwithcontext.html')
   },
-  visibility: {
-    code: require('!!prismjs-loader?lang=typescript!./visibility/popover-visibility'),
-    markup: require('!!prismjs-loader?lang=markup!./visibility/popover-visibility.html')
+  'visibility': {
+    'code': require('!!prismjs-loader?lang=typescript!./visibility/popover-visibility'),
+    'markup': require('!!prismjs-loader?lang=markup!./visibility/popover-visibility.html')
   },
-  container: {
-    code: require('!!prismjs-loader?lang=typescript!./container/popover-container'),
-    markup: require('!!prismjs-loader?lang=markup!./container/popover-container.html')
+  'container': {
+    'code': require('!!prismjs-loader?lang=typescript!./container/popover-container'),
+    'markup': require('!!prismjs-loader?lang=markup!./container/popover-container.html')
   },
-  config: {
-    code: require('!!prismjs-loader?lang=typescript!./config/popover-config'),
-    markup: require('!!prismjs-loader?lang=markup!./config/popover-config.html')
+  'config': {
+    'code': require('!!prismjs-loader?lang=typescript!./config/popover-config'),
+    'markup': require('!!prismjs-loader?lang=markup!./config/popover-config.html')
   }
 };

--- a/demo/src/app/components/progressbar/demos/index.ts
+++ b/demo/src/app/components/progressbar/demos/index.ts
@@ -13,19 +13,19 @@ export const DEMO_DIRECTIVES = [
 ];
 
 export const DEMO_SNIPPETS = {
-  basic: {
-    code: require('!!prismjs-loader?lang=typescript!./basic/progressbar-basic'),
-    markup: require('!!prismjs-loader?lang=markup!./basic/progressbar-basic.html')},
-  showvalue: {
-    code: require('!!prismjs-loader?lang=typescript!./showvalue/progressbar-showvalue'),
-    markup: require('!!prismjs-loader?lang=markup!./showvalue/progressbar-showvalue.html')},
-  striped: {
-    code: require('!!prismjs-loader?lang=typescript!./striped/progressbar-striped'),
-    markup: require('!!prismjs-loader?lang=markup!./striped/progressbar-striped.html')},
-  labels: {
-    code: require('!!prismjs-loader?lang=typescript!./labels/progressbar-labels'),
-    markup: require('!!prismjs-loader?lang=markup!./labels/progressbar-labels.html')},
-  config: {
-    code: require('!!prismjs-loader?lang=typescript!./config/progressbar-config'),
-    markup: require('!!prismjs-loader?lang=markup!./config/progressbar-config.html')}
+  'basic': {
+    'code': require('!!prismjs-loader?lang=typescript!./basic/progressbar-basic'),
+    'markup': require('!!prismjs-loader?lang=markup!./basic/progressbar-basic.html')},
+  'showvalue': {
+    'code': require('!!prismjs-loader?lang=typescript!./showvalue/progressbar-showvalue'),
+    'markup': require('!!prismjs-loader?lang=markup!./showvalue/progressbar-showvalue.html')},
+  'striped': {
+    'code': require('!!prismjs-loader?lang=typescript!./striped/progressbar-striped'),
+    'markup': require('!!prismjs-loader?lang=markup!./striped/progressbar-striped.html')},
+  'labels': {
+    'code': require('!!prismjs-loader?lang=typescript!./labels/progressbar-labels'),
+    'markup': require('!!prismjs-loader?lang=markup!./labels/progressbar-labels.html')},
+  'config': {
+    'code': require('!!prismjs-loader?lang=typescript!./config/progressbar-config'),
+    'markup': require('!!prismjs-loader?lang=markup!./config/progressbar-config.html')}
 };

--- a/demo/src/app/components/rating/demos/index.ts
+++ b/demo/src/app/components/rating/demos/index.ts
@@ -9,28 +9,28 @@ export const DEMO_DIRECTIVES = [NgbdRatingBasic, NgbdRatingConfig,
   NgbdRatingTemplate, NgbdRatingEvents, NgbdRatingDecimal, NgbdRatingForm];
 
 export const DEMO_SNIPPETS = {
-  basic: {
-    code: require('!!prismjs-loader?lang=typescript!./basic/rating-basic'),
-    markup: require('!!prismjs-loader?lang=markup!./basic/rating-basic.html')
+  'basic': {
+    'code': require('!!prismjs-loader?lang=typescript!./basic/rating-basic'),
+    'markup': require('!!prismjs-loader?lang=markup!./basic/rating-basic.html')
   },
-  events: {
-    code: require('!!prismjs-loader?lang=typescript!./events/rating-events'),
-    markup: require('!!prismjs-loader?lang=markup!./events/rating-events.html')
+  'events': {
+    'code': require('!!prismjs-loader?lang=typescript!./events/rating-events'),
+    'markup': require('!!prismjs-loader?lang=markup!./events/rating-events.html')
   },
-  template: {
-    code: require('!!prismjs-loader?lang=typescript!./template/rating-template'),
-    markup: require('!!prismjs-loader?lang=markup!./template/rating-template.html')
+  'template': {
+    'code': require('!!prismjs-loader?lang=typescript!./template/rating-template'),
+    'markup': require('!!prismjs-loader?lang=markup!./template/rating-template.html')
   },
-  decimal: {
-    code: require('!!prismjs-loader?lang=typescript!./decimal/rating-decimal'),
-    markup: require('!!prismjs-loader?lang=markup!./decimal/rating-decimal.html')
+  'decimal': {
+    'code': require('!!prismjs-loader?lang=typescript!./decimal/rating-decimal'),
+    'markup': require('!!prismjs-loader?lang=markup!./decimal/rating-decimal.html')
   },
-  form: {
-    code: require('!!prismjs-loader?lang=typescript!./form/rating-form'),
-    markup: require('!!prismjs-loader?lang=markup!./form/rating-form.html')
+  'form': {
+    'code': require('!!prismjs-loader?lang=typescript!./form/rating-form'),
+    'markup': require('!!prismjs-loader?lang=markup!./form/rating-form.html')
   },
-  config: {
-    code: require('!!prismjs-loader?lang=typescript!./config/rating-config'),
-    markup: require('!!prismjs-loader?lang=markup!./config/rating-config.html')
+  'config': {
+    'code': require('!!prismjs-loader?lang=typescript!./config/rating-config'),
+    'markup': require('!!prismjs-loader?lang=markup!./config/rating-config.html')
   }
 };

--- a/demo/src/app/components/shared/api-docs/api-docs.model.ts
+++ b/demo/src/app/components/shared/api-docs/api-docs.model.ts
@@ -37,6 +37,6 @@ export interface InputDesc extends PropertyDesc {}
 export interface OutputDesc extends PropertyDesc {}
 
 export function signature(method: MethodDesc): string {
-  const args = method.args.map(arg => `${arg.name}: ${arg.type}`).join(', ');
+  const args = method['args'].map(arg => `${arg.name}: ${arg.type}`).join(', ');
   return `${method.name}(${args})`;
 }

--- a/demo/src/app/components/shared/example-box/example-box.component.html
+++ b/demo/src/app/components/shared/example-box/example-box.component.html
@@ -17,12 +17,12 @@
       <ngb-tabset>
         <ngb-tab title="html">
           <ng-template ngbTabContent>
-            <pre class="language-html"><code class="language-html" [innerHTML]="snippets[demo].markup"></code></pre>
+            <pre class="language-html"><code class="language-html" [innerHTML]="snippets[demo]['markup']"></code></pre>
           </ng-template>
         </ngb-tab>
         <ngb-tab title="typescript">
           <ng-template ngbTabContent>
-            <pre class="language-typescript"><code class="language-typescript" [innerHTML]="snippets[demo].code"></code></pre>
+            <pre class="language-typescript"><code class="language-typescript" [innerHTML]="snippets[demo]['code']"></code></pre>
           </ng-template>
         </ngb-tab>
       </ngb-tabset>

--- a/demo/src/app/components/tabset/demos/index.ts
+++ b/demo/src/app/components/tabset/demos/index.ts
@@ -8,24 +8,24 @@ export const DEMO_DIRECTIVES =
     [NgbdTabsetBasic, NgbdTabsetPills, NgbdTabsetPreventchange, NgbdTabsetSelectbyid, NgbdTabsetConfig];
 
 export const DEMO_SNIPPETS = {
-  basic: {
-    code: require('!!prismjs-loader?lang=typescript!./basic/tabset-basic'),
-    markup: require('!!prismjs-loader?lang=markup!./basic/tabset-basic.html')
+  'basic': {
+    'code': require('!!prismjs-loader?lang=typescript!./basic/tabset-basic'),
+    'markup': require('!!prismjs-loader?lang=markup!./basic/tabset-basic.html')
   },
-  pills: {
-    code: require('!!prismjs-loader?lang=typescript!./pills/tabset-pills'),
-    markup: require('!!prismjs-loader?lang=markup!./pills/tabset-pills.html')
+  'pills': {
+    'code': require('!!prismjs-loader?lang=typescript!./pills/tabset-pills'),
+    'markup': require('!!prismjs-loader?lang=markup!./pills/tabset-pills.html')
   },
-  preventchange: {
-    code: require('!!prismjs-loader?lang=typescript!./preventchange/tabset-preventchange'),
-    markup: require('!!prismjs-loader?lang=markup!./preventchange/tabset-preventchange.html')
+  'preventchange': {
+    'code': require('!!prismjs-loader?lang=typescript!./preventchange/tabset-preventchange'),
+    'markup': require('!!prismjs-loader?lang=markup!./preventchange/tabset-preventchange.html')
   },
-  selectbyid: {
-    code: require('!!prismjs-loader?lang=typescript!./selectbyid/tabset-selectbyid'),
-    markup: require('!!prismjs-loader?lang=markup!./selectbyid/tabset-selectbyid.html')
+  'selectbyid': {
+    'code': require('!!prismjs-loader?lang=typescript!./selectbyid/tabset-selectbyid'),
+    'markup': require('!!prismjs-loader?lang=markup!./selectbyid/tabset-selectbyid.html')
   },
-  config: {
-    code: require('!!prismjs-loader?lang=typescript!./config/tabset-config'),
-    markup: require('!!prismjs-loader?lang=markup!./config/tabset-config.html')
+  'config': {
+    'code': require('!!prismjs-loader?lang=typescript!./config/tabset-config'),
+    'markup': require('!!prismjs-loader?lang=markup!./config/tabset-config.html')
   }
 };

--- a/demo/src/app/components/timepicker/demos/index.ts
+++ b/demo/src/app/components/timepicker/demos/index.ts
@@ -12,32 +12,32 @@ export const DEMO_DIRECTIVES = [
 ];
 
 export const DEMO_SNIPPETS = {
-  basic: {
-    code: require('!!prismjs-loader?lang=typescript!./basic/timepicker-basic'),
-    markup: require('!!prismjs-loader?lang=markup!./basic/timepicker-basic.html')
+  'basic': {
+    'code': require('!!prismjs-loader?lang=typescript!./basic/timepicker-basic'),
+    'markup': require('!!prismjs-loader?lang=markup!./basic/timepicker-basic.html')
   },
-  meridian: {
-    code: require('!!prismjs-loader?lang=typescript!./meridian/timepicker-meridian'),
-    markup: require('!!prismjs-loader?lang=markup!./meridian/timepicker-meridian.html')
+  'meridian': {
+    'code': require('!!prismjs-loader?lang=typescript!./meridian/timepicker-meridian'),
+    'markup': require('!!prismjs-loader?lang=markup!./meridian/timepicker-meridian.html')
   },
-  seconds: {
-    code: require('!!prismjs-loader?lang=typescript!./seconds/timepicker-seconds'),
-    markup: require('!!prismjs-loader?lang=markup!./seconds/timepicker-seconds.html')
+  'seconds': {
+    'code': require('!!prismjs-loader?lang=typescript!./seconds/timepicker-seconds'),
+    'markup': require('!!prismjs-loader?lang=markup!./seconds/timepicker-seconds.html')
   },
-  spinners: {
-    code: require('!!prismjs-loader?lang=typescript!./spinners/timepicker-spinners'),
-    markup: require('!!prismjs-loader?lang=markup!./spinners/timepicker-spinners.html')
+  'spinners': {
+    'code': require('!!prismjs-loader?lang=typescript!./spinners/timepicker-spinners'),
+    'markup': require('!!prismjs-loader?lang=markup!./spinners/timepicker-spinners.html')
   },
-  steps: {
-    code: require('!!prismjs-loader?lang=typescript!./steps/timepicker-steps'),
-    markup: require('!!prismjs-loader?lang=markup!./steps/timepicker-steps.html')
+  'steps': {
+    'code': require('!!prismjs-loader?lang=typescript!./steps/timepicker-steps'),
+    'markup': require('!!prismjs-loader?lang=markup!./steps/timepicker-steps.html')
   },
-  validation: {
-    code: require('!!prismjs-loader?lang=typescript!./validation/timepicker-validation'),
-    markup: require('!!prismjs-loader?lang=markup!./validation/timepicker-validation.html')
+  'validation': {
+    'code': require('!!prismjs-loader?lang=typescript!./validation/timepicker-validation'),
+    'markup': require('!!prismjs-loader?lang=markup!./validation/timepicker-validation.html')
   },
-  config: {
-    code: require('!!prismjs-loader?lang=typescript!./config/timepicker-config'),
-    markup: require('!!prismjs-loader?lang=markup!./config/timepicker-config.html')
+  'config': {
+    'code': require('!!prismjs-loader?lang=typescript!./config/timepicker-config'),
+    'markup': require('!!prismjs-loader?lang=markup!./config/timepicker-config.html')
   }
 };

--- a/demo/src/app/components/tooltip/demos/index.ts
+++ b/demo/src/app/components/tooltip/demos/index.ts
@@ -15,28 +15,28 @@ export const DEMO_DIRECTIVES = [
 ];
 
 export const DEMO_SNIPPETS = {
-  basic: {
-    code: require('!!prismjs-loader?lang=typescript!./basic/tooltip-basic'),
-    markup: require('!!prismjs-loader?lang=markup!./basic/tooltip-basic.html')
+  'basic': {
+    'code': require('!!prismjs-loader?lang=typescript!./basic/tooltip-basic'),
+    'markup': require('!!prismjs-loader?lang=markup!./basic/tooltip-basic.html')
   },
-  container: {
-    code: require('!!prismjs-loader?lang=typescript!./container/tooltip-container'),
-    markup: require('!!prismjs-loader?lang=markup!./container/tooltip-container.html')
+  'container': {
+    'code': require('!!prismjs-loader?lang=typescript!./container/tooltip-container'),
+    'markup': require('!!prismjs-loader?lang=markup!./container/tooltip-container.html')
   },
-  tplcontent: {
-    code: require('!!prismjs-loader?lang=typescript!./tplcontent/tooltip-tplcontent'),
-    markup: require('!!prismjs-loader?lang=markup!./tplcontent/tooltip-tplcontent.html')
+  'tplcontent': {
+    'code': require('!!prismjs-loader?lang=typescript!./tplcontent/tooltip-tplcontent'),
+    'markup': require('!!prismjs-loader?lang=markup!./tplcontent/tooltip-tplcontent.html')
   },
-  triggers: {
-    code: require('!!prismjs-loader?lang=typescript!./triggers/tooltip-triggers'),
-    markup: require('!!prismjs-loader?lang=markup!./triggers/tooltip-triggers.html')
+  'triggers': {
+    'code': require('!!prismjs-loader?lang=typescript!./triggers/tooltip-triggers'),
+    'markup': require('!!prismjs-loader?lang=markup!./triggers/tooltip-triggers.html')
   },
-  tplwithcontext: {
-    code: require('!!prismjs-loader?lang=typescript!./tplwithcontext/tooltip-tplwithcontext'),
-    markup: require('!!prismjs-loader?lang=markup!./tplwithcontext/tooltip-tplwithcontext.html')
+  'tplwithcontext': {
+    'code': require('!!prismjs-loader?lang=typescript!./tplwithcontext/tooltip-tplwithcontext'),
+    'markup': require('!!prismjs-loader?lang=markup!./tplwithcontext/tooltip-tplwithcontext.html')
   },
-  config: {
-    code: require('!!prismjs-loader?lang=typescript!./config/tooltip-config'),
-    markup: require('!!prismjs-loader?lang=markup!./config/tooltip-config.html')
+  'config': {
+    'code': require('!!prismjs-loader?lang=typescript!./config/tooltip-config'),
+    'markup': require('!!prismjs-loader?lang=markup!./config/tooltip-config.html')
   }
 };

--- a/demo/src/app/components/typeahead/demos/basic/typeahead-basic.ts
+++ b/demo/src/app/components/typeahead/demos/basic/typeahead-basic.ts
@@ -1,8 +1,8 @@
 import {Component} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/debounceTime';
-import 'rxjs/add/operator/distinctUntilChanged';
+import {map} from 'rxjs/operator/map';
+import {debounceTime} from 'rxjs/operator/debounceTime';
+import {distinctUntilChanged} from 'rxjs/operator/distinctUntilChanged';
 
 const states = ['Alabama', 'Alaska', 'American Samoa', 'Arizona', 'Arkansas', 'California', 'Colorado',
   'Connecticut', 'Delaware', 'District Of Columbia', 'Federated States Of Micronesia', 'Florida', 'Georgia',
@@ -22,10 +22,6 @@ export class NgbdTypeaheadBasic {
   public model: any;
 
   search = (text$: Observable<string>) =>
-    text$
-      .debounceTime(200)
-      .distinctUntilChanged()
-      .map(term => term.length < 2 ? []
-        : states.filter(v => v.toLowerCase().indexOf(term.toLowerCase()) > -1).slice(0, 10));
-
+    map.call(distinctUntilChanged.call(debounceTime.call(text$, 200)),
+      term => term.length < 2 ? [] : states.filter(v => v.toLowerCase().indexOf(term.toLowerCase()) > -1).slice(0, 10));
 }

--- a/demo/src/app/components/typeahead/demos/config/typeahead-config.ts
+++ b/demo/src/app/components/typeahead/demos/config/typeahead-config.ts
@@ -1,9 +1,9 @@
 import {Component} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
 import {NgbTypeaheadConfig} from '@ng-bootstrap/ng-bootstrap';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/debounceTime';
-import 'rxjs/add/operator/distinctUntilChanged';
+import {map} from 'rxjs/operator/map';
+import {debounceTime} from 'rxjs/operator/debounceTime';
+import {distinctUntilChanged} from 'rxjs/operator/distinctUntilChanged';
 
 const states = ['Alabama', 'Alaska', 'American Samoa', 'Arizona', 'Arkansas', 'California', 'Colorado',
   'Connecticut', 'Delaware', 'District Of Columbia', 'Federated States Of Micronesia', 'Florida', 'Georgia',
@@ -29,9 +29,6 @@ export class NgbdTypeaheadConfig {
   }
 
   search = (text$: Observable<string>) =>
-    text$
-      .debounceTime(200)
-      .distinctUntilChanged()
-      .map(term => term.length < 2 ? []
-        : states.filter(v => v.toLowerCase().startsWith(term.toLocaleLowerCase())).splice(0, 10));
+    map.call(distinctUntilChanged.call(debounceTime.call(text$, 200)),
+      term => term.length < 2 ? [] : states.filter(v => v.toLowerCase().startsWith(term.toLocaleLowerCase())).splice(0, 10));
 }

--- a/demo/src/app/components/typeahead/demos/format/typeahead-format.ts
+++ b/demo/src/app/components/typeahead/demos/format/typeahead-format.ts
@@ -1,8 +1,8 @@
 import {Component} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/debounceTime';
-import 'rxjs/add/operator/distinctUntilChanged';
+import {map} from 'rxjs/operator/map';
+import {debounceTime} from 'rxjs/operator/debounceTime';
+import {distinctUntilChanged} from 'rxjs/operator/distinctUntilChanged';
 
 const states = ['Alabama', 'Alaska', 'American Samoa', 'Arizona', 'Arkansas', 'California', 'Colorado',
   'Connecticut', 'Delaware', 'District Of Columbia', 'Federated States Of Micronesia', 'Florida', 'Georgia',
@@ -24,10 +24,6 @@ export class NgbdTypeaheadFormat {
   formatter = (result: string) => result.toUpperCase();
 
   search = (text$: Observable<string>) =>
-    text$
-      .debounceTime(200)
-      .distinctUntilChanged()
-      .map(term => term === '' ? []
-        : states.filter(v => v.toLowerCase().indexOf(term.toLowerCase()) > -1).slice(0, 10));
-
+    map.call(distinctUntilChanged.call(debounceTime.call(text$, 200)),
+      term => term === '' ? [] : states.filter(v => v.toLowerCase().indexOf(term.toLowerCase()) > -1).slice(0, 10));
 }

--- a/demo/src/app/components/typeahead/demos/index.ts
+++ b/demo/src/app/components/typeahead/demos/index.ts
@@ -8,24 +8,24 @@ export const DEMO_DIRECTIVES =
     [NgbdTypeaheadFormat, NgbdTypeaheadHttp, NgbdTypeaheadBasic, NgbdTypeaheadTemplate, NgbdTypeaheadConfig];
 
 export const DEMO_SNIPPETS = {
-  basic: {
-    code: require('!!prismjs-loader?lang=typescript!./basic/typeahead-basic'),
-    markup: require('!!prismjs-loader?lang=markup!./basic/typeahead-basic.html')
+  'basic': {
+    'code': require('!!prismjs-loader?lang=typescript!./basic/typeahead-basic'),
+    'markup': require('!!prismjs-loader?lang=markup!./basic/typeahead-basic.html')
   },
-  format: {
-    code: require('!!prismjs-loader?lang=typescript!./format/typeahead-format'),
-    markup: require('!!prismjs-loader?lang=markup!./format/typeahead-format.html')
+  'format': {
+    'code': require('!!prismjs-loader?lang=typescript!./format/typeahead-format'),
+    'markup': require('!!prismjs-loader?lang=markup!./format/typeahead-format.html')
   },
-  http: {
-    code: require('!!prismjs-loader?lang=typescript!./http/typeahead-http'),
-    markup: require('!!prismjs-loader?lang=markup!./http/typeahead-http.html')
+  'http': {
+    'code': require('!!prismjs-loader?lang=typescript!./http/typeahead-http'),
+    'markup': require('!!prismjs-loader?lang=markup!./http/typeahead-http.html')
   },
-  template: {
-    code: require('!!prismjs-loader?lang=typescript!./template/typeahead-template'),
-    markup: require('!!prismjs-loader?lang=markup!./template/typeahead-template.html')
+  'template': {
+    'code': require('!!prismjs-loader?lang=typescript!./template/typeahead-template'),
+    'markup': require('!!prismjs-loader?lang=markup!./template/typeahead-template.html')
   },
-  config: {
-    code: require('!!prismjs-loader?lang=typescript!./config/typeahead-config'),
-    markup: require('!!prismjs-loader?lang=markup!./config/typeahead-config.html')
+  'config': {
+    'code': require('!!prismjs-loader?lang=typescript!./config/typeahead-config'),
+    'markup': require('!!prismjs-loader?lang=markup!./config/typeahead-config.html')
   }
 };

--- a/demo/src/app/components/typeahead/demos/template/typeahead-template.html
+++ b/demo/src/app/components/typeahead/demos/template/typeahead-template.html
@@ -1,7 +1,7 @@
 <p>A typeahead example that uses custom template for results display and uses object as a model</p>
 
 <ng-template #rt let-r="result" let-t="term">
-  <img [src]="'https://upload.wikimedia.org/wikipedia/commons/thumb/' + r.flag" width="16">
+  <img [src]="'https://upload.wikimedia.org/wikipedia/commons/thumb/' + r['flag']" width="16">
   {{ r.name}}
 </ng-template>
 

--- a/demo/src/app/components/typeahead/demos/template/typeahead-template.ts
+++ b/demo/src/app/components/typeahead/demos/template/typeahead-template.ts
@@ -1,7 +1,7 @@
 import {Component} from '@angular/core';
 import {Observable} from 'rxjs/Observable';
-import 'rxjs/add/operator/debounceTime';
-import 'rxjs/add/operator/map';
+import {map} from 'rxjs/operator/map';
+import {debounceTime} from 'rxjs/operator/debounceTime';
 
 const statesWithFlags = [
   {'name': 'Alabama', 'flag': '5/5c/Flag_of_Alabama.svg/45px-Flag_of_Alabama.svg.png'},
@@ -68,10 +68,8 @@ export class NgbdTypeaheadTemplate {
   public model: any;
 
   search = (text$: Observable<string>) =>
-    text$
-      .debounceTime(200)
-      .map(term => term === '' ? []
-        : statesWithFlags.filter(v => v.name.toLowerCase().indexOf(term.toLowerCase()) > -1).slice(0, 10));
+    map.call(debounceTime.call(text$, 200),
+      term => term === '' ? [] : statesWithFlags.filter(v => v.name.toLowerCase().indexOf(term.toLowerCase()) > -1).slice(0, 10));
 
   formatter = (x: {name: string}) => x.name;
 

--- a/demo/src/app/shared/analytics/analytics.ts
+++ b/demo/src/app/shared/analytics/analytics.ts
@@ -2,7 +2,7 @@ import {Injectable} from '@angular/core';
 import {Router, NavigationEnd} from '@angular/router';
 import {Location} from '@angular/common';
 
-import 'rxjs/add/operator/filter';
+import {filter} from 'rxjs/operator/filter';
 
 declare const ga: any;
 
@@ -24,9 +24,10 @@ export class Analytics {
    */
   trackPageViews() {
     if (this._enabled) {
-      this._router.events.filter((event) => event instanceof NavigationEnd).subscribe(() => {
-        ga('send', {hitType: 'pageview', page: this._location.path()});
-      });
+      filter.call(this._router.events, (event) => event instanceof NavigationEnd)
+        .subscribe(() => {
+          ga('send', {hitType: 'pageview', page: this._location.path()});
+        });
     }
   }
 

--- a/src/datepicker/datepicker-month-view.ts
+++ b/src/datepicker/datepicker-month-view.ts
@@ -36,10 +36,7 @@ import {DayTemplateContext} from './datepicker-day-template-context';
          [class.hidden]="isHidden(day)">
           <ng-template [ngIf]="!isHidden(day)">
             <ng-template [ngTemplateOutlet]="dayTemplate"
-            [ngOutletContext]="{date: {year: day.date.year, month: day.date.month, day: day.date.day},
-              currentMonth: month.number,
-              disabled: isDisabled(day),
-              selected: isSelected(day.date)}">
+            [ngOutletContext]="_getDayContext(day, month)">
             </ng-template>
           </ng-template>
         </div>
@@ -64,6 +61,15 @@ export class NgbDatepickerMonthView {
     if (!this.isDisabled(day) && !this.isHidden(day)) {
       this.select.emit(NgbDate.from(day.date));
     }
+  }
+
+  _getDayContext(day: any, month: any) {
+    return {
+      date: {year: day.date.year, month: day.date.month, day: day.date.day},
+      currentMonth: month.number,
+      disabled: this.isDisabled(day),
+      selected: this.isSelected(day.date)
+    };
   }
 
   isDisabled(day: DayViewModel) { return this.disabled || day.disabled; }

--- a/src/typeahead/typeahead-window.ts
+++ b/src/typeahead/typeahead-window.ts
@@ -32,7 +32,7 @@ export interface ResultTemplateContext {
         (mouseenter)="markActive(idx)"
         (click)="select(result)">
           <ng-template [ngTemplateOutlet]="resultTemplate || rt"
-          [ngOutletContext]="{result: result, term: term, formatter: formatter}"></ng-template>
+          [ngOutletContext]="_getResultContext(result)"></ng-template>
       </button>
     </ng-template>
   `
@@ -78,6 +78,8 @@ export class NgbTypeaheadWindow implements OnInit {
   @Output('select') selectEvent = new EventEmitter();
 
   @Output('activeChange') activeChangeEvent = new EventEmitter();
+
+  _getResultContext(result: any) { return {result: result, term: this.term, formatter: this.formatter}; }
 
   getActive() { return this.results[this.activeIdx]; }
 

--- a/src/util/positioning.ts
+++ b/src/util/positioning.ts
@@ -87,12 +87,12 @@ export class Positioning {
     const placementSecondary = placement.split('-')[1] || 'center';
 
     let targetElPosition: ClientRect = {
-      height: targetElBCR.height || targetElement.offsetHeight,
-      width: targetElBCR.width || targetElement.offsetWidth,
-      top: 0,
-      bottom: targetElBCR.height || targetElement.offsetHeight,
-      left: 0,
-      right: targetElBCR.width || targetElement.offsetWidth
+      'height': targetElBCR.height || targetElement.offsetHeight,
+      'width': targetElBCR.width || targetElement.offsetWidth,
+      'top': 0,
+      'bottom': targetElBCR.height || targetElement.offsetHeight,
+      'left': 0,
+      'right': targetElBCR.width || targetElement.offsetWidth
     };
 
     switch (placementPrimary) {

--- a/src/util/triggers.ts
+++ b/src/util/triggers.ts
@@ -9,7 +9,7 @@ export class Trigger {
 }
 
 const DEFAULT_ALIASES = {
-  hover: ['mouseenter', 'mouseleave']
+  'hover': ['mouseenter', 'mouseleave']
 };
 
 export function parseTriggers(triggers: string, aliases = DEFAULT_ALIASES): Trigger[] {


### PR DESCRIPTION
This PR adds support for building ng-bootstrap with closure-compiler, both the library and the demo.
The changes are about properties access and RxJS imports.

See https://github.com/mlaval/ng-bootstrap-closure-compiler to build the full demo with closure-compiler