### PR TITLE
feat: clickoutside standalone service

### DIFF
--- a/src/util/clickoutside.spec.ts
+++ b/src/util/clickoutside.spec.ts
@@ -1,0 +1,84 @@
+import {Component, ElementRef, OnDestroy, ViewChild} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+
+import {NgbClickOutside, NgbClickOutsideFactory} from './clickoutside';
+
+const getElement = (element: HTMLElement, selector: string): HTMLElement => {
+  return element.querySelector(selector) as HTMLElement;
+};
+
+function dispatchEvent(element: HTMLElement, eventName: string) {
+  const event = document.createEvent('Event');
+  event.initEvent(eventName, true, true);
+  element.dispatchEvent(event);
+  return event;
+}
+
+describe('ngbClickoutside', () => {
+  let fixture;
+  let instance;
+  let coComponent;
+  beforeEach(() => {
+    TestBed.configureTestingModule(
+        {declarations: [TestComponent, ClickedOutsideComponent], providers: [NgbClickOutsideFactory]});
+    fixture = TestBed.createComponent(TestComponent);
+    instance = fixture.componentInstance;
+    coComponent = instance.coComponent;
+
+    fixture.detectChanges();
+  });
+
+  it('should be instantiated on a component', () => {
+    expect(fixture).toBeDefined();
+    expect(instance).toBeDefined();
+    expect(coComponent).toBeDefined();
+    expect(coComponent.clickOutside instanceof NgbClickOutside).toBeTruthy();
+  });
+
+  it('should execute callback when clicked on a parent', () => {
+    spyOn(coComponent, 'onClickOutside');
+    const parent = getElement(fixture.nativeElement, '.parent');
+    dispatchEvent(parent, 'click');
+    fixture.detectChanges();
+
+    expect(coComponent.onClickOutside).toHaveBeenCalled();
+  });
+
+  it('should not execute handler when clicked from a child', () => {
+    spyOn(coComponent, 'onClickOutside');
+    const child = getElement(fixture.nativeElement, '.child');
+    dispatchEvent(child, 'click');
+    fixture.detectChanges();
+
+    expect(coComponent.onClickOutside).not.toHaveBeenCalled();
+  });
+});
+
+@Component({
+  selector: 'clicked-outside',
+  template: `
+    <div class="child"></div>
+  `
+})
+class ClickedOutsideComponent implements OnDestroy {
+  private clickOutside: NgbClickOutside | null = null;
+
+  constructor(private clickFactory: NgbClickOutsideFactory, private element: ElementRef) {
+    this.clickOutside = this.clickFactory.create(this.element.nativeElement, event => this.onClickOutside(event));
+  }
+
+  ngOnDestroy() { this.clickOutside.destroy(); }
+
+  onClickOutside(event) {}
+}
+
+@Component({
+  template: `
+    <div class="parent">
+      <clicked-outside></clicked-outside>
+    </div>
+  `
+})
+class TestComponent {
+  @ViewChild(ClickedOutsideComponent) coComponent;
+}

--- a/src/util/clickoutside.ts
+++ b/src/util/clickoutside.ts
@@ -1,0 +1,62 @@
+import {DOCUMENT} from '@angular/common';
+import {Inject, Injectable, NgZone} from '@angular/core';
+
+/**
+ * Attach a global listener to the document to be executed
+ * whenever user click anywhere _outside_ of a
+ * given `element`.
+ *
+ * Should not be used directly. Use only via {@link NgbClickOutsideFactory}
+ * @private
+ */
+export class NgbClickOutside {
+  private removeListener: () => void;
+
+  /**
+   * @param element Element on which the clickoutside should be set
+   * @param callback Function used as the clickoutside listener
+   * @param document Document on which `mousedown` are listened
+   * @param ngZone The zone Angular is running in
+   */
+  constructor(
+      private _element: HTMLElement, private _callback: (event: MouseEvent) => void, document: Document,
+      private _ngZone: NgZone) {
+    this.onClick = this.onClick.bind(this);
+    this._ngZone.runOutsideAngular(() => {
+      document.addEventListener('click', this.onClick);
+
+      this.removeListener = () => { document.removeEventListener('click', this.onClick); };
+    });
+  }
+
+  /**
+   * Properly destroy the instance by cleaning event listener registered on document
+   */
+  destroy() { this.removeListener(); }
+
+  private onClick(event) {
+    if (!this._element.contains(event.target)) {
+      /* As the document listener is attached outside of the zone, we need to execute user callback inside for proper
+       * change detection to be triggered */
+      this._ngZone.run(() => this._callback(event));
+    }
+  }
+}
+
+/**
+ * Factory service to easily create a `ClickOutside` instance.
+ */
+@Injectable()
+export class NgbClickOutsideFactory {
+  constructor(@Inject(DOCUMENT) private document: Document, private ngZone: NgZone) {}
+
+  /**
+   * Create an instance of `ClickOutside` and return it.
+   * @param element HTMLElement on which the clickoutside should be activated
+   * @param callback Function to be executed whenever a click event occured from outside of element
+   * @returns a `ClickOutside` instance
+   */
+  create(element: HTMLElement, callback: (event: MouseEvent) => void): NgbClickOutside {
+    return new NgbClickOutside(element, callback, this.document, this.ngZone);
+  }
+}


### PR DESCRIPTION
This is a preliminary work to prepare better handling of _clickoutside_ feature on any widget using a popup.

This PR provides a single feature: a service detecting click performed outside of an element.
For now this is an internal service, not meant to be used publicly.

The full picture here is to use it where widget would display something as a popup.
Hence its lifecycle should be the same one as popup. You create/destroy them together.

Usage is simple
+ provide the service in the widget module `providers: [NgbClickOutsideFactory]`
+ inject it in the widget constructor `private _clickoutsideFactory: NgbClickOutsideFactory`
+ call the create method specifying an element & a callback. It returns an instance of `NgbClickOutside`
```typescript
this._clickOutside = this._clickOutsideFactory.create(element, event => { /* User clicked outside of element */ };
```
+ later on, when not needed, properly destroy it `this._clickOutside.destroy()`

---
I could see possible evolution to this feature:
+ specify a list of elements instead of a single one.
+ register 2 callbacks: one executed on capture phase, one on bubbling phase (the actual implementation is using bubbling)