### PR TITLE
feat(NgbTime): add compare methods

### DIFF
--- a/src/timepicker/ngb-time.spec.ts
+++ b/src/timepicker/ngb-time.spec.ts
@@ -219,4 +219,37 @@ describe('NgbTime', () => {
 
   it('should have a validity flag with optional seconds checking',
      () => { expect(new NgbTime(11, 0).isValid(false)).toBeTruthy(); });
+
+  it('should compare times, if seconds not specified in any compare only by hour and minutes', () => {
+    const t = new NgbTime(11, 15, 30);
+    expect(t.before(t)).toBeFalsy();
+    expect(t.after(t)).toBeFalsy();
+
+    expect(new NgbTime(11, 15, 31).after(t)).toBeTruthy();
+    expect(new NgbTime(11, 15, 29).after(t)).toBeFalsy();
+    expect(new NgbTime(11, 15, null).after(t)).toBeFalsy();
+    expect(new NgbTime(11, 16, null).after(t)).toBeTruthy();
+    expect(new NgbTime(11, 14, null).after(t)).toBeFalsy();
+    expect(new NgbTime(12, 0, null).after(t)).toBeTruthy();
+    expect(new NgbTime(10, 0, null).after(t)).toBeFalsy();
+
+    expect(new NgbTime(11, 15, 31).before(t)).toBeFalsy();
+    expect(new NgbTime(11, 15, 29).before(t)).toBeTruthy();
+    expect(new NgbTime(11, 15, null).before(t)).toBeFalsy();
+    expect(new NgbTime(11, 16, null).before(t)).toBeFalsy();
+    expect(new NgbTime(11, 14, null).before(t)).toBeTruthy();
+    expect(new NgbTime(12, 0, null).before(t)).toBeFalsy();
+    expect(new NgbTime(10, 0, null).before(t)).toBeTruthy();
+  });
+
+  it('should compare times only by hour and minutes', () => {
+    const t = new NgbTime(11, 15, 30);
+
+    expect(new NgbTime(11, 15, 31).after(t, false)).toBeFalsy();
+    expect(new NgbTime(11, 15, 29).after(t, false)).toBeFalsy();
+
+    expect(new NgbTime(11, 15, 31).before(t, false)).toBeFalsy();
+    expect(new NgbTime(11, 15, 29).before(t, false)).toBeFalsy();
+  });
+
 });

--- a/src/timepicker/ngb-time.ts
+++ b/src/timepicker/ngb-time.ts
@@ -48,4 +48,16 @@ export class NgbTime {
   }
 
   toString() { return `${this.hour || 0}:${this.minute || 0}:${this.second || 0}`; }
+
+  before(time: NgbTime, compareSecsIfSpecified = true) {
+    return this.hour < time.hour || (this.hour === time.hour && this.minute < time.minute) ||
+        (compareSecsIfSpecified && this.second && time.second && this.hour === time.hour &&
+         this.minute === time.minute && this.second < time.second);
+  }
+
+  after(time: NgbTime, compareSecsIfSpecified = true) {
+    return this.hour > time.hour || (this.hour === time.hour && this.minute > time.minute) ||
+        (compareSecsIfSpecified && this.second && time.second && this.hour === time.hour &&
+         this.minute === time.minute && this.second > time.second);
+  }
 }


### PR DESCRIPTION
Add 'before' and 'after' methods to NgbTime, that can be used to compare times. These methods can be used in a further implementation of time ranges, or in validation for other specific purposes.
There is not a way to compare Times on current NgbTime class.

Before submitting a pull request, please make sure you have at least performed the following:

 - [X] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [X] built and tested the changes locally.
 - [X] added/updated any applicable tests.
 - [X] added/updated any applicable API documentation.
 - [X] added/updated any applicable demos.
