### PR TITLE
Update tabset.ts

### DIFF
--- a/src/tabset/tabset.ts
+++ b/src/tabset/tabset.ts
@@ -79,7 +79,9 @@ export interface NgbTabChangeEvent {
   selector: 'ngb-tabset',
   exportAs: 'ngbTabset',
   template: `
-    <ul [class]="'nav nav-' + type + (justify=='justified'?' nav-justified':'') + (justify=='fill'?' nav-fill':'') + ' justify-content-' + justify" role="tablist">
+    <ul [class]="'nav nav-' + type + (justify=='justified'?' nav-justified':'') 
+                                   + (justify=='fill'?' nav-fill':'') 
+                                   + ' justify-content-' + justify" role="tablist">
       <li class="nav-item" *ngFor="let tab of tabs">
         <a [id]="tab.id" class="nav-link" [class.active]="tab.id === activeId" [class.disabled]="tab.disabled"
           href (click)="!!select(tab.id)" role="tab" [attr.tabindex]="(tab.disabled ? '-1': undefined)"

--- a/src/tabset/tabset.ts
+++ b/src/tabset/tabset.ts
@@ -79,7 +79,7 @@ export interface NgbTabChangeEvent {
   selector: 'ngb-tabset',
   exportAs: 'ngbTabset',
   template: `
-    <ul [class]="'nav nav-' + type + ' justify-content-' + justify" role="tablist">
+    <ul [class]="'nav nav-' + type + (justify=='justified'?' nav-justified':'') + (justify=='fill'?' nav-fill':'') + ' justify-content-' + justify" role="tablist">
       <li class="nav-item" *ngFor="let tab of tabs">
         <a [id]="tab.id" class="nav-link" [class.active]="tab.id === activeId" [class.disabled]="tab.disabled"
           href (click)="!!select(tab.id)" role="tab" [attr.tabindex]="(tab.disabled ? '-1': undefined)"


### PR DESCRIPTION
Add "fill" and "justified" options to "justify" input of tabset.
Result : the .nav-fill or .nav-justified classes are added to the component.

To proportionately fill all available space with your .nav-items, use .nav-fill. Notice that all horizontal space is occupied, but not every nav item has the same width.  For equal-width elements, use .nav-justified. All horizontal space will be occupied by nav links, but unlike the .nav-fill above, every nav item will be the same width.

Before submitting a pull request, please make sure you have at least performed the following:

 - [] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [] built and tested the changes locally.
 - [] added/updated any applicable tests.
 - [] added/updated any applicable API documentation.
 - [] added/updated any applicable demos.
