### PR TITLE
Fix: stop propagation from $event "closeFromClick"...

### DIFF
--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -190,14 +190,26 @@ export class NgbDropdown implements OnInit {
   }
 
   closeFromClick($event) {
-    if (this.autoClose && $event.button !== 2 && !this._isEventFromToggle($event)) {
+    if (!this.autoClose) {
+      return;
+    }
+    let doClose = false;
+    if ($event.button !== 2 && !this._isEventFromToggle($event)) {
       if (this.autoClose === true) {
-        this.close();
+        doClose = true;
       } else if (this.autoClose === 'inside' && this._isEventFromMenu($event)) {
-        this.close();
+        doClose = true;
       } else if (this.autoClose === 'outside' && !this._isEventFromMenu($event)) {
-        this.close();
+        doClose = true;
       }
+    }
+    if (doClose) {
+      if ($event) {
+        $event.preventDefault();
+        $event.stopImmediatePropagation();
+        $event.stopPropagation();
+      }
+      this.close();
     }
   }
 

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -106,7 +106,7 @@ export class NgbDropdownToggle extends NgbDropdownAnchor {
 })
 export class NgbDropdown implements OnInit {
   private _zoneSubscription: any;
-  private _documentClickListener: any;
+  private _documentClickListener: () => void;
 
   @ContentChild(NgbDropdownMenu) private _menu: NgbDropdownMenu;
 
@@ -144,6 +144,7 @@ export class NgbDropdown implements OnInit {
     this.placement = config.placement;
     this.autoClose = config.autoClose;
     this._zoneSubscription = ngZone.onStable.subscribe(() => { this._positionMenu(); });
+    this._documentClickListener = null;
   }
 
   ngOnInit() {
@@ -216,7 +217,10 @@ export class NgbDropdown implements OnInit {
     }
   }
 
-  ngOnDestroy() { this._zoneSubscription.unsubscribe(); }
+  ngOnDestroy() {
+    this._unbindDocumentClickListener();
+    this._zoneSubscription.unsubscribe();
+  }
 
   private _bindDocumentClickListener() {
     if (!this._documentClickListener) {

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -221,7 +221,7 @@ export class NgbDropdown implements OnInit {
 
   ngOnDestroy() { this._zoneSubscription.unsubscribe(); }
 
-  private _isEventFromToggle($event) { return this._anchor.isEventFrom($event); }
+  private _isEventFromToggle($event) { return this._anchor ? this._anchor.isEventFrom($event) : false; }
 
   private _isEventFromMenu($event) { return this._menu ? this._menu.isEventFrom($event) : false; }
 


### PR DESCRIPTION
Fix: stop propagation from $event "closeFromClick" of dropdown that cause execution of angular's digest lifecycle multiple times. 

More dropdown => more digest lifecycle.
