### PR TITLE
feat(datepicker): use the angular locale API

### DIFF
--- a/demo/src/app/components/datepicker/demos/i18n/datepicker-i18n.html
+++ b/demo/src/app/components/datepicker/demos/i18n/datepicker-i18n.html
@@ -1,3 +1,11 @@
+<ngb-alert [dismissible]="false">
+  If you configure the locale and register the locale data as explained in the
+  <a href="https://angular.io/guide/i18n">i18n guide</a>, the date picker will honor
+  the locale and use days and months names from the locale data. You can however
+  provide a custom service, as demonstrated in this example, to customize the
+  days and months names the way you want to.
+</ngb-alert>
+
 <p>Datepicker in French</p>
 
 <ngb-datepicker [(ngModel)]="model"></ngb-datepicker>

--- a/src/datepicker/datepicker-i18n.spec.ts
+++ b/src/datepicker/datepicker-i18n.spec.ts
@@ -1,8 +1,15 @@
 import {NgbDatepickerI18nDefault} from './datepicker-i18n';
+import {TestBed} from '@angular/core/testing';
+import {LOCALE_ID} from '@angular/core';
 
 describe('ngb-datepicker-i18n-default', () => {
 
-  const i18n = new NgbDatepickerI18nDefault();
+  let i18n: NgbDatepickerI18nDefault;
+
+  beforeEach(() => {
+    const locale: string = TestBed.get(LOCALE_ID);
+    i18n = new NgbDatepickerI18nDefault(locale);
+  });
 
   it('should return abbreviated month name', () => {
     expect(i18n.getMonthShortName(0)).toBe(undefined);

--- a/src/datepicker/datepicker-i18n.ts
+++ b/src/datepicker/datepicker-i18n.ts
@@ -1,14 +1,10 @@
-import {Injectable} from '@angular/core';
-
-const WEEKDAYS_SHORT = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
-const MONTHS_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-const MONTHS_FULL = [
-  'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November',
-  'December'
-];
+import {Inject, Injectable, LOCALE_ID} from '@angular/core';
+import {FormStyle, getLocaleDayNames, getLocaleMonthNames, TranslationWidth} from '@angular/common';
 
 /**
  * Type of the service supplying month and weekday names to to NgbDatepicker component.
+ * The default implementation of this service honors the Angular locale, and uses the registered locale data,
+ * as explained in the Angular i18n guide.
  * See the i18n demo for how to extend this class and define a custom provider for i18n.
  */
 @Injectable()
@@ -34,9 +30,23 @@ export abstract class NgbDatepickerI18n {
 
 @Injectable()
 export class NgbDatepickerI18nDefault extends NgbDatepickerI18n {
-  getWeekdayShortName(weekday: number): string { return WEEKDAYS_SHORT[weekday - 1]; }
+  private _weekdaysShort: Array<string>;
+  private _monthsShort: Array<string>;
+  private _monthsFull: Array<string>;
 
-  getMonthShortName(month: number): string { return MONTHS_SHORT[month - 1]; }
+  constructor(@Inject(LOCALE_ID) locale: string) {
+    super();
 
-  getMonthFullName(month: number): string { return MONTHS_FULL[month - 1]; }
+    const weekdaysStartingOnSunday = getLocaleDayNames(locale, FormStyle.Standalone, TranslationWidth.Short);
+    this._weekdaysShort = weekdaysStartingOnSunday.map((day, index) => weekdaysStartingOnSunday[(index + 1) % 7]);
+
+    this._monthsShort = getLocaleMonthNames(locale, FormStyle.Standalone, TranslationWidth.Abbreviated);
+    this._monthsFull = getLocaleMonthNames(locale, FormStyle.Standalone, TranslationWidth.Wide);
+  }
+
+  getWeekdayShortName(weekday: number): string { return this._weekdaysShort[weekday - 1]; }
+
+  getMonthShortName(month: number): string { return this._monthsShort[month - 1]; }
+
+  getMonthFullName(month: number): string { return this._monthsFull[month - 1]; }
 }


### PR DESCRIPTION
the datepicker now honors the Angular LOCALE_ID and uses the registered
locale data to internationalize the months and days names. Unless you
really want custom names, providing a custom NgbDatepickerI18n service
isn't necessary anymore to internationalize the datepicker.

fix #2065

BREAKING CHANGE: if your application provides a LOCALE_ID other than
the default en-US, registers the locale data for this locale, and
doesn't use a custom NgbDatepickerI18n, then the days and months
of the datepicker won't be displayed in English anymore, but in the
langguage of the provided locale.
