### PR TITLE
feat(modal): add injector option

### DIFF
--- a/src/modal/modal-stack.ts
+++ b/src/modal/modal-stack.ts
@@ -37,7 +37,7 @@ export class NgbModalStack {
     }
 
     const activeModal = new NgbActiveModal();
-    const contentRef = this._getContentRef(moduleCFR, contentInjector, content, activeModal);
+    const contentRef = this._getContentRef(moduleCFR, options.injector || contentInjector, content, activeModal);
 
     let windowCmptRef: ComponentRef<NgbModalWindow>;
     let backdropCmptRef: ComponentRef<NgbModalBackdrop>;

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -1,4 +1,13 @@
-import {Component, Injectable, ViewChild, OnDestroy, NgModule, getDebugNode, DebugElement} from '@angular/core';
+import {
+  Component,
+  Injectable,
+  ViewChild,
+  OnDestroy,
+  NgModule,
+  getDebugNode,
+  DebugElement,
+  ReflectiveInjector
+} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {TestBed, ComponentFixture} from '@angular/core/testing';
 
@@ -8,6 +17,11 @@ const NOOP = () => {};
 
 @Injectable()
 class SpyService {
+  called = false;
+}
+
+@Injectable()
+class CustomSpyService {
   called = false;
 }
 
@@ -446,6 +460,21 @@ describe('ngb-modal', () => {
 
   });
 
+  describe('custom injector option', () => {
+
+    it('should render modal with a custom injector', () => {
+      const customInjector = ReflectiveInjector.resolveAndCreate([CustomSpyService]);
+      const modalInstance = fixture.componentInstance.openCmpt(CustomInjectorCmpt, {injector: customInjector});
+      fixture.detectChanges();
+      expect(fixture.nativeElement).toHaveModal('Some content');
+
+      modalInstance.close();
+      fixture.detectChanges();
+      expect(fixture.nativeElement).not.toHaveModal();
+    });
+
+  });
+
   describe('focus management', () => {
 
     it('should focus modal window and return focus to previously focused element', () => {
@@ -494,6 +523,13 @@ describe('ngb-modal', () => {
     });
   });
 });
+
+@Component({selector: 'custom-injector-cmpt', template: 'Some content'})
+export class CustomInjectorCmpt implements OnDestroy {
+  constructor(private _spyService: CustomSpyService) {}
+
+  ngOnDestroy(): void { this._spyService.called = true; }
+}
 
 @Component({selector: 'destroyable-cmpt', template: 'Some content'})
 export class DestroyableCmpt implements OnDestroy {
@@ -560,10 +596,10 @@ class TestComponent {
 }
 
 @NgModule({
-  declarations: [TestComponent, DestroyableCmpt, WithActiveModalCmpt],
+  declarations: [TestComponent, CustomInjectorCmpt, DestroyableCmpt, WithActiveModalCmpt],
   exports: [TestComponent, DestroyableCmpt],
   imports: [CommonModule, NgbModalModule.forRoot()],
-  entryComponents: [DestroyableCmpt, WithActiveModalCmpt],
+  entryComponents: [CustomInjectorCmpt, DestroyableCmpt, WithActiveModalCmpt],
   providers: [SpyService]
 })
 class NgbModalTestModule {

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -19,6 +19,11 @@ export interface NgbModalOptions {
   container?: string;
 
   /**
+   * Injector to use for modal content.
+   */
+  injector?: Injector;
+
+  /**
    * Whether to close the modal when escape key is pressed (true by default).
    */
   keyboard?: boolean;


### PR DESCRIPTION
I have an application whose components depend heavily on scoped providers, which makes it difficult to reuse those components within a modal. This has also come up on stack overflow (we do something similar with a reflective injector):
https://stackoverflow.com/questions/42568336/how-to-open-a-component-in-ng-bootstrap-modal-using-a-specific-injector

We made a small change: add a property 'injector: Injector' to NgbModalOptions and use that within NgbModalStack.open
this._getContentRef(moduleCFR, contentInjector, content, activeModal);
-->
this._getContentRef(moduleCFR, options.injector || contentInjector, content, activeModal);
