### PR TITLE
chore: use bootstrap 4.0.0-beta.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ View all the directives in action at https://ng-bootstrap.github.io
 
 ## Dependencies
 * [Angular](https://angular.io) (tested with 4.0.3)
-* [Bootstrap 4](https://www.getbootstrap.com) (tested with 4.0.0-beta)
+* [Bootstrap 4](https://www.getbootstrap.com) (tested with 4.0.0-beta.2)
 
 ## Installation
 After installing the above dependencies, install `ng-bootstrap` via:

--- a/demo/src/app/app.component.html
+++ b/demo/src/app/app.component.html
@@ -53,7 +53,7 @@
                               target="_blank">MIT license conditions.</a></p>
     <p>
       Documentation licensed under <a href="https://creativecommons.org/licenses/by/3.0/" target="_blank">CC BY 3.0</a>.
-      Design and content of the documentation site heavily inspired by the <a href="http://v4-alpha.getbootstrap.com/"
+      Design and content of the documentation site heavily inspired by the <a href="https:/getbootstrap.com/"
                                                                               target="_blank">original Bootstrap design</a>.</p>
     <p>Icons made by
       <a href="http://www.flaticon.com/authors/eucalyp" target="_blank">Eucalyp</a>,

--- a/demo/src/app/getting-started/getting-started.component.html
+++ b/demo/src/app/getting-started/getting-started.component.html
@@ -11,7 +11,7 @@
       <a href="https://angular.io" target="_blank">Angular</a> (<em>requires</em> Angular version 4 or higher, tested with 4.0.3)
     </li>
     <li>
-      <a href="https://www.getbootstrap.com" target="_blank">Bootstrap CSS</a> (tested with 4.0.0-beta)
+      <a href="https://www.getbootstrap.com" target="_blank">Bootstrap CSS</a> (tested with 4.0.0-beta.2)
     </li>
   </ul>
 
@@ -26,7 +26,7 @@
   </h3>
   <p>We strive to support the same browsers and versions as supported by both Bootstrap 4 and Angular, whichever is more restrictive. Check browser support notes for
     <a href="https://angular.io/docs/ts/latest/guide/browser-support.html" target="_blank">Angular</a> and
-    <a href="http://v4-alpha.getbootstrap.com/getting-started/browsers-devices/" target="_blank">Bootstrap</a>.
+    <a href="https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/" target="_blank">Bootstrap</a>.
   </p>
   <p>Our code is automatically tested on all the supported browsers.</p>
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "angular2-template-loader": "^0.6.0",
     "async-done": "^1.2.2",
     "autoprefixer": "^6.5.1",
-    "bootstrap": "4.0.0-beta",
+    "bootstrap": "4.0.0-beta.2",
     "clang-format": "1.0.35",
     "copy-webpack-plugin": "^4.0.0",
     "core-js": "^2.4.1",


### PR DESCRIPTION
Haven't found any breaking changes between `beta.1` and `beta.2` that affect us. Locally all components seem to be ok.