### PR TITLE
feat(alert): add animations

### DIFF
--- a/demo/src/app/components/alert/demos/closeable/alert-closeable.html
+++ b/demo/src/app/components/alert/demos/closeable/alert-closeable.html
@@ -1,6 +1,6 @@
-<p *ngFor="let alert of alerts">
-  <ngb-alert [type]="alert.type" (close)="closeAlert(alert)">{{ alert.message }}</ngb-alert>
-</p>
+<ngb-alert [type]="alert.type" (close)="closeAlert(alert)" *ngFor="let alert of alerts">
+  {{ alert.message }}
+</ngb-alert>
 <p>
   <button type="button" class="btn btn-primary" (click)="reset()">Reset</button>
 </p>

--- a/demo/src/app/components/alert/index.ts
+++ b/demo/src/app/components/alert/index.ts
@@ -1,7 +1,6 @@
 export * from './alert.component';
 
 import {NgModule} from '@angular/core';
-import {CommonModule} from '@angular/common';
 
 import {NgbdSharedModule} from '../../shared';
 import {NgbdComponentsSharedModule} from '../shared';

--- a/src/alert/alert.spec.ts
+++ b/src/alert/alert.spec.ts
@@ -2,6 +2,7 @@ import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
 import {createGenericTestComponent} from '../test/common';
 
 import {Component} from '@angular/core';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 import {NgbAlertModule} from './alert.module';
 import {NgbAlert} from './alert';
@@ -20,8 +21,10 @@ function getCloseButton(element: HTMLElement): HTMLButtonElement {
 
 describe('ngb-alert', () => {
 
-  beforeEach(
-      () => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAlertModule.forRoot()]}); });
+  beforeEach(() => {
+    TestBed.configureTestingModule(
+        {declarations: [TestComponent], imports: [NoopAnimationsModule, NgbAlertModule.forRoot()]});
+  });
 
   it('should initialize inputs with default values', () => {
     const defaultConfig = new NgbAlertConfig();

--- a/src/alert/alert.ts
+++ b/src/alert/alert.ts
@@ -1,11 +1,7 @@
-import {
-  Component,
-  Input,
-  Output,
-  EventEmitter,
-  ChangeDetectionStrategy,
-} from '@angular/core';
+import {Component, Input, Output, EventEmitter, ChangeDetectionStrategy} from '@angular/core';
+import {trigger, transition, useAnimation} from '@angular/animations';
 
+import {fadeOut} from '../animations/fade';
 import {NgbAlertConfig} from './alert-config';
 
 /**
@@ -14,14 +10,19 @@ import {NgbAlertConfig} from './alert-config';
 @Component({
   selector: 'ngb-alert',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  animations: [trigger('fadeOut', [transition(':leave', useAnimation(fadeOut, {params: {opacity: 1}}))])],
+  host: {
+    '[class]': '"alert alert-" + type + (dismissible ? " alert-dismissible" : "")',
+    'role': 'alert',
+    '[style.display]': '"block"',
+    '[@fadeOut]': ''
+  },
   template: `
-    <div [class]="'alert alert-' + type + (dismissible ? ' alert-dismissible' : '')" role="alert">
-      <button *ngIf="dismissible" type="button" class="close" aria-label="Close" (click)="closeHandler()">
-            <span aria-hidden="true">&times;</span>
-      </button>
-      <ng-content></ng-content>
-    </div>
-    `
+    <button *ngIf="dismissible" type="button" class="close" aria-label="Close" (click)="closeHandler()">
+          <span aria-hidden="true">&times;</span>
+    </button>
+    <ng-content></ng-content>
+    `,
 })
 export class NgbAlert {
   /**


### PR DESCRIPTION
This PR adds fade out animations to alerts. @mattlewis92 would you mind reviewing this one? 

As you can see I didn't re-use the `fadeOut` animations you've defined as it comes with the initial state forcing `0.5` opacity. Maybe we should parametrize it?