### PR TITLE
feat(buttons): allow vertical radio buttons

### DIFF
--- a/demo/src/app/components/buttons/demos/radio/buttons-radio.html
+++ b/demo/src/app/components/buttons/demos/radio/buttons-radio.html
@@ -1,4 +1,4 @@
-<div [(ngModel)]="model" ngbRadioGroup name="radioBasic">
+<div class="btn-group" ngbRadioGroup name="radioBasic" [(ngModel)]="model">
   <label ngbButtonLabel class="btn-primary">
     <input ngbButton type="radio" [value]="1"> Left (pre-checked)
   </label>

--- a/demo/src/app/components/buttons/demos/radioreactive/buttons-radioreactive.html
+++ b/demo/src/app/components/buttons/demos/radioreactive/buttons-radioreactive.html
@@ -1,5 +1,5 @@
 <form [formGroup]="radioGroupForm">
-  <div ngbRadioGroup name="radioBasic" formControlName="model">
+  <div class="btn-group" ngbRadioGroup name="radioBasic" formControlName="model">
     <label ngbButtonLabel class="btn-primary">
       <input ngbButton type="radio" [value]="1"> Left (pre-checked)
     </label>

--- a/src/buttons/radio.spec.ts
+++ b/src/buttons/radio.spec.ts
@@ -258,14 +258,13 @@ describe('ngbRadioGroup', () => {
        });
      }));
 
-  it('should add data-toggle="buttons" and "btn-group" CSS class to button group', () => {
+  it('should add data-toggle="buttons" to button group', () => {
     // Bootstrap for uses presence of data-toggle="buttons" to style radio buttons
     const html = `<div class="foo" ngbRadioGroup></div>`;
 
     const fixture = createTestComponent(html);
 
     expect(fixture.nativeElement.children[0].getAttribute('data-toggle')).toBe('buttons');
-    expect(fixture.nativeElement.children[0]).toHaveCssClass('btn-group');
   });
 
   it('should work with template-driven form validation', async(() => {

--- a/src/buttons/radio.ts
+++ b/src/buttons/radio.ts
@@ -17,7 +17,7 @@ let nextId = 0;
  */
 @Directive({
   selector: '[ngbRadioGroup]',
-  host: {'data-toggle': 'buttons', 'class': 'btn-group', 'role': 'group'},
+  host: {'data-toggle': 'buttons', 'role': 'group'},
   providers: [NGB_RADIO_VALUE_ACCESSOR]
 })
 export class NgbRadioGroup implements ControlValueAccessor {


### PR DESCRIPTION
Closes #1231
Closes #1238

BREAKING CHANGE:

The `btn-group` CSS class needs to added explicitly for radio buttons.

Before:

```
<div ngbRadioGroup ...>
  ...
</div>
```

After:

```
<div class="btn-group" ngbRadioGroup ...>
  ...
</div>
```
