### PR TITLE
feat(datepicker): optional min/max dates for infinite navigation

### DIFF
--- a/src/datepicker/datepicker-tools.spec.ts
+++ b/src/datepicker/datepicker-tools.spec.ts
@@ -3,8 +3,10 @@ import {
   buildMonths,
   checkDateInRange,
   dateComparator,
+  generateSelectBoxMonths,
   getFirstViewDate,
-  isDateSelectable
+  isDateSelectable,
+  generateSelectBoxYears
 } from './datepicker-tools';
 import {NgbDate} from './ngb-date';
 import {NgbCalendar, NgbCalendarGregorian} from './ngb-calendar';
@@ -372,6 +374,86 @@ describe(`datepicker-tools`, () => {
       expect(isDateSelectable(new NgbDate(2016, 11, 10), null, null, false)).toBeTruthy();
       expect(isDateSelectable(new NgbDate(2017, 11, 10), null, null, false)).toBeTruthy();
       expect(isDateSelectable(new NgbDate(2018, 11, 10), null, null, false)).toBeTruthy();
+    });
+  });
+
+  describe(`generateSelectBoxMonths`, () => {
+
+    let calendar: NgbCalendar;
+
+    beforeAll(() => {
+      TestBed.configureTestingModule({providers: [{provide: NgbCalendar, useClass: NgbCalendarGregorian}]});
+      calendar = TestBed.get(NgbCalendar);
+    });
+
+    const test = (minDate, date, maxDate, result) => {
+      expect(generateSelectBoxMonths(calendar, date, minDate, maxDate)).toEqual(result);
+    };
+
+    it(`should handle edge cases`, () => {
+      test(new NgbDate(2018, 6, 1), null, new NgbDate(2018, 6, 10), []);
+      test(null, null, null, []);
+    });
+
+    it(`should generate months correctly`, () => {
+      // clang-format off
+      // different years
+      test(new NgbDate(2017, 1, 1), new NgbDate(2018, 1, 1),  new NgbDate(2019, 1, 1),  [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+      test(null,                    new NgbDate(2018, 6, 10), null,                     [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+      test(null,                    new NgbDate(2018, 1, 1),  new NgbDate(2019, 1, 1),  [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+      test(new NgbDate(2017, 1, 1), new NgbDate(2018, 1, 1),  null,                     [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+
+      // same 'min year'
+      test(new NgbDate(2018, 1, 1), new NgbDate(2018, 6, 10), new NgbDate(2020, 1, 2),  [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+      test(new NgbDate(2018, 6, 1), new NgbDate(2018, 6, 10), new NgbDate(2020, 1, 2),  [6, 7, 8, 9, 10, 11, 12]);
+      test(new NgbDate(2018, 6, 1), new NgbDate(2018, 6, 10), null,                     [6, 7, 8, 9, 10, 11, 12]);
+
+      // same 'max' year
+      test(new NgbDate(2017, 1, 1), new NgbDate(2018, 6, 10), new NgbDate(2018, 12, 1), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+      test(new NgbDate(2017, 1, 1), new NgbDate(2018, 6, 10), new NgbDate(2018, 6, 10), [1, 2, 3, 4, 5, 6]);
+      test(null,                    new NgbDate(2018, 6, 10), new NgbDate(2018, 6, 10), [1, 2, 3, 4, 5, 6]);
+
+      // same 'min' and 'max years'
+      test(new NgbDate(2018, 1, 1), new NgbDate(2018, 6, 10), new NgbDate(2018, 12, 1), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+      test(new NgbDate(2018, 3, 1), new NgbDate(2018, 6, 10), new NgbDate(2018, 12, 1), [3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+      test(new NgbDate(2018, 3, 1), new NgbDate(2018, 6, 10), null,                     [3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+      test(null,                    new NgbDate(2018, 6, 10), new NgbDate(2018, 8, 1),  [1, 2, 3, 4, 5, 6, 7, 8]);
+      test(new NgbDate(2018, 3, 1), new NgbDate(2018, 6, 10), new NgbDate(2018, 8, 1),  [3, 4, 5, 6, 7, 8] );
+      test(new NgbDate(2018, 6, 1), new NgbDate(2018, 6, 10), new NgbDate(2018, 6, 10), [6]);
+      // clang-format on
+    });
+  });
+
+  describe(`generateSelectBoxYears`, () => {
+
+    const test =
+        (minDate, date, maxDate, result) => { expect(generateSelectBoxYears(date, minDate, maxDate)).toEqual(result); };
+    const range = (start, end) => Array.from({length: end - start + 1}, (e, i) => start + i);
+
+    it(`should handle edge cases`, () => {
+      test(new NgbDate(2018, 6, 1), null, new NgbDate(2018, 6, 10), []);
+      test(null, null, null, []);
+    });
+
+    it(`should generate years correctly`, () => {
+      // both 'min' and 'max' are set
+      test(new NgbDate(2017, 1, 1), new NgbDate(2018, 1, 1), new NgbDate(2019, 1, 1), range(2017, 2019));
+      test(new NgbDate(2000, 1, 1), new NgbDate(2018, 1, 1), new NgbDate(3000, 1, 1), range(2000, 3000));
+      test(new NgbDate(2018, 1, 1), new NgbDate(2018, 1, 1), new NgbDate(2018, 1, 1), [2018]);
+
+      // 'min' is not set
+      test(null, new NgbDate(2018, 1, 1), new NgbDate(2019, 1, 1), range(2008, 2019));
+      test(null, new NgbDate(2018, 1, 1), new NgbDate(3000, 1, 1), range(2008, 3000));
+      test(null, new NgbDate(2018, 1, 1), new NgbDate(2018, 1, 1), range(2008, 2018));
+
+      // 'max' is not set
+      test(new NgbDate(2017, 1, 1), new NgbDate(2018, 1, 1), null, range(2017, 2028));
+      test(new NgbDate(2000, 1, 1), new NgbDate(2018, 1, 1), null, range(2000, 2028));
+      test(new NgbDate(2018, 1, 1), new NgbDate(2018, 1, 1), null, range(2018, 2028));
+
+      // both are not set
+      test(null, new NgbDate(2018, 1, 1), null, range(2008, 2028));
+      test(null, new NgbDate(2000, 1, 1), null, range(1990, 2010));
     });
   });
 

--- a/src/datepicker/datepicker-tools.ts
+++ b/src/datepicker/datepicker-tools.ts
@@ -42,18 +42,18 @@ export function isDateSelectable(
 }
 
 export function generateSelectBoxMonths(calendar: NgbCalendar, date: NgbDate, minDate: NgbDate, maxDate: NgbDate) {
-  if (!date || !minDate || !maxDate) {
+  if (!date) {
     return [];
   }
 
   let months = calendar.getMonths();
 
-  if (date.year === minDate.year) {
+  if (minDate && date.year === minDate.year) {
     const index = months.findIndex(month => month === minDate.month);
     months = months.slice(index);
   }
 
-  if (date.year === maxDate.year) {
+  if (maxDate && date.year === maxDate.year) {
     const index = months.findIndex(month => month === maxDate.month);
     months = months.slice(0, index + 1);
   }
@@ -61,8 +61,15 @@ export function generateSelectBoxMonths(calendar: NgbCalendar, date: NgbDate, mi
   return months;
 }
 
-export function generateSelectBoxYears(minDate: NgbDate, maxDate: NgbDate): number[] {
-  return (minDate && maxDate) ? Array.from({length: maxDate.year - minDate.year + 1}, (e, i) => minDate.year + i) : [];
+export function generateSelectBoxYears(date: NgbDate, minDate: NgbDate, maxDate: NgbDate) {
+  if (!date) {
+    return [];
+  }
+
+  const start = minDate && minDate.year || date.year - 10;
+  const end = maxDate && maxDate.year || date.year + 10;
+
+  return Array.from({length: end - start + 1}, (e, i) => start + i);
 }
 
 export function nextMonthDisabled(calendar: NgbCalendar, date: NgbDate, maxDate: NgbDate) {

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -151,80 +151,126 @@ describe('ngb-datepicker', () => {
     expect(getYearSelect(fixture.nativeElement).value).toBe(currentYear);
   });
 
-  it('should handle incorrect minDate values', () => {
-    const fixture = createTestComponent(
-        `<ngb-datepicker [minDate]="minDate" [maxDate]="maxDate" [startDate]="date"></ngb-datepicker>`);
+  it('should allow infinite navigation when min/max dates are not set', () => {
+    const fixture = createTestComponent(`<ngb-datepicker [startDate]="date"></ngb-datepicker>`);
+
+    fixture.detectChanges();
+    expect(getMonthSelect(fixture.nativeElement).value).toBe('8');
+    expect(getYearSelect(fixture.nativeElement).value).toBe('2016');
+
+    fixture.componentInstance.date = {year: 1066, month: 2};
+    fixture.detectChanges();
+    expect(getMonthSelect(fixture.nativeElement).value).toBe('2');
+    expect(getYearSelect(fixture.nativeElement).value).toBe('1066');
+
+    fixture.componentInstance.date = {year: 3066, month: 5};
+    fixture.detectChanges();
+    expect(getMonthSelect(fixture.nativeElement).value).toBe('5');
+    expect(getYearSelect(fixture.nativeElement).value).toBe('3066');
+  });
+
+  it('should allow setting minDate separately', () => {
+    const fixture = createTestComponent(`<ngb-datepicker [minDate]="minDate" [startDate]="date"></ngb-datepicker>`);
+
+    fixture.componentInstance.minDate = {year: 2000, month: 5, day: 20};
+    fixture.detectChanges();
+    expect(getMonthSelect(fixture.nativeElement).value).toBe('8');
+    expect(getYearSelect(fixture.nativeElement).value).toBe('2016');
+
+    fixture.componentInstance.date = {year: 1000, month: 2};
+    fixture.detectChanges();
+    expect(getMonthSelect(fixture.nativeElement).value).toBe('5');
+    expect(getYearSelect(fixture.nativeElement).value).toBe('2000');
+
+    fixture.componentInstance.date = {year: 3000, month: 5};
+    fixture.detectChanges();
+    expect(getMonthSelect(fixture.nativeElement).value).toBe('5');
+    expect(getYearSelect(fixture.nativeElement).value).toBe('3000');
+  });
+
+  it('should allow setting maxDate separately', () => {
+    const fixture = createTestComponent(`<ngb-datepicker [maxDate]="maxDate" [startDate]="date"></ngb-datepicker>`);
+
+    fixture.componentInstance.maxDate = {year: 2050, month: 5, day: 20};
+    fixture.detectChanges();
+    expect(getMonthSelect(fixture.nativeElement).value).toBe('8');
+    expect(getYearSelect(fixture.nativeElement).value).toBe('2016');
+
+    fixture.componentInstance.date = {year: 3000, month: 2};
+    fixture.detectChanges();
+    expect(getMonthSelect(fixture.nativeElement).value).toBe('5');
+    expect(getYearSelect(fixture.nativeElement).value).toBe('2050');
+
+    fixture.componentInstance.date = {year: 1000, month: 5};
+    fixture.detectChanges();
+    expect(getMonthSelect(fixture.nativeElement).value).toBe('5');
+    expect(getYearSelect(fixture.nativeElement).value).toBe('1000');
+  });
+
+  it('should handle minDate edge case values', () => {
+    const fixture = createTestComponent(`<ngb-datepicker [minDate]="minDate" [startDate]="date"></ngb-datepicker>`);
 
     function expectMinDate(year: number, month: number) {
-      fixture.componentInstance.date = {year: 0, month: 1};
+      fixture.componentInstance.date = {year: 1000, month: 1};
       fixture.detectChanges();
       expect(getMonthSelect(fixture.nativeElement).value).toBe(`${month}`);
       expect(getYearSelect(fixture.nativeElement).value).toBe(`${year}`);
-
-      // resetting
-      fixture.componentInstance.date = {year: 1000, month: 1};
-      fixture.detectChanges();
     }
 
     expectMinDate(2010, 1);
 
-    fixture.componentInstance.minDate = null;
-    fixture.detectChanges();
-    expectMinDate(990, 1);
-
-    fixture.componentInstance.minDate = undefined;
-    fixture.detectChanges();
-    expectMinDate(990, 1);
-
+    // ignored
     fixture.componentInstance.minDate = <any>{};
-    fixture.detectChanges();
-    expectMinDate(990, 1);
+    expectMinDate(2010, 1);
 
+    // ignored
     fixture.componentInstance.minDate = <any>new Date();
-    fixture.detectChanges();
-    expectMinDate(990, 1);
+    expectMinDate(2010, 1);
 
+    // ignored
     fixture.componentInstance.minDate = new NgbDate(3000000, 1, 1);
-    fixture.detectChanges();
-    expectMinDate(990, 1);
+    expectMinDate(2010, 1);
+
+    // resetting
+    fixture.componentInstance.minDate = null;
+    expectMinDate(1000, 1);
+
+    // resetting
+    fixture.componentInstance.minDate = undefined;
+    expectMinDate(1000, 1);
   });
 
-  it('should handle incorrect maxDate values', () => {
-    const fixture = createTestComponent(
-        `<ngb-datepicker [minDate]="minDate" [maxDate]="maxDate" [startDate]="date"></ngb-datepicker>`);
+  it('should handle maxDate edge case values', () => {
+    const fixture = createTestComponent(`<ngb-datepicker [maxDate]="maxDate" [startDate]="date"></ngb-datepicker>`);
 
     function expectMaxDate(year: number, month: number) {
       fixture.componentInstance.date = {year: 10000, month: 1};
       fixture.detectChanges();
       expect(getMonthSelect(fixture.nativeElement).value).toBe(`${month}`);
       expect(getYearSelect(fixture.nativeElement).value).toBe(`${year}`);
-
-      // resetting
-      fixture.componentInstance.date = {year: 3000, month: 1};
-      fixture.detectChanges();
     }
 
     expectMaxDate(2020, 12);
 
-    fixture.componentInstance.maxDate = null;
-    fixture.detectChanges();
-    expectMaxDate(3010, 12);
-
-    fixture.componentInstance.maxDate = undefined;
-    fixture.detectChanges();
-    expectMaxDate(3010, 12);
-
+    // ignored
     fixture.componentInstance.maxDate = <any>{};
-    fixture.detectChanges();
-    expectMaxDate(3010, 12);
+    expectMaxDate(2020, 12);
 
+    // ignored
     fixture.componentInstance.maxDate = <any>new Date();
-    fixture.detectChanges();
-    expectMaxDate(3010, 12);
+    expectMaxDate(2020, 12);
 
+    // ignored
     fixture.componentInstance.maxDate = new NgbDate(3000000, 1, 1);
-    fixture.detectChanges();
-    expectMaxDate(3010, 12);
+    expectMaxDate(2020, 12);
+
+    // resetting
+    fixture.componentInstance.maxDate = null;
+    expectMaxDate(10000, 1);
+
+    // resetting
+    fixture.componentInstance.maxDate = undefined;
+    expectMaxDate(10000, 1);
   });
 
   it('should support disabling dates via callback', () => {

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -181,12 +181,12 @@ export class NgbDatepicker implements OnDestroy,
   @Input() markDisabled: (date: NgbDateStruct, current: {year: number, month: number}) => boolean;
 
   /**
-   * Max date for the navigation. If not provided will be 10 years from today or `startDate`
+   * Max date for the navigation. If not provided, 'year' select box will display 10 years after current month
    */
   @Input() maxDate: NgbDateStruct;
 
   /**
-   * Min date for the navigation. If not provided will be 10 years before today or `startDate`
+   * Min date for the navigation. If not provided, 'year' select box will display 10 years before current month
    */
   @Input() minDate: NgbDateStruct;
 
@@ -289,9 +289,7 @@ export class NgbDatepicker implements OnDestroy,
    * If nothing or invalid date provided calendar will open current month.
    * Use 'startDate' input as an alternative
    */
-  navigateTo(date?: {year: number, month: number}) {
-    this._service.open(date ? new NgbDate(date.year, date.month, 1) : this._calendar.getToday());
-  }
+  navigateTo(date?: {year: number, month: number}) { this._service.open(NgbDate.from(date)); }
 
   ngOnDestroy() {
     this._subscription.unsubscribe();
@@ -304,7 +302,9 @@ export class NgbDatepicker implements OnDestroy,
       this._service.markDisabled = this.markDisabled;
       this._service.firstDayOfWeek = this.firstDayOfWeek;
       this._service.navigation = this.navigation;
-      this._setDates();
+      this._service.minDate = NgbDate.from(this.minDate);
+      this._service.maxDate = NgbDate.from(this.maxDate);
+      this.navigateTo(this.startDate);
     }
   }
 
@@ -321,7 +321,15 @@ export class NgbDatepicker implements OnDestroy,
     if (changes['navigation']) {
       this._service.navigation = this.navigation;
     }
-    this._setDates();
+    if (changes['minDate']) {
+      this._service.minDate = NgbDate.from(this.minDate);
+    }
+    if (changes['maxDate']) {
+      this._service.maxDate = NgbDate.from(this.maxDate);
+    }
+    if (changes['startDate']) {
+      this.navigateTo(this.startDate);
+    }
   }
 
   onDateSelect(date: NgbDate) {
@@ -353,18 +361,4 @@ export class NgbDatepicker implements OnDestroy,
   showFocus(focusVisible: boolean) { this._service.focusVisible = focusVisible; }
 
   writeValue(value) { this._service.select(NgbDate.from(this._ngbDateAdapter.fromModel(value))); }
-
-  private _setDates() {
-    const startDate = this._service.toValidDate(this.startDate, this._calendar.getToday());
-    const minDate = this._service.toValidDate(this.minDate, this._calendar.getPrev(startDate, 'y', 10));
-    const maxDate =
-        this._service.toValidDate(this.maxDate, this._calendar.getPrev(this._calendar.getNext(startDate, 'y', 11)));
-
-    this.minDate = {year: minDate.year, month: minDate.month, day: minDate.day};
-    this.maxDate = {year: maxDate.year, month: maxDate.month, day: maxDate.day};
-
-    this._service.minDate = minDate;
-    this._service.maxDate = maxDate;
-    this.navigateTo(startDate);
-  }
 }


### PR DESCRIPTION
Makes `minDate` and `maxDate` optional to allow for infinite navigation

Select box with years will display -10...+10 years from current date if `minDate` and `maxDate` are unspecified.

Fixes #1732
