### PR TITLE
feat(datepicker): ability to prevent popup from closing automatically

### DIFF
--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -68,12 +68,10 @@ describe('NgbInputDatepicker', () => {
       expect(document.activeElement).toBe(fixture.nativeElement.querySelector('ngb-datepicker'));
     });
 
-    it('should close datepicker on select', () => {
+    it('should close datepicker on date selection', () => {
       const fixture = createTestCmpt(`
           <input ngbDatepicker #d="ngbDatepicker">
           <button (click)="open(d)">Open</button>`);
-
-      const buttons = fixture.nativeElement.querySelectorAll('button');
 
       // open
       const button = fixture.nativeElement.querySelector('button');
@@ -86,6 +84,24 @@ describe('NgbInputDatepicker', () => {
       dp.select.emit();
       fixture.detectChanges();
       expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
+    });
+
+    it(`should not close datepicker if 'autoClose' set to 'false'`, () => {
+      const fixture = createTestCmpt(`
+          <input ngbDatepicker #d="ngbDatepicker" [autoClose]="false">
+          <button (click)="open(d)">Open</button>`);
+
+      // open
+      const button = fixture.nativeElement.querySelector('button');
+      button.click();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+
+      // select
+      const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+      dp.select.emit();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
     });
   });
 
@@ -272,7 +288,6 @@ describe('NgbInputDatepicker', () => {
          expect(inputDebugEl.classes['ng-touched']).toBeTruthy();
        }));
   });
-
 
   describe('manual data entry', () => {
 

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -64,6 +64,12 @@ export class NgbInputDatepicker implements OnChanges,
   private _zoneSubscription: any;
 
   /**
+   * Indicates whether the datepicker popup should be closed automatically after date selection or not.
+   * If the value is 'false', the popup can be closed via 'close()' or 'toggle()' methods
+   */
+  @Input() autoClose = true;
+
+  /**
    * Reference for the custom template for the day display
    */
   @Input() dayTemplate: TemplateRef<DayTemplateContext>;
@@ -237,7 +243,9 @@ export class NgbInputDatepicker implements OnChanges,
       this._cRef.instance.registerOnChange((selectedDate) => {
         this.writeValue(selectedDate);
         this._onChange(selectedDate);
-        this.close();
+        if (this.autoClose) {
+          this.close();
+        }
       });
 
       // focus handling
@@ -315,7 +323,11 @@ export class NgbInputDatepicker implements OnChanges,
 
   private _subscribeForDatepickerOutputs(datepickerInstance: NgbDatepicker) {
     datepickerInstance.navigate.subscribe(date => this.navigate.emit(date));
-    datepickerInstance.select.subscribe(() => { this.close(); });
+    datepickerInstance.select.subscribe(() => {
+      if (this.autoClose) {
+        this.close();
+      }
+    });
   }
 
   private _writeModelValue(model: NgbDate) {


### PR DESCRIPTION
Fixes #1984 

The new `autoClose` input in the input-datepicker that will prevent it from auto-closing on date selection:

```typescript
@Input() autoClose: boolean;
```

In future the API should be similar with the one from the dropdown:

```typescript
@Input() autoClose: boolean  | 'outside' | 'inside';
```

@ymeine, FYI