### PR TITLE
fix(demo): reset scrollposition when navigating between component

### DIFF
--- a/demo/src/app/shared/content-wrapper/content-wrapper.component.ts
+++ b/demo/src/app/shared/content-wrapper/content-wrapper.component.ts
@@ -1,10 +1,16 @@
-import {Component, Input} from '@angular/core';
+import {Component, Input, OnChanges} from '@angular/core';
 
 @Component({
   selector: 'ngbd-content-wrapper',
   templateUrl: './content-wrapper.component.html'
 })
-export class ContentWrapper {
+export class ContentWrapper implements OnChanges {
   @Input()
   public component: string;
+
+  ngOnChanges(changes) {
+    if (changes.component) {
+      document.body.scrollIntoView();
+    }
+  }
 }


### PR DESCRIPTION
Fixing one of the most annoying bug to me of this demo site.

From a component demo page, when scrolling down, and clicking in the sidebar to navigate to another component, the scrollPos is now reset to the top of the page !

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
