### PR TITLE
fix(typeahead): avoid unecessery re-creation of DOM nodes

### DIFF
--- a/src/typeahead/typeahead-window.ts
+++ b/src/typeahead/typeahead-window.ts
@@ -32,7 +32,7 @@ export interface ResultTemplateContext {
         (mouseenter)="markActive(idx)"
         (click)="select(result)">
           <ng-template [ngTemplateOutlet]="resultTemplate || rt"
-          [ngOutletContext]="_getResultContext(result)"></ng-template>
+          [ngOutletContext]="{result: result, term: term, formatter: formatter}"></ng-template>
       </button>
     </ng-template>
   `
@@ -78,8 +78,6 @@ export class NgbTypeaheadWindow implements OnInit {
   @Output('select') selectEvent = new EventEmitter();
 
   @Output('activeChange') activeChangeEvent = new EventEmitter();
-
-  _getResultContext(result: any) { return {result: result, term: this.term, formatter: this.formatter}; }
 
   getActive() { return this.results[this.activeIdx]; }
 


### PR DESCRIPTION
#1612 introduced regression (see #1659 for more details). At the end of the day the proper fix need to come from the Angular itself, we are going to track closure support in #1596)

Reverts part of #1612
Fixes #1659

