### PR TITLE
feat(popover): only show a popover if the content is not falsy

### DIFF
--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -147,6 +147,17 @@ describe('ngb-popover', () => {
       expect(spyService.called).toBeTruthy();
     });
 
+    it('should not open a popover if content and title are empty', () => {
+      const fixture = createTestComponent(`<div [ngbPopover]="" [popoverTitle]=""></div>`);
+      const directive = fixture.debugElement.query(By.directive(NgbPopover));
+
+      directive.triggerEventHandler('click', {});
+      fixture.detectChanges();
+      const windowEl = getWindow(fixture.nativeElement);
+
+      expect(windowEl).toBeNull();
+    });
+
     it('should not open a popover if [disablePopover] flag', () => {
       const fixture = createTestComponent(`<div [ngbPopover]="Disabled!" [disablePopover]="true"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
@@ -156,6 +167,44 @@ describe('ngb-popover', () => {
       const windowEl = getWindow(fixture.nativeElement);
 
       expect(windowEl).toBeNull();
+    });
+
+    it('should close the popover if content and title become empty', () => {
+      const fixture = createTestComponent(`<div [ngbPopover]="name" [popoverTitle]="title"></div>`);
+      const directive = fixture.debugElement.query(By.directive(NgbPopover));
+
+      directive.triggerEventHandler('click', {});
+      fixture.detectChanges();
+      expect(getWindow(fixture.nativeElement)).not.toBeNull();
+
+      fixture.componentInstance.name = '';
+      fixture.componentInstance.title = '';
+      fixture.detectChanges();
+      expect(getWindow(fixture.nativeElement)).toBeNull();
+    });
+
+    it('should open the popover if content is empty but title has value', () => {
+      const fixture = createTestComponent(`<div [ngbPopover]="" popoverTitle="title"></div>`);
+      const directive = fixture.debugElement.query(By.directive(NgbPopover));
+
+      directive.triggerEventHandler('click', {});
+      fixture.detectChanges();
+      const windowEl = getWindow(fixture.nativeElement);
+
+      expect(windowEl).not.toBeNull();
+    });
+
+    it('should not close the popover if content becomes empty but title has value', () => {
+      const fixture = createTestComponent(`<div [ngbPopover]="name" popoverTitle="title"></div>`);
+      const directive = fixture.debugElement.query(By.directive(NgbPopover));
+
+      directive.triggerEventHandler('click', {});
+      fixture.detectChanges();
+      expect(getWindow(fixture.nativeElement)).not.toBeNull();
+
+      fixture.componentInstance.name = '';
+      fixture.detectChanges();
+      expect(getWindow(fixture.nativeElement)).not.toBeNull();
     });
 
     it('should allow re-opening previously closed popovers', () => {

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -7,6 +7,7 @@ import {
   ChangeDetectionStrategy,
   OnInit,
   OnDestroy,
+  OnChanges,
   Injector,
   Renderer2,
   ComponentRef,
@@ -14,7 +15,8 @@ import {
   TemplateRef,
   ViewContainerRef,
   ComponentFactoryResolver,
-  NgZone
+  NgZone,
+  SimpleChanges
 } from '@angular/core';
 
 import {listenToTriggers} from '../util/triggers';
@@ -90,13 +92,13 @@ export class NgbPopoverWindow {
  * A lightweight, extensible directive for fancy popover creation.
  */
 @Directive({selector: '[ngbPopover]', exportAs: 'ngbPopover'})
-export class NgbPopover implements OnInit, OnDestroy {
+export class NgbPopover implements OnInit, OnDestroy, OnChanges {
   /**
-   * Content to be displayed as popover.
+   * Content to be displayed as popover. If title and content are empty, the popover won't open.
    */
   @Input() ngbPopover: string | TemplateRef<any>;
   /**
-   * Title of a popover.
+   * Title of a popover. If title and content are empty, the popover won't open.
    */
   @Input() popoverTitle: string;
   /**
@@ -133,6 +135,15 @@ export class NgbPopover implements OnInit, OnDestroy {
   private _windowRef: ComponentRef<NgbPopoverWindow>;
   private _unregisterListenersFn;
   private _zoneSubscription: any;
+  private _isDisabled(): boolean {
+    if (this.disablePopover) {
+      return true;
+    }
+    if (!this.ngbPopover && !this.popoverTitle) {
+      return true;
+    }
+    return false;
+  }
 
   constructor(
       private _elementRef: ElementRef, private _renderer: Renderer2, injector: Injector,
@@ -160,7 +171,7 @@ export class NgbPopover implements OnInit, OnDestroy {
    * The context is an optional value to be injected into the popover template when it is created.
    */
   open(context?: any) {
-    if (!this._windowRef && !this.disablePopover) {
+    if (!this._windowRef && !this._isDisabled()) {
       this._windowRef = this._popupService.open(this.ngbPopover, context);
       this._windowRef.instance.title = this.popoverTitle;
       this._windowRef.instance.id = this._ngbPopoverWindowId;
@@ -217,6 +228,13 @@ export class NgbPopover implements OnInit, OnDestroy {
     this._unregisterListenersFn = listenToTriggers(
         this._renderer, this._elementRef.nativeElement, this.triggers, this.open.bind(this), this.close.bind(this),
         this.toggle.bind(this));
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    // close popover if title and content become empty, or disablePopover set to true
+    if ((changes['ngbPopover'] || changes['popoverTitle'] || changes['disablePopover']) && this._isDisabled()) {
+      this.close();
+    }
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
ngbTooltip was amended to only show a tooltip if the content is not falsy. It would be nice if ngbPopover behave the same way
closes #2188 