### PR TITLE
fix(modal): support server rendering with lazy loading

### DIFF
--- a/src/modal/modal-stack.ts
+++ b/src/modal/modal-stack.ts
@@ -1,7 +1,9 @@
+import {DOCUMENT} from '@angular/common';
 import {
   ApplicationRef,
   Injectable,
   Injector,
+  Inject,
   ReflectiveInjector,
   ComponentFactory,
   ComponentFactoryResolver,
@@ -18,53 +20,57 @@ import {NgbActiveModal, NgbModalRef} from './modal-ref';
 
 @Injectable()
 export class NgbModalStack {
-  private _backdropFactory: ComponentFactory<NgbModalBackdrop>;
-  private _windowFactory: ComponentFactory<NgbModalWindow>;
+  private _document: any;
+  private _windowAttributes = ['backdrop', 'keyboard', 'size', 'windowClass'];
 
   constructor(
       private _applicationRef: ApplicationRef, private _injector: Injector,
-      private _componentFactoryResolver: ComponentFactoryResolver) {
-    this._backdropFactory = _componentFactoryResolver.resolveComponentFactory(NgbModalBackdrop);
-    this._windowFactory = _componentFactoryResolver.resolveComponentFactory(NgbModalWindow);
+      private _componentFactoryResolver: ComponentFactoryResolver, @Inject(DOCUMENT) document) {
+    this._document = document;
   }
 
   open(moduleCFR: ComponentFactoryResolver, contentInjector: Injector, content: any, options): NgbModalRef {
-    const containerSelector = options.container || 'body';
-    const containerEl = document.querySelector(containerSelector);
+    const containerEl =
+        isDefined(options.container) ? this._document.querySelector(options.container) : this._document.body;
 
     if (!containerEl) {
-      throw new Error(`The specified modal container "${containerSelector}" was not found in the DOM.`);
+      throw new Error(`The specified modal container "${options.container || 'body'}" was not found in the DOM.`);
     }
 
     const activeModal = new NgbActiveModal();
     const contentRef = this._getContentRef(moduleCFR, options.injector || contentInjector, content, activeModal);
 
-    let windowCmptRef: ComponentRef<NgbModalWindow>;
-    let backdropCmptRef: ComponentRef<NgbModalBackdrop>;
-    let ngbModalRef: NgbModalRef;
-
-
-    if (options.backdrop !== false) {
-      backdropCmptRef = this._backdropFactory.create(this._injector);
-      this._applicationRef.attachView(backdropCmptRef.hostView);
-      containerEl.appendChild(backdropCmptRef.location.nativeElement);
-    }
-    windowCmptRef = this._windowFactory.create(this._injector, contentRef.nodes);
-    this._applicationRef.attachView(windowCmptRef.hostView);
-    containerEl.appendChild(windowCmptRef.location.nativeElement);
-
-    ngbModalRef = new NgbModalRef(windowCmptRef, contentRef, backdropCmptRef, options.beforeDismiss);
+    let backdropCmptRef: ComponentRef<NgbModalBackdrop> =
+        options.backdrop !== false ? this._attachBackdrop(containerEl) : null;
+    let windowCmptRef: ComponentRef<NgbModalWindow> = this._attachWindowComponent(containerEl, contentRef);
+    let ngbModalRef: NgbModalRef = new NgbModalRef(windowCmptRef, contentRef, backdropCmptRef, options.beforeDismiss);
 
     activeModal.close = (result: any) => { ngbModalRef.close(result); };
     activeModal.dismiss = (reason: any) => { ngbModalRef.dismiss(reason); };
 
     this._applyWindowOptions(windowCmptRef.instance, options);
-
     return ngbModalRef;
   }
 
+  private _attachBackdrop(containerEl: any): ComponentRef<NgbModalBackdrop> {
+    let backdropFactory: ComponentFactory<NgbModalBackdrop> =
+        this._componentFactoryResolver.resolveComponentFactory(NgbModalBackdrop);
+    let backdropCmptRef = backdropFactory.create(this._injector);
+    this._applicationRef.attachView(backdropCmptRef.hostView);
+    containerEl.appendChild(backdropCmptRef.location.nativeElement);
+    return backdropCmptRef;
+  }
+
+  private _attachWindowComponent(containerEl: any, contentRef: any): ComponentRef<NgbModalWindow> {
+    let windowFactory = this._componentFactoryResolver.resolveComponentFactory(NgbModalWindow);
+    let windowCmptRef = windowFactory.create(this._injector, contentRef.nodes);
+    this._applicationRef.attachView(windowCmptRef.hostView);
+    containerEl.appendChild(windowCmptRef.location.nativeElement);
+    return windowCmptRef;
+  }
+
   private _applyWindowOptions(windowInstance: NgbModalWindow, options: Object): void {
-    ['backdrop', 'keyboard', 'size', 'windowClass'].forEach((optionName: string) => {
+    this._windowAttributes.forEach((optionName: string) => {
       if (isDefined(options[optionName])) {
         windowInstance[optionName] = options[optionName];
       }
@@ -77,18 +83,33 @@ export class NgbModalStack {
     if (!content) {
       return new ContentRef([]);
     } else if (content instanceof TemplateRef) {
-      const viewRef = content.createEmbeddedView(context);
-      this._applicationRef.attachView(viewRef);
-      return new ContentRef([viewRef.rootNodes], viewRef);
+      return this._createFromTemplateRef(content, context);
     } else if (isString(content)) {
-      return new ContentRef([[document.createTextNode(`${content}`)]]);
+      return this._createFromString(content);
     } else {
-      const contentCmptFactory = moduleCFR.resolveComponentFactory(content);
-      const modalContentInjector =
-          ReflectiveInjector.resolveAndCreate([{provide: NgbActiveModal, useValue: context}], contentInjector);
-      const componentRef = contentCmptFactory.create(modalContentInjector);
-      this._applicationRef.attachView(componentRef.hostView);
-      return new ContentRef([[componentRef.location.nativeElement]], componentRef.hostView, componentRef);
+      return this._createFromComponent(moduleCFR, contentInjector, content, context);
     }
+  }
+
+  private _createFromTemplateRef(content: TemplateRef<any>, context: NgbActiveModal): ContentRef {
+    const viewRef = content.createEmbeddedView(context);
+    this._applicationRef.attachView(viewRef);
+    return new ContentRef([viewRef.rootNodes], viewRef);
+  }
+
+  private _createFromString(content: string): ContentRef {
+    const component = this._document.createTextNode(`${content}`);
+    return new ContentRef([[component]]);
+  }
+
+  private _createFromComponent(
+      moduleCFR: ComponentFactoryResolver, contentInjector: Injector, content: any,
+      context: NgbActiveModal): ContentRef {
+    const contentCmptFactory = moduleCFR.resolveComponentFactory(content);
+    const modalContentInjector =
+        ReflectiveInjector.resolveAndCreate([{provide: NgbActiveModal, useValue: context}], contentInjector);
+    const componentRef = contentCmptFactory.create(modalContentInjector);
+    this._applicationRef.attachView(componentRef.hostView);
+    return new ContentRef([[componentRef.location.nativeElement]], componentRef.hostView, componentRef);
   }
 }

--- a/src/modal/modal-window.ts
+++ b/src/modal/modal-window.ts
@@ -1,8 +1,10 @@
+import {DOCUMENT} from '@angular/common';
 import {
   Component,
   Output,
   EventEmitter,
   Input,
+  Inject,
   ElementRef,
   Renderer2,
   OnInit,
@@ -30,6 +32,7 @@ import {ModalDismissReasons} from './modal-dismiss-reasons';
 })
 export class NgbModalWindow implements OnInit,
     AfterViewInit, OnDestroy {
+  private _document: any;
   private _elWithFocus: Element;  // element that is focused prior to modal opening
 
   @Input() backdrop: boolean | string = true;
@@ -39,7 +42,9 @@ export class NgbModalWindow implements OnInit,
 
   @Output('dismiss') dismissEvent = new EventEmitter();
 
-  constructor(private _elRef: ElementRef, private _renderer: Renderer2) {}
+  constructor(@Inject(DOCUMENT) document, private _elRef: ElementRef, private _renderer: Renderer2) {
+    this._document = document;
+  }
 
   backdropClick($event): void {
     if (this.backdrop === true && this._elRef.nativeElement === $event.target) {
@@ -56,8 +61,8 @@ export class NgbModalWindow implements OnInit,
   dismiss(reason): void { this.dismissEvent.emit(reason); }
 
   ngOnInit() {
-    this._elWithFocus = document.activeElement;
-    this._renderer.addClass(document.body, 'modal-open');
+    this._elWithFocus = this._document.activeElement;
+    this._renderer.addClass(this._document.body, 'modal-open');
   }
 
   ngAfterViewInit() {
@@ -67,7 +72,7 @@ export class NgbModalWindow implements OnInit,
   }
 
   ngOnDestroy() {
-    const body = document.body;
+    const body = this._document.body;
     const elWithFocus = this._elWithFocus;
 
     let elementToFocus;


### PR DESCRIPTION
Closes #1968
Fixes #858

This PR fix the problem ```No component factory found for NgbModalBackdrop. Did you add it to @NgModule.entryComponents? at noComponentFactoryError``` when using ng-bootstrap on server side.

We had 2 main issues:
- First, on lazy loading for some reason (I don't know how Angular Compiler really works) the service NgbModalStack is injected but the components ```NgbModalWindow``` and ```NgbModalBackdrop``` are not on the [factories list](https://github.com/angular/angular/blob/5.2.5/packages/core/src/linker/component_factory_resolver.ts#L57) yet. For that reason ```ComponentFactory<NgbModalBackdrop>``` and ```ComponentFactory<NgbModalWindow>``` will be initialized only when ```open``` is called.
- A lot of ```document``` access directly. I changed the code so we can inject the document to run on server side.