### PR TITLE
demo(datepicker): fix opacity display in datepicker range demo

### DIFF
--- a/demo/src/app/components/datepicker/demos/range/datepicker-range.ts
+++ b/demo/src/app/components/datepicker/demos/range/datepicker-range.ts
@@ -27,11 +27,11 @@ const after = (one: NgbDateStruct, two: NgbDateStruct) =>
       background-color: #e6e6e6;
     }
     .custom-day.range, .custom-day:hover {
-      background-color: #0275d8;
+      background-color: rgb(2, 117, 216);
       color: white;
     }
-    .faded {
-      opacity: 0.5;
+    .custom-day.faded {
+      background-color: rgba(2, 117, 216, 0.5);
     }
   `]
 })


### PR DESCRIPTION
Chrome, Safari and Firefox used to display the range demo with white stripes at different zoom levels because of opacity:

<img width="490" alt="screen shot 2017-11-20 at 18 30 56" src="https://user-images.githubusercontent.com/8074436/33032725-719dbd04-ce22-11e7-8041-48423ffa62db.png">
