### PR TITLE
feat(datepicker): using DatePipe for generating months and weekdays

### DIFF
--- a/demo/src/app/components/datepicker/demos/calendars/datepicker-calendars.ts
+++ b/demo/src/app/components/datepicker/demos/calendars/datepicker-calendars.ts
@@ -1,7 +1,7 @@
 import {Component, Injectable} from '@angular/core';
 import {NgbDateStruct, NgbCalendar, NgbCalendarIslamicCivil, NgbDatepickerI18n} from '@ng-bootstrap/ng-bootstrap';
 
-const WEEKDAYS_SHORT = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
+const WEEKDAYS_SHORT = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 const MONTHS_SHORT = ['Muh.', 'Saf.', 'Rab. I', 'Rab. II', 'Jum. I', 'Jum. II', 'Raj.', 'Sha.', 'Ram.', 'Shaw.', 'Dhuʻl-Q.', 'Dhuʻl-H.'];
 const MONTHS_FULL = [
   'Muharram', 'Safar', 'Rabiʻ I', 'Rabiʻ II', 'Jumada I', 'Jumada II', 'Rajab', 'Shaʻban', 'Ramadan', 'Shawwal', 'Dhuʻl-Qiʻdah',

--- a/demo/src/app/components/datepicker/demos/i18n/datepicker-i18n.ts
+++ b/demo/src/app/components/datepicker/demos/i18n/datepicker-i18n.ts
@@ -3,11 +3,11 @@ import {NgbDatepickerI18n} from '@ng-bootstrap/ng-bootstrap';
 
 const I18N_VALUES = {
   'en': {
-    weekdays: ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'],
+    weekdays: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
     months: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
   },
   'fr': {
-    weekdays: ['Lu', 'Ma', 'Me', 'Je', 'Ve', 'Sa', 'Di'],
+    weekdays: ['Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam', 'Dim'],
     months: ['Jan', 'Fév', 'Mar', 'Avr', 'Mai', 'Juin', 'Juil', 'Aou', 'Sep', 'Oct', 'Nov', 'Déc'],
   }
 };

--- a/src/datepicker/datepicker-i18n.spec.ts
+++ b/src/datepicker/datepicker-i18n.spec.ts
@@ -2,7 +2,7 @@ import {NgbDatepickerI18nDefault} from './datepicker-i18n';
 
 describe('ngb-datepicker-i18n-default', () => {
 
-  const i18n = new NgbDatepickerI18nDefault();
+  const i18n = new NgbDatepickerI18nDefault('en-US');
 
   it('should return abbreviated month name', () => {
     expect(i18n.getMonthShortName(0)).toBe(undefined);
@@ -20,8 +20,8 @@ describe('ngb-datepicker-i18n-default', () => {
 
   it('should return weekday name', () => {
     expect(i18n.getWeekdayShortName(0)).toBe(undefined);
-    expect(i18n.getWeekdayShortName(1)).toBe('Mo');
-    expect(i18n.getWeekdayShortName(7)).toBe('Su');
+    expect(i18n.getWeekdayShortName(1)).toBe('Mon');
+    expect(i18n.getWeekdayShortName(7)).toBe('Sun');
     expect(i18n.getWeekdayShortName(8)).toBe(undefined);
   });
 

--- a/src/datepicker/datepicker-i18n.ts
+++ b/src/datepicker/datepicker-i18n.ts
@@ -1,14 +1,12 @@
-import {Injectable} from '@angular/core';
-
-const WEEKDAYS_SHORT = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
-const MONTHS_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-const MONTHS_FULL = [
-  'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November',
-  'December'
-];
+import {Injectable, Inject, LOCALE_ID} from '@angular/core';
+import {DatePipe} from '@angular/common';
 
 /**
- * Type of the service supplying month and weekday names to to NgbDatepicker component.
+ * NgbDatePicker automatically translates the days of week and months using the Date pipe of Angular,
+ * using the locale specified with LOCALE_ID.
+ *
+ * If you want to customize the translations you can use this service,
+ * supplying month and weekday names to to NgbDatepicker component.
  * See the i18n demo for how to extend this class and define a custom provider for i18n.
  */
 @Injectable()
@@ -34,9 +32,35 @@ export abstract class NgbDatepickerI18n {
 
 @Injectable()
 export class NgbDatepickerI18nDefault extends NgbDatepickerI18n {
-  getWeekdayShortName(weekday: number): string { return WEEKDAYS_SHORT[weekday - 1]; }
+  private _datePipe: DatePipe;
 
-  getMonthShortName(month: number): string { return MONTHS_SHORT[month - 1]; }
+  private _weekDays = new Array<string>(7);
 
-  getMonthFullName(month: number): string { return MONTHS_FULL[month - 1]; }
+  private _months = new Array<string>(12);
+
+  private _shortMonths = new Array<string>(12);
+
+  constructor(@Inject(LOCALE_ID) locale: string) {
+    super();
+    this._datePipe = new DatePipe(locale);
+
+    for (let i = 0; i < this._weekDays.length; i++) {
+      const date = new Date(0);
+      date.setDate(5 + i);
+      this._weekDays[i] = this._datePipe.transform(date, 'EEE');
+    }
+
+    console.log(this._weekDays);
+
+    for (let i = 0; i < this._months.length; i++) {
+      const date = new Date(0);
+      date.setMonth(i);
+      this._months[i] = this._datePipe.transform(date, 'MMMM');
+      this._shortMonths[i] = this._datePipe.transform(date, 'MMM');
+    }
+  }
+
+  getWeekdayShortName(weekday: number): string { return this._weekDays[weekday - 1]; }
+  getMonthShortName(month: number): string { return this._shortMonths[month - 1]; }
+  getMonthFullName(month: number): string { return this._months[month - 1]; }
 }

--- a/src/datepicker/datepicker-month-view.spec.ts
+++ b/src/datepicker/datepicker-month-view.spec.ts
@@ -50,7 +50,7 @@ describe('ngb-datepicker-month-view', () => {
     const fixture = createTestComponent(
         '<ngb-datepicker-month-view [month]="month" [showWeekdays]="showWeekdays"></ngb-datepicker-month-view>');
 
-    expectWeekdays(fixture.nativeElement, ['Mo']);
+    expectWeekdays(fixture.nativeElement, ['Mon']);
 
     fixture.componentInstance.showWeekdays = false;
     fixture.detectChanges();
@@ -110,7 +110,7 @@ describe('ngb-datepicker-month-view', () => {
   it('should not send date selection events if disabled', () => {
     const fixture = createTestComponent(`
         <ng-template #tpl let-date="date">{{ date.day }}</ng-template>
-        <ngb-datepicker-month-view [month]="month" [dayTemplate]="tpl" [disabled]="true" (select)="onClick($event)">        
+        <ngb-datepicker-month-view [month]="month" [dayTemplate]="tpl" [disabled]="true" (select)="onClick($event)">
         </ngb-datepicker-month-view>
       `);
 
@@ -153,7 +153,7 @@ describe('ngb-datepicker-month-view', () => {
     it('should set default cursor for all dates if disabled', () => {
       const fixture = createTestComponent(`
         <ng-template #tpl let-date="date">{{ date.day }}</ng-template>
-        <ngb-datepicker-month-view [month]="month" [dayTemplate]="tpl" (change)="onClick($event)" [disabled]="true">        
+        <ngb-datepicker-month-view [month]="month" [dayTemplate]="tpl" (change)="onClick($event)" [disabled]="true">
         </ngb-datepicker-month-view>
       `);
 
@@ -207,7 +207,7 @@ describe('ngb-datepicker-month-view', () => {
   it('should collapse weeks outside of current month', () => {
     const fixture = createTestComponent(`
         <ng-template #tpl let-date="date">{{ date.day }}</ng-template>
-        <ngb-datepicker-month-view [month]="monthCollapsedWeeks" [outsideDays]="outsideDays" [dayTemplate]="tpl">        
+        <ngb-datepicker-month-view [month]="monthCollapsedWeeks" [outsideDays]="outsideDays" [dayTemplate]="tpl">
         </ngb-datepicker-month-view>
     `);
 
@@ -225,7 +225,7 @@ describe('ngb-datepicker-month-view', () => {
   it('should collapse weeks regardless of "showWeekNumbers" value', () => {
     const fixture = createTestComponent(`
         <ng-template #tpl let-date="date">{{ date.day }}</ng-template>
-        <ngb-datepicker-month-view [month]="monthCollapsedWeeks" outsideDays="collapsed" [dayTemplate]="tpl">        
+        <ngb-datepicker-month-view [month]="monthCollapsedWeeks" outsideDays="collapsed" [dayTemplate]="tpl">
         </ngb-datepicker-month-view>
     `);
 


### PR DESCRIPTION
Translations of weekdays and months are generated automatically by
NgbDatepickerI18nDefault class, using the default Date pipe of
Angular 2+, instead of forcing the user to provide translations
for each locale that he wants to support.
The customization of the translations is still available by
extending the base class.

Note: is not possible to show a demo of the datepicker translated with a LOCALE_ID different from en-US, because LOCALE_ID can be set only on BrowserModule: https://github.com/angular/angular/issues/16960. So the only way to show a demo maybe is an external plunker.

Before submitting a pull request, please make sure you have at least performed the following:

- [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
