### PR TITLE
Demo fragments processing using NavigationEnd router event

### DIFF
--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -1,3 +1,4 @@
+import {Router, NavigationEnd} from '@angular/router';
 import {Component, OnInit} from '@angular/core';
 import {Analytics} from './shared/analytics/analytics';
 import {componentsList} from './shared';
@@ -13,7 +14,18 @@ export class AppComponent implements OnInit {
 
   components = componentsList;
 
-  constructor(private _analytics: Analytics) {
+  constructor(private _analytics: Analytics, router: Router) {
+    router.events.subscribe(event => {
+      if (event instanceof NavigationEnd) {
+        const { fragment } = router.parseUrl(router.url);
+        if (fragment) {
+          const element = document.querySelector(`#${fragment}`);
+          if (element) {
+            element.scrollIntoView();
+          }
+        }
+      }
+    });
   }
 
   ngOnInit(): void {

--- a/demo/src/app/components/shared/fragment/fragment.directive.ts
+++ b/demo/src/app/components/shared/fragment/fragment.directive.ts
@@ -1,39 +1,12 @@
-import { Subscription } from 'rxjs/Subscription';
-import { Directive, OnInit, AfterViewInit, OnDestroy, Input, Output, EventEmitter, ElementRef } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { Directive, Input } from '@angular/core';
 
 @Directive({
-  selector: 'a[ngbdFragment]',
+  selector: 'a[fragment]',
   host: {
-    '[class.fragment]': 'true'
+    '[class.fragment]': 'true',
+    '[attr.id]': 'fragment'
   }
 })
-export class NgbdFragment implements OnInit, OnDestroy {
+export class NgbdFragment {
   @Input() fragment: string;
-
-  private fragmentRouteSubscription: Subscription;
-
-  constructor(private route: ActivatedRoute, private elementRef: ElementRef) { }
-
-  ngOnInit() {
-    this.fragmentRouteSubscription = this.route.fragment.subscribe(f => {
-      if (f === this.fragment) {
-        this.scrollToFragment(f);
-      }
-    });
-  }
-
-  ngOnDestroy() {
-    if (this.fragmentRouteSubscription) {
-      this.fragmentRouteSubscription.unsubscribe();
-    }
-  }
-
-  /**
-   * Make the fragment scroll into view
-   * @param fragment name of the CSS id to scroll to
-   */
-  private scrollToFragment(fragment: string) {
-    this.elementRef.nativeElement.scrollIntoView(this.elementRef.nativeElement);
-  }
 }

--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -155,13 +155,14 @@ div.api-doc-component > h2 {
     text-decoration: none;
 
     & > .fragment {
-      display: inline-block;
+      opacity: 1;
     }
   }
 }
 
 a.fragment {
-  display: none;
+  opacity: 0;
+  transition: opacity 125ms ease;
   line-height: inherit;
   position: absolute;
   margin-left: -1.2em;


### PR DESCRIPTION
Each fragment url we use in the demo used to be relying on a `NgbdFragment` directive which is subscribing to the router's fragment observable for each instance.
I simply moved this logic to an high order component (`app.component.ts`) in which I just subscribe one time to the router's observable: `router.events`.
The directive still remains but is very simplistic, and just add an id on the host element that corresponds to the fragment name itself.

I also had to tweak a bit the corresponding css code to have them **not** to be using `display: none`