### PR TITLE
chore: fix npm test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "install": "node misc/validate-commit.install.js",
-    "test": "karma start karma.conf.js",
+    "test": "gulp",
     "api-doc-tdd": "jasmine-node misc/api-doc.spec.js --autotest --watch misc/api-doc-test-cases/*.ts misc/api-doc.js",
     "api-doc-test": "jasmine-node misc/api-doc.spec.js"
   },


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.

I spent quite a while wondering why `npm test` wasn't working properly before realising this was broken. I think it's worth keeping the alias as it's almost a standard now to checkout any open source project and type `npm test` to run the tests. Let me know what you think 😄 