### PR TITLE
demo(datepicker): fix select layout and add 'showWeekNumbers' option

### DIFF
--- a/demo/src/app/components/datepicker/demos/multiple/datepicker-multiple.html
+++ b/demo/src/app/components/datepicker/demos/multiple/datepicker-multiple.html
@@ -1,5 +1,6 @@
 
-<ngb-datepicker [displayMonths]="displayMonths" [navigation]="navigation"></ngb-datepicker>
+<ngb-datepicker [displayMonths]="displayMonths" [navigation]="navigation" [showWeekNumbers]="showWeekNumbers">
+</ngb-datepicker>
 
 <hr/>
 
@@ -7,7 +8,8 @@
   <div class="form-group">
     <div class="input-group">
       <input class="form-control" placeholder="yyyy-mm-dd"
-            name="dp" [displayMonths]="displayMonths" [navigation]="navigation" ngbDatepicker #d="ngbDatepicker">
+             name="dp" [displayMonths]="displayMonths" [navigation]="navigation"
+             [showWeekNumbers]="showWeekNumbers" ngbDatepicker #d="ngbDatepicker">
       <div class="input-group-append">
         <button class="btn btn-outline-secondary" (click)="d.toggle()" type="button">
           <img src="img/calendar-icon.svg" style="width: 1.2rem; height: 1rem; cursor: pointer;"/>
@@ -19,15 +21,22 @@
 
 <hr/>
 
-<select class="custom-select" [(ngModel)]="displayMonths">
-  <option [ngValue]="1">One month</option>
-  <option [ngValue]="2">Two months</option>
-  <option [ngValue]="3">Three months</option>
-</select>
+<div class="d-flex">
+  <select class="custom-select" [(ngModel)]="displayMonths">
+    <option [ngValue]="1">One month</option>
+    <option [ngValue]="2">Two months</option>
+    <option [ngValue]="3">Three months</option>
+  </select>
 
-<select class="custom-select" [(ngModel)]="navigation">
-  <option value="none">Without navigation</option>
-  <option value="select">With select boxes</option>
-  <option value="arrows">Without select boxes</option>
-</select>
+  <select class="custom-select" [(ngModel)]="navigation">
+    <option value="none">Without navigation</option>
+    <option value="select">With select boxes</option>
+    <option value="arrows">Without select boxes</option>
+  </select>
+
+  <select class="custom-select" [(ngModel)]="showWeekNumbers">
+    <option [ngValue]="true">Week numbers</option>
+    <option [ngValue]="false">No week numbers</option>
+  </select>
+</div>
 

--- a/demo/src/app/components/datepicker/demos/multiple/datepicker-multiple.ts
+++ b/demo/src/app/components/datepicker/demos/multiple/datepicker-multiple.ts
@@ -2,10 +2,17 @@ import {Component} from '@angular/core';
 
 @Component({
   selector: 'ngbd-datepicker-multiple',
-  templateUrl: './datepicker-multiple.html'
+  templateUrl: './datepicker-multiple.html',
+  styles: [`
+    select.custom-select {
+      margin-right: 0.5rem;
+      width: auto;
+    }
+  `]
 })
 export class NgbdDatepickerMultiple {
 
   displayMonths = 2;
   navigation = 'select';
+  showWeekNumbers = false;
 }


### PR DESCRIPTION
Two things for the `Datpicker Multiple` demo:

- Fix the select box layout (regression after BS beta 3)

Currently looks like this:
<img width="861" alt="screen shot 2018-01-19 at 15 55 33" src="https://user-images.githubusercontent.com/8074436/35156474-36ae4af4-fd31-11e7-86bb-97a3f8c6601b.png">

Fixed version:
<img width="859" alt="screen shot 2018-01-19 at 15 56 22" src="https://user-images.githubusercontent.com/8074436/35156505-51979d16-fd31-11e7-83f7-337db87d7c5a.png">


- Add 'showWeekNumbers' select box