### PR TITLE
fix(tooltip): unregister event listener functions only if present

### DIFF
--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -217,7 +217,11 @@ export class NgbTooltip implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.close();
-    this._unregisterListenersFn();
+    // This check is needed as it might happen that ngOnDestroy is called before ngOnInit
+    // under certain conditions, see: https://github.com/ng-bootstrap/ng-bootstrap/issues/2199
+    if (this._unregisterListenersFn) {
+      this._unregisterListenersFn();
+    }
     this._zoneSubscription.unsubscribe();
   }
 }


### PR DESCRIPTION
Fixes #2199 

See discussion in #2199 for more info. 