### PR TITLE
demo: add anchor link to demo examples

### DIFF
--- a/demo/src/app/components/shared/api-docs/api-docs.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs.component.html
@@ -2,7 +2,7 @@
   <h3 class="title">
     <a
       [routerLink]=""
-      fragment="{{apiDocs.className}}" ngbdFragment
+      [fragment]="apiDocs.className" ngbdFragment
       title="Anchor link to: {{apiDocs.className}}"
     >
       <img src="img/link-symbol.svg" alt="Anchor link to: {{apiDocs.className}}"/>

--- a/demo/src/app/components/shared/example-box/example-box.component.html
+++ b/demo/src/app/components/shared/example-box/example-box.component.html
@@ -1,5 +1,13 @@
 <div class="component-demo">
+  <a [id]="demo"></a>
   <h2>
+    <a
+      [routerLink]=""
+      [fragment]="demo" ngbdFragment
+      title="Anchor link to demo: {{demo}}"
+    >
+      <img src="img/link-symbol.svg" alt="Anchor link to: {{demo}}"/>
+    </a>
     {{ demoTitle }}
     <a
       class="plunker"

--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -205,6 +205,9 @@ div.component-demo {
       .plunker, .stackblitz {
         opacity: 1;
       }
+      & > .title-fragment {
+        opacity: 1;
+      }
     }
   }
 


### PR DESCRIPTION
The anchor links are similar to the ones used for the API doc sections.
They allow linking to a specific example from a stackoverflow comment or answer, for example.
