### PR TITLE
fix(accordion): add 'accordion' css class

### DIFF
--- a/src/accordion/accordion.spec.ts
+++ b/src/accordion/accordion.spec.ts
@@ -1,4 +1,5 @@
 import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
 import {createGenericTestComponent} from '../test/common';
 
 import {Component} from '@angular/core';
@@ -71,6 +72,12 @@ describe('ngb-accordion', () => {
     expectOpenPanels(el, [false, false, false]);
     expect(accordionEl.getAttribute('role')).toBe('tablist');
     expect(accordionEl.getAttribute('aria-multiselectable')).toBe('true');
+  });
+
+  it('should have proper css classes', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+    const accordion = fixture.debugElement.query(By.directive(NgbAccordion));
+    expect(accordion.nativeElement).toHaveCssClass('accordion');
   });
 
   it('should toggle panels based on "activeIds" values', () => {

--- a/src/accordion/accordion.ts
+++ b/src/accordion/accordion.ts
@@ -110,7 +110,7 @@ export interface NgbPanelChangeEvent {
 @Component({
   selector: 'ngb-accordion',
   exportAs: 'ngbAccordion',
-  host: {'role': 'tablist', '[attr.aria-multiselectable]': '!closeOtherPanels'},
+  host: {'class': 'accordion', 'role': 'tablist', '[attr.aria-multiselectable]': '!closeOtherPanels'},
   template: `
     <ng-template ngFor let-panel [ngForOf]="panels">
       <div class="card">


### PR DESCRIPTION
For Bootstrap 4.1
Fixes double border on the accordion: https://github.com/twbs/bootstrap/pull/23839