### PR TITLE
Bootstrap4 beta dropdowns

### DIFF
--- a/demo/src/app/components/dropdown/demos/basic/dropdown-basic.html
+++ b/demo/src/app/components/dropdown/demos/basic/dropdown-basic.html
@@ -13,7 +13,7 @@
   <div class="col text-right">
     <div ngbDropdown [up]="true" class="d-inline-block">
       <button class="btn btn-outline-primary" id="dropdownBasic2" ngbDropdownToggle>Toggle dropup</button>
-      <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownBasic2">
+      <div ngbDropdownMenu class="dropdown-menu-right" aria-labelledby="dropdownBasic2">
         <button class="dropdown-item">Action - 1</button>
         <button class="dropdown-item">Another Action</button>
         <button class="dropdown-item">Something else is here</button>

--- a/demo/src/app/components/dropdown/demos/basic/dropdown-basic.html
+++ b/demo/src/app/components/dropdown/demos/basic/dropdown-basic.html
@@ -2,7 +2,7 @@
   <div class="col">
     <div ngbDropdown class="d-inline-block">
       <button class="btn btn-outline-primary" id="dropdownBasic1" ngbDropdownToggle>Toggle dropdown</button>
-      <div class="dropdown-menu" aria-labelledby="dropdownBasic1">
+      <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
         <button class="dropdown-item">Action - 1</button>
         <button class="dropdown-item">Another Action</button>
         <button class="dropdown-item">Something else is here</button>

--- a/demo/src/app/components/dropdown/demos/config/dropdown-config.html
+++ b/demo/src/app/components/dropdown/demos/config/dropdown-config.html
@@ -2,7 +2,7 @@
 
 <div ngbDropdown>
   <button class="btn btn-outline-primary" id="dropdownConfig" ngbDropdownToggle>Toggle</button>
-  <div class="dropdown-menu" aria-labelledby="dropdownConfig">
+  <div ngbDropdownMenu aria-labelledby="dropdownConfig">
     <button class="dropdown-item">Action - 1</button>
     <button class="dropdown-item">Another Action</button>
     <button class="dropdown-item">Something else is here</button>

--- a/demo/src/app/components/dropdown/demos/manual/dropdown-manual.html
+++ b/demo/src/app/components/dropdown/demos/manual/dropdown-manual.html
@@ -2,7 +2,7 @@
 
 <div class="d-inline-block" ngbDropdown #myDrop="ngbDropdown">
   <button class="btn btn-outline-primary" id="dropdownManual" ngbDropdownToggle>Toggle dropdown</button>
-  <div class="dropdown-menu" aria-labelledby="dropdownManual">
+  <div ngbDropdownMenu aria-labelledby="dropdownManual">
     <button class="dropdown-item">Action - 1</button>
     <button class="dropdown-item">Another Action</button>
     <button class="dropdown-item">Something else is here</button>

--- a/src/dropdown/dropdown.module.ts
+++ b/src/dropdown/dropdown.module.ts
@@ -1,11 +1,11 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
-import {NgbDropdown, NgbDropdownToggle} from './dropdown';
+import {NgbDropdown, NgbDropdownToggle, NgbDropdownMenu} from './dropdown';
 import {NgbDropdownConfig} from './dropdown-config';
 
-export {NgbDropdown, NgbDropdownToggle} from './dropdown';
+export {NgbDropdown, NgbDropdownToggle, NgbDropdownMenu} from './dropdown';
 export {NgbDropdownConfig} from './dropdown-config';
 
-const NGB_DROPDOWN_DIRECTIVES = [NgbDropdownToggle, NgbDropdown];
+const NGB_DROPDOWN_DIRECTIVES = [NgbDropdown, NgbDropdownToggle, NgbDropdownMenu];
 
 @NgModule({declarations: NGB_DROPDOWN_DIRECTIVES, exports: NGB_DROPDOWN_DIRECTIVES})
 export class NgbDropdownModule {

--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -308,11 +308,11 @@ describe('ngb-dropdown-toggle', () => {
     expect(dropdownEl).toHaveCssClass('show');
   });
 
-  it('should close on item click if autoClose is set to false', () => {
+  it('should not close on item click if autoClose is set to false', () => {
     const html = `
       <div ngbDropdown [open]="true" [autoClose]="false">
           <button ngbDropdownToggle>Toggle dropdown</button>
-          <div class="dropdown-menu" aria-labelledby="dropdownMenu1">
+          <div ngbDropdownMenu>
             <a class="dropdown-item">Action</a>
           </div>
       </div>`;
@@ -330,11 +330,11 @@ describe('ngb-dropdown-toggle', () => {
     expect(dropdownEl).toHaveCssClass('show');
   });
 
-  it('should close on item click', () => {
+  it('should close on item click by default', () => {
     const html = `
       <div ngbDropdown [open]="true">
           <button ngbDropdownToggle>Toggle dropdown</button>
-          <div class="dropdown-menu" aria-labelledby="dropdownMenu1">
+          <div ngbDropdownMenu aria-labelledby="dropdownMenu1">
             <a class="dropdown-item">Action</a>
           </div>
       </div>`;
@@ -357,13 +357,13 @@ describe('ngb-dropdown-toggle', () => {
     const html = `
       <div ngbDropdown>
           <button ngbDropdownToggle>Toggle dropdown 1</button>
-          <div class="dropdown-menu">
+          <div ngbDropdownMenu>
             <a class="dropdown-item">Action 1</a>
           </div>
       </div>
       <div ngbDropdown>
           <button ngbDropdownToggle>Toggle dropdown 2</button>
-          <div class="dropdown-menu">
+          <div ngbDropdownMenu>
             <a class="dropdown-item">Action 2</a>
           </div>
       </div>`;
@@ -387,6 +387,71 @@ describe('ngb-dropdown-toggle', () => {
     fixture.detectChanges();
     expect(dropdownEls[0]).not.toHaveCssClass('show');
     expect(dropdownEls[1]).toHaveCssClass('show');
+  });
+
+  describe('outside and inside clicks', () => {
+
+    it('should not close on menu clicks when the "outside" option is used', () => {
+
+      const html = `
+      <div ngbDropdown [open]="true" autoClose="outside">
+          <button ngbDropdownToggle>Toggle dropdown</button>
+          <div ngbDropdownMenu>
+            <a class="dropdown-item">Action</a>
+          </div>
+      </div>`;
+
+      const fixture = createTestComponent(html);
+      const compiled = fixture.nativeElement;
+      const dropdownEl = getDropdownEl(compiled);
+      const buttonEl = compiled.querySelector('button');
+      let linkEl = compiled.querySelector('a');
+
+      fixture.detectChanges();
+      expect(dropdownEl).toHaveCssClass('show');
+
+      // remains open on item click
+      linkEl.click();
+      fixture.detectChanges();
+      expect(dropdownEl).toHaveCssClass('show');
+
+      // but closes on toggle button click
+      buttonEl.click();
+      fixture.detectChanges();
+      expect(dropdownEl).not.toHaveCssClass('show');
+    });
+
+    it('should not close on outside clicks when the "inside" option is used', () => {
+
+      const html = `
+      <button id="outside">Outside</button>
+      <div ngbDropdown [open]="true" autoClose="inside">
+          <button ngbDropdownToggle>Toggle dropdown</button>
+          <div ngbDropdownMenu>
+            <a class="dropdown-item">Action</a>
+          </div>
+      </div>`;
+
+      const fixture = createTestComponent(html);
+      const compiled = fixture.nativeElement;
+      const dropdownEl = getDropdownEl(compiled);
+      const buttonEl = compiled.querySelector('#outside');
+      let linkEl = compiled.querySelector('a');
+
+      fixture.detectChanges();
+      expect(dropdownEl).toHaveCssClass('show');
+
+      // remains open on outside click
+      buttonEl.click();
+      fixture.detectChanges();
+      expect(dropdownEl).toHaveCssClass('show');
+
+      // but closes on item click
+      linkEl.click();
+      fixture.detectChanges();
+      expect(dropdownEl).not.toHaveCssClass('show');
+    });
+
   });
 
   describe('Custom config', () => {

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -1,11 +1,25 @@
-import {forwardRef, Inject, Directive, Input, Output, EventEmitter, ElementRef, ContentChild} from '@angular/core';
+import {
+  forwardRef,
+  Inject,
+  Directive,
+  Input,
+  Output,
+  EventEmitter,
+  ElementRef,
+  ContentChild,
+  OnChanges,
+  SimpleChanges
+} from '@angular/core';
 import {NgbDropdownConfig} from './dropdown-config';
 
 /**
  */
-@Directive({selector: '[ngbDropdownMenu]', host: {'[class.dropdown-menu]': 'true'}})
+@Directive(
+    {selector: '[ngbDropdownMenu]', host: {'[class.dropdown-menu]': 'true', '[class.show]': 'dropdown.isOpen()'}})
 export class NgbDropdownMenu {
-  constructor(private _elementRef: ElementRef) {}
+  isOpen = false;
+
+  constructor(@Inject(forwardRef(() => NgbDropdown)) public dropdown, private _elementRef: ElementRef) {}
 
   isEventFrom($event) { return this._elementRef.nativeElement.contains($event.target); }
 }
@@ -56,6 +70,10 @@ export class NgbDropdown {
 
   /**
    * Indicates that dropdown should be closed when selecting one of dropdown items (click) or pressing ESC.
+   * When it is true (default) dropdowns are automatically closed on both outside and inside (menu) clicks.
+   * When it is false dropdowns are never automatically closed.
+   * When it is 'outside' dropdowns are automatically closed on outside clicks but not on menu clicks.
+   * When it is 'inside' dropdowns are automatically on menu clicks but not on outside clicks.
    */
   @Input() autoClose: boolean | 'outside' | 'inside';
 
@@ -74,7 +92,6 @@ export class NgbDropdown {
     this.up = config.up;
     this.autoClose = config.autoClose;
   }
-
 
   /**
    * Checks if the dropdown menu is open or not.
@@ -130,19 +147,7 @@ export class NgbDropdown {
     }
   }
 
-  private _isEventFromToggle($event) {
-    if (this._toggle) {
-      return this._toggle.isEventFrom($event);
-    }
+  private _isEventFromToggle($event) { return this._toggle ? this._toggle.isEventFrom($event) : false; }
 
-    return false;
-  }
-
-  private _isEventFromMenu($event) {
-    if (this._menu) {
-      return this._menu.isEventFrom($event);
-    }
-
-    return false;
-  }
+  private _isEventFromMenu($event) { return this._menu ? this._menu.isEventFrom($event) : false; }
 }

--- a/src/test/typings/custom-jasmine.d.ts
+++ b/src/test/typings/custom-jasmine.d.ts
@@ -3,5 +3,6 @@ declare module jasmine {
     toHaveCssClass(expected: any): boolean;
     toHaveModal(content?: string | string[], selector?: string): boolean;
     toHaveBackdrop(): boolean;
+    toBeShown(): boolean;
   }
 }


### PR DESCRIPTION
This builds on top of #1743 and adds Bootstrap 4.beta specific markup changes (the `show` class needs to be added on the menu now).