### PR TITLE
feat(popover): introduce disabled flag

### DIFF
--- a/src/popover/popover-config.spec.ts
+++ b/src/popover/popover-config.spec.ts
@@ -7,5 +7,6 @@ describe('ngb-popover-config', () => {
     expect(config.placement).toBe('top');
     expect(config.triggers).toBe('click');
     expect(config.container).toBeUndefined();
+    expect(config.disablePopover).toBe(false);
   });
 });

--- a/src/popover/popover-config.ts
+++ b/src/popover/popover-config.ts
@@ -11,5 +11,5 @@ export class NgbPopoverConfig {
   placement: PlacementArray = 'top';
   triggers = 'click';
   container: string;
-  disablePopover: boolean = false;
+  disablePopover = false;
 }

--- a/src/popover/popover-config.ts
+++ b/src/popover/popover-config.ts
@@ -11,4 +11,5 @@ export class NgbPopoverConfig {
   placement: PlacementArray = 'top';
   triggers = 'click';
   container: string;
+  disablePopover: boolean = false;
 }

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -147,8 +147,8 @@ describe('ngb-popover', () => {
       expect(spyService.called).toBeTruthy();
     });
 
-    it('should not open a popover if [disabled] flag', () => {
-      const fixture = createTestComponent(`<div [ngbPopover]="Disabled!" [disabled]="true"></div>`);
+    it('should not open a popover if [disablePopover] flag', () => {
+      const fixture = createTestComponent(`<div [ngbPopover]="Disabled!" [disablePopover]="true"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
       directive.triggerEventHandler('click', {});

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -147,6 +147,17 @@ describe('ngb-popover', () => {
       expect(spyService.called).toBeTruthy();
     });
 
+    it('should not open a popover if [disabled] flag', () => {
+      const fixture = createTestComponent(`<div [ngbPopover]="Disabled!" [disabled]="true"></div>`);
+      const directive = fixture.debugElement.query(By.directive(NgbPopover));
+
+      directive.triggerEventHandler('click', {});
+      fixture.detectChanges();
+      const windowEl = getWindow(fixture.nativeElement);
+
+      expect(windowEl).toBeNull();
+    });
+
     it('should allow re-opening previously closed popovers', () => {
       const fixture = createTestComponent(`<div ngbPopover="Great tip!" popoverTitle="Title"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -118,7 +118,7 @@ export class NgbPopover implements OnInit, OnDestroy {
   /**
    * A flag indicating if a given popover is disabled and should not be displayed.
    */
-  @Input() disabled = false;
+  @Input() disablePopover = false;
   /**
    * Emits an event when the popover is shown
    */
@@ -159,7 +159,7 @@ export class NgbPopover implements OnInit, OnDestroy {
    * The context is an optional value to be injected into the popover template when it is created.
    */
   open(context?: any) {
-    if (!this._windowRef && !this.disabled) {
+    if (!this._windowRef && !this.disablePopover) {
       this._windowRef = this._popupService.open(this.ngbPopover, context);
       this._windowRef.instance.title = this.popoverTitle;
       this._windowRef.instance.id = this._ngbPopoverWindowId;

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -118,7 +118,7 @@ export class NgbPopover implements OnInit, OnDestroy {
   /**
    * A flag indicating if a given popover is disabled and should not be displayed.
    */
-  @Input() disablePopover = false;
+  @Input() disablePopover: boolean;
   /**
    * Emits an event when the popover is shown
    */
@@ -141,6 +141,7 @@ export class NgbPopover implements OnInit, OnDestroy {
     this.placement = config.placement;
     this.triggers = config.triggers;
     this.container = config.container;
+    this.disablePopover = config.disablePopover;
     this._popupService = new PopupService<NgbPopoverWindow>(
         NgbPopoverWindow, injector, viewContainerRef, _renderer, componentFactoryResolver);
 

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -116,6 +116,10 @@ export class NgbPopover implements OnInit, OnDestroy {
    */
   @Input() container: string;
   /**
+   * A flag indicating if a given popover is disabled and should not be displayed.
+   */
+  @Input() disabled = false;
+  /**
    * Emits an event when the popover is shown
    */
   @Output() shown = new EventEmitter();
@@ -155,7 +159,7 @@ export class NgbPopover implements OnInit, OnDestroy {
    * The context is an optional value to be injected into the popover template when it is created.
    */
   open(context?: any) {
-    if (!this._windowRef) {
+    if (!this._windowRef && !this.disabled) {
       this._windowRef = this._popupService.open(this.ngbPopover, context);
       this._windowRef.instance.title = this.popoverTitle;
       this._windowRef.instance.id = this._ngbPopoverWindowId;


### PR DESCRIPTION
Fixes #2188

PR created as a continuation of PR #2217 

`[disabled]` would be a useful feature for popover\toltip, allowing user to create conditional popover\tooltip.
`<div [ngbPopover]="It can be conditionally hidden!" [disabled]="hidePopover"></div>`

