### PR TITLE
docs: allow deprecation and new features in documentation

### DIFF
--- a/demo/src/app/components/shared/api-docs/api-docs-badge.component.ts
+++ b/demo/src/app/components/shared/api-docs/api-docs-badge.component.ts
@@ -11,13 +11,20 @@ const BADGES = {
 
 @Component({
   selector: 'ngbd-api-docs-badge',
-  template: `<h5><span class="badge" [ngClass]="badgeClass">{{text}}</span></h5>`,
+  template: `
+    <h5>
+      <span *ngIf="deprecated" class="badge badge-secondary" >Deprecated {{ deprecated.version }}</span> 
+      <span class="badge" [ngClass]="badgeClass">{{text}}</span>
+    </h5>
+  `,
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class NgbdApiDocsBadge {
 
   badgeClass;
   text;
+
+  @Input() deprecated: {version: string};
 
   @Input()
   set type(type: string) {

--- a/demo/src/app/components/shared/api-docs/api-docs-class.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs-class.component.html
@@ -1,4 +1,4 @@
-<div class="api-doc-component">
+<div class="api-doc-component" [class.deprecated]="apiDocs.deprecated">
   <h3>
     <a
       class="title-fragment"
@@ -19,7 +19,8 @@
       <img src="img/github.svg" alt="Link to Github {{apiDocs.className}}"/>
     </a>
   </h3>
-  <ngbd-api-docs-badge [type]="apiDocs.type"></ngbd-api-docs-badge>
+  <ngbd-api-docs-badge [type]="apiDocs.type" [deprecated]="apiDocs.deprecated"></ngbd-api-docs-badge>
+  <p *ngIf="apiDocs.deprecated">{{ apiDocs.deprecated.description }}</p>
   <p class="lead">{{apiDocs.description}}</p>
 
   <ng-template [ngIf]="apiDocs.properties && apiDocs.properties.length">
@@ -27,10 +28,15 @@
       <h4>Properties</h4>
       <table class="table table-sm">
         <tbody>
-        <tr *ngFor="let prop of apiDocs.properties">
-          <td class="label-cell"><code>{{prop.name}}</code></td>
+        <tr *ngFor="let prop of apiDocs.properties" [class.deprecated]="prop.deprecated">
+          <td class="label-cell">
+            <code>{{prop.name}}</code><br>
+            <span *ngIf="prop.since" class="badge badge-info">since {{ prop.since.version }}</span>
+            <span *ngIf="prop.deprecated" class="badge badge-secondary">deprecated {{ prop.deprecated.version }}</span>
+          </td>
           <td class="content-cell">
-            <p>{{ prop.description }}</p>
+            <p *ngIf="prop.deprecated">{{ prop.deprecated.description }}</p>
+            <p class="description">{{ prop.description }}</p>
             <div class="meta">
               <div>
                 <i>Type: </i><code>{{ prop.type }}</code>
@@ -51,14 +57,19 @@
       <h4>Methods</h4>
       <table class="table table-sm">
         <tbody>
-          <tr *ngFor="let method of apiDocs.methods">
-            <td class="label-cell"><code>{{method.name}}</code></td>
+          <tr *ngFor="let method of apiDocs.methods" [class.deprecated]="method.deprecated">
+            <td class="label-cell">
+              <code>{{method.name}}</code><br>
+              <span *ngIf="method.since" class="badge badge-info">since {{ method.since.version }}</span>
+              <span *ngIf="method.deprecated" class="badge badge-secondary">deprecated {{ method.deprecated.version }}</span>
+            </td>
             <td class="content-cell">
-                <p>
+                <p class="signature">
                     <code>{{methodSignature(method)}}</code>
                     <small class="text-muted" title="Return type">=&gt; {{ method.returnType }}</small>
                 </p>
-                <p>{{ method.description }}</p>
+                <p *ngIf="method.deprecated">{{ method.deprecated.description }}</p>
+                <p class="description">{{ method.description }}</p>
             </td>
           </tr>
         </tbody>

--- a/demo/src/app/components/shared/api-docs/api-docs-config.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs-config.component.html
@@ -1,4 +1,4 @@
-<div (click)="trackSourceClick()" class="api-doc-component">
+<div (click)="trackSourceClick()" class="api-doc-component" [class.deprecated]="apiDocs.deprecated">
   <h3>
     <a
       class="title-fragment"
@@ -19,13 +19,14 @@
       <img src="img/github.svg" alt="Link to Github {{apiDocs.className}}"/>
     </a>
   </h3>
-  <ngbd-api-docs-badge type="Configuration"></ngbd-api-docs-badge>
+  <ngbd-api-docs-badge type="Configuration" [deprecated]="apiDocs.deprecated"></ngbd-api-docs-badge>
+  <p *ngIf="apiDocs.deprecated">{{ apiDocs.deprecated.description }}</p>
   <p class="lead">{{apiDocs.description}}</p>
 
   <ng-template [ngIf]="apiDocs.properties && apiDocs.properties.length">
     <section>
       <h4>Properties</h4>
-      <p>
+      <p class="description">
         <ng-template ngFor let-property [ngForOf]="apiDocs.properties">
           <code>{{ property.name }}</code>
         </ng-template>

--- a/demo/src/app/components/shared/api-docs/api-docs.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs.component.html
@@ -1,5 +1,5 @@
-<div class="api-doc-component">
-  <h2 class="title">
+<div class="api-doc-component" [class.deprecated]="apiDocs.deprecated">
+  <h3 class="title">
     <a
       [routerLink]=""
       fragment="{{apiDocs.className}}" ngbdFragment
@@ -17,15 +17,16 @@
     >
       <img src="img/github.svg" alt="Link to Github {{apiDocs.className}}"/>
     </a>
-  </h2>
-  <ngbd-api-docs-badge [type]="apiDocs.type"></ngbd-api-docs-badge>
+  </h3>
+  <ngbd-api-docs-badge [type]="apiDocs.type" [deprecated]="apiDocs.deprecated"></ngbd-api-docs-badge>
+  <p *ngIf="apiDocs.deprecated">{{ apiDocs.deprecated.description }}</p>
   <p class="lead">
     {{apiDocs.description}}
   </p>
 
   <section>
-    <h4>Selector <small><code>{{apiDocs.selector}}</code></small></h4>
-    <h6 *ngIf="apiDocs.exportAs">Exported as <small><code>{{apiDocs.exportAs}}</code></small></h6>
+    <h4>Selector <small><code class="selector">{{apiDocs.selector}}</code></small></h4>
+    <h6 *ngIf="apiDocs.exportAs">Exported as <small><code class="export-as">{{apiDocs.exportAs}}</code></small></h6>
   </section>
 
   <ng-template [ngIf]="apiDocs.inputs.length">
@@ -33,9 +34,14 @@
       <h4>Inputs</h4>
       <table class="table table-sm">
         <tbody>
-        <tr *ngFor="let input of apiDocs.inputs">
-          <td class="label-cell"><code>{{input.name}}</code></td>
+        <tr *ngFor="let input of apiDocs.inputs" [class.deprecated]="input.deprecated">
+          <td class="label-cell">
+            <code>{{input.name}}</code><br>
+            <span *ngIf="input.since" class="badge badge-info">since {{ input.since.version }}</span>
+            <span *ngIf="input.deprecated" class="badge badge-secondary">deprecated {{ input.deprecated.version }}</span>
+          </td>
           <td class="content-cell">
+            <p *ngIf="input.deprecated">{{ input.deprecated.description }}</p>
             <p class="description">{{ input.description }}</p>
             <div class="meta">
               <div>
@@ -58,9 +64,16 @@
       <h4>Outputs</h4>
       <table class="table table-sm">
         <tbody>
-          <tr *ngFor="let output of apiDocs.outputs">
-            <td class="label-cell"><code>{{output.name}}</code></td>
-            <td class="content-cell">{{output.description}}</td>
+          <tr *ngFor="let output of apiDocs.outputs" [class.deprecated]="output.deprecated">
+            <td class="label-cell">
+              <code>{{output.name}}</code><br>
+              <span *ngIf="output.since" class="badge badge-info">since {{ output.since.version }}</span>
+              <span *ngIf="output.deprecated" class="badge badge-secondary">deprecated {{ output.deprecated.version }}</span>
+            </td>
+            <td class="content-cell">
+              <p *ngIf="output.deprecated">{{ output.deprecated.description }}</p>
+              <p class="description">{{ output.description }}</p>
+            </td>
           </tr>
         </tbody>
       </table>
@@ -72,14 +85,19 @@
       <h4>Methods</h4>
       <table class="table table-sm">
         <tbody>
-          <tr *ngFor="let method of apiDocs.methods">
-            <td class="label-cell"><code>{{method.name}}</code></td>
+          <tr *ngFor="let method of apiDocs.methods" [class.deprecated]="method.deprecated">
+            <td class="label-cell">
+              <code>{{method.name}}</code><br>
+              <span *ngIf="method.since" class="badge badge-info">since {{ method.since.version }}</span>
+              <span *ngIf="method.deprecated" class="badge badge-secondary">deprecated {{ method.deprecated.version }}</span>
+            </td>
             <td class="content-cell">
-                <p>
+                <p class="signature">
                     <code>{{methodSignature(method)}}</code>
                     <small class="text-muted" title="Return type">=&gt; {{ method.returnType }}</small>
                 </p>
-                <p>{{ method.description }}</p>
+                <p *ngIf="method.deprecated">{{ method.deprecated.description }}</p>
+                <p class="description">{{ method.description }}</p>
             </td>
           </tr>
         </tbody>

--- a/demo/src/app/components/shared/api-docs/api-docs.model.ts
+++ b/demo/src/app/components/shared/api-docs/api-docs.model.ts
@@ -3,6 +3,8 @@ export interface ClassDesc {
   fileName: string;
   className: string;
   description: string;
+  deprecated?: VersionDesc;
+  since?: VersionDesc;
   properties: PropertyDesc[];
   methods: MethodDesc[];
 }
@@ -18,14 +20,23 @@ export interface PropertyDesc {
   name: string;
   type: string;
   description: string;
+  deprecated?: VersionDesc;
+  since?: VersionDesc;
   defaultValue?: string;
 }
 
 export interface MethodDesc {
   name: string;
   description: string;
+  deprecated?: VersionDesc;
+  since?: VersionDesc;
   args: ArgumentDesc[];
   returnType: string;
+}
+
+export interface VersionDesc {
+  version: string;
+  description: string;
 }
 
 export interface ArgumentDesc {

--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -10,6 +10,24 @@
   height: 256px;
 }
 
+.deprecated {
+  h3 {
+    text-decoration: line-through;
+  }
+
+  h5 {
+    display: inline-block;
+  }
+
+  td.label-cell code, p.signature, code.selector, code.export-as {
+    text-decoration: line-through;
+  }
+
+  .description, .meta, .lead {
+    opacity: 0.5;
+  }
+}
+
 .bd-masthead, .jumbotron {
   background-color: #0143A3;
   background: linear-gradient(135deg, #0143A3, #0273D4);

--- a/misc/api-doc-test-cases/release-deprecation.ts
+++ b/misc/api-doc-test-cases/release-deprecation.ts
@@ -1,0 +1,73 @@
+import {Component, Directive, Injectable, Input, Output} from '@angular/core';
+
+/**
+ * Description
+ *
+ * @deprecated 2.0.0 description
+ */
+@Directive({
+  selector: '[ngbDirective]'
+})
+export class NgbDirective {
+  /**
+   * Description
+   *
+   * @deprecated 2.0.0 description
+   */
+  @Input() input;
+
+  /**
+   * Description
+   *
+   * @deprecated 2.0.0 description
+   */
+  @Output() output;
+
+  /**
+   * Description
+   *
+   * @deprecated 2.0.0 description
+   */
+  property;
+
+  /**
+   * Description
+   *
+   * @deprecated 2.0.0 description
+   */
+  method() {}
+}
+
+/**
+ * Description
+ *
+ * @deprecated 2.0.0 description
+ */
+@Component({
+  selector: 'ngb-component'
+})
+export class NgbComponent {}
+
+
+/**
+ * Description
+ *
+ * @deprecated 2.0.0 description
+ */
+@Injectable()
+export class NgbService {}
+
+/**
+ * Description
+ *
+ * @deprecated 2.0.0 description
+ */
+export class NgbClass {}
+
+/**
+ * Description
+ *
+ * @deprecated 2.0.0 description
+ */
+export interface NgbInterface {
+}

--- a/misc/api-doc-test-cases/release-features.ts
+++ b/misc/api-doc-test-cases/release-features.ts
@@ -1,0 +1,72 @@
+import {Component, Directive, Injectable, Input, Output} from '@angular/core';
+
+/**
+ * Description
+ *
+ * @since 2.0.0
+ */
+@Directive({
+  selector: '[ngbDirective]'
+})
+export class NgbDirective {
+  /**
+   * Description
+   *
+   * @since 2.0.0
+   */
+  @Input() input;
+
+  /**
+   * Description
+   *
+   * @since 2.0.0
+   */
+  @Output() output;
+
+  /**
+   * Description
+   *
+   * @since 2.0.0
+   */
+  property;
+
+  /**
+   * Description
+   *
+   * @since 2.0.0
+   */
+  method() {}
+}
+
+/**
+ * Description
+ *
+ * @since 2.0.0
+ */
+@Component({
+  selector: 'ngb-component'
+})
+export class NgbComponent {}
+
+
+/**
+ * Description
+ *
+ * @since 2.0.0
+ */
+@Injectable()
+export class NgbService {}
+
+/**
+ * Description
+ *
+ * @since 2.0.0
+ */
+export class NgbClass {}
+
+/**
+ * Description
+ *
+ * @since 2.0.0
+ */
+export interface NgbInterface {}

--- a/misc/api-doc.spec.js
+++ b/misc/api-doc.spec.js
@@ -223,4 +223,34 @@ describe('APIDocVisitor', function() {
     expect(classDocs.methods[0].returnType).toBe('void');
   });
 
+  it('should extract deprecation information', function() {
+    var docs = apiDoc(['misc/api-doc-test-cases/release-deprecation.ts']);
+
+    expect(docs.NgbDirective.deprecated).toEqual({version: '2.0.0', description: 'description'});
+    expect(docs.NgbComponent.deprecated).toEqual({version: '2.0.0', description: 'description'});
+    expect(docs.NgbService.deprecated).toEqual({version: '2.0.0', description: 'description'});
+    expect(docs.NgbClass.deprecated).toEqual({version: '2.0.0', description: 'description'});
+    expect(docs.NgbInterface.deprecated).toEqual({version: '2.0.0', description: 'description'});
+
+    expect(docs.NgbDirective.inputs[0].deprecated).toEqual({version: '2.0.0', description: 'description'});
+    expect(docs.NgbDirective.outputs[0].deprecated).toEqual({version: '2.0.0', description: 'description'});
+    expect(docs.NgbDirective.properties[0].deprecated).toEqual({version: '2.0.0', description: 'description'});
+    expect(docs.NgbDirective.methods[0].deprecated).toEqual({version: '2.0.0', description: 'description'});
+  });
+
+  it('should extract feature introduction information', function() {
+    var docs = apiDoc(['misc/api-doc-test-cases/release-features.ts']);
+
+    expect(docs.NgbDirective.since).toEqual({version: '2.0.0', description: ''});
+    expect(docs.NgbComponent.since).toEqual({version: '2.0.0', description: ''});
+    expect(docs.NgbService.since).toEqual({version: '2.0.0', description: ''});
+    expect(docs.NgbClass.since).toEqual({version: '2.0.0', description: ''});
+    expect(docs.NgbInterface.since).toEqual({version: '2.0.0', description: ''});
+
+    expect(docs.NgbDirective.inputs[0].since).toEqual({version: '2.0.0', description: ''});
+    expect(docs.NgbDirective.outputs[0].since).toEqual({version: '2.0.0', description: ''});
+    expect(docs.NgbDirective.properties[0].since).toEqual({version: '2.0.0', description: ''});
+    expect(docs.NgbDirective.methods[0].since).toEqual({version: '2.0.0', description: ''});
+  });
+
 });


### PR DESCRIPTION
New features and deprecations should be reflected in documentation after `1.0.0`

Parsing additional `@deprecated` and `@since` annotations:

<img width="521" alt="screen shot 2018-03-14 at 15 45 36" src="https://user-images.githubusercontent.com/8074436/37409850-984492c6-279f-11e8-943f-e5d1c3aaf922.png">

In documentation it will be reflected like this:

<img width="856" alt="screen shot 2018-03-14 at 15 44 11" src="https://user-images.githubusercontent.com/8074436/37409902-b590d5b0-279f-11e8-97eb-efadfaea9e34.png">

IDEs would also strikethrough deprecated methods and classes

If you deprecate the whole class:

<img width="882" alt="screen shot 2018-03-14 at 15 44 44" src="https://user-images.githubusercontent.com/8074436/37409983-e8e4d6fa-279f-11e8-84aa-3e94746ef621.png">

Or a component/directive:

<img width="884" alt="screen shot 2018-03-14 at 15 44 27" src="https://user-images.githubusercontent.com/8074436/37410025-fb474382-279f-11e8-8b35-9a53d9e00912.png">

