### PR TITLE
refactor(datepicker): generate 'month' and 'year' boxes in the service

### DIFF
--- a/src/datepicker/datepicker-navigation-select.spec.ts
+++ b/src/datepicker/datepicker-navigation-select.spec.ts
@@ -31,91 +31,31 @@ describe('ngb-datepicker-navigation-select', () => {
 
   it('should generate month options correctly', () => {
     const fixture =
-        createTestComponent(`<ngb-datepicker-navigation-select [date]="date" [minDate]="minDate" [maxDate]="maxDate">`);
-
+        createTestComponent(`<ngb-datepicker-navigation-select [date]="date" [months]="months" [years]="years">`);
     expect(getOptionValues(getMonthSelect(fixture.nativeElement))).toEqual([
-      '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'
+      '1', '2', '3', '4', '5', '6', '7', '8', '9', '10'
     ]);
 
-    fixture.componentInstance.minDate = new NgbDate(2016, 7, 1);
+    fixture.componentInstance.months = [1, 2, 3];
     fixture.detectChanges();
-    expect(getOptionValues(getMonthSelect(fixture.nativeElement))).toEqual(['7', '8', '9', '10', '11', '12']);
-
-    fixture.componentInstance.maxDate = new NgbDate(2016, 9, 1);
-    fixture.detectChanges();
-    expect(getOptionValues(getMonthSelect(fixture.nativeElement))).toEqual(['7', '8', '9']);
-
-    fixture.componentInstance.minDate = new NgbDate(2015, 1, 1);
-    fixture.detectChanges();
-    expect(getOptionValues(getMonthSelect(fixture.nativeElement))).toEqual([
-      '1', '2', '3', '4', '5', '6', '7', '8', '9'
-    ]);
-  });
-
-  it('should update months when current date changes', () => {
-    const fixture =
-        createTestComponent(`<ngb-datepicker-navigation-select [date]="date" [minDate]="minDate" [maxDate]="maxDate">`);
-
-    fixture.componentInstance.minDate = new NgbDate(2015, 7, 1);
-    fixture.componentInstance.maxDate = new NgbDate(2017, 7, 1);
-    fixture.detectChanges();
-    expect(getOptionValues(getMonthSelect(fixture.nativeElement))).toEqual([
-      '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'
-    ]);
-
-    fixture.componentInstance.date = new NgbDate(2015, 9, 1);
-    fixture.detectChanges();
-    expect(getOptionValues(getMonthSelect(fixture.nativeElement))).toEqual(['7', '8', '9', '10', '11', '12']);
-
-    fixture.componentInstance.date = new NgbDate(2017, 5, 1);
-    fixture.detectChanges();
-    expect(getOptionValues(getMonthSelect(fixture.nativeElement))).toEqual(['1', '2', '3', '4', '5', '6', '7']);
-  });
-
-  it('should update months when current date changes between valid dates and null / undefined', () => {
-    const fixture =
-        createTestComponent(`<ngb-datepicker-navigation-select [date]="date" [minDate]="minDate" [maxDate]="maxDate">`);
-
-    fixture.componentInstance.date = new NgbDate(2016, 1, 1);
-    fixture.componentInstance.minDate = new NgbDate(2015, 7, 1);
-    fixture.componentInstance.maxDate = new NgbDate(2016, 7, 1);
-    fixture.detectChanges();
-    expect(getOptionValues(getMonthSelect(fixture.nativeElement))).toEqual(['1', '2', '3', '4', '5', '6', '7']);
-
-    fixture.componentInstance.date = null;
-    fixture.detectChanges();
-    expect(getOptionValues(getMonthSelect(fixture.nativeElement))).toEqual([
-      '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'
-    ]);
-
-    fixture.componentInstance.date = new NgbDate(2016, 5, 1);
-    fixture.detectChanges();
-    expect(getOptionValues(getMonthSelect(fixture.nativeElement))).toEqual(['1', '2', '3', '4', '5', '6', '7']);
+    expect(getOptionValues(getMonthSelect(fixture.nativeElement))).toEqual(['1', '2', '3']);
   });
 
   it('should generate year options correctly', () => {
     const fixture =
-        createTestComponent(`<ngb-datepicker-navigation-select [date]="date" [minDate]="minDate" [maxDate]="maxDate">`);
+        createTestComponent(`<ngb-datepicker-navigation-select [date]="date" [months]="months" [years]="years">`);
 
     const yearSelect = getYearSelect(fixture.nativeElement);
-    expect(getOptionValues(yearSelect)).toEqual(['2015', '2016', '2017', '2018', '2019', '2020']);
-
-    fixture.componentInstance.maxDate = new NgbDate(2017, 1, 1);
-    fixture.detectChanges();
     expect(getOptionValues(yearSelect)).toEqual(['2015', '2016', '2017']);
 
-    fixture.componentInstance.minDate = new NgbDate(2014, 1, 1);
+    fixture.componentInstance.years = [2001, 2002, 2003];
     fixture.detectChanges();
-    expect(getOptionValues(yearSelect)).toEqual(['2014', '2015', '2016', '2017']);
-
-    fixture.componentInstance.minDate = new NgbDate(2017, 1, 1);
-    fixture.detectChanges();
-    expect(getOptionValues(yearSelect)).toEqual(['2017']);
+    expect(getOptionValues(yearSelect)).toEqual(['2001', '2002', '2003']);
   });
 
   it('should send date selection events', () => {
     const fixture = createTestComponent(
-        `<ngb-datepicker-navigation-select [date]="date" [minDate]="minDate" [maxDate]="maxDate" (select)="onSelect($event)">`);
+        `<ngb-datepicker-navigation-select [date]="date" [months]="months" [years]="years" (select)="onSelect($event)">`);
 
     const monthSelect = getMonthSelect(fixture.nativeElement);
     const yearSelect = getYearSelect(fixture.nativeElement);
@@ -137,7 +77,7 @@ describe('ngb-datepicker-navigation-select', () => {
 
   it('should select months and years when date changes', () => {
     const fixture =
-        createTestComponent(`<ngb-datepicker-navigation-select [date]="date" [minDate]="minDate" [maxDate]="maxDate">`);
+        createTestComponent(`<ngb-datepicker-navigation-select [date]="date" [months]="months" [years]="years">`);
 
     expect(getMonthSelect(fixture.nativeElement).value).toBe('8');
     expect(getYearSelect(fixture.nativeElement).value).toBe('2016');
@@ -156,7 +96,7 @@ describe('ngb-datepicker-navigation-select', () => {
 
   it('should have disabled select boxes when disabled', () => {
     const fixture = createTestComponent(
-        `<ngb-datepicker-navigation-select [disabled]="true" [date]="date" [minDate]="minDate" [maxDate]="maxDate">`);
+        `<ngb-datepicker-navigation-select [disabled]="true" [date]="date" [months]="months" [years]="years">`);
 
     expect(getMonthSelect(fixture.nativeElement).disabled).toBe(true);
     expect(getYearSelect(fixture.nativeElement).disabled).toBe(true);
@@ -167,8 +107,8 @@ describe('ngb-datepicker-navigation-select', () => {
 @Component({selector: 'test-cmp', template: ''})
 class TestComponent {
   date = new NgbDate(2016, 8, 22);
-  minDate = new NgbDate(2015, 1, 1);
-  maxDate = new NgbDate(2020, 1, 1);
+  months = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+  years = [2015, 2016, 2017];
 
   onSelect = () => {};
 }

--- a/src/datepicker/datepicker-navigation-select.ts
+++ b/src/datepicker/datepicker-navigation-select.ts
@@ -1,8 +1,7 @@
-import {Component, Input, Output, EventEmitter, OnChanges, SimpleChanges, ChangeDetectionStrategy} from '@angular/core';
+import {Component, Input, Output, EventEmitter, ChangeDetectionStrategy} from '@angular/core';
 import {NgbDate} from './ngb-date';
 import {toInteger} from '../util/util';
 import {NgbDatepickerI18n} from './datepicker-i18n';
-import {NgbCalendar} from './ngb-calendar';
 
 @Component({
   selector: 'ngb-datepicker-navigation-select',
@@ -37,45 +36,17 @@ import {NgbCalendar} from './ngb-calendar';
     </select>
   `
 })
-export class NgbDatepickerNavigationSelect implements OnChanges {
-  months: number[];
-  years: number[] = [];
-
+export class NgbDatepickerNavigationSelect {
   @Input() date: NgbDate;
   @Input() disabled: boolean;
-  @Input() maxDate: NgbDate;
-  @Input() minDate: NgbDate;
+  @Input() months: number[];
+  @Input() years: number[];
 
   @Output() select = new EventEmitter<NgbDate>();
 
-  constructor(public i18n: NgbDatepickerI18n, private calendar: NgbCalendar) { this.months = calendar.getMonths(); }
-
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes['maxDate'] || changes['minDate'] || changes['date']) {
-      this._generateYears();
-      this._generateMonths();
-    }
-  }
+  constructor(public i18n: NgbDatepickerI18n) {}
 
   changeMonth(month: string) { this.select.emit(new NgbDate(this.date.year, toInteger(month), 1)); }
 
   changeYear(year: string) { this.select.emit(new NgbDate(toInteger(year), this.date.month, 1)); }
-
-  private _generateMonths() {
-    this.months = this.calendar.getMonths();
-
-    if (this.date && this.date.year === this.minDate.year) {
-      const index = this.months.findIndex(month => month === this.minDate.month);
-      this.months = this.months.slice(index);
-    }
-
-    if (this.date && this.date.year === this.maxDate.year) {
-      const index = this.months.findIndex(month => month === this.maxDate.month);
-      this.months = this.months.slice(0, index + 1);
-    }
-  }
-
-  private _generateYears() {
-    this.years = Array.from({length: this.maxDate.year - this.minDate.year + 1}, (e, i) => this.minDate.year + i);
-  }
 }

--- a/src/datepicker/datepicker-navigation.spec.ts
+++ b/src/datepicker/datepicker-navigation.spec.ts
@@ -31,7 +31,7 @@ describe('ngb-datepicker-navigation', () => {
 
   it('should toggle navigation select component', () => {
     const fixture = createTestComponent(`<ngb-datepicker-navigation [showSelect]="showSelect" [date]="date"
-          [minDate]="minDate" [maxDate]="maxDate"></ngb-datepicker-navigation>`);
+          [selectBoxes]="selectBoxes" [minDate]="minDate" [maxDate]="maxDate"></ngb-datepicker-navigation>`);
 
     expect(fixture.debugElement.query(By.directive(NgbDatepickerNavigationSelect))).not.toBeNull();
     expect(getMonthSelect(fixture.nativeElement).value).toBe('8');
@@ -44,7 +44,7 @@ describe('ngb-datepicker-navigation', () => {
 
   it('should send date selection event', () => {
     const fixture = createTestComponent(`<ngb-datepicker-navigation [showSelect]="true" [date]="date"
-          [minDate]="minDate" [maxDate]="maxDate" (select)="onSelect($event)"></ngb-datepicker-navigation>`);
+          [selectBoxes]="selectBoxes"[minDate]="minDate" [maxDate]="maxDate" (select)="onSelect($event)"></ngb-datepicker-navigation>`);
 
     const monthSelect = getMonthSelect(fixture.nativeElement);
     const yearSelect = getYearSelect(fixture.nativeElement);
@@ -59,7 +59,7 @@ describe('ngb-datepicker-navigation', () => {
 
   it('should make prev navigation button disabled', () => {
     const fixture = createTestComponent(`<ngb-datepicker-navigation [showSelect]="true" [date]="date"
-          [minDate]="minDate" [maxDate]="maxDate"></ngb-datepicker-navigation>`);
+          [selectBoxes]="selectBoxes" [minDate]="minDate" [maxDate]="maxDate"></ngb-datepicker-navigation>`);
 
     const links = getNavigationLinks(fixture.nativeElement);
     expect(links[0].hasAttribute('disabled')).toBeFalsy();
@@ -84,7 +84,7 @@ describe('ngb-datepicker-navigation', () => {
 
   it('should make next navigation button disabled', () => {
     const fixture = createTestComponent(`<ngb-datepicker-navigation [showSelect]="true" [date]="date"
-          [minDate]="minDate" [maxDate]="maxDate"></ngb-datepicker-navigation>`);
+          [selectBoxes]="selectBoxes" [minDate]="minDate" [maxDate]="maxDate"></ngb-datepicker-navigation>`);
 
     const links = getNavigationLinks(fixture.nativeElement);
     expect(links[1].hasAttribute('disabled')).toBeFalsy();
@@ -109,7 +109,7 @@ describe('ngb-datepicker-navigation', () => {
 
   it('should have disabled navigation buttons and year and month select boxes when disabled', () => {
     const fixture = createTestComponent(`<ngb-datepicker-navigation [disabled]="true" [showSelect]="true"
-          [date]="date" [minDate]="minDate" [maxDate]="maxDate"></ngb-datepicker-navigation>`);
+          [selectBoxes]="selectBoxes" [date]="date" [minDate]="minDate" [maxDate]="maxDate"></ngb-datepicker-navigation>`);
 
     const links = getNavigationLinks(fixture.nativeElement);
     expect(links[0].hasAttribute('disabled')).toBeTruthy();
@@ -150,6 +150,7 @@ class TestComponent {
   minDate = new NgbDate(2015, 0, 1);
   maxDate = new NgbDate(2020, 11, 31);
   showSelect = true;
+  selectBoxes = {months: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], years: [2015, 2016, 2017, 2018, 2019, 2020]};
 
   onNavigate = () => {};
   onSelect = () => {};

--- a/src/datepicker/datepicker-navigation.ts
+++ b/src/datepicker/datepicker-navigation.ts
@@ -76,9 +76,9 @@ import {NgbCalendar} from './ngb-calendar';
   </div>
     <ngb-datepicker-navigation-select *ngIf="showSelect" class="d-block ngb-dp-navigation-select"
       [date]="date"
-      [minDate]="minDate"
-      [maxDate]="maxDate"
       [disabled] = "disabled"
+      [months]="selectBoxes.months"
+      [years]="selectBoxes.years"
       (select)="selectDate($event)">
     </ngb-datepicker-navigation-select>
 
@@ -106,6 +106,7 @@ export class NgbDatepickerNavigation {
   @Input() minDate: NgbDate;
   @Input() months: MonthViewModel[] = [];
   @Input() showSelect: boolean;
+  @Input() selectBoxes: {years: number[], months: number[]};
   @Input() showWeekNumbers: boolean;
 
   @Output() navigate = new EventEmitter<NavigationEvent>();

--- a/src/datepicker/datepicker-service.spec.ts
+++ b/src/datepicker/datepicker-service.spec.ts
@@ -428,6 +428,59 @@ describe('ngb-datepicker-service', () => {
       service.navigation = 'select';  // ignored
       expect(mock.onNext).toHaveBeenCalledTimes(1);
     });
+
+    describe(`select`, () => {
+
+      it(`should not generate 'months' and 'years' for non-select navigations`, () => {
+        service.minDate = new NgbDate(2010, 5, 1);
+        service.maxDate = new NgbDate(2012, 5, 1);
+        service.focus(new NgbDate(2011, 5, 1));
+        expect(model.selectBoxes.years).not.toEqual([]);
+        expect(model.selectBoxes.months).not.toEqual([]);
+
+        service.navigation = 'none';
+        expect(model.selectBoxes.years).toEqual([]);
+        expect(model.selectBoxes.months).toEqual([]);
+
+        service.navigation = 'arrows';
+        expect(model.selectBoxes.years).toEqual([]);
+        expect(model.selectBoxes.months).toEqual([]);
+      });
+
+      it(`should generate 'months' and 'years' for given min/max dates`, () => {
+        service.minDate = new NgbDate(2010, 5, 1);
+        service.maxDate = new NgbDate(2012, 5, 1);
+        service.focus(new NgbDate(2011, 5, 1));
+
+        expect(model.selectBoxes.years).toEqual([2010, 2011, 2012]);
+        expect(model.selectBoxes.months).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+
+        service.focus(new NgbDate(2010, 5, 1));
+        expect(model.selectBoxes.years).toEqual([2010, 2011, 2012]);
+        expect(model.selectBoxes.months).toEqual([5, 6, 7, 8, 9, 10, 11, 12]);
+
+        service.focus(new NgbDate(2012, 5, 1));
+        expect(model.selectBoxes.years).toEqual([2010, 2011, 2012]);
+        expect(model.selectBoxes.months).toEqual([1, 2, 3, 4, 5]);
+      });
+
+      it(`should update 'months' and 'years' when  min/max dates change`, () => {
+        service.minDate = new NgbDate(2010, 5, 1);
+        service.maxDate = new NgbDate(2012, 5, 1);
+        service.focus(new NgbDate(2011, 5, 1));
+
+        expect(model.selectBoxes.years).toEqual([2010, 2011, 2012]);
+        expect(model.selectBoxes.months).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+
+        service.minDate = new NgbDate(2011, 2, 1);
+        expect(model.selectBoxes.years).toEqual([2011, 2012]);
+        expect(model.selectBoxes.months).toEqual([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+
+        service.maxDate = new NgbDate(2011, 8, 1);
+        expect(model.selectBoxes.years).toEqual([2011]);
+        expect(model.selectBoxes.months).toEqual([2, 3, 4, 5, 6, 7, 8]);
+      });
+    });
   });
 
   describe(`markDisabled`, () => {

--- a/src/datepicker/datepicker-service.ts
+++ b/src/datepicker/datepicker-service.ts
@@ -4,7 +4,15 @@ import {DatepickerViewModel, NgbMarkDisabled} from './datepicker-view-model';
 import {Injectable} from '@angular/core';
 import {isInteger} from '../util/util';
 import {Subject} from 'rxjs/Subject';
-import {buildMonths, checkDateInRange, checkMinBeforeMax, isChangedDate, isDateSelectable} from './datepicker-tools';
+import {
+  buildMonths,
+  checkDateInRange,
+  checkMinBeforeMax,
+  isChangedDate,
+  isDateSelectable,
+  generateSelectBoxYears,
+  generateSelectBoxMonths
+} from './datepicker-tools';
 
 import {filter} from 'rxjs/operator/filter';
 import {Observable} from 'rxjs/Observable';
@@ -22,6 +30,7 @@ export class NgbDatepickerService {
     focusVisible: false,
     months: [],
     navigation: 'select',
+    selectBoxes: {years: [], months: []},
     selectedDate: null
   };
 
@@ -228,6 +237,23 @@ export class NgbDatepickerService {
             state.focusDate.after(state.lastDate)) {
           state.focusDate = startDate;
         }
+      }
+
+      // adjusting months/years for the select box navigation
+      if (state.navigation === 'select') {
+        // years ->  boundaries (min/max were changed)
+        if ('minDate' in patch || 'maxDate' in patch || state.selectBoxes.years.length === 0) {
+          state.selectBoxes.years = generateSelectBoxYears(state.minDate, state.maxDate);
+        }
+
+        // months -> when current year or boundaries change
+        if ('minDate' in patch || 'maxDate' in patch || state.selectBoxes.months.length === 0 ||
+            this._state.firstDate.year !== state.firstDate.year) {
+          state.selectBoxes.months =
+              generateSelectBoxMonths(this._calendar, state.focusDate, state.minDate, state.maxDate);
+        }
+      } else {
+        state.selectBoxes = {years: [], months: []};
       }
     }
 

--- a/src/datepicker/datepicker-tools.ts
+++ b/src/datepicker/datepicker-tools.ts
@@ -41,6 +41,30 @@ export function isDateSelectable(
   // clang-format on
 }
 
+export function generateSelectBoxMonths(calendar: NgbCalendar, date: NgbDate, minDate: NgbDate, maxDate: NgbDate) {
+  if (!date || !minDate || !maxDate) {
+    return [];
+  }
+
+  let months = calendar.getMonths();
+
+  if (date.year === minDate.year) {
+    const index = months.findIndex(month => month === minDate.month);
+    months = months.slice(index);
+  }
+
+  if (date.year === maxDate.year) {
+    const index = months.findIndex(month => month === maxDate.month);
+    months = months.slice(0, index + 1);
+  }
+
+  return months;
+}
+
+export function generateSelectBoxYears(minDate: NgbDate, maxDate: NgbDate): number[] {
+  return (minDate && maxDate) ? Array.from({length: maxDate.year - minDate.year + 1}, (e, i) => minDate.year + i) : [];
+}
+
 export function buildMonths(
     calendar: NgbCalendar, months: MonthViewModel[], date: NgbDate, minDate: NgbDate, maxDate: NgbDate,
     displayMonths: number, firstDayOfWeek: number, markDisabled: NgbMarkDisabled, force: boolean): MonthViewModel[] {

--- a/src/datepicker/datepicker-view-model.ts
+++ b/src/datepicker/datepicker-view-model.ts
@@ -37,6 +37,10 @@ export type DatepickerViewModel = {
   minDate?: NgbDate,
   months: MonthViewModel[],
   navigation: 'select' | 'arrows' | 'none',
+  selectBoxes: {
+    years: number[],
+    months: number[]
+  },
   selectedDate: NgbDate
 }
 // clang-format on

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -127,6 +127,7 @@ export interface NgbDatepickerNavigateEvent {
         [disabled]="model.disabled"
         [showWeekNumbers]="showWeekNumbers"
         [showSelect]="model.navigation === 'select'"
+        [selectBoxes]="model.selectBoxes"
         (navigate)="onNavigateEvent($event)"
         (select)="onNavigateDateSelect($event)">
       </ngb-datepicker-navigation>


### PR DESCRIPTION
Moving values generation for navigation select boxes (`year` and `month`) from components to the service