### PR TITLE
demo(typeahead): use HttpClient instead of deprecated Jsonp

### DIFF
--- a/demo/src/app/components/typeahead/demos/http/typeahead-http.ts
+++ b/demo/src/app/components/typeahead/demos/http/typeahead-http.ts
@@ -1,5 +1,5 @@
 import {Component, Injectable} from '@angular/core';
-import {Jsonp, URLSearchParams} from '@angular/http';
+import {HttpClient, HttpParams} from '@angular/common/http';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/catch';
@@ -10,25 +10,27 @@ import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/operator/merge';
 
+const WIKI_URL = 'https://en.wikipedia.org/w/api.php';
+const PARAMS = new HttpParams({
+  fromObject: {
+    action: 'opensearch',
+    format: 'json',
+    origin: '*'
+  }
+});
+
 @Injectable()
 export class WikipediaService {
-  constructor(private _jsonp: Jsonp) {}
+  constructor(private http: HttpClient) {}
 
   search(term: string) {
     if (term === '') {
       return Observable.of([]);
     }
 
-    let wikiUrl = 'https://en.wikipedia.org/w/api.php';
-    let params = new URLSearchParams();
-    params.set('search', term);
-    params.set('action', 'opensearch');
-    params.set('format', 'json');
-    params.set('callback', 'JSONP_CALLBACK');
-
-    return this._jsonp
-      .get(wikiUrl, {search: params})
-      .map(response => <string[]> response.json()[1]);
+    return this.http
+      .get(WIKI_URL, {params: PARAMS.set('search', term)})
+      .map(response => response[1]);
   }
 }
 

--- a/demo/src/app/shared/index.ts
+++ b/demo/src/app/shared/index.ts
@@ -2,7 +2,7 @@ import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {RouterModule} from '@angular/router';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {JsonpModule} from '@angular/http';
+import {HttpClientModule} from '@angular/common/http';
 
 import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 
@@ -24,7 +24,7 @@ export {componentsList} from './side-nav/side-nav.component';
     NgbModule,
     FormsModule,
     ReactiveFormsModule,
-    JsonpModule
+    HttpClientModule
   ],
   declarations: [
     ComponentWrapper,


### PR DESCRIPTION
* remove [deprecated `Jsonp` service](https://angular.io/api/http/Jsonp#deprecation-notes) from demo app
* use CORS instead of JSONP, as, apparently, wikipedia supports it when specifying `origin: *` → https://www.mediawiki.org/wiki/API:Cross-site_requests