### PR TITLE
feat(modal): focustrap

### DIFF
--- a/src/modal/modal-window.spec.ts
+++ b/src/modal/modal-window.spec.ts
@@ -1,14 +1,15 @@
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 
-import {NgbModalWindow} from './modal-window';
+import {NgbFocusTrapFactory} from '../util/focus-trap';
 import {ModalDismissReasons} from './modal-dismiss-reasons';
+import {NgbModalWindow} from './modal-window';
 
 describe('ngb-modal-dialog', () => {
 
   let fixture: ComponentFixture<NgbModalWindow>;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({declarations: [NgbModalWindow]});
+    TestBed.configureTestingModule({declarations: [NgbModalWindow], providers: [NgbFocusTrapFactory]});
     fixture = TestBed.createComponent(NgbModalWindow);
   });
 

--- a/src/modal/modal.module.ts
+++ b/src/modal/modal.module.ts
@@ -1,9 +1,10 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {ModuleWithProviders, NgModule} from '@angular/core';
 
-import {NgbModalBackdrop} from './modal-backdrop';
-import {NgbModalWindow} from './modal-window';
-import {NgbModalStack} from './modal-stack';
+import {NgbFocusTrapFactory} from '../util/focus-trap';
 import {NgbModal} from './modal';
+import {NgbModalBackdrop} from './modal-backdrop';
+import {NgbModalStack} from './modal-stack';
+import {NgbModalWindow} from './modal-window';
 
 export {NgbModal, NgbModalOptions} from './modal';
 export {NgbModalRef, NgbActiveModal} from './modal-ref';
@@ -15,5 +16,7 @@ export {ModalDismissReasons} from './modal-dismiss-reasons';
   providers: [NgbModal]
 })
 export class NgbModalModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbModalModule, providers: [NgbModal, NgbModalStack]}; }
+  static forRoot(): ModuleWithProviders {
+    return {ngModule: NgbModalModule, providers: [NgbModal, NgbModalStack, NgbFocusTrapFactory]};
+  }
 }


### PR DESCRIPTION
Same as #2332.

Very rough implementation of focustrap for modals.
With current master implementation of focustrap that landed via 6961cb3, the bug described and fixed in #2328 is present.

This PR does not have any tests, as writing UT for that would end up in duplicating NgbFocusTrap UT.

Nonetheless, as soon as Protractor is setup on the project, we then can write a whole bunch of new dedicated tests.