### PR TITLE
chore: upgrade to bootstrap 4.0.0 stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ View all the directives in action at https://ng-bootstrap.github.io
 
 ## Dependencies
 * [Angular](https://angular.io) (tested with 5.0.2)
-* [Bootstrap 4](https://www.getbootstrap.com) (tested with 4.0.0-beta.3)
+* [Bootstrap 4](https://www.getbootstrap.com) (tested with 4.0.0)
 
 ## Installation
 After installing the above dependencies, install `ng-bootstrap` via:

--- a/demo/src/app/getting-started/getting-started.component.html
+++ b/demo/src/app/getting-started/getting-started.component.html
@@ -11,7 +11,7 @@
       <a href="https://angular.io" target="_blank">Angular</a> (<em>requires</em> Angular version 5 or higher, tested with 5.0.2)
     </li>
     <li>
-      <a href="https://www.getbootstrap.com" target="_blank">Bootstrap CSS</a> (tested with 4.0.0-beta.3)
+      <a href="https://www.getbootstrap.com" target="_blank">Bootstrap CSS</a> (tested with 4.0.0)
     </li>
   </ul>
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "angular2-template-loader": "^0.6.0",
     "async-done": "^1.2.2",
     "autoprefixer": "^7.2.2",
-    "bootstrap": "4.0.0-beta.3",
+    "bootstrap": "4.0.0",
     "clang-format": "1.0.35",
     "copy-webpack-plugin": "^4.2.3",
     "core-js": "^2.4.1",


### PR DESCRIPTION
It was an easy one, there is no major changes since beta 3.

http://blog.getbootstrap.com/2018/01/18/bootstrap-4/