### PR TITLE
fix(datepicker): support `NgbDateAdapter` in `NgbInputDatepicker`

### DIFF
--- a/src/datepicker/ngb-date-adapter.spec.ts
+++ b/src/datepicker/ngb-date-adapter.spec.ts
@@ -7,30 +7,36 @@ describe('ngb-date model adapter', () => {
 
   describe('fromModel', () => {
 
-    it('should convert null undefined as null', () => {
+    it('should convert invalid and incomplete values to null', () => {
       expect(adapter.fromModel(null)).toBeNull();
       expect(adapter.fromModel(undefined)).toBeNull();
+      expect(adapter.fromModel(<any>'')).toBeNull();
+      expect(adapter.fromModel(<any>'s')).toBeNull();
+      expect(adapter.fromModel(<any>2)).toBeNull();
+      expect(adapter.fromModel(<any>{})).toBeNull();
+      expect(adapter.fromModel(<any>new Date())).toBeNull();
+      expect(adapter.fromModel(<any>{year: 2017, month: 10})).toBeNull();
     });
 
     it('should convert valid date',
        () => { expect(adapter.fromModel({year: 2016, month: 5, day: 1})).toEqual({year: 2016, month: 5, day: 1}); });
-
-    it('should do its best parsing incomplete dates',
-       () => { expect(adapter.fromModel({year: 2011, month: 5, day: null})).toEqual({year: 2011, month: 5, day: 1}); });
   });
 
   describe('toModel', () => {
 
-    it('should convert null and undefined as null', () => {
-      expect(adapter.toModel(null)).toBe(null);
-      expect(adapter.toModel(undefined)).toBe(null);
+    it('should convert invalid and incomplete values to null', () => {
+      expect(adapter.toModel(null)).toBeNull();
+      expect(adapter.toModel(undefined)).toBeNull();
+      expect(adapter.toModel(<any>'')).toBeNull();
+      expect(adapter.toModel(<any>'s')).toBeNull();
+      expect(adapter.toModel(<any>2)).toBeNull();
+      expect(adapter.toModel(<any>{})).toBeNull();
+      expect(adapter.toModel(<any>new Date())).toBeNull();
+      expect(adapter.toModel(<any>{year: 2017, month: 10})).toBeNull();
     });
 
     it('should convert a valid date',
        () => { expect(adapter.toModel({year: 2016, month: 10, day: 15})).toEqual({year: 2016, month: 10, day: 15}); });
-
-    it('should try its best with invalid dates',
-       () => { expect(adapter.toModel({year: 2016, month: 10, day: null})).toEqual({year: 2016, month: 10, day: 1}); });
   });
 
 });

--- a/src/datepicker/ngb-date-adapter.ts
+++ b/src/datepicker/ngb-date-adapter.ts
@@ -33,7 +33,7 @@ export class NgbDateStructAdapter extends NgbDateAdapter<NgbDateStruct> {
    * @return {NgbDateStruct}
    */
   fromModel(date: NgbDateStruct): NgbDateStruct {
-    return date ? {year: date.year, month: date.month, day: date.day || 1} : null;
+    return (date && date.year && date.month && date.day) ? {year: date.year, month: date.month, day: date.day} : null;
   }
 
   /**
@@ -42,6 +42,6 @@ export class NgbDateStructAdapter extends NgbDateAdapter<NgbDateStruct> {
    * @return {NgbDateStruct}
    */
   toModel(date: NgbDateStruct): NgbDateStruct {
-    return date ? {year: date.year, month: date.month, day: date.day || 1} : null;
+    return (date && date.year && date.month && date.day) ? {year: date.year, month: date.month, day: date.day} : null;
   }
 }


### PR DESCRIPTION
1. Support for the `NgbDateAdapter` in the datepicker with input
2. Default `NgbDateStructAdapter` is more forgiving now (`'2017-11'` transformed into `{year: 2017, month: 11, day: 1}`)so I changed one test case for this as well.

@msosa, could you take a look?

Fixes #2002