### PR TITLE
feat(modal): add component instance type

### DIFF
--- a/demo/src/app/components/modal/demos/basic/modal-basic.ts
+++ b/demo/src/app/components/modal/demos/basic/modal-basic.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, TemplateRef} from '@angular/core';
 
 import {NgbModal, ModalDismissReasons} from '@ng-bootstrap/ng-bootstrap';
 
@@ -12,7 +12,7 @@ export class NgbdModalBasic {
   constructor(private modalService: NgbModal) {}
 
   open(content) {
-    this.modalService.open(content).result.then((result) => {
+    this.modalService.open<TemplateRef<any>>(content).result.then((result) => {
       this.closeResult = `Closed with: ${result}`;
     }, (reason) => {
       this.closeResult = `Dismissed ${this.getDismissReason(reason)}`;

--- a/demo/src/app/components/modal/demos/component/modal-component.ts
+++ b/demo/src/app/components/modal/demos/component/modal-component.ts
@@ -33,7 +33,7 @@ export class NgbdModalComponent {
   constructor(private modalService: NgbModal) {}
 
   open() {
-    const modalRef = this.modalService.open(NgbdModalContent);
+    const modalRef = this.modalService.open<NgbdModalContent>(NgbdModalContent);
     modalRef.componentInstance.name = 'World';
   }
 }

--- a/demo/src/app/components/modal/demos/customclass/modal-customclass.ts
+++ b/demo/src/app/components/modal/demos/customclass/modal-customclass.ts
@@ -1,4 +1,4 @@
-import {Component, ViewEncapsulation} from '@angular/core';
+import {Component, ViewEncapsulation, TemplateRef} from '@angular/core';
 
 import {NgbModal, ModalDismissReasons} from '@ng-bootstrap/ng-bootstrap';
 
@@ -22,7 +22,7 @@ export class NgbdModalCustomclass {
   constructor(private modalService: NgbModal) {}
 
   open(content) {
-    this.modalService.open(content, { windowClass: 'dark-modal' });
+    this.modalService.open<TemplateRef<any>>(content, { windowClass: 'dark-modal' });
   }
 
 }

--- a/src/modal/modal-ref.ts
+++ b/src/modal/modal-ref.ts
@@ -26,7 +26,7 @@ export class NgbActiveModal {
  * A reference to a newly opened modal.
  */
 @Injectable()
-export class NgbModalRef {
+export class NgbModalRef<ComponentType> {
   private _resolve: (result?: any) => void;
   private _reject: (reason?: any) => void;
 
@@ -34,14 +34,14 @@ export class NgbModalRef {
    * The instance of component used as modal's content.
    * Undefined when a TemplateRef is used as modal's content.
    */
-  get componentInstance(): any {
+  get componentInstance(): ComponentType {
     if (this._contentRef.componentRef) {
       return this._contentRef.componentRef.instance;
     }
   }
 
   // only needed to keep TS1.8 compatibility
-  set componentInstance(instance: any) {}
+  set componentInstance(instance: ComponentType) {}
 
   /**
    * A promise that is resolved when a modal is closed and rejected when a modal is dismissed.

--- a/src/modal/modal-stack.ts
+++ b/src/modal/modal-stack.ts
@@ -28,7 +28,8 @@ export class NgbModalStack {
     this._windowFactory = _componentFactoryResolver.resolveComponentFactory(NgbModalWindow);
   }
 
-  open(moduleCFR: ComponentFactoryResolver, contentInjector: Injector, content: any, options): NgbModalRef {
+  open<ComponentType>(moduleCFR: ComponentFactoryResolver, contentInjector: Injector, content: any, options):
+      NgbModalRef<ComponentType> {
     const containerSelector = options.container || 'body';
     const containerEl = document.querySelector(containerSelector);
 
@@ -41,7 +42,7 @@ export class NgbModalStack {
 
     let windowCmptRef: ComponentRef<NgbModalWindow>;
     let backdropCmptRef: ComponentRef<NgbModalBackdrop>;
-    let ngbModalRef: NgbModalRef;
+    let ngbModalRef: NgbModalRef<ComponentType>;
 
 
     if (options.backdrop !== false) {
@@ -53,7 +54,7 @@ export class NgbModalStack {
     this._applicationRef.attachView(windowCmptRef.hostView);
     containerEl.appendChild(windowCmptRef.location.nativeElement);
 
-    ngbModalRef = new NgbModalRef(windowCmptRef, contentRef, backdropCmptRef);
+    ngbModalRef = new NgbModalRef<ComponentType>(windowCmptRef, contentRef, backdropCmptRef);
 
     activeModal.close = (result: any) => { ngbModalRef.close(result); };
     activeModal.dismiss = (reason: any) => { ngbModalRef.dismiss(reason); };

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -6,7 +6,8 @@ import {
   NgModule,
   getDebugNode,
   DebugElement,
-  ReflectiveInjector
+  ReflectiveInjector,
+  TemplateRef
 } from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {TestBed, ComponentFixture} from '@angular/core/testing';
@@ -602,7 +603,7 @@ export class WithActiveModalCmpt {
 })
 class TestComponent {
   name = 'World';
-  openedModal: NgbModalRef;
+  openedModal: NgbModalRef<TemplateRef<any>>;
   show = true;
   @ViewChild('content') tplContent;
   @ViewChild('destroyableContent') tplDestroyableContent;
@@ -613,7 +614,7 @@ class TestComponent {
   constructor(private modalService: NgbModal) {}
 
   open(content: string, options?: Object) {
-    this.openedModal = this.modalService.open(content, options);
+    this.openedModal = this.modalService.open<TemplateRef<any>>(content, options);
     return this.openedModal;
   }
   close() {

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -54,7 +54,7 @@ export class NgbModal {
    * components can be injected with an instance of the NgbActiveModal class. You can use methods on the
    * NgbActiveModal class to close / dismiss modals from "inside" of a component.
    */
-  open(content: any, options: NgbModalOptions = {}): NgbModalRef {
-    return this._modalStack.open(this._moduleCFR, this._injector, content, options);
+  open<ComponentType>(content: any, options: NgbModalOptions = {}): NgbModalRef<ComponentType> {
+    return this._modalStack.open<ComponentType>(this._moduleCFR, this._injector, content, options);
   }
 }


### PR DESCRIPTION
BREAKING CHANGE:
you now need to pass a component type to the modal open function.

Before:
```
modalService.open(ModalComponent);
```

After:
```
modalService.open<ModalComponent>(ModalComponent);
```

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.

It may be better to wait for TS 2.3 as a minimum where generic defaults are possible, so it would be a worse breaking change for users as it would only require them to upgrade their TS version.