### PR TITLE
fix timepicker and datepicker btn-link

### DIFF
--- a/src/datepicker/datepicker-navigation.ts
+++ b/src/datepicker/datepicker-navigation.ts
@@ -14,7 +14,7 @@ import {NgbCalendar} from './ngb-calendar';
       line-height: 1.85rem;
     }
     :host.collapsed {
-      margin-bottom: -2rem;        
+      margin-bottom: -2rem;
     }
     .ngb-dp-navigation-chevron::before {
       border-style: solid;
@@ -27,28 +27,18 @@ import {NgbCalendar} from './ngb-calendar';
       -ms-transform: rotate(-135deg);
       width: 0.75em;
       margin: 0 0 0 0.5rem;
-    }    
+    }
     .ngb-dp-navigation-chevron.right:before {
       -webkit-transform: rotate(45deg);
       -ms-transform: rotate(45deg);
       transform: rotate(45deg);
       margin: 0 0.5rem 0 0;
     }
-    .btn-link {
-      cursor: pointer;
-      border: 0;
-      outline: 0;
-    }
-    .btn-link[disabled] {
-      cursor: not-allowed;
-      opacity: .65;
-    }    
   `],
   template: `
-    <button type="button" class="btn-link" (click)="!!doNavigate(navigation.PREV)" [disabled]="prevDisabled()" tabindex="-1">
-      <span class="ngb-dp-navigation-chevron"></span>    
+    <button type="button" class="btn btn-sm btn-link" (click)="!!doNavigate(navigation.PREV)" [disabled]="prevDisabled()" tabindex="-1">
+      <span class="ngb-dp-navigation-chevron"></span>
     </button>
-    
     <ngb-datepicker-navigation-select *ngIf="showSelect" class="d-block" [style.width.rem]="months * 9"
       [date]="date"
       [minDate]="minDate"
@@ -56,8 +46,7 @@ import {NgbCalendar} from './ngb-calendar';
       [disabled] = "disabled"
       (select)="selectDate($event)">
     </ngb-datepicker-navigation-select>
-    
-    <button type="button" class="btn-link" (click)="!!doNavigate(navigation.NEXT)" [disabled]="nextDisabled()" tabindex="-1">
+    <button type="button" class="btn btn-sm btn-link" (click)="!!doNavigate(navigation.NEXT)" [disabled]="nextDisabled()" tabindex="-1">
       <span class="ngb-dp-navigation-chevron right"></span>
     </button>
   `

--- a/src/timepicker/timepicker.ts
+++ b/src/timepicker/timepicker.ts
@@ -57,16 +57,6 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
       transform: rotate(135deg);
     }
 
-    .btn-link {
-      border: 0;
-      outline: 0;
-    }
-
-    .btn-link.disabled {
-      cursor: not-allowed;
-      opacity: .65;
-    }
-
     input {
       text-align: center;
       display: inline-block;
@@ -77,7 +67,7 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
     <fieldset [disabled]="disabled" [class.disabled]="disabled">
       <div class="ngb-tp">
         <div class="ngb-tp-hour">
-          <button *ngIf="spinners" type="button" class="btn-link" [ngClass]="setButtonSize()" (click)="changeHour(hourStep)"
+          <button *ngIf="spinners" type="button" class="btn btn-link" [ngClass]="setButtonSize()" (click)="changeHour(hourStep)"
             [disabled]="disabled" [class.disabled]="disabled">
             <span class="chevron"></span>
             <span class="sr-only">Increment hours</span>
@@ -85,7 +75,7 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
           <input type="text" class="form-control" [ngClass]="setFormControlSize()" maxlength="2" size="2" placeholder="HH"
             [value]="formatHour(model?.hour)" (change)="updateHour($event.target.value)"
             [readonly]="readonlyInputs" [disabled]="disabled" aria-label="Hours">
-          <button *ngIf="spinners" type="button" class="btn-link" [ngClass]="setButtonSize()" (click)="changeHour(-hourStep)"
+          <button *ngIf="spinners" type="button" class="btn btn-link" [ngClass]="setButtonSize()" (click)="changeHour(-hourStep)"
             [disabled]="disabled" [class.disabled]="disabled">
             <span class="chevron bottom"></span>
             <span class="sr-only">Decrement hours</span>
@@ -93,7 +83,7 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
         </div>
         <div class="ngb-tp-spacer">:</div>
         <div class="ngb-tp-minute">
-          <button *ngIf="spinners" type="button" class="btn-link" [ngClass]="setButtonSize()" (click)="changeMinute(minuteStep)"
+          <button *ngIf="spinners" type="button" class="btn btn-link" [ngClass]="setButtonSize()" (click)="changeMinute(minuteStep)"
             [disabled]="disabled" [class.disabled]="disabled">
             <span class="chevron"></span>
             <span class="sr-only">Increment minutes</span>
@@ -101,7 +91,7 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
           <input type="text" class="form-control" [ngClass]="setFormControlSize()" maxlength="2" size="2" placeholder="MM"
             [value]="formatMinSec(model?.minute)" (change)="updateMinute($event.target.value)"
             [readonly]="readonlyInputs" [disabled]="disabled" aria-label="Minutes">
-          <button *ngIf="spinners" type="button" class="btn-link" [ngClass]="setButtonSize()" (click)="changeMinute(-minuteStep)"
+          <button *ngIf="spinners" type="button" class="btn btn-link" [ngClass]="setButtonSize()" (click)="changeMinute(-minuteStep)"
             [disabled]="disabled" [class.disabled]="disabled">
             <span class="chevron bottom"></span>
             <span class="sr-only">Decrement minutes</span>
@@ -109,7 +99,7 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
         </div>
         <div *ngIf="seconds" class="ngb-tp-spacer">:</div>
         <div *ngIf="seconds" class="ngb-tp-second">
-          <button *ngIf="spinners" type="button" class="btn-link" [ngClass]="setButtonSize()" (click)="changeSecond(secondStep)"
+          <button *ngIf="spinners" type="button" class="btn btn-link" [ngClass]="setButtonSize()" (click)="changeSecond(secondStep)"
             [disabled]="disabled" [class.disabled]="disabled">
             <span class="chevron"></span>
             <span class="sr-only">Increment seconds</span>
@@ -117,7 +107,7 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
           <input type="text" class="form-control" [ngClass]="setFormControlSize()" maxlength="2" size="2" placeholder="SS"
             [value]="formatMinSec(model?.second)" (change)="updateSecond($event.target.value)"
             [readonly]="readonlyInputs" [disabled]="disabled" aria-label="Seconds">
-          <button *ngIf="spinners" type="button" class="btn-link" [ngClass]="setButtonSize()" (click)="changeSecond(-secondStep)"
+          <button *ngIf="spinners" type="button" class="btn btn-link" [ngClass]="setButtonSize()" (click)="changeSecond(-secondStep)"
             [disabled]="disabled" [class.disabled]="disabled">
             <span class="chevron bottom"></span>
             <span class="sr-only">Decrement seconds</span>


### PR DESCRIPTION
Following #1947 I add the class `btn` next to `btn-link` in the timepicker.

I also found that it need to be changed in the datepicker. There was already the issue #1851 with a fix with some css to hide the border but it is not needed if we add the class `btn`.

I also remove the other css of the `btn-link` because I think we should follow the bootstrap implementation (button without a link should not have a custom cursor and outline is for accessibility).