### PR TITLE
fix(datepicker): add class "show" to visible datepicker dropdown

### DIFF
--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -308,6 +308,7 @@ export class NgbInputDatepicker implements OnChanges,
   private _applyPopupStyling(nativeElement: any) {
     this._renderer.addClass(nativeElement, 'dropdown-menu');
     this._renderer.setStyle(nativeElement, 'padding', '0');
+    this._renderer.addClass(nativeElement, 'show');
   }
 
   private _subscribeForDatepickerOutputs(datepickerInstance: NgbDatepicker) {


### PR DESCRIPTION
Default behaviour of class "dropdown-menu" in bootstrap 4 is to make it invisble. To make it visible it is necessary to add class "show" to the element.  Forcing display: inline-block is dirty fix and cause problems with custom boostrap templates.

Class "d-inline-block" is deleted only when popup styles are applied, so it doesn't cause problems with inline element.
