### PR TITLE
fix(typeahead): don't show hint if there is no active option

### DIFF
--- a/src/typeahead/typeahead-window.ts
+++ b/src/typeahead/typeahead-window.ts
@@ -79,6 +79,8 @@ export class NgbTypeaheadWindow implements OnInit {
 
   @Output('activeChange') activeChangeEvent = new EventEmitter();
 
+  hasActive() { return this.activeIdx > -1 && this.activeIdx < this.results.length; }
+
   getActive() { return this.results[this.activeIdx]; }
 
   markActive(activeIdx: number) {

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -978,6 +978,21 @@ describe('ngb-typeahead', () => {
              expect(inputEl.selectionEnd).toBe(2);
            });
          }));
+
+      it('should not show hint when there is no result selected', async(() => {
+           const fixture = createTestComponent(
+               `<input type="text" [(ngModel)]="model" [ngbTypeahead]="find" [showHint]="true" [focusFirst]="false"/>`);
+           fixture.detectChanges();
+           const compiled = fixture.nativeElement;
+           const inputEl = getNativeInput(compiled);
+
+           fixture.whenStable().then(() => {
+             changeInput(compiled, 'on');
+             fixture.detectChanges();
+             expectWindowResults(compiled, ['one', 'one more']);
+             expect(inputEl.value).toBe('on');
+           });
+         }));
     });
 
     describe('Custom config', () => {

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -313,7 +313,7 @@ export class NgbTypeahead implements ControlValueAccessor,
   }
 
   private _showHint() {
-    if (this.showHint && this._inputValueBackup != null) {
+    if (this.showHint && this._windowRef.instance.hasActive() && this._inputValueBackup != null) {
       const userInputLowerCase = this._inputValueBackup.toLowerCase();
       const formattedVal = this._formatItemForInput(this._windowRef.instance.getActive());
 
@@ -350,12 +350,13 @@ export class NgbTypeahead implements ControlValueAccessor,
         if (this.resultTemplate) {
           this._windowRef.instance.resultTemplate = this.resultTemplate;
         }
-        this._showHint();
 
         // The observable stream we are subscribing to might have async steps
         // and if a component containing typeahead is using the OnPush strategy
         // the change detection turn wouldn't be invoked automatically.
         this._windowRef.changeDetectorRef.detectChanges();
+
+        this._showHint();
       }
     });
   }


### PR DESCRIPTION
Fixes #2185
