### PR TITLE
refactor(accordion): remove redundant internal state

### DIFF
--- a/src/accordion/accordion.ts
+++ b/src/accordion/accordion.ts
@@ -52,6 +52,11 @@ export class NgbPanel {
   @Input() id = `ngb-panel-${nextId++}`;
 
   /**
+   * A flag telling if the panel is currently open
+   */
+  isOpen = false;
+
+  /**
    *  The title for the panel.
    */
   @Input() title: string;
@@ -98,15 +103,15 @@ export interface NgbPanelChangeEvent {
     <ng-template ngFor let-panel [ngForOf]="panels">
       <div class="card">
         <div role="tab" id="{{panel.id}}-header"
-          [class]="'card-header ' + (panel.type ? 'card-'+panel.type: type ? 'card-'+type : '')" [class.active]="isOpen(panel.id)">
+          [class]="'card-header ' + (panel.type ? 'card-'+panel.type: type ? 'card-'+type : '')" [class.active]="panel.isOpen">
           <a href (click)="!!toggle(panel.id)" [class.text-muted]="panel.disabled" [attr.tabindex]="(panel.disabled ? '-1' : null)"
-            [attr.aria-expanded]="isOpen(panel.id)" [attr.aria-controls]="(isOpen(panel.id) ? panel.id : null)"
+            [attr.aria-expanded]="panel.isOpen" [attr.aria-controls]="(panel.isOpen ? panel.id : null)"
             [attr.aria-disabled]="panel.disabled">
             {{panel.title}}<ng-template [ngTemplateOutlet]="panel.titleTpl?.templateRef"></ng-template>
           </a>
         </div>
         <div id="{{panel.id}}" role="tabpanel" [attr.aria-labelledby]="panel.id + '-header'" 
-             class="card-body {{isOpen(panel.id) ? 'show' : null}}" *ngIf="!destroyOnHide || isOpen(panel.id)">
+             class="card-body {{panel.isOpen ? 'show' : null}}" *ngIf="!destroyOnHide || panel.isOpen">
              <ng-template [ngTemplateOutlet]="panel.contentTpl.templateRef"></ng-template>
         </div>
       </div>
@@ -114,16 +119,6 @@ export interface NgbPanelChangeEvent {
   `
 })
 export class NgbAccordion implements AfterContentChecked {
-  /**
-   * A map that stores each panel state
-   */
-  private _states: Map<string, boolean> = new Map<string, boolean>();
-
-  /**
-   * A map that stores references to all panels
-   */
-  private _panelRefs: Map<string, NgbPanel> = new Map<string, NgbPanel>();
-
   @ContentChildren(NgbPanel) panels: QueryList<NgbPanel>;
 
   /**
@@ -161,17 +156,16 @@ export class NgbAccordion implements AfterContentChecked {
    * Programmatically toggle a panel with a given id.
    */
   toggle(panelId: string) {
-    const panel = this._panelRefs.get(panelId);
+    const panel = this.panels.find(p => p.id === panelId);
 
     if (panel && !panel.disabled) {
-      const nextState = !this._states.get(panelId);
       let defaultPrevented = false;
 
       this.panelChange.emit(
-          {panelId: panelId, nextState: nextState, preventDefault: () => { defaultPrevented = true; }});
+          {panelId: panelId, nextState: !panel.isOpen, preventDefault: () => { defaultPrevented = true; }});
 
       if (!defaultPrevented) {
-        this._states.set(panelId, nextState);
+        panel.isOpen = !panel.isOpen;
 
         if (this.closeOtherPanels) {
           this._closeOthers(panelId);
@@ -186,7 +180,9 @@ export class NgbAccordion implements AfterContentChecked {
     if (isString(this.activeIds)) {
       this.activeIds = this.activeIds.split(/\s*,\s*/);
     }
-    this._updateStates();
+
+    // update panels open states
+    this.panels.forEach(panel => panel.isOpen = !panel.disabled && this.activeIds.indexOf(panel.id) > -1);
 
     // closeOthers updates
     if (this.activeIds.length > 1 && this.closeOtherPanels) {
@@ -195,30 +191,15 @@ export class NgbAccordion implements AfterContentChecked {
     }
   }
 
-  /**
-   * @internal
-   */
-  isOpen(panelId: string): boolean { return this._states.get(panelId); }
-
   private _closeOthers(panelId: string) {
-    this._states.forEach((state, id) => {
-      if (id !== panelId) {
-        this._states.set(id, false);
+    this.panels.forEach(panel => {
+      if (panel.id !== panelId) {
+        panel.isOpen = false;
       }
     });
   }
 
   private _updateActiveIds() {
-    this.activeIds =
-        this.panels.toArray().filter(panel => this.isOpen(panel.id) && !panel.disabled).map(panel => panel.id);
-  }
-
-  private _updateStates() {
-    this._states.clear();
-    this._panelRefs.clear();
-    this.panels.toArray().forEach((panel) => {
-      this._states.set(panel.id, this.activeIds.indexOf(panel.id) > -1 && !panel.disabled);
-      this._panelRefs.set(panel.id, panel);
-    });
+    this.activeIds = this.panels.filter(panel => panel.isOpen && !panel.disabled).map(panel => panel.id);
   }
 }


### PR DESCRIPTION
Clean up accordion internal state a little:
- remove redundant `_panelRefs` and `_states`
- instead add `isOpen` flag on the panel itself
