### PR TITLE
feat(collapse): add animations

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,18 +48,18 @@
   },
   "homepage": "https://github.com/ng-bootstrap/ng-bootstrap#readme",
   "dependencies": {
-    "@angular/animations": "4.2.0",
-    "@angular/common": "4.2.0",
-    "@angular/core": "4.2.0",
-    "@angular/forms": "4.2.0"
+    "@angular/animations": "4.3.6",
+    "@angular/common": "4.3.6",
+    "@angular/core": "4.3.6",
+    "@angular/forms": "4.3.6"
   },
   "devDependencies": {
-    "@angular/compiler": "4.2.0",
-    "@angular/compiler-cli": "4.2.0",
-    "@angular/http": "4.2.0",
-    "@angular/platform-browser": "4.2.0",
-    "@angular/platform-browser-dynamic": "4.2.0",
-    "@angular/router": "4.2.0",
+    "@angular/compiler": "4.3.6",
+    "@angular/compiler-cli": "4.3.6",
+    "@angular/http": "4.3.6",
+    "@angular/platform-browser": "4.3.6",
+    "@angular/platform-browser-dynamic": "4.3.6",
+    "@angular/router": "4.3.6",
     "@ngtools/webpack": "1.3.0",
     "@types/jasmine": "2.5.41",
     "@types/node": "^6.0.46",

--- a/src/collapse/collapse.ts
+++ b/src/collapse/collapse.ts
@@ -1,12 +1,25 @@
-import {Directive, Input} from '@angular/core';
+import {Component, Input} from '@angular/core';
+import {animate, animation, state, style, trigger, transition, useAnimation} from '@angular/animations';
+
+
+const collapseAnimation =
+    animation([style({height: '{{from}}', overflow: 'hidden'}), animate('0.95s ease', style({height: '{{to}}'}))]);
 
 /**
- * The NgbCollapse directive provides a simple way to hide and show an element with animations.
+ * The NgbCollapse component provides a simple way to hide and show an element with animations.
  */
-@Directive({
+@Component({
   selector: '[ngbCollapse]',
   exportAs: 'ngbCollapse',
-  host: {'[class.collapse]': 'true', '[class.show]': '!collapsed'}
+  host: {'[@collapse]': 'collapsed ? "collapsed" : "expanded"'},
+  template: '<ng-content></ng-content>',
+  animations: [trigger(
+      'collapse',
+      [
+        state('collapsed', style({display: 'none'})),
+        transition('collapsed => expanded', [useAnimation(collapseAnimation, {params: {from: '0', to: '*'}})]),
+        transition('expanded => collapsed', [useAnimation(collapseAnimation, {params: {from: '*', to: '0'}})]),
+      ])]
 })
 export class NgbCollapse {
   /**

--- a/src/test/typings/custom-jasmine.d.ts
+++ b/src/test/typings/custom-jasmine.d.ts
@@ -4,5 +4,6 @@ declare module jasmine {
     toHaveModal(content?: string | string[], selector?: string): boolean;
     toHaveBackdrop(): boolean;
     toBeShown(): boolean;
+    toBeExpanded(): boolean;
   }
 }


### PR DESCRIPTION
BREAKING CHANGE:

The `ngbCollapse` is a component now (used to be a directive).
Since this change you can't use `ngbCollapse` on other components
(but still can get the same effect by using it on a wrapper element
above).

Also requires Angular 4.3.6 as a minimal version.