### PR TITLE
feat(demo): Component page using a tabset

### DIFF
--- a/demo/src/app/app.routing.ts
+++ b/demo/src/app/app.routing.ts
@@ -21,27 +21,114 @@ import {
   NgbdTypeahead
 } from './components';
 
+const DEFAULT_API_PATH = {path: '', pathMatch: 'full', redirectTo: 'api'};
+
+const componentRoutes = [{
+    path: 'components/accordion',
+    children: [
+      DEFAULT_API_PATH,
+      {path: ':tab', component: NgbdAccordion}
+    ]
+  }, {
+    path: 'components/alert',
+    children: [
+      DEFAULT_API_PATH,
+      {path: ':tab', component: NgbdAlert}
+    ]
+  }, {
+    path: 'components/buttons',
+    children: [
+      DEFAULT_API_PATH,
+      {path: ':tab', component: NgbdButtons}
+    ]
+  }, {
+    path: 'components/carousel',
+    children: [
+      DEFAULT_API_PATH,
+      {path: ':tab', component: NgbdCarousel}
+    ]
+  }, {
+    path: 'components/collapse',
+    children: [
+      DEFAULT_API_PATH,
+      {path: ':tab', component: NgbdCollapse}
+    ]
+  }, {
+    path: 'components/datepicker',
+    children: [
+      DEFAULT_API_PATH,
+      {path: ':tab', component: NgbdDatepicker}
+    ]
+  }, {
+    path: 'components/dropdown',
+    children: [
+      DEFAULT_API_PATH,
+      {path: ':tab', component: NgbdDropdown}
+    ]
+  }, {
+    path: 'components/modal',
+    children: [
+      DEFAULT_API_PATH,
+      {path: ':tab', component: NgbdModal}
+    ]
+  }, {
+    path: 'components/pagination',
+    children: [
+      DEFAULT_API_PATH,
+      {path: ':tab', component: NgbdPagination}
+    ]
+  }, {
+    path: 'components/popover',
+    children: [
+      DEFAULT_API_PATH,
+      {path: ':tab', component: NgbdPopover}
+    ]
+  }, {
+    path: 'components/progressbar',
+    children: [
+      DEFAULT_API_PATH,
+      {path: ':tab', component: NgbdProgressbar}
+    ]
+  }, {
+    path: 'components/rating',
+    children: [
+      DEFAULT_API_PATH,
+      {path: ':tab', component: NgbdRating}
+    ]
+  }, {
+    path: 'components/tabs',
+    children: [
+      DEFAULT_API_PATH,
+      {path: ':tab', component: NgbdTabs}
+    ]
+  }, {
+    path: 'components/timepicker',
+    children: [
+      DEFAULT_API_PATH,
+      {path: ':tab', component: NgbdTimepicker}
+    ]
+  }, {
+    path: 'components/tooltip',
+    children: [
+      DEFAULT_API_PATH,
+      {path: ':tab', component: NgbdTooltip}
+    ]
+  }, {
+    path: 'components/typeahead',
+    children: [
+      DEFAULT_API_PATH,
+      {path: ':tab', component: NgbdTypeahead}
+    ]
+  }
+];
+
 const routes: Routes = [
   {path: '', pathMatch: 'full', redirectTo: 'home'},
   {path: 'home', component: DefaultComponent},
   {path: 'getting-started', component: GettingStarted},
-  {path: 'components', redirectTo: 'components/accordion'},
-  {path: 'components/accordion', component: NgbdAccordion},
-  {path: 'components/alert', component: NgbdAlert},
-  {path: 'components/buttons', component: NgbdButtons},
-  {path: 'components/carousel', component: NgbdCarousel},
-  {path: 'components/collapse', component: NgbdCollapse},
-  {path: 'components/datepicker', component: NgbdDatepicker},
-  {path: 'components/dropdown', component: NgbdDropdown},
-  {path: 'components/modal', component: NgbdModal},
-  {path: 'components/pagination', component: NgbdPagination},
-  {path: 'components/popover', component: NgbdPopover},
-  {path: 'components/progressbar', component: NgbdProgressbar},
-  {path: 'components/rating', component: NgbdRating},
-  {path: 'components/tabs', component: NgbdTabs},
-  {path: 'components/timepicker', component: NgbdTimepicker},
-  {path: 'components/tooltip', component: NgbdTooltip},
-  {path: 'components/typeahead', component: NgbdTypeahead}
+  {path: 'components', pathMatch: 'full', redirectTo: 'components/accordion' },
+  ...componentRoutes,
+  { path: '**', redirectTo: 'home' }
 ];
 
 export const routing: ModuleWithProviders = RouterModule.forRoot(routes, {useHash: true});

--- a/demo/src/app/getting-started/getting-started.component.html
+++ b/demo/src/app/getting-started/getting-started.component.html
@@ -1,4 +1,4 @@
-<ngbd-content-wrapper component="Getting Started">
+<ngbd-content-wrapper title="Getting Started">
   <h3>
     Dependencies
   </h3>

--- a/demo/src/app/shared/content-wrapper/content-wrapper.component.html
+++ b/demo/src/app/shared/content-wrapper/content-wrapper.component.html
@@ -1,12 +1,34 @@
 <div class="jumbotron">
   <div class="container">
-    <h1>{{ component }}</h1>
+    <h1>{{ title || component }}</h1>
   </div>
 </div>
 <div class="container">
   <div class="row">
     <div class="col-12 col-lg-9">
-      <ng-content></ng-content>
+      <ngb-tabset
+        class="root-nav"
+        *ngIf="component; else page"
+        (tabChange)="tabChange($event)"
+        [activeId]="activeTab"
+      >
+        <ngb-tab title="API" id="api">
+          <ng-template ngbTabContent>
+            <ng-content select="ngbd-api-docs"></ng-content>
+            <ng-content select="ngbd-api-docs-class"></ng-content>
+            <ng-content select="ngbd-api-docs-config"></ng-content>
+          </ng-template>
+        </ngb-tab>
+        <ngb-tab title="Examples" id="examples">
+          <ng-template ngbTabContent>
+            <ng-content select="ngbd-example-box"></ng-content>
+          </ng-template>
+        </ngb-tab>
+      </ngb-tabset>
+
+      <ng-template #page>
+        <ng-content></ng-content>
+      </ng-template>
     </div>
     <div class="col-12 col-lg-3 hidden-md-down">
       <ngbd-side-nav></ngbd-side-nav>

--- a/demo/src/app/shared/content-wrapper/content-wrapper.component.ts
+++ b/demo/src/app/shared/content-wrapper/content-wrapper.component.ts
@@ -1,16 +1,35 @@
 import {Component, Input, OnChanges} from '@angular/core';
+import {ActivatedRoute, Router} from '@angular/router';
+
+const DEFAULT_TAB = 'api';
+const VALID_TABS = [DEFAULT_TAB, 'examples'];
 
 @Component({
   selector: 'ngbd-content-wrapper',
   templateUrl: './content-wrapper.component.html'
 })
-export class ContentWrapper implements OnChanges {
+export class ContentWrapper {
+  @Input()
+  public title: string | false = false;
+
   @Input()
   public component: string;
 
-  ngOnChanges(changes) {
-    if (changes.component) {
+  public activeTab: string;
+
+  constructor(private route: ActivatedRoute, private router: Router) {
+    this.route.params.subscribe(params => {
+      const tab = params['tab'];
+      if (VALID_TABS.indexOf(tab) !== -1) {
+        this.activeTab = tab;
+      } else {
+        this.router.navigate(['..', DEFAULT_TAB], {relativeTo: this.route});
+      }
       document.body.scrollIntoView();
-    }
+    });
+  }
+
+  tabChange(event) {
+    this.router.navigate(['..', event.nextId], {relativeTo: this.route});
   }
 }

--- a/demo/src/app/shared/index.ts
+++ b/demo/src/app/shared/index.ts
@@ -13,7 +13,7 @@ import {Analytics} from './analytics/analytics';
 export {componentsList} from './side-nav/side-nav.component';
 
 @NgModule({
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, NgbModule],
   exports: [
     CommonModule,
     RouterModule,

--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -219,3 +219,29 @@ span.token.tag {
   font-size: 1em;
   padding: 0;
 }
+
+ngbd-content-wrapper {
+  .jumbotron {
+    border-radius: 0;
+  }
+}
+
+.root-nav {
+  $offset: 73px;
+  > .nav-tabs {
+    transform: translateY(-$offset);
+
+    .nav-link, .nav-link:not(.active):hover {
+      color: #f9f9f9;
+    }
+
+    .nav-link:not(.active):hover {
+      background-color: rgba(255,255,255, 0.15);
+      border-color: rgba(255,255,255, 0.15);
+    }
+  }
+
+  > .tab-content {
+    transform: translateY(-$offset / 2);
+  }
+}


### PR DESCRIPTION
The main idea behind is that it basically prevents the user to have to scroll down the entire page when you want just see a demo.

I updated the demo Component page to actually use a `nab-tabset` to separate *api* from *examples*.
The router part, and thus the url, is now reflecting this new level of indirection.

<img width="522" alt="screen shot 2017-06-29 at 16 26 37" src="https://user-images.githubusercontent.com/1152740/27692677-9e36c3c6-5ce7-11e7-8250-7b3bc0e6c4a7.png">

What do you think ?