### PR TITLE
chore(demo): Examples as default tab with mobile friendly display

### DIFF
--- a/demo/src/app/app.routing.ts
+++ b/demo/src/app/app.routing.ts
@@ -20,8 +20,9 @@ import {
   NgbdTooltip,
   NgbdTypeahead
 } from './components';
+import {DEFAULT_TAB} from './shared/component-wrapper/component-wrapper.component';
 
-const DEFAULT_API_PATH = {path: '', pathMatch: 'full', redirectTo: 'api'};
+const DEFAULT_API_PATH = {path: '', pathMatch: 'full', redirectTo: DEFAULT_TAB};
 
 const componentRoutes = [{
     path: 'components/accordion',

--- a/demo/src/app/shared/component-wrapper/component-wrapper.component.html
+++ b/demo/src/app/shared/component-wrapper/component-wrapper.component.html
@@ -11,16 +11,16 @@
         (tabChange)="tabChange($event)"
         [activeId]="activeTab"
       >
+        <ngb-tab title="Examples" id="examples">
+          <ng-template ngbTabContent>
+            <ng-content select="ngbd-example-box"></ng-content>
+          </ng-template>
+        </ngb-tab>
         <ngb-tab title="API" id="api">
           <ng-template ngbTabContent>
             <ng-content select="ngbd-api-docs"></ng-content>
             <ng-content select="ngbd-api-docs-class"></ng-content>
             <ng-content select="ngbd-api-docs-config"></ng-content>
-          </ng-template>
-        </ngb-tab>
-        <ngb-tab title="Examples" id="examples">
-          <ng-template ngbTabContent>
-            <ng-content select="ngbd-example-box"></ng-content>
           </ng-template>
         </ngb-tab>
       </ngb-tabset>

--- a/demo/src/app/shared/component-wrapper/component-wrapper.component.ts
+++ b/demo/src/app/shared/component-wrapper/component-wrapper.component.ts
@@ -1,8 +1,8 @@
 import {Component, Input} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
 
-const DEFAULT_TAB = 'api';
-const VALID_TABS = [DEFAULT_TAB, 'examples'];
+export const DEFAULT_TAB = 'examples';
+const VALID_TABS = [DEFAULT_TAB, 'api'];
 
 @Component({
   selector: 'ngbd-component-wrapper',

--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -245,3 +245,26 @@ ngbd-component-wrapper, ngbd-page-wrapper {
     transform: translateY(-$offset / 2);
   }
 }
+
+@mixin center-nav-tab-on-small-screens() {
+  .jumbotron > .container {
+    margin-bottom: 2rem;
+    h1 {
+      text-align: center;
+    }
+  }
+
+  .root-nav {
+    ul {
+      justify-content: center !important;
+    }
+  }
+}
+
+@media (max-width: 768px) and (orientation:portrait) {
+  @include center-nav-tab-on-small-screens();
+}
+
+@media (max-width: 568px) and (max-height: 320px)  {
+  @include center-nav-tab-on-small-screens();
+}


### PR DESCRIPTION
Via this PR I am fixing this long running "visual issue" I introduced on #1645 that on mobile header title is not properly aligned with the tab-set.

<img width="280" alt="screen shot 2017-08-28 at 11 50 04" src="https://user-images.githubusercontent.com/1152740/29773480-ff6b025c-8bfd-11e7-9ad9-aad78cdd6073.png">

To bypass this issue, that is a nightmare to fix with only CSS media queries (thank you Apple with your split screen functionality !!) I propose to simply center both title and tabset on such devices when this is a relatively small viewport.

Here is a capture:

<img width="284" alt="screen shot 2017-08-28 at 11 36 16" src="https://user-images.githubusercontent.com/1152740/29773484-0313e32e-8bfe-11e7-9531-ad25a1d0f545.png">


As I am tweaking tab-set code, I am also taking the opportunity to swap both tabs (API & Examples) and activate Example as the default one in all environment, not only mobile.

What do you think guys ? cc @pkozlowski-opensource 