### PR TITLE
fix(accordion): restore 'type' input behaviour for styling panels

### DIFF
--- a/src/accordion/accordion.spec.ts
+++ b/src/accordion/accordion.spec.ts
@@ -489,9 +489,9 @@ describe('ngb-accordion', () => {
     fixture.detectChanges();
 
     let el = fixture.nativeElement.querySelectorAll('.card-header');
-    expect(el[0]).toHaveCssClass('card-warning');
-    expect(el[1]).toHaveCssClass('card-warning');
-    expect(el[2]).toHaveCssClass('card-warning');
+    expect(el[0]).toHaveCssClass('bg-warning');
+    expect(el[1]).toHaveCssClass('bg-warning');
+    expect(el[2]).toHaveCssClass('bg-warning');
   });
 
   it('should override the type in accordion with type in panel', () => {
@@ -505,9 +505,9 @@ describe('ngb-accordion', () => {
     fixture.detectChanges();
 
     let el = fixture.nativeElement.querySelectorAll('.card-header');
-    expect(el[0]).toHaveCssClass('card-success');
-    expect(el[1]).toHaveCssClass('card-danger');
-    expect(el[2]).toHaveCssClass('card-warning');
+    expect(el[0]).toHaveCssClass('bg-success');
+    expect(el[1]).toHaveCssClass('bg-danger');
+    expect(el[2]).toHaveCssClass('bg-warning');
   });
 
   it('should have the proper roles', () => {

--- a/src/accordion/accordion.ts
+++ b/src/accordion/accordion.ts
@@ -63,7 +63,8 @@ export class NgbPanel {
 
   /**
    *  Accordion's types of panels to be applied per panel basis.
-   *  Bootstrap 4 recognizes the following types: "success", "info", "warning" and "danger".
+   *  Bootstrap recognizes the following types: "primary", "secondary", "success", "danger", "warning", "info", "light"
+   * and "dark"
    */
   @Input() type: string;
 
@@ -103,7 +104,7 @@ export interface NgbPanelChangeEvent {
     <ng-template ngFor let-panel [ngForOf]="panels">
       <div class="card">
         <div role="tab" id="{{panel.id}}-header"
-          [class]="'card-header ' + (panel.type ? 'card-'+panel.type: type ? 'card-'+type : '')" [class.active]="panel.isOpen">
+          [class]="'card-header ' + (panel.type ? 'bg-'+panel.type: type ? 'bg-'+type : '')" [class.active]="panel.isOpen">
           <a href (click)="!!toggle(panel.id)" [class.text-muted]="panel.disabled" [attr.tabindex]="(panel.disabled ? '-1' : null)"
             [attr.aria-expanded]="panel.isOpen" [attr.aria-controls]="(panel.isOpen ? panel.id : null)"
             [attr.aria-disabled]="panel.disabled">
@@ -138,7 +139,8 @@ export class NgbAccordion implements AfterContentChecked {
 
   /**
    *  Accordion's types of panels to be applied globally.
-   *  Bootstrap 4 recognizes the following types: "success", "info", "warning" and "danger".
+   *  Bootstrap recognizes the following types: "primary", "secondary", "success", "danger", "warning", "info", "light"
+   * and "dark
    */
   @Input() type: string;
 


### PR DESCRIPTION
See discussion in the issue, this PR simply restores the the previous behaviour

Fixes #1897 