### PR TITLE
fix(modal): don't use deprecated 'ReflectiveInjector'

### DIFF
--- a/src/modal/modal-stack.ts
+++ b/src/modal/modal-stack.ts
@@ -4,7 +4,6 @@ import {
   Injectable,
   Injector,
   Inject,
-  ReflectiveInjector,
   ComponentFactory,
   ComponentFactoryResolver,
   ComponentRef,
@@ -119,8 +118,7 @@ export class NgbModalStack {
       moduleCFR: ComponentFactoryResolver, contentInjector: Injector, content: any,
       context: NgbActiveModal): ContentRef {
     const contentCmptFactory = moduleCFR.resolveComponentFactory(content);
-    const modalContentInjector =
-        ReflectiveInjector.resolveAndCreate([{provide: NgbActiveModal, useValue: context}], contentInjector);
+    const modalContentInjector = Injector.create([{provide: NgbActiveModal, useValue: context}], contentInjector);
     const componentRef = contentCmptFactory.create(modalContentInjector);
     this._applicationRef.attachView(componentRef.hostView);
     return new ContentRef([[componentRef.location.nativeElement]], componentRef.hostView, componentRef);

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -6,7 +6,7 @@ import {
   NgModule,
   getDebugNode,
   DebugElement,
-  ReflectiveInjector
+  Injector
 } from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {TestBed, ComponentFixture} from '@angular/core/testing';
@@ -515,7 +515,7 @@ describe('ngb-modal', () => {
   describe('custom injector option', () => {
 
     it('should render modal with a custom injector', () => {
-      const customInjector = ReflectiveInjector.resolveAndCreate([CustomSpyService]);
+      const customInjector = Injector.create([{provide: CustomSpyService, useClass: CustomSpyService, deps: []}]);
       const modalInstance = fixture.componentInstance.openCmpt(CustomInjectorCmpt, {injector: customInjector});
       fixture.detectChanges();
       expect(fixture.nativeElement).toHaveModal('Some content');


### PR DESCRIPTION
`ReflectiveInjector` was deprecated in v5, see https://angular.io/api/core/ReflectiveInjector#deprecation-notes