### PR TITLE
feat(modal): Add option to drag the modal

### DIFF
--- a/demo/src/app/components/modal/demos/draggable/modal-draggable.html
+++ b/demo/src/app/components/modal/demos/draggable/modal-draggable.html
@@ -1,0 +1,16 @@
+<ng-template #content let-c="close" let-d="dismiss">
+  <div class="modal-header">
+    <h4 class="modal-title">Drag me</h4>
+    <button type="button" class="close" aria-label="Close" (click)="d('Cross click')">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <div class="modal-body">
+    <p>One fine body&hellip;</p>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-outline-dark" (click)="c('Close click')">Close</button>
+  </div>
+</ng-template>
+
+<button class="btn btn-lg btn-outline-primary" (click)="open(content)">Launch demo modal</button>

--- a/demo/src/app/components/modal/demos/draggable/modal-draggable.ts
+++ b/demo/src/app/components/modal/demos/draggable/modal-draggable.ts
@@ -1,0 +1,17 @@
+import {Component} from '@angular/core';
+
+import {NgbModal, ModalDismissReasons} from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+  selector: 'ngbd-modal-draggable',
+  templateUrl: './modal-draggable.html'
+})
+export class NgbdModalDraggable {
+  closeResult: string;
+
+  constructor(private modalService: NgbModal) {}
+
+  open(content) {
+    this.modalService.open(content, { draggableSelector: '.modal-header' });
+  }
+}

--- a/demo/src/app/components/modal/demos/index.ts
+++ b/demo/src/app/components/modal/demos/index.ts
@@ -1,8 +1,9 @@
 import {NgbdModalBasic} from './basic/modal-basic';
 import {NgbdModalComponent, NgbdModalContent} from './component/modal-component';
 import {NgbdModalCustomclass} from './customclass/modal-customclass';
+import {NgbdModalDraggable} from './draggable/modal-draggable';
 
-export const DEMO_DIRECTIVES = [NgbdModalBasic, NgbdModalComponent, NgbdModalCustomclass];
+export const DEMO_DIRECTIVES = [NgbdModalBasic, NgbdModalComponent, NgbdModalCustomclass, NgbdModalDraggable];
 export {NgbdModalContent} from './component/modal-component';
 
 export const DEMO_SNIPPETS = {
@@ -14,5 +15,8 @@ export const DEMO_SNIPPETS = {
     'markup': require('!!prismjs-loader?lang=markup!./component/modal-component.html')},
   'customclass': {
     'code': require('!!prismjs-loader?lang=typescript!./customclass/modal-customclass'),
-    'markup': require('!!prismjs-loader?lang=markup!./customclass/modal-customclass.html')}
+    'markup': require('!!prismjs-loader?lang=markup!./customclass/modal-customclass.html')},
+  'draggable': {
+    'code': require('!!prismjs-loader?lang=typescript!./draggable/modal-draggable'),
+    'markup': require('!!prismjs-loader?lang=markup!./draggable/modal-draggable.html')}
 };

--- a/demo/src/app/components/modal/modal.component.ts
+++ b/demo/src/app/components/modal/modal.component.ts
@@ -19,6 +19,9 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-example-box demoTitle="Modal with custom class" [snippets]="snippets" component="modal" demo="customclass">
           <ngbd-modal-customclass></ngbd-modal-customclass>
       </ngbd-example-box>
+      <ngbd-example-box demoTitle="Modal draggable" [snippets]="snippets" component="modal" demo="draggable">
+          <ngbd-modal-draggable></ngbd-modal-draggable>
+      </ngbd-example-box>
     </ngbd-component-wrapper>
   `
 })

--- a/src/modal/modal-stack.ts
+++ b/src/modal/modal-stack.ts
@@ -21,7 +21,7 @@ import {NgbActiveModal, NgbModalRef} from './modal-ref';
 @Injectable()
 export class NgbModalStack {
   private _document: any;
-  private _windowAttributes = ['backdrop', 'keyboard', 'size', 'windowClass'];
+  private _windowAttributes = ['backdrop', 'draggableSelector', 'keyboard', 'size', 'windowClass'];
 
   constructor(
       private _applicationRef: ApplicationRef, private _injector: Injector,

--- a/src/modal/modal-window.ts
+++ b/src/modal/modal-window.ts
@@ -34,8 +34,11 @@ export class NgbModalWindow implements OnInit,
     AfterViewInit, OnDestroy {
   private _document: any;
   private _elWithFocus: Element;  // element that is focused prior to modal opening
+  private _posX: number;
+  private _posY: number;
 
   @Input() backdrop: boolean | string = true;
+  @Input() draggableSelector: string = null;
   @Input() keyboard = true;
   @Input() size: string;
   @Input() windowClass: string;
@@ -69,6 +72,14 @@ export class NgbModalWindow implements OnInit,
     if (!this._elRef.nativeElement.contains(document.activeElement)) {
       this._elRef.nativeElement['focus'].apply(this._elRef.nativeElement, []);
     }
+
+    if (this.draggableSelector) {
+      const draggableArea: HTMLElement = this._elRef.nativeElement.querySelector(this.draggableSelector);
+      draggableArea.style.cursor = 'move';
+      draggableArea.onmousedown = (e: MouseEvent) => {
+        this.startDrag(e);
+      };
+    }
   }
 
   ngOnDestroy() {
@@ -86,4 +97,50 @@ export class NgbModalWindow implements OnInit,
     this._elWithFocus = null;
     this._renderer.removeClass(body, 'modal-open');
   }
+
+  private startDrag(e: MouseEvent) {
+    const modalDialog: HTMLElement = this._elRef.nativeElement.querySelector('.modal-dialog');
+    modalDialog.style.marginTop = modalDialog.offsetTop + 'px';
+    modalDialog.style.marginLeft = modalDialog.offsetLeft + 'px';
+    modalDialog.style.marginBottom = '0';
+    modalDialog.style.marginRight = '0';
+    this._posX = e.clientX;
+    this._posY = e.clientY;
+    document.onmousemove = (event) => {
+      this.dragModal(event);
+    };
+    document.onmouseup = () => {
+      document.onmouseup = null;
+      document.onmousemove = null;
+    };
+  }
+
+  private dragModal(e: MouseEvent) {
+    const modalDialog: HTMLElement = this._elRef.nativeElement.querySelector('.modal-dialog');
+    const deltaX = this._posX - e.clientX;
+    const deltaY = this._posY - e.clientY;
+    const top: number = parseInt(modalDialog.style.marginTop.split('px')[0], 10);
+    const left: number = parseInt(modalDialog.style.marginLeft.split('px')[0], 10);
+    let marginTop = modalDialog.offsetTop - deltaY;
+    let marginLeft = modalDialog.offsetLeft - deltaX;
+    let marginBottom = window.innerHeight - modalDialog.offsetTop - modalDialog.offsetHeight + deltaY;
+    let marginRight = window.innerWidth - modalDialog.offsetLeft - modalDialog.offsetWidth + deltaX;
+    if (marginTop < 0) {
+      marginTop = 0;
+    } else if (marginBottom < 0) {
+      marginTop = window.innerHeight - modalDialog.offsetHeight;
+    } else {
+      this._posY = e.clientY;
+    }
+    if (marginLeft < 0) {
+      marginLeft = 0;
+    } else if (marginRight < 0) {
+      marginLeft = window.innerWidth - modalDialog.offsetWidth;
+    } else {
+      this._posX = e.clientX;
+    }
+    modalDialog.style.marginTop = marginTop + 'px';
+    modalDialog.style.marginLeft = marginLeft + 'px';
+  }
+
 }

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -25,6 +25,11 @@ export interface NgbModalOptions {
   container?: string;
 
   /**
+   * Selector of the area draggable (null by default).
+   */
+  draggableSelector?: string;
+
+  /**
    * Injector to use for modal content.
    */
   injector?: Injector;


### PR DESCRIPTION
Add an option `draggableSelector`.
By example, with the option `{ draggableSelector: '.modal-header' }` the header of the modal can be draggable.
Fix #1378