### PR TITLE
docs: update popover-visibility example

### DIFF
--- a/demo/src/app/components/popover/demos/visibility/popover-visibility.html
+++ b/demo/src/app/components/popover/demos/visibility/popover-visibility.html
@@ -1,11 +1,11 @@
 <button type="button" class="btn btn-outline-secondary" placement="top"
         ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on top"
-        #popover="ngbPopover">
+        #popover="ngbPopover" (shown)="isOpen = true" (hidden)="isOpen = false">
   Open Popover
 </button>
 
 <hr />
 
 <p>
-  Popover is currently: <code>{{ popover.isOpen() ? 'open' : 'closed' }}</code>
+  Popover is currently: <code>{{ isOpen ? 'open' : 'closed' }}</code>
 </p>

--- a/demo/src/app/components/popover/demos/visibility/popover-visibility.ts
+++ b/demo/src/app/components/popover/demos/visibility/popover-visibility.ts
@@ -5,5 +5,5 @@ import {Component} from '@angular/core';
   templateUrl: './popover-visibility.html'
 })
 export class NgbdPopoverVisibility {
-
+  isOpen: boolean;
 }


### PR DESCRIPTION
Update example to use popover's `shown` and `hidden` events.
The current example is titled 'Popover visibility events',
but does not demonstrate binding to `shown` and `hidden` events

Before submitting a pull request, please make sure you have at least performed the following:

 - [X] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [X] built and tested the changes locally.
 - [] added/updated any applicable tests.
 - [] added/updated any applicable API documentation.
 - [X] added/updated any applicable demos.
