### PR TITLE
demo: add colored badges for items in documentation

### DIFF
--- a/demo/src/app/components/shared/api-docs/api-docs-badge.component.ts
+++ b/demo/src/app/components/shared/api-docs/api-docs-badge.component.ts
@@ -1,0 +1,27 @@
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
+
+const BADGES = {
+  'Directive': 'success',
+  'Component': 'success',
+  'Service': 'primary',
+  'Configuration': 'primary',
+  'Class': 'danger',
+  'Interface': 'danger'
+};
+
+@Component({
+  selector: 'ngbd-api-docs-badge',
+  template: `<h5><span class="badge" [ngClass]="badgeClass">{{text}}</span></h5>`,
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class NgbdApiDocsBadge {
+
+  badgeClass;
+  text;
+
+  @Input()
+  set type(type: string) {
+    this.text = type;
+    this.badgeClass = `badge-${BADGES[type] || 'secondary'}`;
+  }
+}

--- a/demo/src/app/components/shared/api-docs/api-docs-class.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs-class.component.html
@@ -19,7 +19,7 @@
       <img src="img/github.svg" alt="Link to Github {{apiDocs.className}}"/>
     </a>
   </h3>
-  <h5><small class="text-muted">Class / Service</small></h5>
+  <ngbd-api-docs-badge [type]="apiDocs.type"></ngbd-api-docs-badge>
   <p class="lead">{{apiDocs.description}}</p>
 
   <ng-template [ngIf]="apiDocs.properties && apiDocs.properties.length">

--- a/demo/src/app/components/shared/api-docs/api-docs-config.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs-config.component.html
@@ -19,7 +19,7 @@
       <img src="img/github.svg" alt="Link to Github {{apiDocs.className}}"/>
     </a>
   </h3>
-  <h5><small class="text-muted">Configuration</small></h5>
+  <ngbd-api-docs-badge type="Configuration"></ngbd-api-docs-badge>
   <p class="lead">{{apiDocs.description}}</p>
 
   <ng-template [ngIf]="apiDocs.properties && apiDocs.properties.length">

--- a/demo/src/app/components/shared/api-docs/api-docs.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs.component.html
@@ -18,7 +18,7 @@
       <img src="img/github.svg" alt="Link to Github {{apiDocs.className}}"/>
     </a>
   </h2>
-  <h5><small class="text-muted">Directive</small></h5>
+  <ngbd-api-docs-badge [type]="apiDocs.type"></ngbd-api-docs-badge>
   <p class="lead">
     {{apiDocs.description}}
   </p>

--- a/demo/src/app/components/shared/api-docs/api-docs.model.ts
+++ b/demo/src/app/components/shared/api-docs/api-docs.model.ts
@@ -1,4 +1,5 @@
 export interface ClassDesc {
+  type: string;
   fileName: string;
   className: string;
   description: string;

--- a/demo/src/app/components/shared/api-docs/index.ts
+++ b/demo/src/app/components/shared/api-docs/index.ts
@@ -1,3 +1,4 @@
 export * from './api-docs.component';
+export * from './api-docs-badge.component';
 export * from './api-docs-class.component';
 export * from './api-docs-config.component';

--- a/demo/src/app/components/shared/index.ts
+++ b/demo/src/app/components/shared/index.ts
@@ -3,13 +3,14 @@ import {NgModule} from '@angular/core';
 import {NgbdSharedModule} from '../../shared';
 import {ExampleBoxComponent} from './example-box/example-box.component';
 import {NgbdApiDocs} from './api-docs/api-docs.component';
+import {NgbdApiDocsBadge} from './api-docs/api-docs-badge.component';
 import {NgbdApiDocsClass} from './api-docs/api-docs-class.component';
 import {NgbdApiDocsConfig} from './api-docs/api-docs-config.component';
 import {NgbdFragment} from './fragment/fragment.directive';
 
 @NgModule({
   imports: [NgbdSharedModule],
-  declarations: [ExampleBoxComponent, NgbdApiDocs, NgbdApiDocsClass, NgbdApiDocsConfig, NgbdFragment],
-  exports: [ExampleBoxComponent, NgbdApiDocs, NgbdApiDocsClass, NgbdApiDocsConfig, NgbdFragment]
+  declarations: [ExampleBoxComponent, NgbdApiDocsBadge, NgbdApiDocs, NgbdApiDocsClass, NgbdApiDocsConfig, NgbdFragment],
+  exports: [ExampleBoxComponent, NgbdApiDocsBadge, NgbdApiDocs, NgbdApiDocsClass, NgbdApiDocsConfig, NgbdFragment]
 })
 export class NgbdComponentsSharedModule {}

--- a/misc/api-doc-test-cases/types.ts
+++ b/misc/api-doc-test-cases/types.ts
@@ -1,0 +1,34 @@
+import {Component, Directive, Injectable} from '@angular/core';
+
+@Directive({
+  selector: '[ngbDirective]'
+})
+/**
+ * Should be 'Directive'
+ */
+export class NgbDirective {}
+
+@Component({
+  selector: 'ngb-component'
+})
+/**
+ * Should be 'Component'
+ */
+export class NgbComponent {}
+
+
+@Injectable()
+/**
+ * Should be 'Service'
+ */
+export class NgbService {}
+
+/**
+ * Should be 'Class'
+ */
+export class NgbClass {}
+
+/**
+ * Should be 'Interface'
+ */
+export interface NgbInterface {}

--- a/misc/api-doc.spec.js
+++ b/misc/api-doc.spec.js
@@ -23,6 +23,18 @@ describe('APIDocVisitor', function() {
     expect(docs.Bar.description).toBe('Bar doc');
   });
 
+  it('should extract basic type info from classes', function() {
+    var docs = apiDoc(['misc/api-doc-test-cases/types.ts']);
+
+    expect(Object.keys(docs).length).toBe(5);
+
+    expect(docs.NgbDirective.type).toBe('Directive');
+    expect(docs.NgbComponent.type).toBe('Component');
+    expect(docs.NgbService.type).toBe('Service');
+    expect(docs.NgbClass.type).toBe('Class');
+    expect(docs.NgbInterface.type).toBe('Interface');
+  });
+
   it('should extract inputs info', function() {
     var inputDocs = apiDoc(['./misc/api-doc-test-cases/directives-with-inputs.ts']).Foo.inputs;
 


### PR DESCRIPTION
- Adding type information extraction to the api generation → `Component`, `Directive`, `Class`, `Service`, `Interface`
- Adding colored badges on the demo site
- `Configuration` is a special one set directly in demo components

<details>
  <summary>See the sample screenshot here (omitted inputs/outputs for simplcity)</summary>
<img src="https://user-images.githubusercontent.com/8074436/29929490-ed2721f0-8e6b-11e7-888d-6dedd76959dc.png" />
</details>