### PR TITLE
feat(accordion): improve accessibility in accordance with WAI-ARIA

### DIFF
--- a/src/accordion/accordion.module.ts
+++ b/src/accordion/accordion.module.ts
@@ -1,13 +1,21 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
-import {NgbAccordion, NgbPanel, NgbPanelTitle, NgbPanelContent, NgbPanelChangeEvent} from './accordion';
+import {
+  NgbAccordion,
+  NgbPanel,
+  NgbPanelTitle,
+  NgbPanelContent,
+  NgbPanelChangeEvent,
+  Heading,
+  Region
+} from './accordion';
 import {NgbAccordionConfig} from './accordion-config';
 
 export {NgbAccordion, NgbPanel, NgbPanelTitle, NgbPanelContent, NgbPanelChangeEvent} from './accordion';
 export {NgbAccordionConfig} from './accordion-config';
 
-const NGB_ACCORDION_DIRECTIVES = [NgbAccordion, NgbPanel, NgbPanelTitle, NgbPanelContent];
+const NGB_ACCORDION_DIRECTIVES = [NgbAccordion, NgbPanel, NgbPanelTitle, NgbPanelContent, Heading, Region];
 
 @NgModule({declarations: NGB_ACCORDION_DIRECTIVES, exports: NGB_ACCORDION_DIRECTIVES, imports: [CommonModule]})
 export class NgbAccordionModule {

--- a/src/accordion/accordion.spec.ts
+++ b/src/accordion/accordion.spec.ts
@@ -58,7 +58,7 @@ describe('ngb-accordion', () => {
 
   it('should initialize inputs with default values', () => {
     const defaultConfig = new NgbAccordionConfig();
-    const accordionCmp = new NgbAccordion(defaultConfig);
+    const accordionCmp = new NgbAccordion(defaultConfig, null);
     expect(accordionCmp.type).toBe(defaultConfig.type);
     expect(accordionCmp.closeOtherPanels).toBe(defaultConfig.closeOthers);
   });
@@ -69,7 +69,7 @@ describe('ngb-accordion', () => {
     const el = fixture.nativeElement;
     fixture.detectChanges();
     expectOpenPanels(el, [false, false, false]);
-    expect(accordionEl.getAttribute('role')).toBe('tablist');
+    expect(accordionEl.getAttribute('role')).toBe('presentation');
     expect(accordionEl.getAttribute('aria-multiselectable')).toBe('true');
   });
 
@@ -559,10 +559,10 @@ describe('ngb-accordion', () => {
     fixture.detectChanges();
 
     const headers = getPanels(fixture.nativeElement);
-    headers.forEach((header: HTMLElement) => expect(header.getAttribute('role')).toBe('tab'));
+    headers.forEach((header: HTMLElement) => expect(header.getAttribute('role')).toBe('heading'));
 
     const contents = getPanelsContent(fixture.nativeElement);
-    contents.forEach((content: HTMLElement) => expect(content.getAttribute('role')).toBe('tabpanel'));
+    contents.forEach((content: HTMLElement) => expect(content.getAttribute('role')).toBe('region'));
   });
 
   describe('Custom config', () => {


### PR DESCRIPTION
Now that ng-bootstrap is stable, we can improve accessibility in accordance with WAI-ARIA.

see: https://www.w3.org/TR/wai-aria-practices/examples/accordion/accordion.html


Key | Function
-- | --
Space or Enter | When focus is on the accordion header of a collapsed section, expands the section.
Down Arrow | <ul><li> When focus is on an accordion header, moves focus to the next accordion header. </li><li> When focus is on last accordion header, moves focus to first accordion header.</li></ul>
Up Arrow | <ul><li>When focus is on an accordion header, moves focus to the previous accordion header.</li><li>When focus is on first accordion header, moves focus to last accordion header.</li></ul>
Home | When focus is on an accordion header, moves focus to the first accordion header.
End | When focus is on an accordion header, moves focus to the last accordion header.
Control + Page Down | <ul><li>When focus is inside an accordion panel or on an accordion header, moves focus to the next accordion header.</li><li>When focus is on last accordion header or inside last accordion panel, moves focus to first accordion header.</li></ul>
Control + Page Up | <ul><li>When focus is inside an accordion panel, moves focus to the header for that panel.</li><li>When focus is on an accordion header, moves focus to the previous accordion header.</li><li>When focus is on first accordion header, moves focus to last accordion header.</li></ul>




