### PR TITLE
feat(dropdown): distinguish inside and outside clicks for autoClose

### DIFF
--- a/demo/src/app/components/dropdown/demos/basic/dropdown-basic.html
+++ b/demo/src/app/components/dropdown/demos/basic/dropdown-basic.html
@@ -2,7 +2,7 @@
   <div class="col">
     <div ngbDropdown class="d-inline-block">
       <button class="btn btn-outline-primary" id="dropdownBasic1" ngbDropdownToggle>Toggle dropdown</button>
-      <div class="dropdown-menu" aria-labelledby="dropdownBasic1">
+      <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
         <button class="dropdown-item">Action - 1</button>
         <button class="dropdown-item">Another Action</button>
         <button class="dropdown-item">Something else is here</button>

--- a/demo/src/app/components/dropdown/demos/config/dropdown-config.html
+++ b/demo/src/app/components/dropdown/demos/config/dropdown-config.html
@@ -2,7 +2,7 @@
 
 <div ngbDropdown>
   <button class="btn btn-outline-primary" id="dropdownConfig" ngbDropdownToggle>Toggle</button>
-  <div class="dropdown-menu" aria-labelledby="dropdownConfig">
+  <div ngbDropdownMenu aria-labelledby="dropdownConfig">
     <button class="dropdown-item">Action - 1</button>
     <button class="dropdown-item">Another Action</button>
     <button class="dropdown-item">Something else is here</button>

--- a/demo/src/app/components/dropdown/demos/manual/dropdown-manual.html
+++ b/demo/src/app/components/dropdown/demos/manual/dropdown-manual.html
@@ -2,7 +2,7 @@
 
 <div class="d-inline-block" ngbDropdown #myDrop="ngbDropdown">
   <button class="btn btn-outline-primary" id="dropdownManual" ngbDropdownToggle>Toggle dropdown</button>
-  <div class="dropdown-menu" aria-labelledby="dropdownManual">
+  <div ngbDropdownMenu aria-labelledby="dropdownManual">
     <button class="dropdown-item">Action - 1</button>
     <button class="dropdown-item">Another Action</button>
     <button class="dropdown-item">Something else is here</button>

--- a/src/dropdown/dropdown.module.ts
+++ b/src/dropdown/dropdown.module.ts
@@ -1,11 +1,11 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
-import {NgbDropdown, NgbDropdownToggle} from './dropdown';
+import {NgbDropdown, NgbDropdownToggle, NgbDropdownMenu} from './dropdown';
 import {NgbDropdownConfig} from './dropdown-config';
 
-export {NgbDropdown, NgbDropdownToggle} from './dropdown';
+export {NgbDropdown, NgbDropdownToggle, NgbDropdownMenu} from './dropdown';
 export {NgbDropdownConfig} from './dropdown-config';
 
-const NGB_DROPDOWN_DIRECTIVES = [NgbDropdownToggle, NgbDropdown];
+const NGB_DROPDOWN_DIRECTIVES = [NgbDropdown, NgbDropdownToggle, NgbDropdownMenu];
 
 @NgModule({declarations: NGB_DROPDOWN_DIRECTIVES, exports: NGB_DROPDOWN_DIRECTIVES})
 export class NgbDropdownModule {

--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -308,11 +308,11 @@ describe('ngb-dropdown-toggle', () => {
     expect(dropdownEl).toHaveCssClass('show');
   });
 
-  it('should close on item click if autoClose is set to false', () => {
+  it('should not close on item click if autoClose is set to false', () => {
     const html = `
       <div ngbDropdown [open]="true" [autoClose]="false">
           <button ngbDropdownToggle>Toggle dropdown</button>
-          <div class="dropdown-menu" aria-labelledby="dropdownMenu1">
+          <div ngbDropdownMenu>
             <a class="dropdown-item">Action</a>
           </div>
       </div>`;
@@ -330,11 +330,11 @@ describe('ngb-dropdown-toggle', () => {
     expect(dropdownEl).toHaveCssClass('show');
   });
 
-  it('should close on item click', () => {
+  it('should close on item click by default', () => {
     const html = `
       <div ngbDropdown [open]="true">
           <button ngbDropdownToggle>Toggle dropdown</button>
-          <div class="dropdown-menu" aria-labelledby="dropdownMenu1">
+          <div ngbDropdownMenu aria-labelledby="dropdownMenu1">
             <a class="dropdown-item">Action</a>
           </div>
       </div>`;
@@ -357,13 +357,13 @@ describe('ngb-dropdown-toggle', () => {
     const html = `
       <div ngbDropdown>
           <button ngbDropdownToggle>Toggle dropdown 1</button>
-          <div class="dropdown-menu">
+          <div ngbDropdownMenu>
             <a class="dropdown-item">Action 1</a>
           </div>
       </div>
       <div ngbDropdown>
           <button ngbDropdownToggle>Toggle dropdown 2</button>
-          <div class="dropdown-menu">
+          <div ngbDropdownMenu>
             <a class="dropdown-item">Action 2</a>
           </div>
       </div>`;
@@ -387,6 +387,71 @@ describe('ngb-dropdown-toggle', () => {
     fixture.detectChanges();
     expect(dropdownEls[0]).not.toHaveCssClass('show');
     expect(dropdownEls[1]).toHaveCssClass('show');
+  });
+
+  describe('outside and inside clicks', () => {
+
+    it('should not close on menu clicks when the "outside" option is used', () => {
+
+      const html = `
+      <div ngbDropdown [open]="true" autoClose="outside">
+          <button ngbDropdownToggle>Toggle dropdown</button>
+          <div ngbDropdownMenu>
+            <a class="dropdown-item">Action</a>
+          </div>
+      </div>`;
+
+      const fixture = createTestComponent(html);
+      const compiled = fixture.nativeElement;
+      const dropdownEl = getDropdownEl(compiled);
+      const buttonEl = compiled.querySelector('button');
+      let linkEl = compiled.querySelector('a');
+
+      fixture.detectChanges();
+      expect(dropdownEl).toHaveCssClass('show');
+
+      // remains open on item click
+      linkEl.click();
+      fixture.detectChanges();
+      expect(dropdownEl).toHaveCssClass('show');
+
+      // but closes on toggle button click
+      buttonEl.click();
+      fixture.detectChanges();
+      expect(dropdownEl).not.toHaveCssClass('show');
+    });
+
+    it('should not close on outside clicks when the "inside" option is used', () => {
+
+      const html = `
+      <button id="outside">Outside</button>
+      <div ngbDropdown [open]="true" autoClose="inside">
+          <button ngbDropdownToggle>Toggle dropdown</button>
+          <div ngbDropdownMenu>
+            <a class="dropdown-item">Action</a>
+          </div>
+      </div>`;
+
+      const fixture = createTestComponent(html);
+      const compiled = fixture.nativeElement;
+      const dropdownEl = getDropdownEl(compiled);
+      const buttonEl = compiled.querySelector('#outside');
+      let linkEl = compiled.querySelector('a');
+
+      fixture.detectChanges();
+      expect(dropdownEl).toHaveCssClass('show');
+
+      // remains open on outside click
+      buttonEl.click();
+      fixture.detectChanges();
+      expect(dropdownEl).toHaveCssClass('show');
+
+      // but closes on item click
+      linkEl.click();
+      fixture.detectChanges();
+      expect(dropdownEl).not.toHaveCssClass('show');
+    });
+
   });
 
   describe('Custom config', () => {


### PR DESCRIPTION
Closes #1022

BREAKING CHANGE:

Dropdown menu now requires usage of the new `ngbDropdownMenu` directive.

Before:

```html
<div ngbDropdown>
  <button ngbDropdownToggle>Toggle dropdown</button>
  <div class="dropdown-menu">
    <a class="dropdown-item">Action</a>
  </div>
</div>
```

After (notice **ngbDropdownMenu**):

```html
<div ngbDropdown>
  <button ngbDropdownToggle>Toggle dropdown</button>
  <div ngbDropdownMenu>
    <a class="dropdown-item">Action</a>
  </div>
</div>
```

