### PR TITLE
fix(dropdown): correct dropup position with Bootstrap 4.1

### DIFF
--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -101,6 +101,22 @@ describe('ngb-dropdown', () => {
     expect(getDropdownEl(compiled)).toHaveCssClass('dropdown');
   });
 
+  it('should have x-placement attribute reflecting placement', () => {
+    const html = `
+      <div ngbDropdown placement="bottom-right">
+          <button ngbDropdownAnchor></button>
+          <div ngbDropdownMenu>
+            <a class="dropdown-item">dropDown item</a>
+            <a class="dropdown-item">dropDown item</a>
+          </div>
+      </div>`;
+
+    const fixture = createTestComponent(html);
+    const compiled = fixture.nativeElement;
+
+    expect(getMenuEl(compiled).getAttribute('x-placement')).toBe('bottom-right');
+  });
+
   it('should be open initially if open expression is true', () => {
     const html = `
       <div ngbDropdown [open]="true">

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -16,8 +16,10 @@ import {positionElements, PlacementArray, Placement} from '../util/positioning';
 
 /**
  */
-@Directive(
-    {selector: '[ngbDropdownMenu]', host: {'[class.dropdown-menu]': 'true', '[class.show]': 'dropdown.isOpen()'}})
+@Directive({
+  selector: '[ngbDropdownMenu]',
+  host: {'[class.dropdown-menu]': 'true', '[class.show]': 'dropdown.isOpen()', '[attr.x-placement]': 'placement'}
+})
 export class NgbDropdownMenu {
   placement: Placement = 'bottom';
   isOpen = false;


### PR DESCRIPTION
Fixes #2297

Not sure if this is the best fix...

Essentially we need to add `bottom` and `right` styles equal to `auto;` when a popup is open. We've got 2 options to do so:
- force styles with Angular bindings (but this is kind of "brutal" since people can't override those styles)
- use Bootstrap CSS classes as in this PR

Please let me know what you think - we can either get this PR in or have another fix with styles forced.