### PR TITLE
fix(build): freeze gulp-clang-format package

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "file-loader": "^1.1.5",
     "glob": "^7.1.1",
     "gulp": "^3.9.1",
-    "gulp-clang-format": "^1.0.23",
+    "gulp-clang-format": "1.0.23",
     "gulp-conventional-changelog": "^1.1.0",
     "gulp-ddescribe-iit": "^1.3.0",
     "gulp-file": "^0.3.0",


### PR DESCRIPTION
Just to unblock current situation, need to move to yarn or lock packages

`enforce-format` failing with `gulp-check-format` starting from `1.0.24`