### PR TITLE
feat(demo): components navigation sidebar is sticky

### DIFF
--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -70,7 +70,12 @@
 
 @media (min-width: 768px) {
   .bd-sidebar {
-    padding-left: 1rem
+    padding-left: 1rem;
+
+    display: inline-block;
+    position: -webkit-sticky;
+    position: sticky;
+    top: 1rem;
   }
 }
 


### PR DESCRIPTION
Simply implement sticky positioning using the corresponding CSS technique.
Supported almost in all recent browsers (appart IE and Edge).

So anywhere it is supported it makes the components browsing nice and user friendly, elsewhere it graceful degrades to not work 👍 

For information here is the [Can I Use](http://caniuse.com/#feat=css-sticky)

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.