### PR TITLE
feat(modal):  support for promises in beforeDismiss hook

### DIFF
--- a/src/modal/modal-ref.ts
+++ b/src/modal/modal-ref.ts
@@ -68,14 +68,31 @@ export class NgbModalRef {
     }
   }
 
+  private _dismiss(reason?: any) {
+    this._reject(reason);
+    this._removeModalElements();
+  }
+
   /**
    * Can be used to dismiss a modal, passing an optional reason.
    */
   dismiss(reason?: any): void {
     if (this._windowCmptRef) {
-      if (!this._beforeDismiss || this._beforeDismiss() !== false) {
-        this._reject(reason);
-        this._removeModalElements();
+      if (!this._beforeDismiss) {
+        this._dismiss(reason);
+      } else {
+        const dismiss = this._beforeDismiss();
+        if (dismiss && dismiss.then) {
+          dismiss.then(
+              result => {
+                if (result !== false) {
+                  this._dismiss(reason);
+                }
+              },
+              () => {});
+        } else if (dismiss !== false) {
+          this._dismiss(reason);
+        }
       }
     }
   }

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -9,7 +9,7 @@ import {
   Injector
 } from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {TestBed, ComponentFixture} from '@angular/core/testing';
+import {TestBed, ComponentFixture, async} from '@angular/core/testing';
 
 import {NgbModalModule, NgbModal, NgbActiveModal, NgbModalRef} from './modal.module';
 
@@ -392,6 +392,48 @@ describe('ngb-modal', () => {
       fixture.detectChanges();
       expect(fixture.nativeElement).not.toHaveModal();
     });
+
+    it('should not dismiss when the returned promise is resolved with false', async(() => {
+         const modalInstance = fixture.componentInstance.openTplDismiss({beforeDismiss: () => Promise.resolve(false)});
+         fixture.detectChanges();
+         expect(fixture.nativeElement).toHaveModal();
+
+         (<HTMLElement>document.querySelector('button#dismiss')).click();
+         fixture.detectChanges();
+         fixture.whenStable().then(() => {
+           expect(fixture.nativeElement).toHaveModal();
+
+           modalInstance.close();
+           fixture.detectChanges();
+           expect(fixture.nativeElement).not.toHaveModal();
+         });
+       }));
+
+    it('should not dismiss when the returned promise is rejected', async(() => {
+         const modalInstance = fixture.componentInstance.openTplDismiss({beforeDismiss: () => Promise.reject('error')});
+         fixture.detectChanges();
+         expect(fixture.nativeElement).toHaveModal();
+
+         (<HTMLElement>document.querySelector('button#dismiss')).click();
+         fixture.detectChanges();
+         fixture.whenStable().then(() => {
+           expect(fixture.nativeElement).toHaveModal();
+
+           modalInstance.close();
+           fixture.detectChanges();
+           expect(fixture.nativeElement).not.toHaveModal();
+         });
+       }));
+
+    it('should dismiss when the returned promise is not resolved with false', async(() => {
+         fixture.componentInstance.openTplDismiss({beforeDismiss: () => Promise.resolve()});
+         fixture.detectChanges();
+         expect(fixture.nativeElement).toHaveModal();
+
+         (<HTMLElement>document.querySelector('button#dismiss')).click();
+         fixture.detectChanges();
+         fixture.whenStable().then(() => { expect(fixture.nativeElement).not.toHaveModal(); });
+       }));
 
     it('should dismiss when the callback is not defined', () => {
       fixture.componentInstance.openTplDismiss({});

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -15,9 +15,10 @@ export interface NgbModalOptions {
 
   /**
    * Function called when a modal will be dismissed.
-   * If this function returns false, the modal is not dismissed.
+   * If this function returns false, the promise is resolved with false or the promise is rejected, the modal is not
+   * dismissed.
    */
-  beforeDismiss?: () => boolean;
+  beforeDismiss?: () => boolean | Promise<boolean>;
 
   /**
    * To center the modal vertically (false by default).


### PR DESCRIPTION
NgbModalOptions#beforeDismiss may now return a promise. The modal is closed if the promise is resolved with false or if it is rejected.

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.
