### PR TITLE
fix(datepicker): date selection regression for non-visible dates

### DIFF
--- a/demo/src/app/components/datepicker/demos/calendars/islamic-calendars.html
+++ b/demo/src/app/components/datepicker/demos/calendars/islamic-calendars.html
@@ -5,7 +5,7 @@
 
 <hr/>
 
-<button class="btn btn-sm btn-outline-primary" (click)="dp.navigateTo(); selectToday();">Select Today</button>
+<button class="btn btn-sm btn-outline-primary" (click)="selectToday();">Select Today</button>
 <button class="btn btn-sm btn-outline-primary" (click)="dp.navigateTo()">To current month</button>
 <button class="btn btn-sm btn-outline-primary" (click)="dp.navigateTo({year: 1434, month: 2})">To Saf. 1434</button>
 

--- a/src/datepicker/datepicker-service.spec.ts
+++ b/src/datepicker/datepicker-service.spec.ts
@@ -729,6 +729,20 @@ describe('ngb-datepicker-service', () => {
       expect(mockSelect.onNext).toHaveBeenCalledTimes(1);
     });
 
+    it(`should emit date selection event for non-visible dates'`, () => {
+      const date = new NgbDate(2017, 5, 5);
+      service.focus(date);
+      expect(model.selectedDate).toBeNull();
+      expect(selectDate).toBeNull();
+
+      let invisibleDate = new NgbDate(2016, 5, 5);
+      service.select(invisibleDate, {emitEvent: true});
+      expect(model.selectedDate).toEqual(invisibleDate);
+      expect(selectDate).toEqual(invisibleDate);
+
+      expect(mockSelect.onNext).toHaveBeenCalledTimes(1);
+    });
+
     it(`should not emit date selection event for disabled dates'`, () => {
       // marking 5th day of each month as disabled
       service.markDisabled = (date) => date && date.day === 5;

--- a/src/datepicker/datepicker-service.ts
+++ b/src/datepicker/datepicker-service.ts
@@ -92,7 +92,9 @@ export class NgbDatepickerService {
   }
 
   focusSelect() {
-    if (isDateSelectable(this._state.months, this._state.focusDate)) {
+    if (isDateSelectable(
+            this._state.focusDate, this._state.minDate, this._state.maxDate, this._state.disabled,
+            this._state.markDisabled)) {
       this.select(this._state.focusDate, {emitEvent: true});
     }
   }
@@ -110,7 +112,9 @@ export class NgbDatepickerService {
         this._nextState({selectedDate: validDate});
       }
 
-      if (options.emitEvent && isDateSelectable(this._state.months, validDate)) {
+      if (options.emitEvent &&
+          isDateSelectable(
+              validDate, this._state.minDate, this._state.maxDate, this._state.disabled, this._state.markDisabled)) {
         this._select$.next(validDate);
       }
     }
@@ -213,7 +217,7 @@ export class NgbDatepickerService {
 
       // reset selected date if 'markDisabled' returns true
       if ('selectedDate' in patch && state.selectedDate !== null) {
-        if (!isDateSelectable(state.months, state.selectedDate)) {
+        if (!isDateSelectable(state.selectedDate, state.minDate, state.maxDate, state.disabled, state.markDisabled)) {
           state.selectedDate = null;
         }
       }

--- a/src/datepicker/datepicker-tools.spec.ts
+++ b/src/datepicker/datepicker-tools.spec.ts
@@ -1,4 +1,11 @@
-import {buildMonth, buildMonths, checkDateInRange, dateComparator, getFirstViewDate} from './datepicker-tools';
+import {
+  buildMonth,
+  buildMonths,
+  checkDateInRange,
+  dateComparator,
+  getFirstViewDate,
+  isDateSelectable
+} from './datepicker-tools';
 import {NgbDate} from './ngb-date';
 import {NgbCalendar, NgbCalendarGregorian} from './ngb-calendar';
 import {TestBed} from '@angular/core/testing';
@@ -328,6 +335,43 @@ describe(`datepicker-tools`, () => {
     months.forEach(month => {
       it(`should return the correct first view date`,
          () => { expect(getFirstViewDate(calendar, month.date, 1)).toEqual(month.first); });
+    });
+  });
+
+  describe(`isDateSelectable()`, () => {
+
+    // disabling 15th of any month
+    const markDisabled: NgbMarkDisabled = (date, month) => date.day === 15;
+
+    it(`should return false if date is invalid`, () => {
+      expect(isDateSelectable(null, null, null, false)).toBeFalsy();
+      expect(isDateSelectable(undefined, null, null, false)).toBeFalsy();
+    });
+
+    it(`should return false if datepicker is disabled`, () => {
+      expect(isDateSelectable(new NgbDate(2016, 11, 10), null, null, true)).toBeFalsy();
+      expect(isDateSelectable(new NgbDate(2017, 11, 10), null, null, true)).toBeFalsy();
+      expect(isDateSelectable(new NgbDate(2018, 11, 10), null, null, true)).toBeFalsy();
+    });
+
+    it(`should take into account markDisabled values`, () => {
+      expect(isDateSelectable(new NgbDate(2016, 11, 15), null, null, false, markDisabled)).toBeFalsy();
+      expect(isDateSelectable(new NgbDate(2017, 11, 15), null, null, false, markDisabled)).toBeFalsy();
+      expect(isDateSelectable(new NgbDate(2018, 11, 15), null, null, false, markDisabled)).toBeFalsy();
+    });
+
+    it(`should take into account minDate values`, () => {
+      expect(isDateSelectable(new NgbDate(2017, 11, 10), new NgbDate(2018, 11, 10), null, false)).toBeFalsy();
+    });
+
+    it(`should take into account maxDate values`, () => {
+      expect(isDateSelectable(new NgbDate(2017, 11, 10), null, new NgbDate(2016, 11, 10), false)).toBeFalsy();
+    });
+
+    it(`should return true for normal values`, () => {
+      expect(isDateSelectable(new NgbDate(2016, 11, 10), null, null, false)).toBeTruthy();
+      expect(isDateSelectable(new NgbDate(2017, 11, 10), null, null, false)).toBeTruthy();
+      expect(isDateSelectable(new NgbDate(2018, 11, 10), null, null, false)).toBeTruthy();
     });
   });
 

--- a/src/datepicker/datepicker-tools.ts
+++ b/src/datepicker/datepicker-tools.ts
@@ -1,6 +1,7 @@
 import {NgbDate} from './ngb-date';
 import {DayViewModel, MonthViewModel, NgbMarkDisabled} from './datepicker-view-model';
 import {NgbCalendar} from './ngb-calendar';
+import {isDefined} from '../util/util';
 
 export function isChangedDate(prev: NgbDate, next: NgbDate) {
   return !dateComparator(prev, next);
@@ -27,20 +28,17 @@ export function checkDateInRange(date: NgbDate, minDate: NgbDate, maxDate: NgbDa
   return date;
 }
 
-export function isDateSelectable(months: MonthViewModel[], date: NgbDate) {
-  let selectable = false;
-  const month = months.find(curMonth => curMonth.year === date.year && curMonth.number === date.month);
-  if (month) {
-    month.weeks.find(week => {
-      const day = week.days.find(day => date.equals(day.date));
-      if (day && !day.context.disabled) {
-        selectable = true;
-      }
-      return !!day;
-    });
-  }
-
-  return selectable;
+export function isDateSelectable(
+    date: NgbDate, minDate: NgbDate, maxDate: NgbDate, isDisabled: boolean, markDisabled?: NgbMarkDisabled) {
+  // clang-format off
+  return !(
+    !isDefined(date) ||
+    isDisabled ||
+    (markDisabled && markDisabled(date, {year: date.year, month: date.month})) ||
+    (minDate && date.before(minDate)) ||
+    (maxDate && date.after(maxDate))
+  );
+  // clang-format on
 }
 
 export function buildMonths(


### PR DESCRIPTION
The regression: Impossible to select date using `ngModel` if the dates are not currently visible: ex. simple datepicker demo → 'Select Today' button sets `ngModel` to `null`
Introduced in #1888

Cause: `isDateSelectable(date)` method used to check if we should emit date selection event

Fix: rewrite `isDateSelectable(date)` to take into account `minDate`, `maxDate`, `disabled` and `markDisabled`, not only currently visible months