### PR TITLE
feat(tooltip): optionally get content from 'title' attribute

### DIFF
--- a/demo/src/app/components/tooltip/demos/index.ts
+++ b/demo/src/app/components/tooltip/demos/index.ts
@@ -1,4 +1,5 @@
 import {NgbdTooltipBasic} from './basic/tooltip-basic';
+import {NgbdTooltipTitle} from './title/tooltip-title';
 import {NgbdTooltipContainer} from './container/tooltip-container';
 import {NgbdTooltipTplcontent} from './tplcontent/tooltip-tplcontent';
 import {NgbdTooltipTplwithcontext} from './tplwithcontext/tooltip-tplwithcontext';
@@ -7,6 +8,7 @@ import {NgbdTooltipConfig} from './config/tooltip-config';
 
 export const DEMO_DIRECTIVES = [
   NgbdTooltipBasic,
+  NgbdTooltipTitle,
   NgbdTooltipContainer,
   NgbdTooltipTplcontent,
   NgbdTooltipTriggers,
@@ -18,6 +20,10 @@ export const DEMO_SNIPPETS = {
   'basic': {
     'code': require('!!prismjs-loader?lang=typescript!./basic/tooltip-basic'),
     'markup': require('!!prismjs-loader?lang=markup!./basic/tooltip-basic.html')
+  },
+  'title': {
+    'code': require('!!prismjs-loader?lang=typescript!./title/tooltip-title'),
+    'markup': require('!!prismjs-loader?lang=markup!./title/tooltip-title.html')
   },
   'container': {
     'code': require('!!prismjs-loader?lang=typescript!./container/tooltip-container'),

--- a/demo/src/app/components/tooltip/demos/title/tooltip-title.html
+++ b/demo/src/app/components/tooltip/demos/title/tooltip-title.html
@@ -1,0 +1,7 @@
+<p>
+  Tooltips can get their content via the HTML <code>title</code> attribute, if you fancy amore semantic approach.
+</p>
+
+<button type="button" class="btn btn-outline-secondary" title="Yay semantics!" placement="top" ngbTooltip>
+  I'm using the actual <code>title</code> attribute!
+</button>

--- a/demo/src/app/components/tooltip/demos/title/tooltip-title.ts
+++ b/demo/src/app/components/tooltip/demos/title/tooltip-title.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'ngbd-tooltip-title',
+  templateUrl: './tooltip-title.html'
+})
+export class NgbdTooltipTitle {
+}

--- a/demo/src/app/components/tooltip/tooltip.component.ts
+++ b/demo/src/app/components/tooltip/tooltip.component.ts
@@ -11,6 +11,10 @@ import {DEMO_SNIPPETS} from './demos';
         <ngbd-tooltip-basic></ngbd-tooltip-basic>
       </ngbd-example-box>
       <ngbd-example-box
+        demoTitle="Optionally use HTML title attribute" [snippets]="snippets" component="tooltip" demo="title">
+        <ngbd-tooltip-title></ngbd-tooltip-title>
+      </ngbd-example-box>
+      <ngbd-example-box
         demoTitle="HTML and bindings in tooltips" [snippets]="snippets" component="tooltip" demo="tplcontent">
         <ngbd-tooltip-tplcontent></ngbd-tooltip-tplcontent>
       </ngbd-example-box>

--- a/src/tooltip/tooltip.spec.ts
+++ b/src/tooltip/tooltip.spec.ts
@@ -465,6 +465,26 @@ describe('ngb-tooltip', () => {
     });
   });
 
+  describe('Use title attribute as content', () => {
+    it('should get tooltip content from the title attribute when present', () => {
+      const elementTitle = 'Great tip!';
+      const fixture = createTestComponent(`<div title="${elementTitle}" ngbTooltip></div>`);
+      const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+      const defaultConfig = new NgbTooltipConfig();
+
+      directive.triggerEventHandler('mouseenter', {});
+      fixture.detectChanges();
+      const windowEl = getWindow(fixture.nativeElement);
+
+      expect(windowEl.textContent.trim()).toBe('Great tip!');
+      expect(directive.nativeElement.getAttribute('title')).toBeNull();
+
+      directive.triggerEventHandler('mouseleave', {});
+      fixture.detectChanges();
+      expect(directive.nativeElement.getAttribute('title')).toEqual(elementTitle);
+    });
+  });
+
   describe('Custom config', () => {
     let config: NgbTooltipConfig;
 

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -49,7 +49,7 @@ let nextId = 0;
     :host.bs-tooltip-left .arrow, :host.bs-tooltip-right .arrow {
       top: 50%;
     }
-    
+
     :host.bs-tooltip-left-top .arrow, :host.bs-tooltip-right-top .arrow {
       top: 0.7em;
     }
@@ -116,6 +116,7 @@ export class NgbTooltip implements OnInit, OnDestroy {
   private _windowRef: ComponentRef<NgbTooltipWindow>;
   private _unregisterListenersFn;
   private _zoneSubscription: any;
+  private _elementTitle: string;
 
   constructor(
       private _elementRef: ElementRef, private _renderer: Renderer2, injector: Injector,
@@ -143,6 +144,13 @@ export class NgbTooltip implements OnInit, OnDestroy {
   @Input()
   set ngbTooltip(value: string | TemplateRef<any>) {
     this._ngbTooltip = value;
+    const htmlElement: HTMLElement = this._elementRef.nativeElement;
+    this._elementTitle = htmlElement.getAttribute('title');
+
+    if (!value && this._elementTitle) {
+      this._renderer.removeAttribute(htmlElement, 'title');
+      this._ngbTooltip = this._elementTitle;
+    }
     if (!value && this._windowRef) {
       this.close();
     }
@@ -187,6 +195,9 @@ export class NgbTooltip implements OnInit, OnDestroy {
   close(): void {
     if (this._windowRef != null) {
       this._renderer.removeAttribute(this._elementRef.nativeElement, 'aria-describedby');
+      if (this._elementTitle) {
+        this._renderer.setAttribute(this._elementRef.nativeElement, 'title', this._elementTitle);
+      }
       this._popupService.close();
       this._windowRef = null;
       this.hidden.emit();


### PR DESCRIPTION
Hi :)

I recently used tooltips in my app, and noticed we don't use `title` to get the content for the tooltip.  
That sounded like something I could contribute, so here's my pull-request.

Tooltips do what the HTML `title` attribute already does, so it's
semantically correct to "transform" the title attribute into a
JavaScript tooltip.

Also, Bootstrap does it: https://github.com/twbs/bootstrap/blob/v4-dev/js/src/tooltip.js#L426