### PR TITLE
feat(autoclose): service & all popup based widgets

### DIFF
--- a/demo/src/app/components/datepicker/demos/popup/datepicker-popup.html
+++ b/demo/src/app/components/datepicker/demos/popup/datepicker-popup.html
@@ -2,9 +2,9 @@
   <div class="form-group">
     <div class="input-group">
       <input class="form-control" placeholder="yyyy-mm-dd"
-             name="dp" [(ngModel)]="model" ngbDatepicker #d="ngbDatepicker">
+             name="dp" [(ngModel)]="model" [ngbDatepicker]="toggler" #d="ngbDatepicker">
       <div class="input-group-append">
-        <button type="button" class="btn btn-outline-secondary" [ngbDatepickerToggle]="d" (click)="d.toggle()">
+        <button type="button" class="btn btn-outline-secondary" [ngbDatepickerToggle]="d" #toggler (click)="d.toggle()">
           <img src="img/calendar-icon.svg" style="width: 1.2rem; height: 1rem; cursor: pointer;"/>
         </button>
       </div>

--- a/demo/src/app/components/dropdown/demos/basic/dropdown-basic.html
+++ b/demo/src/app/components/dropdown/demos/basic/dropdown-basic.html
@@ -3,7 +3,7 @@
     <div ngbDropdown class="d-inline-block">
       <button class="btn btn-outline-primary" id="dropdownBasic1" ngbDropdownToggle>Toggle dropdown</button>
       <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
-        <button class="dropdown-item">Action - 1</button>
+        <button (click)="onClick('Action - 1')" class="dropdown-item">Action - 1</button>
         <button class="dropdown-item">Another Action</button>
         <button class="dropdown-item">Something else is here</button>
       </div>

--- a/demo/src/app/components/dropdown/demos/basic/dropdown-basic.ts
+++ b/demo/src/app/components/dropdown/demos/basic/dropdown-basic.ts
@@ -5,4 +5,7 @@ import {Component} from '@angular/core';
   templateUrl: './dropdown-basic.html'
 })
 export class NgbdDropdownBasic {
+    public onClick(message: string) {
+        console.log(message);
+    }
 }

--- a/demo/src/app/components/modal/demos/basic/modal-basic.html
+++ b/demo/src/app/components/modal/demos/basic/modal-basic.html
@@ -18,6 +18,14 @@
           </div>
         </div>
       </div>
+      <div ngbDropdown class="d-inline-block">
+        <button class="btn btn-outline-primary" id="dropdownBasic1" ngbDropdownToggle>Toggle dropdown</button>
+        <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
+          <button (click)="onDropdownClick('Action - 1')" class="dropdown-item">Action - 1</button>
+          <button class="dropdown-item">Another Action</button>
+          <button class="dropdown-item">Something else is here</button>
+        </div>
+      </div>
     </form>
   </div>
   <div class="modal-footer">

--- a/demo/src/app/components/modal/demos/basic/modal-basic.ts
+++ b/demo/src/app/components/modal/demos/basic/modal-basic.ts
@@ -11,8 +11,17 @@ export class NgbdModalBasic {
 
   constructor(private modalService: NgbModal) {}
 
+  onDropdownClick(message: string) {
+      console.log(message);
+  }
+
   open(content) {
-    this.modalService.open(content, {ariaLabelledBy: 'modal-basic-title'}).result.then((result) => {
+    this.modalService.open(content, {
+    	ariaLabelledBy: 'modal-basic-title',
+        // backdrop: true
+        // backdrop: false
+        backdrop: 'static'
+    }).result.then((result) => {
       this.closeResult = `Closed with: ${result}`;
     }, (reason) => {
       this.closeResult = `Dismissed ${this.getDismissReason(reason)}`;

--- a/demo/src/app/components/popover/demos/basic/popover-basic.html
+++ b/demo/src/app/components/popover/demos/basic/popover-basic.html
@@ -1,15 +1,18 @@
-<button type="button" class="btn btn-outline-secondary mr-2" placement="top"
-        ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on top">
+<button type="button" class="btn btn-outline-secondary" placement="top"
+        ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on top"
+        [autoClose]="true">
   Popover on top
 </button>
 
-<button type="button" class="btn btn-outline-secondary mr-2" placement="right"
-        ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on right">
+<button type="button" class="btn btn-outline-secondary" placement="right"
+        ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on right"
+        [autoClose]="'inside'">
   Popover on right
 </button>
 
-<button type="button" class="btn btn-outline-secondary mr-2" placement="bottom"
-        ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on bottom">
+<button type="button" class="btn btn-outline-secondary" placement="bottom"
+        ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on bottom"
+        [autoClose]="'outside'">
   Popover on bottom
 </button>
 

--- a/demo/src/app/components/tooltip/demos/basic/tooltip-basic.html
+++ b/demo/src/app/components/tooltip/demos/basic/tooltip-basic.html
@@ -1,10 +1,10 @@
-<button type="button" class="btn btn-outline-secondary mr-2" placement="top" ngbTooltip="Tooltip on top">
+<button type="button" class="btn btn-outline-secondary mr-2" placement="top" ngbTooltip="Tooltip on top" [autoClose]="true">
   Tooltip on top
 </button>
-<button type="button" class="btn btn-outline-secondary mr-2" placement="right" ngbTooltip="Tooltip on right">
+<button type="button" class="btn btn-outline-secondary mr-2" placement="right" ngbTooltip="Tooltip on right" [autoClose]="'inside'">
   Tooltip on right
 </button>
-<button type="button" class="btn btn-outline-secondary mr-2" placement="bottom" ngbTooltip="Tooltip on bottom">
+<button type="button" class="btn btn-outline-secondary mr-2" placement="bottom" ngbTooltip="Tooltip on bottom" [autoClose]="'outside'">
   Tooltip on bottom
 </button>
 <button type="button" class="btn btn-outline-secondary mr-2" placement="left" ngbTooltip="Tooltip on left">

--- a/demo/src/app/components/tooltip/demos/tplwithcontext/tooltip-tplwithcontext.ts
+++ b/demo/src/app/components/tooltip/demos/tplwithcontext/tooltip-tplwithcontext.ts
@@ -6,17 +6,17 @@ import {Component, ViewChild} from '@angular/core';
   templateUrl: './tooltip-tplwithcontext.html'
 })
 export class NgbdTooltipTplwithcontext {
-  greeting = {};
+  context: {greeting?: string} = {};
   name = 'World';
 
   @ViewChild('t') public tooltip: NgbTooltip;
 
-  public changeGreeting(greeting: any): void {
+  public changeGreeting(context: any): void {
     const isOpen = this.tooltip.isOpen();
     this.tooltip.close();
-    if (greeting !== this.greeting || !isOpen) {
-      this.greeting = greeting;
-      this.tooltip.open(greeting);
+    if (context.greeting !== this.context.greeting || !isOpen) {
+      this.context = context;
+      this.tooltip.open(context);
     }
   }
 }

--- a/demo/src/app/components/tooltip/demos/triggers/tooltip-triggers.html
+++ b/demo/src/app/components/tooltip/demos/triggers/tooltip-triggers.html
@@ -11,7 +11,7 @@
   Alternatively you can take full manual control over tooltip opening / closing events.
 </p>
 
-<button type="button" class="btn btn-outline-secondary mr-2" ngbTooltip="What a great tip!" triggers="manual" #t="ngbTooltip" (click)="t.open()">
+<button type="button" class="btn btn-outline-secondary mr-2" ngbTooltip="What a great tip!" triggers="manual" #t="ngbTooltip" (click)="t.open()" [autoClose]="'outside'">
   Click me to open a tooltip
 </button>
 <button type="button" class="btn btn-outline-secondary mr-2" (click)="t.close()">

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,7 @@ gulp.task('check-format', function() {
   return gulp
       .src([
         'gulpfile.js', 'karma-test-shim.js', 'misc/api-doc.js', 'misc/api-doc.spec.js', 'misc/demo-gen.js',
-        'src/**/*.ts'
+        'src/**/*.ts', '!src/util/keys.ts'
       ])
       .pipe(gulpFormat.checkFormat('file', clangFormat))
       .on('warning', function(e) {

--- a/src/datepicker/datepicker.module.ts
+++ b/src/datepicker/datepicker.module.ts
@@ -1,6 +1,7 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule, DatePipe} from '@angular/common';
 import {FormsModule} from '@angular/forms';
+import {AutoCloseService} from '../util/autoclose.service';
 import {NgbDatepicker, NgbDatepickerNavigateEvent} from './datepicker';
 import {NgbDatepickerMonthView} from './datepicker-month-view';
 import {NgbDatepickerNavigation} from './datepicker-navigation';
@@ -47,7 +48,7 @@ export class NgbDatepickerModule {
     return {
       ngModule: NgbDatepickerModule,
       providers: [
-        {provide: NgbCalendar, useClass: NgbCalendarGregorian},
+        AutoCloseService, {provide: NgbCalendar, useClass: NgbCalendarGregorian},
         {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nDefault},
         {provide: NgbDateParserFormatter, useClass: NgbDateISOParserFormatter},
         {provide: NgbDateAdapter, useClass: NgbDateStructAdapter}, NgbDatepickerConfig, DatePipe

--- a/src/dropdown/dropdown.module.ts
+++ b/src/dropdown/dropdown.module.ts
@@ -1,5 +1,6 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 import {NgbDropdown, NgbDropdownAnchor, NgbDropdownToggle, NgbDropdownMenu} from './dropdown';
+import {AutoCloseService} from '../util/autoclose.service';
 import {NgbDropdownConfig} from './dropdown-config';
 
 export {NgbDropdown, NgbDropdownToggle, NgbDropdownMenu} from './dropdown';
@@ -9,5 +10,7 @@ const NGB_DROPDOWN_DIRECTIVES = [NgbDropdown, NgbDropdownAnchor, NgbDropdownTogg
 
 @NgModule({declarations: NGB_DROPDOWN_DIRECTIVES, exports: NGB_DROPDOWN_DIRECTIVES})
 export class NgbDropdownModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbDropdownModule, providers: [NgbDropdownConfig]}; }
+  static forRoot(): ModuleWithProviders {
+    return {ngModule: NgbDropdownModule, providers: [NgbDropdownConfig, AutoCloseService]};
+  }
 }

--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -5,6 +5,8 @@ import {Key} from '../util/key';
 import {Component} from '@angular/core';
 import {By} from '@angular/platform-browser';
 
+import {createKeyboardEvent} from '../util/keys';
+
 import {NgbDropdownModule} from './dropdown.module';
 import {NgbDropdown} from './dropdown';
 import {NgbDropdownConfig} from './dropdown-config';
@@ -324,7 +326,7 @@ describe('ngb-dropdown-toggle', () => {
     fixture.detectChanges();
     expect(compiled).toBeShown();
 
-    buttonEl.click();
+    buttonEl.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 0}));
     fixture.detectChanges();
     expect(compiled).not.toBeShown();
   });
@@ -491,7 +493,7 @@ describe('ngb-dropdown-toggle', () => {
     fixture.detectChanges();
     expect(compiled).toBeShown();
 
-    linkEl.click();
+    linkEl.dispatchEvent(new MouseEvent('click', {bubbles: true, button: 0}));
     fixture.detectChanges();
     expect(compiled).not.toBeShown();
   });
@@ -522,12 +524,14 @@ describe('ngb-dropdown-toggle', () => {
     expect(dropdownEls[0]).not.toHaveCssClass('show');
     expect(dropdownEls[1]).not.toHaveCssClass('show');
 
-    buttonEls[0].click();
+    buttonEls[0].dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 0}));
+    buttonEls[0].dispatchEvent(new MouseEvent('click', {bubbles: true, button: 0}));
     fixture.detectChanges();
     expect(dropdownEls[0]).toHaveCssClass('show');
     expect(dropdownEls[1]).not.toHaveCssClass('show');
 
-    buttonEls[1].click();
+    buttonEls[1].dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 0}));
+    buttonEls[1].dispatchEvent(new MouseEvent('click', {bubbles: true, button: 0}));
     fixture.detectChanges();
     expect(dropdownEls[0]).not.toHaveCssClass('show');
     expect(dropdownEls[1]).toHaveCssClass('show');
@@ -584,12 +588,12 @@ describe('ngb-dropdown-toggle', () => {
       expect(compiled).toBeShown();
 
       // remains open on outside click
-      buttonEl.click();
+      buttonEl.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 0}));
       fixture.detectChanges();
       expect(compiled).toBeShown();
 
       // but closes on item click
-      linkEl.click();
+      linkEl.dispatchEvent(new MouseEvent('click', {bubbles: true, button: 0}));
       fixture.detectChanges();
       expect(compiled).not.toBeShown();
     });

--- a/src/modal/modal-stack.ts
+++ b/src/modal/modal-stack.ts
@@ -10,6 +10,7 @@ import {
   TemplateRef
 } from '@angular/core';
 
+import {AutoCloseService} from '../util/autoclose.service';
 import {ContentRef} from '../util/popup';
 import {isDefined, isString} from '../util/util';
 
@@ -25,7 +26,8 @@ export class NgbModalStack {
 
   constructor(
       private _applicationRef: ApplicationRef, private _injector: Injector,
-      private _componentFactoryResolver: ComponentFactoryResolver, @Inject(DOCUMENT) document) {
+      private _componentFactoryResolver: ComponentFactoryResolver, @Inject(DOCUMENT) document,
+      private _autoCloseService: AutoCloseService) {
     this._document = document;
   }
 
@@ -43,7 +45,8 @@ export class NgbModalStack {
     let backdropCmptRef: ComponentRef<NgbModalBackdrop> =
         options.backdrop !== false ? this._attachBackdrop(containerEl) : null;
     let windowCmptRef: ComponentRef<NgbModalWindow> = this._attachWindowComponent(containerEl, contentRef);
-    let ngbModalRef: NgbModalRef = new NgbModalRef(windowCmptRef, contentRef, backdropCmptRef, options.beforeDismiss);
+    let ngbModalRef: NgbModalRef =
+        new NgbModalRef(this._autoCloseService, windowCmptRef, contentRef, backdropCmptRef, options.beforeDismiss);
 
     activeModal.close = (result: any) => { ngbModalRef.close(result); };
     activeModal.dismiss = (reason: any) => { ngbModalRef.dismiss(reason); };

--- a/src/modal/modal-window.spec.ts
+++ b/src/modal/modal-window.spec.ts
@@ -1,7 +1,6 @@
 import {TestBed, ComponentFixture} from '@angular/core/testing';
 
 import {NgbModalWindow} from './modal-window';
-import {ModalDismissReasons} from './modal-dismiss-reasons';
 
 describe('ngb-modal-dialog', () => {
 
@@ -48,65 +47,4 @@ describe('ngb-modal-dialog', () => {
       expect(dialogEl.getAttribute('role')).toBe('document');
     });
   });
-
-  describe('dismiss', () => {
-
-    it('should dismiss on backdrop click by default', (done) => {
-      fixture.detectChanges();
-
-      fixture.componentInstance.dismissEvent.subscribe(($event) => {
-        expect($event).toBe(ModalDismissReasons.BACKDROP_CLICK);
-        done();
-      });
-
-      fixture.nativeElement.click();
-    });
-
-    it('should not dismiss on modal content click when there is active backdrop', (done) => {
-      fixture.detectChanges();
-      fixture.componentInstance.dismissEvent.subscribe(
-          () => { done.fail(new Error('Should not trigger dismiss event')); });
-
-      fixture.nativeElement.querySelector('.modal-content').click();
-      setTimeout(done, 200);
-    });
-
-    it('should ignore backdrop clicks when there is no backdrop', (done) => {
-      fixture.componentInstance.backdrop = false;
-      fixture.detectChanges();
-
-      fixture.componentInstance.dismissEvent.subscribe(($event) => {
-        expect($event).toBe(ModalDismissReasons.BACKDROP_CLICK);
-        done.fail(new Error('Should not trigger dismiss event'));
-      });
-
-      fixture.nativeElement.querySelector('.modal-dialog').click();
-      setTimeout(done, 200);
-    });
-
-    it('should ignore backdrop clicks when backdrop is "static"', (done) => {
-      fixture.componentInstance.backdrop = 'static';
-      fixture.detectChanges();
-
-      fixture.componentInstance.dismissEvent.subscribe(($event) => {
-        expect($event).toBe(ModalDismissReasons.BACKDROP_CLICK);
-        done.fail(new Error('Should not trigger dismiss event'));
-      });
-
-      fixture.nativeElement.querySelector('.modal-dialog').click();
-      setTimeout(done, 200);
-    });
-
-    it('should dismiss on esc press by default', (done) => {
-      fixture.detectChanges();
-
-      fixture.componentInstance.dismissEvent.subscribe(($event) => {
-        expect($event).toBe(ModalDismissReasons.ESC);
-        done();
-      });
-
-      fixture.debugElement.triggerEventHandler('keyup.esc', {});
-    });
-  });
-
 });

--- a/src/modal/modal-window.ts
+++ b/src/modal/modal-window.ts
@@ -21,9 +21,7 @@ import {ngbFocusTrap} from '../util/focus-trap';
     '[class]': '"modal fade show d-block" + (windowClass ? " " + windowClass : "")',
     'role': 'dialog',
     'tabindex': '-1',
-    '(keyup.esc)': 'escKey($event)',
-    '(click)': 'backdropClick($event)',
-    '[attr.aria-labelledby]': 'ariaLabelledBy',
+    '[attr.aria-labelledby]': 'ariaLabelledBy'
   },
   template: `
     <div [class]="'modal-dialog' + (size ? ' modal-' + size : '') + (centered ? ' modal-dialog-centered' : '')" role="document">
@@ -48,18 +46,6 @@ export class NgbModalWindow implements OnInit,
   constructor(@Inject(DOCUMENT) document, private _elRef: ElementRef<HTMLElement>, private _renderer: Renderer2) {
     this._document = document;
     ngbFocusTrap(this._elRef.nativeElement, this.dismissEvent);
-  }
-
-  backdropClick($event): void {
-    if (this.backdrop === true && this._elRef.nativeElement === $event.target) {
-      this.dismiss(ModalDismissReasons.BACKDROP_CLICK);
-    }
-  }
-
-  escKey($event): void {
-    if (this.keyboard && !$event.defaultPrevented) {
-      this.dismiss(ModalDismissReasons.ESC);
-    }
   }
 
   dismiss(reason): void { this.dismissEvent.emit(reason); }

--- a/src/modal/modal.module.ts
+++ b/src/modal/modal.module.ts
@@ -1,5 +1,7 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 
+import {AutoCloseService} from '../util/autoclose.service';
+
 import {NgbModalBackdrop} from './modal-backdrop';
 import {NgbModalWindow} from './modal-window';
 import {NgbModalStack} from './modal-stack';
@@ -15,5 +17,7 @@ export {ModalDismissReasons} from './modal-dismiss-reasons';
   providers: [NgbModal]
 })
 export class NgbModalModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbModalModule, providers: [NgbModal, NgbModalStack]}; }
+  static forRoot(): ModuleWithProviders {
+    return {ngModule: NgbModalModule, providers: [NgbModal, NgbModalStack, AutoCloseService]};
+  }
 }

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -11,6 +11,8 @@ import {
 import {CommonModule} from '@angular/common';
 import {TestBed, ComponentFixture, async} from '@angular/core/testing';
 
+import {createKeyboardEvent} from '../util/keys';
+
 import {NgbModalModule, NgbModal, NgbActiveModal, NgbModalRef} from './modal.module';
 
 const NOOP = () => {};
@@ -473,7 +475,8 @@ describe('ngb-modal', () => {
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveModal('foo');
 
-      (<DebugElement>getDebugNode(document.querySelector('ngb-modal-window'))).triggerEventHandler('keyup.esc', {});
+      (<DebugElement>getDebugNode(document.querySelector('ngb-modal-window')))
+          .nativeElement.dispatchEvent(createKeyboardEvent({type: 'keyup', name: 'Escape'}));
       fixture.detectChanges();
       expect(fixture.nativeElement).not.toHaveModal();
     });
@@ -483,23 +486,8 @@ describe('ngb-modal', () => {
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveModal('foo');
 
-      (<DebugElement>getDebugNode(document.querySelector('ngb-modal-window'))).triggerEventHandler('keyup.esc', {});
-      fixture.detectChanges();
-      expect(fixture.nativeElement).toHaveModal();
-
-      modalInstance.close();
-      fixture.detectChanges();
-      expect(fixture.nativeElement).not.toHaveModal();
-    });
-
-    it('should not dismiss modals on ESC when default is prevented', () => {
-      const modalInstance = fixture.componentInstance.open('foo', {keyboard: true});
-      fixture.detectChanges();
-      expect(fixture.nativeElement).toHaveModal('foo');
-
-      (<DebugElement>getDebugNode(document.querySelector('ngb-modal-window'))).triggerEventHandler('keyup.esc', {
-        defaultPrevented: true
-      });
+      (<DebugElement>getDebugNode(document.querySelector('ngb-modal-window')))
+          .nativeElement.dispatchEvent(createKeyboardEvent({type: 'keyup', name: 'Escape'}));
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveModal();
 

--- a/src/popover/popover.module.ts
+++ b/src/popover/popover.module.ts
@@ -3,6 +3,7 @@ import {NgModule, ModuleWithProviders} from '@angular/core';
 import {NgbPopover, NgbPopoverWindow} from './popover';
 import {NgbPopoverConfig} from './popover-config';
 import {Placement} from '../util/positioning';
+import {AutoCloseService} from '../util/autoclose.service';
 
 export {NgbPopover} from './popover';
 export {NgbPopoverConfig} from './popover-config';
@@ -10,5 +11,7 @@ export {Placement} from '../util/positioning';
 
 @NgModule({declarations: [NgbPopover, NgbPopoverWindow], exports: [NgbPopover], entryComponents: [NgbPopoverWindow]})
 export class NgbPopoverModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbPopoverModule, providers: [NgbPopoverConfig]}; }
+  static forRoot(): ModuleWithProviders {
+    return {ngModule: NgbPopoverModule, providers: [NgbPopoverConfig, AutoCloseService]};
+  }
 }

--- a/src/tooltip/tooltip.module.ts
+++ b/src/tooltip/tooltip.module.ts
@@ -3,6 +3,7 @@ import {NgModule, ModuleWithProviders} from '@angular/core';
 import {NgbTooltip, NgbTooltipWindow} from './tooltip';
 import {NgbTooltipConfig} from './tooltip-config';
 import {Placement} from '../util/positioning';
+import {AutoCloseService} from '../util/autoclose.service';
 
 export {NgbTooltipConfig} from './tooltip-config';
 export {NgbTooltip} from './tooltip';
@@ -10,5 +11,7 @@ export {Placement} from '../util/positioning';
 
 @NgModule({declarations: [NgbTooltip, NgbTooltipWindow], exports: [NgbTooltip], entryComponents: [NgbTooltipWindow]})
 export class NgbTooltipModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbTooltipModule, providers: [NgbTooltipConfig]}; }
+  static forRoot(): ModuleWithProviders {
+    return {ngModule: NgbTooltipModule, providers: [NgbTooltipConfig, AutoCloseService]};
+  }
 }

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -16,9 +16,12 @@ import {
   ComponentFactoryResolver,
   NgZone
 } from '@angular/core';
+
 import {listenToTriggers} from '../util/triggers';
 import {positionElements, Placement, PlacementArray} from '../util/positioning';
 import {PopupService} from '../util/popup';
+import {AutoCloseService, Subscriber, AutoCloseType} from '../util/autoclose.service';
+
 import {NgbTooltipConfig} from './tooltip-config';
 
 let nextId = 0;
@@ -64,7 +67,11 @@ export class NgbTooltipWindow {
   @Input() placement: Placement = 'top';
   @Input() id: string;
 
-  constructor(private _element: ElementRef<HTMLElement>, private _renderer: Renderer2) {}
+  anchorEl;
+
+  constructor(private _element: ElementRef<HTMLElement>, private _renderer: Renderer2) {
+    this.anchorEl = _element.nativeElement;
+  }
 
   applyPlacement(_placement: Placement) {
     // remove the current placement classes
@@ -97,6 +104,14 @@ export class NgbTooltip implements OnInit, OnDestroy {
    */
   @Input() triggers: string;
   /**
+   * Toggles and configures the autoclose feature.
+   * When false, it will never automatically close using this feature (triggers might do so though).
+   * When true, the widget will close on clicks inside, outside and on escape key press.
+   * When 'outside', the widget will close on clicks outside of it and on escape key press.
+   * When 'inside', the widget will close on clicks inside of it and on escape key press.
+   */
+  @Input() autoClose: AutoCloseType;
+  /**
    * A selector specifying the element the tooltip should be appended to.
    * Currently only supports "body".
    */
@@ -122,11 +137,12 @@ export class NgbTooltip implements OnInit, OnDestroy {
   private _windowRef: ComponentRef<NgbTooltipWindow>;
   private _unregisterListenersFn;
   private _zoneSubscription: any;
+  private _autoCloseSubscriber: Subscriber;
 
   constructor(
       private _elementRef: ElementRef<HTMLElement>, private _renderer: Renderer2, injector: Injector,
       componentFactoryResolver: ComponentFactoryResolver, viewContainerRef: ViewContainerRef, config: NgbTooltipConfig,
-      ngZone: NgZone) {
+      ngZone: NgZone, autoCloseService: AutoCloseService) {
     this.placement = config.placement;
     this.triggers = config.triggers;
     this.container = config.container;
@@ -142,6 +158,12 @@ export class NgbTooltip implements OnInit, OnDestroy {
                 this.container === 'body'));
       }
     });
+    this._autoCloseSubscriber = autoCloseService.createSubscriber(autoCloseService.subscriptionSpecFactory({
+      getAutoClose: () => this.autoClose,
+      getElementsInside: () => [this._windowRef.instance.anchorEl],
+      getTogglingElement: () => this._elementRef.nativeElement,
+      close: () => this.close()
+    }));
   }
 
   /**
@@ -184,6 +206,8 @@ export class NgbTooltip implements OnInit, OnDestroy {
               this._elementRef.nativeElement, this._windowRef.location.nativeElement, this.placement,
               this.container === 'body'));
 
+      this._autoCloseSubscriber.subscribe();
+
       this.shown.emit();
     }
   }
@@ -193,6 +217,7 @@ export class NgbTooltip implements OnInit, OnDestroy {
    */
   close(): void {
     if (this._windowRef != null) {
+      this._autoCloseSubscriber.unsubscribe();
       this._renderer.removeAttribute(this._elementRef.nativeElement, 'aria-describedby');
       this._popupService.close();
       this._windowRef = null;

--- a/src/typeahead/typeahead.module.ts
+++ b/src/typeahead/typeahead.module.ts
@@ -1,6 +1,8 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
+import {AutoCloseService} from '../util/autoclose.service';
+
 import {NgbHighlight} from './highlight';
 import {NgbTypeaheadWindow} from './typeahead-window';
 import {NgbTypeahead, NgbTypeaheadSelectItemEvent} from './typeahead';
@@ -22,7 +24,8 @@ export class NgbTypeaheadModule {
   static forRoot(): ModuleWithProviders {
     return {
       ngModule: NgbTypeaheadModule,
-      providers: [Live, NgbTypeaheadConfig, {provide: ARIA_LIVE_DELAY, useValue: DEFAULT_ARIA_LIVE_DELAY}]
+      providers:
+          [Live, NgbTypeaheadConfig, {provide: ARIA_LIVE_DELAY, useValue: DEFAULT_ARIA_LIVE_DELAY}, AutoCloseService]
     };
   }
 }

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -7,6 +7,8 @@ import {Validators, FormControl, FormGroup, FormsModule, ReactiveFormsModule} fr
 import {By} from '@angular/platform-browser';
 import {Observable, Subject} from 'rxjs';
 
+import {createKeyboardEvent} from '../util/keys';
+
 import {NgbTypeahead} from './typeahead';
 import {NgbTypeaheadModule} from './typeahead.module';
 import {NgbTypeaheadConfig} from './typeahead-config';
@@ -200,7 +202,7 @@ describe('ngb-typeahead', () => {
       fixture.detectChanges();
       expect(getWindow(compiled)).not.toBeNull();
 
-      fixture.nativeElement.click();
+      fixture.nativeElement.dispatchEvent(new MouseEvent('mousedown', {bubbles: true, button: 0}));
       expect(getWindow(compiled)).toBeNull();
     });
 
@@ -224,8 +226,9 @@ describe('ngb-typeahead', () => {
       fixture.detectChanges();
       expect(getWindow(compiled)).not.toBeNull();
 
-      const event = createKeyDownEvent(Key.Escape);
-      getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+      const event = createKeyboardEvent({type: 'keydown', name: 'Escape'});
+      spyOn(event, 'preventDefault');
+      document.dispatchEvent(event);
       fixture.detectChanges();
       expect(getWindow(compiled)).toBeNull();
       expect(event.preventDefault).toHaveBeenCalled();
@@ -493,9 +496,8 @@ describe('ngb-typeahead', () => {
          fixture.detectChanges();
          tick(50);
 
-         // Press Escape while second is still in proggress
-         const event = createKeyDownEvent(Key.Escape);
-         getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+         // Press Escape while second is still in progress
+         document.dispatchEvent(createKeyboardEvent({type: 'keydown', name: 'Escape'}));
          fixture.detectChanges();
 
          // Results for second input are loaded (window shouldn't be opened in this case)
@@ -914,8 +916,7 @@ describe('ngb-typeahead', () => {
              expect(inputEl.selectionStart).toBe(2);
              expect(inputEl.selectionEnd).toBe(3);
 
-             const event = createKeyDownEvent(Key.Escape);
-             getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+             document.dispatchEvent(createKeyboardEvent({type: 'keydown', name: 'Escape'}));
              fixture.detectChanges();
              expect(inputEl.value).toBe('on');
              expect(inputEl.selectionStart).toBe(2);

--- a/src/util/autoclose.md
+++ b/src/util/autoclose.md
@@ -1,0 +1,271 @@
+Autoclose service documentation
+
+----
+
+
+
+
+
+# Motivation
+
+Many widgets share a common trait: their content are displayed in a popup and this popup can be closed on some events.
+
+Therefore the goal of this service is to have a single piece of code taking care of this logic, hiding all technical details, in order to both: 
+
+- reduce the (duplicated) code inside each widget
+- have a common, consistent behavior
+
+
+
+
+
+# Getting started
+
+Basic scenario: 
+
+- inject the service into your class
+- using this service: create a subscriber with a proper spec and store it as an instance variable
+- using this subscriber: subscribe to the events when you open the dropdown you want to control
+- using the subscriber: unsubscribe from the events when closing the dropdown (on a close method and/or on destroy)
+
+The subscription spec provides some static and some dynamic filters to determine if the popup should be closed or not when some events occur.
+
+The service handles two kind of events: 
+
+- the <kbd>escape</kbd> key, on either `keydown` or `keyup` (defaults to `keyup`)
+- the left-click mouse events, on either `mousedown` or `mouseup` (defaults to `mousedown`) when clicking outside the popup and `click` when clicking inside (see below for details)
+
+In addition to filtering the events, the service checks the mode of the widget (should auto close or not, when clicking inside or not, when clicking outside or not, etc.) and then depending on the mode will choose whether to process or not using the event's target.
+
+At the lowest level, a subscriber spec looks like that: 
+
+- `close`: will eventually be called if all filters have passed; should implement the closing of the popup
+- `keyEvent`: listen to <kbd>escape</kbd> either on `keydown` or `keyup`
+- `mouseEvent`: listen to left-click either on `mousedown` or `mouseup`
+- `shouldAutoClose`: return `false` to deactivate auto closing, `true` to activate it; subsequent filters will then be called to determine if it should actually be closed or not
+- `shouldCloseOnEscape`: return `true` if you want so
+- `shouldCloseOnClickOutside`: return `true` is you want so; _outside_ elements usually means everything out of the popup
+- `shouldCloseOnClickInside`: return `true` is you want so; _inside_ elements usually means everything in the popup
+- `isTargetInside`: return `true` if you consider the given element is inside the popup, `false` otherwise
+- `isTargetTogglingElement`: return `true` if you consider the given element is the toggling element (in this case we leave the closing to you to prevent the close-then-reopen effect), `false` otherwise
+
+While this gives you great flexibility (and you can adapt the semantics to your specific needs), there is a common pattern which emerged and would lead to repeating the same code again and again. Therefore, we provide a facility to create such a structure above, but from a higher level one: 
+
+- forwarded properties: `keyEvent`, `mouseEvent`, `close`; pass them as you would do above
+- `getAutoClose`: return `false` to deactivate auto closing, `true` to activate it in all situations, otherwise `'inside'` for closing only when clicking inside the popup, and `'outside'` for when it's outside
+- `getElementsInside`: return a list of elements that are considered to be inside the popup (they'll be checked with `element.contains(target)`). If you don't provide it, or return `null`, the target will never be considered to be inside the popup.
+- `getTogglingElement`: return the element that is considered as the toggling element (it will be checked with `element.contains(target)`. If you don't provide it, we will consider there is no toggling element.
+
+## Examples
+
+### High-level
+
+```typescript
+import {Injectable, OnDestroy, Input} from '@angular/core';
+
+import {AutoCloseService, Subscriber, AutoCloseType} from '.../autoclose.service';
+
+@Injectable()
+class MyWidget implements OnDestroy {
+	private _autoCloseSubscriber: Subscriber;
+	@Input() autoClose: AutoCloseType;
+
+	constructor(autoCloseService: AutoCloseService) {
+		this._autoCloseSubscriber = autoCloseService.createSubscriber(autoCloseService.subscriptionSpecFactory({
+			getAutoClose: () => this.autoClose,
+			getElementsInside: () => [this._popup],
+			getTogglingElement: () => this._toggleButton,
+			close: () => this.close()
+	  }));
+	}
+	
+	ngOnDestroy() {
+		// ...
+		this._autoCloseSubscriber.unsubscribe();
+		// ...
+	}
+	
+	open() {
+		// ...
+		this._autoCloseSubscriber.subscribe();
+		// ...
+	}
+	
+	close() {
+		// ...
+		this._autoCloseSubscriber.unsubscribe();
+		// ...
+	}
+}
+```
+
+### Low-level
+
+In this example, we consider the popup to be surrounded by an overlay: 
+
+- when pressing <kbd>escape</kbd>, we should close
+- when clicking on the overlay, we should close
+- when clicking inside the popup or outside (except the overlay), we should not close
+- physically, the popup is inside the overlay, but there is no intermediate element between the two (direct parent-child relationship)
+- there is a possibility to disable the overlay
+
+So we adapt the semantics to: 
+
+- consider that the overlay exclusively is _the inside_
+- the rest is _the outside_ (including the popup)
+
+```typescript
+import {Injectable, OnDestroy, Input} from '@angular/core';
+
+import {AutoCloseService, Subscriber} from '.../autoclose.service';
+
+@Injectable()
+class MyWidget implements OnDestroy {
+	private _autoCloseSubscriber: Subscriber;
+
+	constructor(autoCloseService: AutoCloseService) {
+		this._autoCloseSubscriber = autoCloseService.createSubscriber(autoCloseService.subscriptionSpecFactory({
+			shouldAutoClose: () => true,
+			isTargetInside: (target) => target === this._overlay,
+			shouldCloseOnEscape: () => true,
+			shouldCloseOnClickOutside: () => false,
+			shouldCloseOnClickInside: () => this._overlay != null,
+			close: () => this.close()
+	  }));
+	}
+	
+	ngOnDestroy() {
+		// ...
+		this._autoCloseSubscriber.unsubscribe();
+		// ...
+	}
+	
+	open() {
+		// ...
+		this._autoCloseSubscriber.subscribe();
+		// ...
+	}
+	
+	close() {
+		// ...
+		this._autoCloseSubscriber.unsubscribe();
+		// ...
+	}
+}
+```
+
+
+
+
+
+# API
+
+## Types
+
+### Subscription
+
+- `SubscriptionSpec`: the description of a subscription, used to subscribe
+	- static filters
+		- `keyEvent`: the key event type upon which to react
+		- `mouseEvent`: the mouse event type upon which to react
+
+	- dynamic filters
+		- `shouldAutoClose`: a global first check, tells if the widget is in auto close mode (this is not sufficient to return `true` here to make it close, see below)
+		- `shouldCloseOnEscape`: tells whether the widget should close when <kbd>escape</kbd> has been pressed
+		- `shouldCloseOnClickOutside`: tells whether the widget should close when a proper mouse event occurred in a zone which is outside (determined thanks to `isTargetInside`, see below)
+		- `shouldCloseOnClickInside`: tells whether the widget should close when a proper mouse event occurred in a zone which is inside (determined thanks to `isTargetInside`, see below)
+	- event's target location checking
+		- `isTargetTogglingElement`: tells whether it is considered to be on the element used to toggle the popup (if true, we don't close, since it's the responsibility of this element to do so and it would conflict with it)
+		- `isTargetInside`: tells whether it is considered to be inside the popup
+	- implementation
+		- `close`: callback used to close the widget
+- `CallbackPayload`: the object passed to callbacks used to check if the content should be closed or not (see `SubscriptionSpec`)
+	- `event`: the DOM event upon which the check occurs, so you can inspect it or interact with it
+- `Subscription`: what is returned when subscribing; it is a function used to unsubscribe, it's a facilitation 
+
+### Facilitation
+
+- usually widgets have an input property used to tell if auto close should be on or not, and if so in which mode
+	- `AutoCloseMode`: if this property is of this type, auto close is on but only for all <kbd>escape</kbd> events and for mouse events occurring either `inside` or `outside` as determined by the given value
+	- `AutoCloseType`: otherwise the property can be __either__ of type `AutoCloseMode` or a simple boolean, in which case a value of `false` turns off the feature while `trues` turns it on
+- `SubscriptionSpecFactorySpec`: a simplified, higher-level subscription spec, used to generate a lower level one; the goal is to avoid writing the same code multiple times for similar use cases
+	- delegated properties: 
+	    - `keyEvent`
+	    - `mouseEvent`
+	    - `close`
+    - fetch information: 
+      - `getAutoClose`: gets the auto close property value, as described above (of type `AutoCloseType`): generates `shouldAutoClose`, `shouldCloseOnEscape` and is used by generated `shouldCloseOnClickOutside` and `shouldCloseOnClickInside`
+      - `getElementsInside`: gets the list of elements to be considered as to be inside the popup; generates `isTargetInside`
+      - `getTogglingElement`: gets the element to be considered as to be the toggling element; generates `isTargetTogglingElement`; if not provided, it is considered there is no toggling element
+- `Subscriber`: wraps a subscription spec and provides utilities to subscribe, unsubscribe, toggle the subscription, all of that using the same subscription spec and with proper state checking (to avoid subscribing multiple times and so on)
+	- `toggle`: toggles the subscription on and off
+	- the returned object itself is actually a function calling this `toggle`
+  - `subscribe`: registers the subscription
+  - `unsubscribe`: removes the subscription
+
+## Service
+
+### Low level
+
+- `subscribe(subscriptionSpec)`: registers the given subscription, putting it first and returns a function to easily unsubscribe
+- `unsubscribe(subscriptionSpec)`: removes given subscription
+- `createSubscriber(subscriptionSpec)`: creates and returns a `Subscriber` from given `SubscriptionSpec`
+
+### Facilitation
+
+- `subscriptionSpecFactory(subscriptionSpecFactorySpec)`: creates a `SubscriptionSpec` from a `SubscriptionSpecFactorySpec`
+- `isTargetTogglingElementFactory(getTogglingElement)`: creates a `isTargetTogglingElement` function from one which gets the toggling element
+- `isTargetInsideFactory(getElementsInside)`: creates a `isTargetTogglingElement` function from one which gets the list of elements inside
+- `shouldCloseFactory(getAutoClose)`: creates `shouldClose`, `shouldCloseOnEscape`, `shouldCloseOnClickOutside`, `shouldCloseOnClickInside` functions from one which returns the auto close value of type `AutoCloseType`
+
+### Utilities
+
+They are generic and would have their place somewhere else.
+
+- `arraySome(array, predicate)`: returns `true` if at least one element from the given array satisfies the given predicate, `false` otherwise
+- `safeElementContains(element, descendant)`: returns `false` if any of the two given elements are not defined, otherwise uses the DOM method `element.contains(descendant)`
+
+
+
+
+
+# Internals
+
+## DOM events listening
+
+All potentially used events are listened to when creating the instance of the service, and the listeners are removed on destroy. Here is the list of events: 
+
+- `click`, handled by `onClickEvent`
+- `mousedown`, handled by `onMouseEvent`
+- `mouseup`, handled by `onMouseEvent`
+- `keydown`, handled by `onKeyEvent`
+- `keyup`, handled by `onKeyEvent`
+
+When one of these events is triggered, then the filtering occurs (global one and per subscription). So it needs to be efficient.
+
+There is room for optimization, like for instance listening only if strictly necessary, but this must be done with great care since the events handling (see below) for now relies on listening to all of these events.
+
+## Subscriptions management
+
+Subscriptions specs are stored as is, the object passed by the user is not replaced nor modified, it is used as an id for the subscription. Therefore it is important the users keep them, or use the subscriber utility, which does that for them.
+
+This also means that default values are not computed once and for all, and the spec could be changed dynamically (by mutating the object) to alter the whole behavior. However this is an unlikely use case, since this would mean the nature of the widget using this utility changes itself.
+
+There is room for optimization, for instance by considering the spec as immutable we could optimize the default values. But in this case, if users want to change the spec — again, this is very unlikely — we should provide a way to replace it.
+
+Regarding the data structure used to store the subscriptions, it is the equivalent of a stack. It is very important to process the subscriptions in the reverse order of their registration, because we stop processing subscriptions for a given user action when one subscription has been called. By processing in this order, we can handle the case of nested popups, where the innermost popups are registered last, and processed first. So for instance an opened dropdown inside a modal dialog will be closed on first <kbd>escape</kbd> press, and the modal will be closed on the second <kbd>escape</kbd> only.
+
+## Events handling: subscriptions calls
+
+Upon every listened events, checks are done: 
+
+- global checks, not related to any subscribers; to listen to __<kbd>escape</kbd>__ key events only, __left-click__ mouse events only, etc.
+- checks per subscriptions
+
+This is described in the user documentation therefore no need to tell more about it here.
+
+There is a technical aspect to be described though: the processing of a __single user action__. A single user action triggers a sequence of events, usually of the same type. Therefore, our check routine will be called upon every of those events. However we want to handle all of these events as a whole — as one single user action — for this sole requirement described previously: stop processing more subscribers when one has already been called.
+
+For that, luckily our class is a singleton and there can be only one single user action at a time: this way we can store an internal state to check what has been done during the handling of previous events for a same user action.
+
+So we reset the state when handling the first event of the sequence (for instance `mousedown` for mouse events), and at the end of each handler we store the state, which in our case just tells whether a subscription has already been called or not. This state can then be checked to skip the subscriptions checking for subsequent events part of the same user action.

--- a/src/util/autoclose.service.ts
+++ b/src/util/autoclose.service.ts
@@ -1,0 +1,320 @@
+import {Injectable, RendererFactory2, OnDestroy} from '@angular/core';
+
+import {isDefined} from './util';
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Types: subscription
+////////////////////////////////////////////////////////////////////////////////
+
+export interface CallbackPayload { event: Event; }
+
+export interface SubscriptionSpec {
+  keyEvent?: 'keyup' | 'keydown';
+  mouseEvent?: 'mouseup' | 'mousedown';
+
+  shouldAutoClose?(): boolean;
+  shouldCloseOnEscape?(payload: CallbackPayload): boolean;
+  shouldCloseOnClickOutside?(payload: CallbackPayload): boolean;
+  shouldCloseOnClickInside?(payload: CallbackPayload): boolean;
+
+  isTargetTogglingElement?(target: HTMLElement): boolean;
+  isTargetInside?(target: HTMLElement): boolean;
+
+  close(event: Event, payload: {reason: 'escape' | 'outside_click' | 'inside_click', eventType: string});
+}
+
+// For TypeScript 2.8
+// export type SubscriptionInstance = {
+//   { +readonly [P in keyof SubscriptionSpec]-?: SubscriptionSpec[P] };
+// }
+export interface SubscriptionInstance {
+  readonly keyEvent: SubscriptionSpec['keyEvent'], readonly mouseEvent: SubscriptionSpec['mouseEvent'],
+
+      readonly shouldAutoClose: SubscriptionSpec['shouldAutoClose'],
+      readonly shouldCloseOnEscape: SubscriptionSpec['shouldCloseOnEscape'],
+      readonly shouldCloseOnClickOutside: SubscriptionSpec['shouldCloseOnClickOutside'],
+      readonly shouldCloseOnClickInside: SubscriptionSpec['shouldCloseOnClickInside'],
+
+      readonly isTargetTogglingElement: SubscriptionSpec['isTargetTogglingElement'],
+      readonly isTargetInside: SubscriptionSpec['isTargetInside'],
+
+      readonly close: SubscriptionSpec['close']
+}
+
+export type SubscriptionToken = Function;
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Types: subscriber
+////////////////////////////////////////////////////////////////////////////////
+
+export type Subscriber = {
+  (): void; isSubscribed: () => boolean; toggle: () => void; subscribe: () => void; unsubscribe: () => void;
+};
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Types: high-level api
+////////////////////////////////////////////////////////////////////////////////
+
+export type AutoCloseMode = 'inside' | 'outside';
+export type AutoCloseType = boolean | AutoCloseMode;
+
+export interface SubscriptionSpecFactorySpec {
+  keyEvent?: SubscriptionSpec['keyEvent'];
+  mouseEvent?: SubscriptionSpec['mouseEvent'];
+  close: SubscriptionSpec['close'];
+
+  getAutoClose?: () => AutoCloseType;
+  getElementsInside?: () => HTMLElement[];
+  getTogglingElement?: () => HTMLElement;
+}
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Service
+////////////////////////////////////////////////////////////////////////////////
+
+@Injectable()
+export class AutoCloseService implements OnDestroy {
+  ////////////////////////////////////////////////////////////////////////////
+  // Events listening
+  ////////////////////////////////////////////////////////////////////////////
+
+  private listenersSubscriptions: Function[];
+
+  constructor(rendererFactory: RendererFactory2) {
+    const renderer = rendererFactory.createRenderer(null, null);
+
+    this.listenersSubscriptions = [
+      ['click', 'onClickEvent'], ['mousedown', 'onMouseEvent'], ['mouseup', 'onMouseEvent'], ['keydown', 'onKeyEvent'],
+      ['keyup', 'onKeyEvent']
+    ].map(([type, handler]) => renderer.listen('document', type, event => this[handler](event, type)));
+  }
+
+  ngOnDestroy() { this.listenersSubscriptions.forEach(subscription => subscription()); }
+
+
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Subscribing management
+  ////////////////////////////////////////////////////////////////////////////
+
+  // tslint:disable-next-line:member-ordering
+  private subscriptions: SubscriptionInstance[] = [];
+
+  public subscribe(subscription: SubscriptionInstance): SubscriptionToken {
+    const {subscriptions} = this;
+
+    if (!subscriptions.includes(subscription)) {
+      subscriptions.unshift(subscription);
+    }
+
+    return () => this.unsubscribe(subscription);
+  }
+
+  private unsubscribe(subscription: SubscriptionInstance) {
+    this.subscriptions = this.subscriptions.filter(item => item !== subscription);
+  }
+
+  public createSubscriber(subscriptionSpec: SubscriptionSpec): Subscriber {
+    const subscriptionInstance = this.normalizeSubscription(subscriptionSpec);
+
+    let subscriptionToken: SubscriptionToken = null;
+    const _isSubscribed = () => isDefined(subscriptionToken);
+    const _subscribe = () => subscriptionToken = this.subscribe(subscriptionInstance);
+    const _unsubscribe = () => (subscriptionToken(), subscriptionToken = null);
+    const _toggle = () => !_isSubscribed() ? _subscribe() : _unsubscribe();
+
+    const subscriber: any = () => _toggle();
+    subscriber.toggle = _toggle;
+    subscriber.isSubscribed = _isSubscribed;
+    subscriber.subscribe = () => !_isSubscribed() && _subscribe();
+    subscriber.unsubscribe = () => _isSubscribed() && _unsubscribe();
+
+    return subscriber;
+  }
+
+
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Event handling
+  ////////////////////////////////////////////////////////////////////////////
+
+  // tslint:disable-next-line:member-ordering
+  private _subscriptionExecuted: boolean;
+
+  // A few notes:
+  // - we handle the left click only
+  // - the click event comes last among mouse events of a same user action, so:
+  //   - it's no time to reset the `_subscriptionExecuted` flag anyways
+  //   - there's no need to update this flag at the end since there's no further event
+  // - if during a same user action a subscription already got called, we skip processing until next user action
+  private onClickEvent(event: MouseEvent, eventType: string) {
+    if (event.button !== 0 || this._subscriptionExecuted) {
+      return;
+    }
+
+    this.arraySome(this.subscriptions, ({shouldAutoClose, shouldCloseOnClickInside, isTargetInside, close}) => {
+      // note: if we can't determine if target is inside (i.e. `isTargetInside` is not defined):
+      // - we won't call subscriptions here
+      // - anyways the subscriptions would have been called in previous mouse events then
+      // note: we call filters in an order so that potentially more costly processing occurs less probably
+      if (isDefined(isTargetInside) && shouldAutoClose() && shouldCloseOnClickInside({event}) &&
+          isTargetInside(<HTMLElement>event.target)) {
+        close(event, {reason: 'inside_click', eventType});
+        return true;
+      }
+
+      return false;
+    });
+  }
+
+  // A few notes:
+  // - we handle the left click only
+  // - for one user action, the first mouse event is `mousedown` so it's a good time to reset the
+  // `_subscriptionExecuted` flag
+  // - if during a same user action a subscription already got called, we skip processing until next user action
+  private onMouseEvent(event: MouseEvent, eventType: string) {
+    if (event.button !== 0) {
+      return;
+    }
+
+    if (eventType === 'mousedown') {
+      this._subscriptionExecuted = null;
+    } else if (this._subscriptionExecuted) {
+      return;
+    }
+
+    this._subscriptionExecuted =
+        this.ensureTrueFlag(this._subscriptionExecuted, this.arraySome(this.subscriptions, subscription => {
+          const {mouseEvent, shouldAutoClose, shouldCloseOnClickOutside, isTargetTogglingElement, isTargetInside,
+                 close} = subscription;
+          const target = <HTMLElement>event.target;
+
+          // note: `shouldCloseOnClickOutside` makes no sense if we can't check if
+          // target is inside/outside (i.e. if `isTargetInside` is not defined)
+          if (mouseEvent === eventType && shouldAutoClose() && !isTargetTogglingElement(target) &&
+              (!isDefined(isTargetInside) || (!isTargetInside(target) && shouldCloseOnClickOutside({event})))) {
+            close(event, {reason: 'outside_click', eventType});
+            return true;
+          }
+          return false;
+        }));
+  }
+
+  // A few notes:
+  // - we handle the `escape` key only
+  // - for one user action, the first keyboard event is `keydown` so it's a good time to reset the
+  // `_subscriptionExecuted` flag
+  // - if during a same user action a subscription already got called, we skip processing until next user action
+  private onKeyEvent(event: KeyboardEvent, eventType: string) {
+    if (!['Escape', 'Esc'].includes(event.key)) {
+      return;
+    }
+
+    if (eventType === 'keydown') {
+      this._subscriptionExecuted = null;
+    } else if (this._subscriptionExecuted) {
+      return;
+    }
+
+    this._subscriptionExecuted = this.ensureTrueFlag(
+        this._subscriptionExecuted,
+        this.arraySome(this.subscriptions, ({keyEvent, shouldAutoClose, shouldCloseOnEscape, close}) => {
+          if (keyEvent === eventType && shouldAutoClose() && shouldCloseOnEscape({event})) {
+            close(event, {reason: 'escape', eventType});
+            return true;
+          }
+          return false;
+        }));
+  }
+
+
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Subscription implementation
+  ////////////////////////////////////////////////////////////////////////////
+
+  private normalizeSubscription(subscriptionSpec: SubscriptionSpec): SubscriptionInstance {
+    return {
+      keyEvent: this.withDefault(subscriptionSpec.keyEvent, 'keyup'),
+      mouseEvent: this.withDefault(subscriptionSpec.mouseEvent, 'mousedown'),
+
+      shouldAutoClose: this.withDefault(subscriptionSpec.shouldAutoClose, () => true),
+      shouldCloseOnEscape: this.withDefault(subscriptionSpec.shouldCloseOnEscape, () => true),
+
+      shouldCloseOnClickOutside: this.withDefault(subscriptionSpec.shouldCloseOnClickOutside, () => true),
+      shouldCloseOnClickInside: this.withDefault(subscriptionSpec.shouldCloseOnClickInside, () => false),
+
+      isTargetTogglingElement: this.withDefault(subscriptionSpec.isTargetTogglingElement, () => false),
+      isTargetInside: subscriptionSpec.isTargetInside,
+      close: subscriptionSpec.close
+    };
+  }
+
+  public subscriptionSpecFactory(arg: SubscriptionSpecFactorySpec): SubscriptionSpec {
+    const getAutoClose = this.withDefault(arg.getAutoClose, () => false);
+
+    const autoCloseIsTrueOr = (alternative: AutoCloseMode) => () => {
+      const autoClose = getAutoClose();
+      return !!(autoClose === true || autoClose === alternative);
+    };
+
+    const shouldAutoClose = () => {
+      const autoClose = getAutoClose();
+      return autoClose === true || autoClose === 'inside' || autoClose === 'outside';
+    };
+
+    const {getElementsInside} = arg;
+    const isTargetInside = !isDefined(getElementsInside) ?
+        () => false :
+        target => {
+          const elements = getElementsInside();
+          return !isDefined(elements) ? false :
+                                        this.arraySome(elements, element => this.safeElementContains(element, target));
+        }
+
+        const {getTogglingElement} = arg;
+    const isTargetTogglingElement = !isDefined(getTogglingElement) ?
+        () => false :
+        (target: HTMLElement) => this.safeElementContains(getTogglingElement(), target);
+
+    return {
+      close: arg.close,
+      keyEvent: arg.keyEvent,
+      mouseEvent: arg.mouseEvent,
+
+      isTargetInside,
+      isTargetTogglingElement,
+
+      shouldAutoClose,
+      shouldCloseOnEscape: shouldAutoClose,
+      shouldCloseOnClickInside: autoCloseIsTrueOr('inside'),
+      shouldCloseOnClickOutside: autoCloseIsTrueOr('outside')
+    };
+  }
+
+
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Utilities
+  ////////////////////////////////////////////////////////////////////////////
+
+  private ensureTrueFlag(previousValue, newValue) { return previousValue !== true ? newValue : previousValue; }
+
+  private arraySome<T>(array: T[], predicate: (item: T, index: number, array: T[]) => boolean): boolean {
+    return array.findIndex(predicate) !== -1;
+  }
+
+  private safeElementContains(element?: HTMLElement, descendant?: HTMLElement): boolean {
+    return (!isDefined(element) || !isDefined(descendant)) ? false : element.contains(descendant);
+  }
+
+  private withDefault<T>(value: T, defaultValue: T): T { return isDefined(value) ? value : defaultValue; }
+}

--- a/src/util/keys.ts
+++ b/src/util/keys.ts
@@ -1,0 +1,144 @@
+import {isDefined} from './util';
+
+
+
+interface KeySpecInput {
+  name?: string;
+  keys: string[];
+  code: number;
+}
+
+export interface KeySpec {
+  name: string;
+  key: string;
+  keys: string[];
+  code: number;
+}
+
+const KEY_SPECS_INPUTS: KeySpecInput[] = [
+  {               keys: ['Tab'                  ], code:  9},
+  {               keys: ['Enter'                ], code: 13},
+  {               keys: ['Escape'   , 'Esc'     ], code: 27},
+  {name: 'Space', keys: [' '        , 'Spacebar'], code: 32},
+
+  {               keys: ['PageUp'               ], code: 33},
+  {               keys: ['PageDown'             ], code: 34},
+  {               keys: ['End'                  ], code: 35},
+  {               keys: ['Home'                 ], code: 36},
+
+  {               keys: ['ArrowLeft' , 'Left'   ], code: 37},
+  {               keys: ['ArrowUp'   , 'Up'     ], code: 38},
+  {               keys: ['ArrowRight', 'Right'  ], code: 39},
+  {               keys: ['ArrowDown' , 'Down'   ], code: 40}
+];
+
+export const KEY_SPECS: KeySpec[] = KEY_SPECS_INPUTS.map(({name, keys, code}: KeySpecInput) => {
+  const key = keys[0];
+
+  if (!isDefined(name)) {
+    name = key;
+  }
+
+  return {name, key, keys, code};
+});
+
+
+
+export const CODES_TO_SPECS = {};
+KEY_SPECS.forEach(spec => CODES_TO_SPECS[spec.code] = spec);
+
+export const KEYS_TO_SPECS = {};
+KEY_SPECS.forEach(spec => spec.keys.forEach(key => KEYS_TO_SPECS[key] = spec));
+
+export const NAMES_TO_SPECS = {};
+KEY_SPECS.forEach(spec => NAMES_TO_SPECS[spec.name] = spec);
+
+
+
+export function getKeySpecFromEvent(event: KeyboardEvent): KeySpec {
+  const {key, keyCode, which} = event;
+
+  let spec = null;
+
+  if (isDefined(key)) {
+    spec = KEYS_TO_SPECS[key];
+  }
+
+  if (!isDefined(spec)) {
+    const code = isDefined(keyCode) ? keyCode : isDefined(which) ? which : null;
+    if (isDefined(code)) {
+      spec = CODES_TO_SPECS[code];
+    }
+  }
+
+  return spec;
+}
+
+export function getKeyPropertyFromEvent(property: string, event: KeyboardEvent): any {
+  const spec = getKeySpecFromEvent(event);
+  return isDefined(spec) ? spec[property] : null;
+}
+
+export function getKey    (event: KeyboardEvent): string { return getKeyPropertyFromEvent('key' , event); }
+export function getKeyCode(event: KeyboardEvent): number { return getKeyPropertyFromEvent('code', event); }
+export function getKeyName(event: KeyboardEvent): string { return getKeyPropertyFromEvent('name', event); }
+
+
+
+export function checkKey(name: string, event: KeyboardEvent): boolean { return getKeyName(event) === name; }
+
+
+export function isTab   (event: KeyboardEvent): boolean { return checkKey('Tab'   , event); }
+export function isEnter (event: KeyboardEvent): boolean { return checkKey('Enter' , event); }
+export function isEscape(event: KeyboardEvent): boolean { return checkKey('Escape', event); }
+export function isSpace (event: KeyboardEvent): boolean { return checkKey('Space' , event); }
+
+
+export function isPageUp  (event: KeyboardEvent): boolean { return checkKey('PageUp'  , event); }
+export function isPageDown(event: KeyboardEvent): boolean { return checkKey('PageDown', event); }
+export function isEnd     (event: KeyboardEvent): boolean { return checkKey('End'     , event); }
+export function isHome    (event: KeyboardEvent): boolean { return checkKey('Home'    , event); }
+
+
+export function isArrowLeft (event: KeyboardEvent): boolean { return checkKey('ArrowLeft' , event); }
+export function isArrowUp   (event: KeyboardEvent): boolean { return checkKey('ArrowUp'   , event); }
+export function isArrowRight(event: KeyboardEvent): boolean { return checkKey('ArrowRight', event); }
+export function isArrowDown (event: KeyboardEvent): boolean { return checkKey('ArrowDown' , event); }
+
+
+
+export interface FakeEvent extends Event {
+  which: number;
+  keyCode: number;
+  key: string;
+};
+
+export function createKeyboardEvent(input): Event {
+  if (!isDefined(input)) {
+    input = {};
+  }
+
+  let {type, name, options} = input;
+
+  if (!isDefined(type)) {
+    type = 'keyup';
+  }
+
+  const event = new Event(type, {bubbles: true}) as FakeEvent;
+
+  if (isDefined(name)) {
+    const spec = NAMES_TO_SPECS[name];
+    if (isDefined(spec)) {
+      const {key, code} = spec;
+      event.which = code;
+      event.keyCode = code;
+      event.key = key;
+    }
+  }
+
+  if (isDefined(options)) {
+    Object.assign(event, options);
+  }
+
+  return event;
+}


### PR DESCRIPTION
The autoclose feature brings a generic utility to handle the following use cases of popup widgets: 

- close popup on click inside
- close popup on click outside
- close popup on escape press

This PR also integrates it for each popup based widget.

There is 1 commit for the generic service, and 1 commit per modified widget.