### PR TITLE
fix(Modal): backdrop click events

### DIFF
--- a/src/modal/modal-window.spec.ts
+++ b/src/modal/modal-window.spec.ts
@@ -107,6 +107,28 @@ describe('ngb-modal-dialog', () => {
 
       fixture.debugElement.triggerEventHandler('keyup.esc', {});
     });
+
+    it('should dismiss the modal on backdrop click on mousedown', (done) => {
+      fixture.detectChanges();
+
+      fixture.componentInstance.dismissEvent.subscribe(($event) => {
+        expect($event).toBe(ModalDismissReasons.BACKDROP_CLICK);
+        done();
+      });
+
+      fixture.nativeElement.dispatchEvent(new Event('mousedown'));
+    });
+
+    it('should dismiss the modal on backdrop click on touchstart', (done) => {
+      fixture.detectChanges();
+
+      fixture.componentInstance.dismissEvent.subscribe(($event) => {
+        expect($event).toBe(ModalDismissReasons.BACKDROP_CLICK);
+        done();
+      });
+
+      fixture.nativeElement.dispatchEvent(new Event('touchstart'));
+    });
   });
 
 });

--- a/src/modal/modal-window.ts
+++ b/src/modal/modal-window.ts
@@ -20,7 +20,8 @@ import {ModalDismissReasons} from './modal-dismiss-reasons';
     'tabindex': '-1',
     'style': 'display: block;',
     '(keyup.esc)': 'escKey($event)',
-    '(click)': 'backdropClick($event)'
+    '(mousedown)': 'backdropClick($event)',
+    '(touchstart)': 'backdropClick($event)'
   },
   template: `
     <div [class]="'modal-dialog' + (size ? ' modal-' + size : '')" role="document">


### PR DESCRIPTION
Closes #1950

The ``click`` event was replaced with ``touchstart`` and ``mousedown``. This way the modal closes only when the backdrop was clicked directly and did not start anywhere else, as described in the bug report.
