### PR TITLE
Fixed ngDropDown when rendered on server side with ng-universal

### DIFF
--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -34,17 +34,17 @@ export class NgbDropdownMenu {
 
   applyPlacement(_placement: Placement) {
     // remove the current placement classes
-    this._renderer.removeClass(this._elementRef.nativeElement.parentElement, 'dropup');
-    this._renderer.removeClass(this._elementRef.nativeElement.parentElement, 'dropdown');
+    this._renderer.removeClass(this._elementRef.nativeElement.parentNode, 'dropup');
+    this._renderer.removeClass(this._elementRef.nativeElement.parentNode, 'dropdown');
     this.placement = _placement;
     /**
      * apply the new placement
      * in case of top use up-arrow or down-arrow otherwise
      */
     if (_placement.search('^top') !== -1) {
-      this._renderer.addClass(this._elementRef.nativeElement.parentElement, 'dropup');
+      this._renderer.addClass(this._elementRef.nativeElement.parentNode, 'dropup');
     } else {
-      this._renderer.addClass(this._elementRef.nativeElement.parentElement, 'dropdown');
+      this._renderer.addClass(this._elementRef.nativeElement.parentNode, 'dropdown');
     }
   }
 }


### PR DESCRIPTION

Fixed this error when rendered with [ng-universal](https://github.com/angular/universal) on server side:

`TypeError: Cannot read property 'attribs' of undefined`