### PR TITLE
refactor(datepicker): move 'navigation' type handling to service

### DIFF
--- a/src/datepicker/datepicker-service.spec.ts
+++ b/src/datepicker/datepicker-service.spec.ts
@@ -408,6 +408,28 @@ describe('ngb-datepicker-service', () => {
 
   });
 
+  describe(`navigation`, () => {
+
+    it(`should emit navigation values`, () => {
+      // default = 'selected'
+      service.focus(new NgbDate(2015, 5, 1));
+      expect(model.navigation).toEqual('select');
+
+      service.navigation = 'none';
+      expect(model.navigation).toEqual('none');
+
+      service.navigation = 'arrows';
+      expect(model.navigation).toEqual('arrows');
+    });
+
+    it(`should not emit the same 'navigation' value twice`, () => {
+      service.focus(new NgbDate(2017, 5, 1));
+
+      service.navigation = 'select';  // ignored
+      expect(mock.onNext).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe(`markDisabled`, () => {
 
     it(`should mark dates as disabled by passing 'markDisabled'`, () => {

--- a/src/datepicker/datepicker-service.ts
+++ b/src/datepicker/datepicker-service.ts
@@ -15,8 +15,15 @@ export class NgbDatepickerService {
 
   private _select$ = new Subject<NgbDate>();
 
-  private _state: DatepickerViewModel =
-      {disabled: false, displayMonths: 1, firstDayOfWeek: 1, focusVisible: false, months: [], selectedDate: null};
+  private _state: DatepickerViewModel = {
+    disabled: false,
+    displayMonths: 1,
+    firstDayOfWeek: 1,
+    focusVisible: false,
+    months: [],
+    navigation: 'select',
+    selectedDate: null
+  };
 
   get model$(): Observable<DatepickerViewModel> {
     return filter.call(this._model$.asObservable(), model => model.months.length > 0);
@@ -63,6 +70,12 @@ export class NgbDatepickerService {
   set minDate(date: NgbDate) {
     if (date === undefined || this._calendar.isValid(date) && isChangedDate(this._state.minDate, date)) {
       this._nextState({minDate: date});
+    }
+  }
+
+  set navigation(navigation: 'select' | 'arrows' | 'none') {
+    if (this._state.navigation !== navigation) {
+      this._nextState({navigation: navigation});
     }
   }
 

--- a/src/datepicker/datepicker-view-model.ts
+++ b/src/datepicker/datepicker-view-model.ts
@@ -36,6 +36,7 @@ export type DatepickerViewModel = {
   maxDate?: NgbDate,
   minDate?: NgbDate,
   months: MonthViewModel[],
+  navigation: 'select' | 'arrows' | 'none',
   selectedDate: NgbDate
 }
 // clang-format on

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -98,14 +98,14 @@ export interface NgbDatepickerNavigateEvent {
 
     <div class="ngb-dp-header bg-light pt-1 rounded-top" [style.height.rem]="getHeaderHeight()"
          [style.marginBottom.rem]="-getHeaderMargin()">
-      <ngb-datepicker-navigation *ngIf="navigation !== 'none'"
+      <ngb-datepicker-navigation *ngIf="model.navigation !== 'none'"
         [date]="model.firstDate"
         [minDate]="model.minDate"
         [maxDate]="model.maxDate"
         [months]="model.months.length"
         [disabled]="model.disabled"
         [showWeekNumbers]="showWeekNumbers"
-        [showSelect]="navigation === 'select'"
+        [showSelect]="model.navigation === 'select'"
         (navigate)="onNavigateEvent($event)"
         (select)="onNavigateDateSelect($event)">
       </ngb-datepicker-navigation>
@@ -114,7 +114,7 @@ export interface NgbDatepickerNavigateEvent {
     <div class="ngb-dp-months d-flex px-1 pb-1">
       <ng-template ngFor let-month [ngForOf]="model.months" let-i="index">
         <div class="ngb-dp-month d-block ml-3">
-          <div *ngIf="navigation !== 'select' || displayMonths > 1" class="ngb-dp-month-name text-center">
+          <div *ngIf="model.navigation !== 'select' || displayMonths > 1" class="ngb-dp-month-name text-center">
             {{ i18n.getMonthFullName(month.number) }} {{ month.year }}
           </div>
           <ngb-datepicker-month-view
@@ -293,6 +293,7 @@ export class NgbDatepicker implements OnDestroy,
       this._service.displayMonths = toInteger(this.displayMonths);
       this._service.markDisabled = this.markDisabled;
       this._service.firstDayOfWeek = this.firstDayOfWeek;
+      this._service.navigation = this.navigation;
       this._setDates();
     }
   }
@@ -306,6 +307,9 @@ export class NgbDatepicker implements OnDestroy,
     }
     if (changes['firstDayOfWeek']) {
       this._service.firstDayOfWeek = this.firstDayOfWeek;
+    }
+    if (changes['navigation']) {
+      this._service.navigation = this.navigation;
     }
     this._setDates();
   }


### PR DESCRIPTION
As a part of moving the rest of the state from components to the `NgbDatepickerService`.
This is a prerequisite for fixing min/max dates handling
