### PR TITLE
demo: adapt demo to 'preserveWhiteSpaces' turned off

### DIFF
--- a/demo/src/app/components/accordion/demos/toggle/accordion-toggle.html
+++ b/demo/src/app/components/accordion/demos/toggle/accordion-toggle.html
@@ -23,6 +23,6 @@
 
 <hr/>
 
-<button class="btn btn-sm btn-outline-primary" (click)="acc.toggle('toggle-1')">Toggle first</button>
-<button class="btn btn-sm btn-outline-primary" (click)="acc.toggle('toggle-2')">Toggle second</button>
+<button class="btn btn-sm btn-outline-primary mr-2" (click)="acc.toggle('toggle-1')">Toggle first</button>
+<button class="btn btn-sm btn-outline-primary mr-2" (click)="acc.toggle('toggle-2')">Toggle second</button>
 

--- a/demo/src/app/components/datepicker/demos/basic/datepicker-basic.html
+++ b/demo/src/app/components/datepicker/demos/basic/datepicker-basic.html
@@ -4,9 +4,9 @@
 
 <hr/>
 
-<button class="btn btn-sm btn-outline-primary" (click)="selectToday()">Select Today</button>
-<button class="btn btn-sm btn-outline-primary" (click)="dp.navigateTo()">To current month</button>
-<button class="btn btn-sm btn-outline-primary" (click)="dp.navigateTo({year: 2013, month: 2})">To Feb 2013</button>
+<button class="btn btn-sm btn-outline-primary mr-2" (click)="selectToday()">Select Today</button>
+<button class="btn btn-sm btn-outline-primary mr-2" (click)="dp.navigateTo()">To current month</button>
+<button class="btn btn-sm btn-outline-primary mr-2" (click)="dp.navigateTo({year: 2013, month: 2})">To Feb 2013</button>
 
 <hr/>
 

--- a/demo/src/app/components/datepicker/demos/calendars/islamic-calendars.html
+++ b/demo/src/app/components/datepicker/demos/calendars/islamic-calendars.html
@@ -5,9 +5,9 @@
 
 <hr/>
 
-<button class="btn btn-sm btn-outline-primary" (click)="selectToday();">Select Today</button>
-<button class="btn btn-sm btn-outline-primary" (click)="dp.navigateTo()">To current month</button>
-<button class="btn btn-sm btn-outline-primary" (click)="dp.navigateTo({year: 1434, month: 2})">To Saf. 1434</button>
+<button class="btn btn-sm btn-outline-primary mr-2" (click)="selectToday();">Select Today</button>
+<button class="btn btn-sm btn-outline-primary mr-2" (click)="dp.navigateTo()">To current month</button>
+<button class="btn btn-sm btn-outline-primary mr-2" (click)="dp.navigateTo({year: 1434, month: 2})">To Saf. 1434</button>
 
 <hr/>
 

--- a/demo/src/app/components/dropdown/demos/manual/dropdown-manual.html
+++ b/demo/src/app/components/dropdown/demos/manual/dropdown-manual.html
@@ -1,13 +1,13 @@
 <p>You can easily control dropdowns programmatically using the exported dropdown instance.</p>
 
 <div class="d-inline-block" ngbDropdown #myDrop="ngbDropdown">
-  <button class="btn btn-outline-primary" id="dropdownManual" ngbDropdownAnchor (focus)="myDrop.open()">Toggle dropdown</button>
+  <button class="btn btn-outline-primary mr-2" id="dropdownManual" ngbDropdownAnchor (focus)="myDrop.open()">Toggle dropdown</button>
   <div ngbDropdownMenu aria-labelledby="dropdownManual">
     <button class="dropdown-item">Action - 1</button>
     <button class="dropdown-item">Another Action</button>
     <button class="dropdown-item">Something else is here</button>
   </div>
 
-  <button class="btn btn-outline-success" (click)="$event.stopPropagation(); myDrop.open();">Open from outside</button>
-  <button class="btn btn-outline-danger" (click)="$event.stopPropagation(); myDrop.close();">Close from outside</button>
+  <button class="btn btn-outline-success mr-2" (click)="$event.stopPropagation(); myDrop.open();">Open from outside</button>
+  <button class="btn btn-outline-danger mr-2" (click)="$event.stopPropagation(); myDrop.close();">Close from outside</button>
 </div>

--- a/demo/src/app/components/dropdown/demos/split/dropdown-split.html
+++ b/demo/src/app/components/dropdown/demos/split/dropdown-split.html
@@ -1,6 +1,6 @@
 <p>Bootstrap split buttons and dropdowns on button groups are supported with the existing dropdown directives.</p>
 
-<div class="btn-group">
+<div class="btn-group mr-3">
   <button type="button" class="btn btn-outline-success">Plain ol' button</button>
   <div class="btn-group" ngbDropdown role="group" aria-label="Button group with nested dropdown">
     <button class="btn btn-outline-primary" ngbDropdownToggle>Drop me</button>
@@ -12,7 +12,7 @@
   </div>
 </div>
 
-<div class="btn-group">
+<div class="btn-group mr-3">
   <button type="button" class="btn btn-primary">Split me</button>
   <div class="btn-group" ngbDropdown role="group" aria-label="Button group with nested dropdown">
     <button class="btn btn-primary dropdown-toggle-split" ngbDropdownToggle></button>
@@ -24,7 +24,7 @@
   </div>
 </div>
 
-<div class="btn-group">
+<div class="btn-group mr-3">
   <div class="btn-group" ngbDropdown role="group" aria-label="Button group with nested dropdown">
     <button class="btn btn-outline-danger" ngbDropdownToggle>Select me</button>
     <div class="dropdown-menu" ngbDropdownMenu>

--- a/demo/src/app/components/modal/demos/options/modal-options.html
+++ b/demo/src/app/components/modal/demos/options/modal-options.html
@@ -13,8 +13,8 @@
   </div>
 </ng-template>
 
-<button class="btn btn-outline-primary mb-1" (click)="openWindowCustomClass(content)">Modal with window custom class</button>
-<button class="btn btn-outline-primary mb-1" (click)="openBackDropCustomClass(content)">Modal with backdrop custom class</button>
-<button class="btn btn-outline-primary mb-1" (click)="openSm(content)">Small modal</button>
-<button class="btn btn-outline-primary mb-1" (click)="openLg(content)">Large modal</button>
-<button class="btn btn-outline-primary mb-1" (click)="openVerticallyCentered(content)">Modal vertically centered</button>
+<button class="btn btn-outline-primary mb-2 mr-2" (click)="openWindowCustomClass(content)">Modal with window custom class</button>
+<button class="btn btn-outline-primary mb-2 mr-2" (click)="openBackDropCustomClass(content)">Modal with backdrop custom class</button>
+<button class="btn btn-outline-primary mb-2 mr-2" (click)="openSm(content)">Small modal</button>
+<button class="btn btn-outline-primary mb-2 mr-2" (click)="openLg(content)">Large modal</button>
+<button class="btn btn-outline-primary mb-2 mr-2" (click)="openVerticallyCentered(content)">Modal vertically centered</button>

--- a/demo/src/app/components/popover/demos/basic/popover-basic.html
+++ b/demo/src/app/components/popover/demos/basic/popover-basic.html
@@ -1,19 +1,19 @@
-<button type="button" class="btn btn-outline-secondary" placement="top"
+<button type="button" class="btn btn-outline-secondary mr-2" placement="top"
         ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on top">
   Popover on top
 </button>
 
-<button type="button" class="btn btn-outline-secondary" placement="right"
+<button type="button" class="btn btn-outline-secondary mr-2" placement="right"
         ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on right">
   Popover on right
 </button>
 
-<button type="button" class="btn btn-outline-secondary" placement="bottom"
+<button type="button" class="btn btn-outline-secondary mr-2" placement="bottom"
         ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on bottom">
   Popover on bottom
 </button>
 
-<button type="button" class="btn btn-outline-secondary" placement="left"
+<button type="button" class="btn btn-outline-secondary mr-2" placement="left"
         ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on left">
   Popover on left
 </button>

--- a/demo/src/app/components/popover/demos/container/popover-container.html
+++ b/demo/src/app/components/popover/demos/container/popover-container.html
@@ -2,9 +2,9 @@
 	Set the <code>container</code> property to "body" to have the popover be appended to the body instead of the triggering element's parent. This option is useful if the element triggering the popover is inside an element that clips its contents (i.e. <code>overflow: hidden</code>).
 </p>
 
-<div class='row'>
-	<div class='card'>
-		<button type="button" class="btn btn-outline-secondary"
+<div class="row">
+	<div class="card px-1 py-5">
+		<button type="button" class="btn btn-outline-secondary mb-2"
 						ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
 			Default popover
 		</button>

--- a/demo/src/app/components/popover/demos/container/popover-container.ts
+++ b/demo/src/app/components/popover/demos/container/popover-container.ts
@@ -3,7 +3,7 @@ import {Component} from '@angular/core';
 @Component({
   selector: 'ngbd-popover-container',
   templateUrl: './popover-container.html',
-  styles: ['.card { padding: 50px 0; text-align: center; overflow:hidden }']
+  styles: ['.card { overflow: hidden }']
 })
 export class NgbdPopoverContainer {
 }

--- a/demo/src/app/components/popover/demos/tplwithcontext/popover-tplwithcontext.html
+++ b/demo/src/app/components/popover/demos/tplwithcontext/popover-tplwithcontext.html
@@ -6,12 +6,12 @@
 <p>
   How would you like to greet <strong [ngbPopover]="popContent" popoverTitle="Greeting" #p="ngbPopover" triggers="manual">me</strong>?
 </p>
-<button type="button" class="btn btn-outline-secondary" (click)="changeGreeting({ greeting: 'Bonjour' })">
+<button type="button" class="btn btn-outline-secondary mr-2" (click)="changeGreeting({ greeting: 'Bonjour' })">
   French
 </button>
-<button type="button" class="btn btn-outline-secondary" (click)="changeGreeting({ greeting: 'Gutentag' })">
+<button type="button" class="btn btn-outline-secondary mr-2" (click)="changeGreeting({ greeting: 'Gutentag' })">
   German
 </button>
-<button type="button" class="btn btn-outline-secondary" (click)="changeGreeting({ greeting: 'Hello' })">
+<button type="button" class="btn btn-outline-secondary mr-2" (click)="changeGreeting({ greeting: 'Hello' })">
   English
 </button>

--- a/demo/src/app/components/popover/demos/triggers/popover-triggers.html
+++ b/demo/src/app/components/popover/demos/triggers/popover-triggers.html
@@ -11,9 +11,9 @@
   Alternatively you can take full manual control over popover opening / closing events.
 </p>
 
-<button type="button" class="btn btn-outline-secondary" ngbPopover="What a great tip!" triggers="manual" #p="ngbPopover" (click)="p.open()" popoverTitle="Pop title">
+<button type="button" class="btn btn-outline-secondary mr-2" ngbPopover="What a great tip!" triggers="manual" #p="ngbPopover" (click)="p.open()" popoverTitle="Pop title">
   Click me to open a popover
 </button>
-<button type="button" class="btn btn-outline-secondary" (click)="p.close()">
+<button type="button" class="btn btn-outline-secondary mr-2" (click)="p.close()">
   Click me to close a popover
 </button>

--- a/demo/src/app/components/rating/demos/decimal/rating-decimal.html
+++ b/demo/src/app/components/rating/demos/decimal/rating-decimal.html
@@ -10,5 +10,5 @@
 
 <hr>
 <pre>Rate: <b>{{currentRate}}</b></pre>
-<button class="btn btn-sm btn-outline-primary" (click)="currentRate = 1.35">1.35</button>
-<button class="btn btn-sm btn-outline-primary" (click)="currentRate = 4.72">4.72</button>
+<button class="btn btn-sm btn-outline-primary mr-2" (click)="currentRate = 1.35">1.35</button>
+<button class="btn btn-sm btn-outline-primary mr-2" (click)="currentRate = 4.72">4.72</button>

--- a/demo/src/app/components/rating/demos/decimal/rating-decimal.ts
+++ b/demo/src/app/components/rating/demos/decimal/rating-decimal.ts
@@ -5,7 +5,7 @@ import {Component} from '@angular/core';
   templateUrl: './rating-decimal.html',
   styles: [`
     .star {
-      position: relative;  
+      position: relative;
       display: inline-block;
       font-size: 3rem;
       color: #d3d3d3;

--- a/demo/src/app/components/rating/demos/form/rating-form.html
+++ b/demo/src/app/components/rating/demos/form/rating-form.html
@@ -10,7 +10,7 @@
 
 <hr>
 <pre>Model: <b>{{ ctrl.value }}</b></pre>
-<button class="btn btn-sm btn-outline-{{ ctrl.disabled ? 'danger' : 'success'}}" (click)="toggle()">
+<button class="btn btn-sm btn-outline-{{ ctrl.disabled ? 'danger' : 'success'}} mr-2" (click)="toggle()">
   {{ ctrl.disabled ? "control disabled" : " control enabled" }}
 </button>
-<button class="btn btn-sm btn-outline-primary" (click)="ctrl.setValue(null)">Clear</button>
+<button class="btn btn-sm btn-outline-primary mr-2" (click)="ctrl.setValue(null)">Clear</button>

--- a/demo/src/app/components/shared/example-box/example-box.component.html
+++ b/demo/src/app/components/shared/example-box/example-box.component.html
@@ -32,7 +32,7 @@
       <ngb-tab id="{{component}}-{{demo}}-html">
         <ng-template ngbTabTitle>
           <small class="badge badge-secondary" title="HTML template">T</small>
-          <span>{{component}}-{{demo}}.html</span>
+          <span class="ml-2">{{component}}-{{demo}}.html</span>
         </ng-template>
         <ng-template ngbTabContent>
           <ngbd-code [code]="snippets[demo]['markup']" lang="html"></ngbd-code>
@@ -41,7 +41,7 @@
       <ngb-tab id="{{component}}-{{demo}}-typescript">
         <ng-template ngbTabTitle>
           <small class="badge badge-info" title="Component class">C</small>
-          <span>{{component}}-{{demo}}.ts</span>
+          <span class="ml-2">{{component}}-{{demo}}.ts</span>
         </ng-template>
         <ng-template ngbTabContent>
           <ngbd-code [code]="snippets[demo]['code']" lang="typescript"></ngbd-code>

--- a/demo/src/app/components/tooltip/demos/basic/tooltip-basic.html
+++ b/demo/src/app/components/tooltip/demos/basic/tooltip-basic.html
@@ -1,12 +1,12 @@
-<button type="button" class="btn btn-outline-secondary" placement="top" ngbTooltip="Tooltip on top">
+<button type="button" class="btn btn-outline-secondary mr-2" placement="top" ngbTooltip="Tooltip on top">
   Tooltip on top
 </button>
-<button type="button" class="btn btn-outline-secondary" placement="right" ngbTooltip="Tooltip on right">
+<button type="button" class="btn btn-outline-secondary mr-2" placement="right" ngbTooltip="Tooltip on right">
   Tooltip on right
 </button>
-<button type="button" class="btn btn-outline-secondary" placement="bottom" ngbTooltip="Tooltip on bottom">
+<button type="button" class="btn btn-outline-secondary mr-2" placement="bottom" ngbTooltip="Tooltip on bottom">
   Tooltip on bottom
 </button>
-<button type="button" class="btn btn-outline-secondary" placement="left" ngbTooltip="Tooltip on left">
+<button type="button" class="btn btn-outline-secondary mr-2" placement="left" ngbTooltip="Tooltip on left">
   Tooltip on left
 </button>

--- a/demo/src/app/components/tooltip/demos/container/tooltip-container.html
+++ b/demo/src/app/components/tooltip/demos/container/tooltip-container.html
@@ -2,9 +2,9 @@
 	Set the <code>container</code> property to "body" to have the tooltip be appended to the body instead of the triggering element's parent. This option is useful if the element triggering the tooltip is inside an element that clips its contents (i.e. <code>overflow: hidden</code>).
 </p>
 
-<div class='row'>
-	<div class='card'>
-		<button type="button" class="btn btn-outline-secondary"
+<div class="row">
+	<div class="card px-1 py-5">
+		<button type="button" class="btn btn-outline-secondary mb-2"
 						ngbTooltip="Vivamus sagittis lacus vel augue laoreet rutrum faucibus.">
 			Default tooltip
 		</button>

--- a/demo/src/app/components/tooltip/demos/container/tooltip-container.ts
+++ b/demo/src/app/components/tooltip/demos/container/tooltip-container.ts
@@ -3,7 +3,7 @@ import {Component} from '@angular/core';
 @Component({
   selector: 'ngbd-tooltip-container',
   templateUrl: './tooltip-container.html',
-  styles: ['.card { padding: 50px 0; text-align: center; overflow:hidden }']
+  styles: ['.card { overflow:hidden }']
 })
 export class NgbdTooltipContainer {
 }

--- a/demo/src/app/components/tooltip/demos/tplwithcontext/tooltip-tplwithcontext.html
+++ b/demo/src/app/components/tooltip/demos/tplwithcontext/tooltip-tplwithcontext.html
@@ -6,12 +6,12 @@
 <p>
   How would you like to greet <strong [ngbTooltip]="tipContent" #t="ngbTooltip" triggers="manual">me</strong>?
 </p>
-<button type="button" class="btn btn-outline-secondary" (click)="changeGreeting({ greeting: 'Bonjour' })">
+<button type="button" class="btn btn-outline-secondary mr-2" (click)="changeGreeting({ greeting: 'Bonjour' })">
   French
 </button>
-<button type="button" class="btn btn-outline-secondary" (click)="changeGreeting({ greeting: 'Gutentag' })">
+<button type="button" class="btn btn-outline-secondary mr-2" (click)="changeGreeting({ greeting: 'Gutentag' })">
   German
 </button>
-<button type="button" class="btn btn-outline-secondary" (click)="changeGreeting({ greeting: 'Hello' })">
+<button type="button" class="btn btn-outline-secondary mr-2" (click)="changeGreeting({ greeting: 'Hello' })">
   English
 </button>

--- a/demo/src/app/components/tooltip/demos/triggers/tooltip-triggers.html
+++ b/demo/src/app/components/tooltip/demos/triggers/tooltip-triggers.html
@@ -11,9 +11,9 @@
   Alternatively you can take full manual control over tooltip opening / closing events.
 </p>
 
-<button type="button" class="btn btn-outline-secondary" ngbTooltip="What a great tip!" triggers="manual" #t="ngbTooltip" (click)="t.open()">
+<button type="button" class="btn btn-outline-secondary mr-2" ngbTooltip="What a great tip!" triggers="manual" #t="ngbTooltip" (click)="t.open()">
   Click me to open a tooltip
 </button>
-<button type="button" class="btn btn-outline-secondary" (click)="t.close()">
+<button type="button" class="btn btn-outline-secondary mr-2" (click)="t.close()">
   Click me to close a tooltip
 </button>

--- a/demo/src/app/shared/component-wrapper/component-wrapper.component.html
+++ b/demo/src/app/shared/component-wrapper/component-wrapper.component.html
@@ -17,9 +17,8 @@
             <div class="examples-legend">
               <strong>Legend</strong>
               <p>
-                <ng-container *ngFor="let type of fileTypes; last as last">
-                  <small class="badge {{type[2]}}">{{type[0]}}</small> {{type[1]}}
-                  <ng-container *ngIf="!last">&nbsp;</ng-container>
+                <ng-container *ngFor="let type of fileTypes;">
+                  <small class="badge {{type[2]}} mr-2">{{type[0]}}</small>{{type[1]}}<br>
                 </ng-container>
               </p>
             </div>

--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -47,6 +47,10 @@
     width: 80%;
     font-size: 2rem;
     color: #fff;
+
+    a {
+      margin: 0 0.5rem;
+    }
   }
 
   .btn {
@@ -75,6 +79,10 @@
   ngbd-default & {
     text-align: center;
     margin-top: 2rem;
+  }
+
+  > iframe, > a {
+    margin-left: 0.5rem;
   }
 }
 
@@ -200,6 +208,7 @@ div.component-demo {
       text-decoration: none;
       opacity: 0.3;
       transition: opacity .5s;
+      margin-left: 0.3rem;
     }
     &:hover {
       .plunker, .stackblitz {

--- a/tsconfig-aot.json
+++ b/tsconfig-aot.json
@@ -19,7 +19,6 @@
     "./demo/src/*.ts"
   ],
   "angularCompilerOptions": {
-    "strictMetadataEmit": false,
-    "preserveWhitespaces": true
+    "strictMetadataEmit": false
   }
 }


### PR DESCRIPTION
This PR will adapt demo site to look the same as before with `preserveWhitespaces` turned off.

Alternatively we should pass the `"preserveWhitespaces": true` to JIT mode, not only for AOT