### PR TITLE
fix(pagination): remove internal annotation

### DIFF
--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -126,9 +126,6 @@ export class NgbPagination implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void { this._updatePages(this.page); }
 
-  /**
-   * @internal
-   */
   isEllipsis(pageNumber): boolean { return pageNumber === -1; }
 
   /**


### PR DESCRIPTION
`isEllipsis` was an internal field used in the template,
and that was thowing errors with the Angular compiler option `fullTemplateTypeCheck`.
This removes the internal annotation.

Fixes #2038