### PR TITLE
chore: update to Bootstrap 4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ View all the directives in action at https://ng-bootstrap.github.io
 
 ## Dependencies
 * [Angular](https://angular.io) (tested with 5.0.2)
-* [Bootstrap 4](https://www.getbootstrap.com) (tested with 4.0.0)
+* [Bootstrap 4](https://www.getbootstrap.com) (tested with 4.1.0)
 
 ## Installation
 After installing the above dependencies, install `ng-bootstrap` via:
@@ -89,7 +89,14 @@ See [this](https://github.com/angular/angular/blob/master/README.md) for up-to-d
 * Edge (20+)
 * Safari (7+)
 
-Also check [Bootstrap 4's notes](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/#supported-browsers) on browsers support.
+Also check [Bootstrap 4's notes](https://getbootstrap.com/docs/4.1/getting-started/browsers-devices/#supported-browsers) on browsers support.
+
+## Version compatibility
+
+| NG Bootstrap | Angular | Bootstrap |
+| :----------: |:-------:| :--------:|
+| ^2.0.0       | ^6.0.0  | ~4.1.0    |
+| ^1.0.0       | ^5.0.0  | ~4.0.0    |
 
 ## Contributing to the project
 

--- a/demo/src/app/getting-started/getting-started.component.html
+++ b/demo/src/app/getting-started/getting-started.component.html
@@ -11,7 +11,7 @@
       <a href="https://angular.io" target="_blank">Angular</a> (<em>requires</em> Angular version 5 or higher, tested with 5.0.2)
     </li>
     <li>
-      <a href="https://www.getbootstrap.com" target="_blank">Bootstrap CSS</a> (tested with 4.0.0)
+      <a href="https://www.getbootstrap.com" target="_blank">Bootstrap CSS</a> (tested with 4.1.0)
     </li>
   </ul>
 
@@ -26,7 +26,7 @@
   </h3>
   <p>We strive to support the same browsers and versions as supported by both Bootstrap 4 and Angular, whichever is more restrictive. Check browser support notes for
     <a href="https://angular.io/docs/ts/latest/guide/browser-support.html" target="_blank">Angular</a> and
-    <a href="https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/" target="_blank">Bootstrap</a>.
+    <a href="https://getbootstrap.com/docs/4.1/getting-started/browsers-devices/" target="_blank">Bootstrap</a>.
   </p>
   <p>Our code is automatically tested on all the supported browsers.</p>
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "angular2-template-loader": "^0.6.0",
     "async-done": "^1.2.2",
     "autoprefixer": "^7.2.2",
-    "bootstrap": "4.0.0",
+    "bootstrap": "4.1.0",
     "clang-format": "1.0.35",
     "copy-webpack-plugin": "^4.2.3",
     "core-js": "^2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -730,9 +730,9 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
-bootstrap@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.0.0.tgz#ceb03842c145fcc1b9b4e15da2a05656ba68469a"
+bootstrap@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.1.0.tgz#110b05c31a236d56dbc9adcda6dd16f53738a28a"
 
 brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
Add bootstrap 4.1 dependency for 2.0 milestone.

Add a table with version compatibility in the readme.