### PR TITLE
refactor(typeahead): use CSS classes instead of inline styles

### DIFF
--- a/src/typeahead/typeahead-window.ts
+++ b/src/typeahead/typeahead-window.ts
@@ -20,7 +20,7 @@ export interface ResultTemplateContext {
 @Component({
   selector: 'ngb-typeahead-window',
   exportAs: 'ngbTypeaheadWindow',
-  host: {'class': 'dropdown-menu', 'style': 'display: block', 'role': 'listbox', '[id]': 'id'},
+  host: {'class': 'dropdown-menu show', 'role': 'listbox', '[id]': 'id'},
   template: `
     <ng-template #rt let-result="result" let-term="term" let-formatter="formatter">
       <ngb-highlight [result]="formatter(result)" [term]="term"></ngb-highlight>


### PR DESCRIPTION
Related to #2085 and #2013
 