### PR TITLE
chore: add Edge 15 and Safari 11 to SauceLabs

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -141,7 +141,7 @@ function startKarmaServer(isTddMode, isSaucelabs, done) {
   if (isSaucelabs) {
     config['reporters'] = ['dots', 'saucelabs'];
     config['browsers'] =
-        ['SL_CHROME', 'SL_FIREFOX', 'SL_IE10', 'SL_IE11', 'SL_EDGE13', 'SL_EDGE14', 'SL_SAFARI9', 'SL_SAFARI10'];
+        ['SL_CHROME', 'SL_FIREFOX', 'SL_IE10', 'SL_IE11', 'SL_EDGE14', 'SL_EDGE15', 'SL_SAFARI10', 'SL_SAFARI11'];
 
     if (process.env.TRAVIS) {
       var buildId = `TRAVIS #${process.env.TRAVIS_BUILD_NUMBER} (${process.env.TRAVIS_BUILD_ID})`;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -61,30 +61,30 @@ module.exports = function(config) {
         platform: 'Windows 8.1',
         version: '11'
       },
-      'SL_EDGE13': {
-        base: 'SauceLabs',
-        browserName: 'MicrosoftEdge',
-        platform: 'Windows 10',
-        version: '13.10586'
-      },
       'SL_EDGE14': {
         base: 'SauceLabs',
         browserName: 'MicrosoftEdge',
         platform: 'Windows 10',
         version: '14.14393'
       },
-      'SL_SAFARI9': {
+      'SL_EDGE15': {
         base: 'SauceLabs',
-        browserName: 'safari',
-        platform: 'OS X 10.11',
-        version: '9.0'
+        browserName: 'MicrosoftEdge',
+        platform: 'Windows 10',
+        version: '15.15063'
       },
       'SL_SAFARI10': {
         base: 'SauceLabs',
         browserName: 'safari',
         platform: 'OS X 10.11',
         version: '10.0'
-      }
+      },
+      'SL_SAFARI11': {
+        base: 'SauceLabs',
+        browserName: 'safari',
+        platform: 'macOS 10.12',
+        version: '11.0'
+      },
     },
 
     sauceLabs: {


### PR DESCRIPTION
Use two latest versions of Edge and Safari:

- Edge → 14 and 15, drop 13
- Safari → 11 and 10, drop 9