### PR TITLE
chore: bump up Angular dependency to 6.0.0-rc.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,18 +46,18 @@
   },
   "homepage": "https://github.com/ng-bootstrap/ng-bootstrap#readme",
   "dependencies": {
-    "@angular/common": "6.0.0-rc.3",
-    "@angular/core": "6.0.0-rc.3",
-    "@angular/forms": "6.0.0-rc.3",
-    "rxjs": "6.0.0-rc.1"
+    "@angular/common": "6.0.0-rc.4",
+    "@angular/core": "6.0.0-rc.4",
+    "@angular/forms": "6.0.0-rc.4",
+    "rxjs": "6.0.0-turbo-rc.4"
   },
   "devDependencies": {
-    "@angular/compiler": "6.0.0-rc.3",
-    "@angular/compiler-cli": "6.0.0-rc.3",
-    "@angular/http": "6.0.0-rc.3",
-    "@angular/platform-browser": "6.0.0-rc.3",
-    "@angular/platform-browser-dynamic": "6.0.0-rc.3",
-    "@angular/router": "6.0.0-rc.3",
+    "@angular/compiler": "6.0.0-rc.4",
+    "@angular/compiler-cli": "6.0.0-rc.4",
+    "@angular/http": "6.0.0-rc.4",
+    "@angular/platform-browser": "6.0.0-rc.4",
+    "@angular/platform-browser-dynamic": "6.0.0-rc.4",
+    "@angular/router": "6.0.0-rc.4",
     "@ngtools/webpack": "1.10.2",
     "@types/jasmine": "~2.8.3",
     "@types/node": "^6.0.46",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,60 +2,60 @@
 # yarn lockfile v1
 
 
-"@angular/common@6.0.0-rc.3":
-  version "6.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@angular/common/-/common-6.0.0-rc.3.tgz#361af1aaa19a24d42724c9088ecebe316f1c58e9"
+"@angular/common@6.0.0-rc.4":
+  version "6.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@angular/common/-/common-6.0.0-rc.4.tgz#3728fd8d3a39e36133720f25714d1a8af8fe7279"
   dependencies:
     tslib "^1.9.0"
 
-"@angular/compiler-cli@6.0.0-rc.3":
-  version "6.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-6.0.0-rc.3.tgz#4c42d9c369806dbeb30a0ed24d403c296d08f176"
+"@angular/compiler-cli@6.0.0-rc.4":
+  version "6.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-6.0.0-rc.4.tgz#4bfdbcec0cf613cbc3445b2e7c909ad52e2d1e4a"
   dependencies:
     chokidar "^1.4.2"
     minimist "^1.2.0"
     reflect-metadata "^0.1.2"
     tsickle "^0.27.2"
 
-"@angular/compiler@6.0.0-rc.3":
-  version "6.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-6.0.0-rc.3.tgz#bfe1b0de9a9cf0082f98c9e96374bb3b29e56e3c"
+"@angular/compiler@6.0.0-rc.4":
+  version "6.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-6.0.0-rc.4.tgz#a6247acec51fbecee7e62e0cd411da4362151c6b"
   dependencies:
     tslib "^1.9.0"
 
-"@angular/core@6.0.0-rc.3":
-  version "6.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-6.0.0-rc.3.tgz#be943f3f4e113c03a65bac7968e46995428fdf0d"
+"@angular/core@6.0.0-rc.4":
+  version "6.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-6.0.0-rc.4.tgz#a4f5e404d7b5e807dbca72230f08f4ab1143904e"
   dependencies:
     tslib "^1.9.0"
 
-"@angular/forms@6.0.0-rc.3":
-  version "6.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-6.0.0-rc.3.tgz#8f8f666e99b83e8db1862df66e900aed39c1859f"
+"@angular/forms@6.0.0-rc.4":
+  version "6.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-6.0.0-rc.4.tgz#98e38c0bad6a62077cccc14b4ac0fcc2bae31a23"
   dependencies:
     tslib "^1.9.0"
 
-"@angular/http@6.0.0-rc.3":
-  version "6.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@angular/http/-/http-6.0.0-rc.3.tgz#3be824888781557b6e3fc686b2a4b8100f200806"
+"@angular/http@6.0.0-rc.4":
+  version "6.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@angular/http/-/http-6.0.0-rc.4.tgz#d8f1f14073827ec348c87060d6f9fdad1a015c4c"
   dependencies:
     tslib "^1.9.0"
 
-"@angular/platform-browser-dynamic@6.0.0-rc.3":
-  version "6.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-6.0.0-rc.3.tgz#78c4cfd09bd9ab827948cd2baf9627cb1f48298a"
+"@angular/platform-browser-dynamic@6.0.0-rc.4":
+  version "6.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-6.0.0-rc.4.tgz#964602737b33777de217a87e76c3313b8470d15d"
   dependencies:
     tslib "^1.9.0"
 
-"@angular/platform-browser@6.0.0-rc.3":
-  version "6.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-6.0.0-rc.3.tgz#0df64aa7404d67c14ca7ea12db907ab32ee75a2b"
+"@angular/platform-browser@6.0.0-rc.4":
+  version "6.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-6.0.0-rc.4.tgz#339480bd74debaec79ed0fe73a2a7420c9e0f71f"
   dependencies:
     tslib "^1.9.0"
 
-"@angular/router@6.0.0-rc.3":
-  version "6.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@angular/router/-/router-6.0.0-rc.3.tgz#67e134582fae35fd395c87efd47f87efcd641a03"
+"@angular/router@6.0.0-rc.4":
+  version "6.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@angular/router/-/router-6.0.0-rc.4.tgz#4ee6acc105e8ad9d6d04de7c41e17f9385e952e0"
   dependencies:
     tslib "^1.9.0"
 
@@ -7056,9 +7056,9 @@ run-sequence@^1.2.2:
     chalk "*"
     gulp-util "*"
 
-rxjs@6.0.0-rc.1:
-  version "6.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.0.0-rc.1.tgz#24de21d36803d022c5823f44dc51eaf6074fa85c"
+rxjs@6.0.0-turbo-rc.4:
+  version "6.0.0-turbo-rc.4"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.0.0-turbo-rc.4.tgz#5995dab91914f03ee4a68d923678333ae626d2ec"
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
This is in preparation for cutting an 2.0.0-rc.0