### PR TITLE
demo: fixes not working 'getting-started' url

### DIFF
--- a/demo/src/app/components/accordion/accordion.component.ts
+++ b/demo/src/app/components/accordion/accordion.component.ts
@@ -4,7 +4,7 @@ import {DEMO_SNIPPETS} from './demos';
 @Component({
   selector: 'ngbd-accordion',
   template: `
-    <ngbd-content-wrapper component="Accordion">
+    <ngbd-component-wrapper component="Accordion">
       <ngbd-api-docs directive="NgbAccordion"></ngbd-api-docs>
       <ngbd-api-docs directive="NgbPanel"></ngbd-api-docs>
       <ngbd-api-docs directive="NgbPanelTitle"></ngbd-api-docs>
@@ -26,7 +26,7 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Global configuration of accordions" [snippets]="snippets" component="accordion" demo="config">
         <ngbd-accordion-config></ngbd-accordion-config>
       </ngbd-example-box>
-    </ngbd-content-wrapper>
+    </ngbd-component-wrapper>
   `
 })
 export class NgbdAccordion {

--- a/demo/src/app/components/alert/alert.component.ts
+++ b/demo/src/app/components/alert/alert.component.ts
@@ -4,7 +4,7 @@ import {DEMO_SNIPPETS} from './demos';
 @Component({
   selector: 'ngbd-alert',
   template: `
-    <ngbd-content-wrapper component="Alert">
+    <ngbd-component-wrapper component="Alert">
       <ngbd-api-docs directive="NgbAlert"></ngbd-api-docs>
       <ngbd-api-docs-config type="NgbAlertConfig"></ngbd-api-docs-config>
       <ngbd-example-box demoTitle="Basic Alert" [snippets]="snippets" component="alert" demo="basic">
@@ -22,7 +22,7 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Global configuration of alerts" [snippets]="snippets" component="alert" demo="config">
         <ngbd-alert-config></ngbd-alert-config>
       </ngbd-example-box>
-    </ngbd-content-wrapper>
+    </ngbd-component-wrapper>
   `
 })
 export class NgbdAlert {

--- a/demo/src/app/components/buttons/buttons.component.ts
+++ b/demo/src/app/components/buttons/buttons.component.ts
@@ -4,7 +4,7 @@ import {DEMO_SNIPPETS} from './demos';
 @Component({
   selector: 'ngbd-buttons',
   template: `
-    <ngbd-content-wrapper component="Buttons">
+    <ngbd-component-wrapper component="Buttons">
       <ngbd-api-docs directive="NgbRadioGroup"></ngbd-api-docs>
       <ngbd-api-docs directive="NgbRadio"></ngbd-api-docs>
       <ngbd-example-box demoTitle="Radio buttons" [snippets]="snippets" component="buttons" demo="radio">
@@ -19,7 +19,7 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Checkbox buttons (Reactive Forms)" [snippets]="snippets" component="buttons" demo="checkboxReactive">
         <ngbd-buttons-checkbox-reactive></ngbd-buttons-checkbox-reactive>
       </ngbd-example-box>
-    </ngbd-content-wrapper>
+    </ngbd-component-wrapper>
   `
 })
 export class NgbdButtons {

--- a/demo/src/app/components/carousel/carousel.component.ts
+++ b/demo/src/app/components/carousel/carousel.component.ts
@@ -4,7 +4,7 @@ import {DEMO_SNIPPETS} from './demos';
 @Component({
   selector: 'ngbd-carousel',
   template: `
-    <ngbd-content-wrapper component="Carousel">
+    <ngbd-component-wrapper component="Carousel">
       <ngbd-api-docs directive="NgbCarousel"></ngbd-api-docs>
       <ngbd-api-docs directive="NgbSlide"></ngbd-api-docs>
       <ngbd-api-docs-class type="NgbSlideEvent"></ngbd-api-docs-class>
@@ -15,7 +15,7 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Global configuration of carousels" [snippets]="snippets" component="carousel" demo="config">
         <ngbd-carousel-config></ngbd-carousel-config>
       </ngbd-example-box>
-    </ngbd-content-wrapper>
+    </ngbd-component-wrapper>
   `
 })
 export class NgbdCarousel {

--- a/demo/src/app/components/collapse/collapse.component.html
+++ b/demo/src/app/components/collapse/collapse.component.html
@@ -1,6 +1,6 @@
-<ngbd-content-wrapper component="Collapse">
+<ngbd-component-wrapper component="Collapse">
   <ngbd-api-docs directive="NgbCollapse"></ngbd-api-docs>
   <ngbd-example-box demoTitle="Demo" [snippets]="snippets" component="collapse" demo="basic">
     <ngbd-collapse-basic></ngbd-collapse-basic>
   </ngbd-example-box>
-</ngbd-content-wrapper>
+</ngbd-component-wrapper>

--- a/demo/src/app/components/datepicker/datepicker.component.ts
+++ b/demo/src/app/components/datepicker/datepicker.component.ts
@@ -4,7 +4,7 @@ import {DEMO_SNIPPETS} from './demos';
 @Component({
   selector: 'ngbd-datepicker',
   template: `
-    <ngbd-content-wrapper component="Datepicker">
+    <ngbd-component-wrapper component="Datepicker">
       <ngbd-api-docs directive="NgbDatepicker"></ngbd-api-docs>
       <ngbd-api-docs directive="NgbInputDatepicker"></ngbd-api-docs>
       <ngbd-api-docs-class type="NgbDateStruct"></ngbd-api-docs-class>
@@ -40,7 +40,7 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Global configuration of datepickers" [snippets]="snippets" component="datepicker" demo="config">
         <ngbd-datepicker-config></ngbd-datepicker-config>
       </ngbd-example-box>
-    </ngbd-content-wrapper>
+    </ngbd-component-wrapper>
   `
 })
 export class NgbdDatepicker {

--- a/demo/src/app/components/dropdown/dropdown.component.ts
+++ b/demo/src/app/components/dropdown/dropdown.component.ts
@@ -4,7 +4,7 @@ import {DEMO_SNIPPETS} from './demos';
 @Component({
   selector: 'ngbd-dropdown',
   template: `
-    <ngbd-content-wrapper component="Dropdown">
+    <ngbd-component-wrapper component="Dropdown">
       <ngbd-api-docs directive="NgbDropdown"></ngbd-api-docs>
       <ngbd-api-docs directive="NgbDropdownToggle"></ngbd-api-docs>
       <ngbd-api-docs-config type="NgbDropdownConfig"></ngbd-api-docs-config>
@@ -17,7 +17,7 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Global configuration of dropdowns" [snippets]="snippets" component="dropdown" demo="config">
         <ngbd-dropdown-config></ngbd-dropdown-config>
       </ngbd-example-box>
-    </ngbd-content-wrapper>
+    </ngbd-component-wrapper>
   `
 })
 export class NgbdDropdown {

--- a/demo/src/app/components/modal/modal.component.ts
+++ b/demo/src/app/components/modal/modal.component.ts
@@ -5,7 +5,7 @@ import {DEMO_SNIPPETS} from './demos';
 @Component({
   selector: 'ngbd-modal',
   template: `
-    <ngbd-content-wrapper component="Modal">
+    <ngbd-component-wrapper component="Modal">
       <ngbd-api-docs-class type="NgbModal"></ngbd-api-docs-class>
       <ngbd-api-docs-class type="NgbModalOptions"></ngbd-api-docs-class>
       <ngbd-api-docs-class type="NgbModalRef"></ngbd-api-docs-class>
@@ -19,7 +19,7 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Modal with custom class" [snippets]="snippets" component="modal" demo="customclass">
           <ngbd-modal-customclass></ngbd-modal-customclass>
       </ngbd-example-box>
-    </ngbd-content-wrapper>
+    </ngbd-component-wrapper>
   `
 })
 export class NgbdModal {

--- a/demo/src/app/components/pagination/pagination.component.ts
+++ b/demo/src/app/components/pagination/pagination.component.ts
@@ -4,7 +4,7 @@ import {DEMO_SNIPPETS} from './demos';
 @Component({
   selector: 'ngbd-pagination',
   template: `
-    <ngbd-content-wrapper component="Pagination">
+    <ngbd-component-wrapper component="Pagination">
       <ngbd-api-docs directive="NgbPagination"></ngbd-api-docs>
       <ngbd-api-docs-config type="NgbPaginationConfig"></ngbd-api-docs-config>
       <ngbd-example-box demoTitle="Basic pagination" [snippets]="snippets" component="pagination" demo="basic">
@@ -22,7 +22,7 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Global configuration" [snippets]="snippets" component="pagination" demo="config">
         <ngbd-pagination-config></ngbd-pagination-config>
       </ngbd-example-box>
-    </ngbd-content-wrapper>
+    </ngbd-component-wrapper>
   `
 })
 export class NgbdPagination {

--- a/demo/src/app/components/popover/popover.component.ts
+++ b/demo/src/app/components/popover/popover.component.ts
@@ -4,7 +4,7 @@ import {DEMO_SNIPPETS} from './demos';
 @Component({
   selector: 'ngbd-popover',
   template: `
-    <ngbd-content-wrapper component="Popover">
+    <ngbd-component-wrapper component="Popover">
       <ngbd-api-docs directive="NgbPopover"></ngbd-api-docs>
       <ngbd-api-docs-config type="NgbPopoverConfig"></ngbd-api-docs-config>
       <ngbd-example-box demoTitle="Quick and easy popovers" [snippets]="snippets" component="popover" demo="basic">
@@ -34,7 +34,7 @@ import {DEMO_SNIPPETS} from './demos';
         demoTitle="Global configuration of popovers" [snippets]="snippets" component="popover" demo="config">
         <ngbd-popover-config></ngbd-popover-config>
       </ngbd-example-box>
-    </ngbd-content-wrapper>
+    </ngbd-component-wrapper>
   `
 })
 export class NgbdPopover {

--- a/demo/src/app/components/progressbar/progressbar.component.ts
+++ b/demo/src/app/components/progressbar/progressbar.component.ts
@@ -4,7 +4,7 @@ import {DEMO_SNIPPETS} from './demos';
 @Component({
   selector: 'ngbd-progressbar',
   template: `
-    <ngbd-content-wrapper component="Progressbar">
+    <ngbd-component-wrapper component="Progressbar">
       <ngbd-api-docs directive="NgbProgressbar"></ngbd-api-docs>
       <ngbd-api-docs-config type="NgbProgressbarConfig"></ngbd-api-docs-config>
       <ngbd-example-box demoTitle="Contextual progress bars" [snippets]="snippets" component="progressbar" demo="basic">
@@ -22,7 +22,7 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Global configuration of progress bars" [snippets]="snippets" component="progressbar" demo="config">
         <ngbd-progressbar-config></ngbd-progressbar-config>
       </ngbd-example-box>
-    </ngbd-content-wrapper>
+    </ngbd-component-wrapper>
   `
 })
 export class NgbdProgressbar {

--- a/demo/src/app/components/rating/rating.component.html
+++ b/demo/src/app/components/rating/rating.component.html
@@ -1,4 +1,4 @@
-<ngbd-content-wrapper component="Rating">
+<ngbd-component-wrapper component="Rating">
   <ngbd-api-docs directive="NgbRating"></ngbd-api-docs>
   <ngbd-api-docs-class type="StarTemplateContext"></ngbd-api-docs-class>
   <ngbd-api-docs-config type="NgbRatingConfig"></ngbd-api-docs-config>
@@ -20,4 +20,4 @@
   <ngbd-example-box demoTitle="Global configuration of ratings" [snippets]="snippets" component="rating" demo="config">
     <ngbd-rating-config></ngbd-rating-config>
   </ngbd-example-box>
-</ngbd-content-wrapper>
+</ngbd-component-wrapper>

--- a/demo/src/app/components/tabset/tabset.component.ts
+++ b/demo/src/app/components/tabset/tabset.component.ts
@@ -4,7 +4,7 @@ import {DEMO_SNIPPETS} from './demos';
 @Component({
   selector: 'ngbd-tabs',
   template: `
-    <ngbd-content-wrapper component="Tabs">
+    <ngbd-component-wrapper component="Tabs">
       <ngbd-api-docs directive="NgbTabset"></ngbd-api-docs>
       <ngbd-api-docs directive="NgbTab"></ngbd-api-docs>
       <ngbd-api-docs directive="NgbTabTitle"></ngbd-api-docs>
@@ -26,7 +26,7 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Global configuration of tabs" [snippets]="snippets" component="tabset" demo="config">
         <ngbd-tabset-config></ngbd-tabset-config>
       </ngbd-example-box>
-    </ngbd-content-wrapper>
+    </ngbd-component-wrapper>
   `
 })
 export class NgbdTabs {

--- a/demo/src/app/components/timepicker/timepicker.component.ts
+++ b/demo/src/app/components/timepicker/timepicker.component.ts
@@ -4,7 +4,7 @@ import {DEMO_SNIPPETS} from './demos';
 @Component({
   selector: 'ngbd-timepicker',
   template: `
-    <ngbd-content-wrapper component="Timepicker">
+    <ngbd-component-wrapper component="Timepicker">
       <ngbd-api-docs directive="NgbTimepicker"></ngbd-api-docs>
       <ngbd-api-docs-class type="NgbTimeStruct"></ngbd-api-docs-class>
       <ngbd-api-docs-config type="NgbTimepickerConfig"></ngbd-api-docs-config>
@@ -29,7 +29,7 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Global configuration of timepickers" [snippets]="snippets" component="timepicker" demo="config">
         <ngbd-timepicker-config></ngbd-timepicker-config>
       </ngbd-example-box>
-    </ngbd-content-wrapper>
+    </ngbd-component-wrapper>
   `
 })
 export class NgbdTimepicker {

--- a/demo/src/app/components/tooltip/tooltip.component.ts
+++ b/demo/src/app/components/tooltip/tooltip.component.ts
@@ -4,7 +4,7 @@ import {DEMO_SNIPPETS} from './demos';
 @Component({
   selector: 'ngbd-tooltip',
   template: `
-    <ngbd-content-wrapper component="Tooltip">
+    <ngbd-component-wrapper component="Tooltip">
       <ngbd-api-docs directive="NgbTooltip"></ngbd-api-docs>
       <ngbd-api-docs-config type="NgbTooltipConfig"></ngbd-api-docs-config>
       <ngbd-example-box demoTitle="Quick and easy tooltips" [snippets]="snippets" component="tooltip" demo="basic">
@@ -30,7 +30,7 @@ import {DEMO_SNIPPETS} from './demos';
         demoTitle="Global configuration of tooltips" [snippets]="snippets" component="tooltip" demo="config">
         <ngbd-tooltip-config></ngbd-tooltip-config>
       </ngbd-example-box>
-    </ngbd-content-wrapper>
+    </ngbd-component-wrapper>
   `
 })
 export class NgbdTooltip {

--- a/demo/src/app/components/typeahead/typeahead.component.ts
+++ b/demo/src/app/components/typeahead/typeahead.component.ts
@@ -4,7 +4,7 @@ import {DEMO_SNIPPETS} from './demos';
 @Component({
   selector: 'ngbd-typeahead',
   template: `
-    <ngbd-content-wrapper component="Typeahead">
+    <ngbd-component-wrapper component="Typeahead">
       <ngbd-api-docs directive="NgbTypeahead"></ngbd-api-docs>
       <ngbd-api-docs-class type="NgbTypeaheadSelectItemEvent"></ngbd-api-docs-class>
       <ngbd-api-docs-class type="ResultTemplateContext"></ngbd-api-docs-class>
@@ -24,7 +24,7 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Global configuration of typeaheads" [snippets]="snippets" component="typeahead" demo="config">
         <ngbd-typeahead-config></ngbd-typeahead-config>
       </ngbd-example-box>
-    </ngbd-content-wrapper>
+    </ngbd-component-wrapper>
   `
 })
 export class NgbdTypeahead {

--- a/demo/src/app/getting-started/getting-started.component.html
+++ b/demo/src/app/getting-started/getting-started.component.html
@@ -1,4 +1,4 @@
-<ngbd-content-wrapper title="Getting Started">
+<ngbd-page-wrapper title="Getting Started">
   <h3>
     Dependencies
   </h3>
@@ -104,4 +104,4 @@ export class OtherModule &#123;
     Please take a moment to read our
     <a href="https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CODE_OF_CONDUCT.md" target="_blank">Code of Conduct</a>.
   </p>
-</ngbd-content-wrapper>
+</ngbd-page-wrapper>

--- a/demo/src/app/shared/component-wrapper/component-wrapper.component.html
+++ b/demo/src/app/shared/component-wrapper/component-wrapper.component.html
@@ -1,6 +1,6 @@
 <div class="jumbotron">
   <div class="container">
-    <h1>{{ title || component }}</h1>
+    <h1>{{ component }}</h1>
   </div>
 </div>
 <div class="container">
@@ -8,7 +8,6 @@
     <div class="col-12 col-lg-9">
       <ngb-tabset
         class="root-nav"
-        *ngIf="component; else page"
         (tabChange)="tabChange($event)"
         [activeId]="activeTab"
       >
@@ -25,10 +24,6 @@
           </ng-template>
         </ngb-tab>
       </ngb-tabset>
-
-      <ng-template #page>
-        <ng-content></ng-content>
-      </ng-template>
     </div>
     <div class="col-12 col-lg-3 hidden-md-down">
       <ngbd-side-nav></ngbd-side-nav>

--- a/demo/src/app/shared/component-wrapper/component-wrapper.component.ts
+++ b/demo/src/app/shared/component-wrapper/component-wrapper.component.ts
@@ -1,16 +1,14 @@
-import {Component, Input, OnChanges} from '@angular/core';
+import {Component, Input} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
 
 const DEFAULT_TAB = 'api';
 const VALID_TABS = [DEFAULT_TAB, 'examples'];
 
 @Component({
-  selector: 'ngbd-content-wrapper',
-  templateUrl: './content-wrapper.component.html'
+  selector: 'ngbd-component-wrapper',
+  templateUrl: './component-wrapper.component.html'
 })
-export class ContentWrapper {
-  @Input()
-  public title: string | false = false;
+export class ComponentWrapper {
 
   @Input()
   public component: string;

--- a/demo/src/app/shared/index.ts
+++ b/demo/src/app/shared/index.ts
@@ -6,7 +6,8 @@ import {JsonpModule} from '@angular/http';
 
 import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 
-import {ContentWrapper} from './content-wrapper/content-wrapper.component';
+import {ComponentWrapper} from './component-wrapper/component-wrapper.component';
+import {PageWrapper} from './page-wrapper/page-wrapper.component';
 import {SideNavComponent} from './side-nav/side-nav.component';
 import {Analytics} from './analytics/analytics';
 
@@ -17,7 +18,8 @@ export {componentsList} from './side-nav/side-nav.component';
   exports: [
     CommonModule,
     RouterModule,
-    ContentWrapper,
+    ComponentWrapper,
+    PageWrapper,
     SideNavComponent,
     NgbModule,
     FormsModule,
@@ -25,7 +27,8 @@ export {componentsList} from './side-nav/side-nav.component';
     JsonpModule
   ],
   declarations: [
-    ContentWrapper,
+    ComponentWrapper,
+    PageWrapper,
     SideNavComponent,
   ],
   providers: [Analytics]

--- a/demo/src/app/shared/page-wrapper/page-wrapper.component.html
+++ b/demo/src/app/shared/page-wrapper/page-wrapper.component.html
@@ -1,0 +1,15 @@
+<div class="jumbotron">
+  <div class="container">
+    <h1>{{ title }}</h1>
+  </div>
+</div>
+<div class="container">
+  <div class="row">
+    <div class="col-12 col-lg-9">
+      <ng-content></ng-content>
+    </div>
+    <div class="col-12 col-lg-3 hidden-md-down">
+      <ngbd-side-nav></ngbd-side-nav>
+    </div>
+  </div>
+</div>

--- a/demo/src/app/shared/page-wrapper/page-wrapper.component.ts
+++ b/demo/src/app/shared/page-wrapper/page-wrapper.component.ts
@@ -1,0 +1,10 @@
+import {Component, Input} from '@angular/core';
+
+@Component({
+  selector: 'ngbd-page-wrapper',
+  templateUrl: './page-wrapper.component.html'
+})
+export class PageWrapper {
+  @Input()
+  public title: string;
+}

--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -220,7 +220,7 @@ span.token.tag {
   padding: 0;
 }
 
-ngbd-content-wrapper {
+ngbd-component-wrapper, ngbd-page-wrapper {
   .jumbotron {
     border-radius: 0;
   }


### PR DESCRIPTION
Bug was because of the following redirect chain → `/getting-started` → `../api` → nothing matches → `''` → `home`

Content-wrapper seems to be used both as a wrapper for components and for normal pages → so if there no `component` input, doesn't make sense to listen to router events and trying to redirect to `api` by default

I guess this should be refactored further as we add more normal pages...