### PR TITLE
chore: use providedIn instead of forRoot()

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,21 +42,20 @@ Once installed you need to import our main module:
 ```js
 import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 ```
-The only remaining part is to list the imported module in your application module. The exact method will be slightly
-different for the root (top-level) module for which you should end up with the code similar to (notice `NgbModule.forRoot()`):
+The only remaining part is to list the imported module in your application module:
 ```js
 import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 
 @NgModule({
   declarations: [AppComponent, ...],
-  imports: [NgbModule.forRoot(), ...],  
+  imports: [NgbModule, ...],
   bootstrap: [AppComponent]
 })
 export class AppModule {
 }
 ```
 
-Other modules in your application can simply import `NgbModule`:
+Other modules in your application can also import `NgbModule`:
 
 ```js
 import {NgbModule} from '@ng-bootstrap/ng-bootstrap';

--- a/demo/src/app/app.module.ts
+++ b/demo/src/app/app.module.ts
@@ -19,7 +19,7 @@ import {NgbdSharedModule} from './shared';
   imports: [
     BrowserModule,
     routing,
-    NgbModule.forRoot(),
+    NgbModule,
     NgbdDemoModule,
     NgbdSharedModule
   ],

--- a/demo/src/app/getting-started/getting-started.component.html
+++ b/demo/src/app/getting-started/getting-started.component.html
@@ -43,13 +43,12 @@
 
   <p>
     The only remaining part is to list the imported module in your root module and any additional application modules that make use
-    of the components in this library. The exact method will be slightly different for the root (top-level) module for which you
-    should end up with the code similar to (notice <code>NgbModule.forRoot()</code>):
+    of the components in this library:
   </p>
 
   <ngbd-code [code]="codeRoot" lang="typescript"></ngbd-code>
 
-  <p>Other modules in your application can simply import <code>NgbModule</code>:</p>
+  <p>Other modules in your application can also import <code>NgbModule</code>:</p>
 
   <ngbd-code [code]="codeOther" lang="typescript"></ngbd-code>
   <br>

--- a/demo/src/app/getting-started/getting-started.component.ts
+++ b/demo/src/app/getting-started/getting-started.component.ts
@@ -15,7 +15,7 @@ import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 
 @NgModule({
   declarations: [AppComponent, ...],
-  imports: [NgbModule.forRoot(), ...],
+  imports: [NgbModule, ...],
   bootstrap: [AppComponent]
 })
 export class AppModule {

--- a/misc/plunk-gen.js
+++ b/misc/plunk-gen.js
@@ -32,7 +32,7 @@ import { ${demoImports} } from '${demoImport}';
   selector: 'my-app',
   template: \`
     <div class="container-fluid">
-    
+
     <hr>
     <p>
       This is a demo plnkr forked from the <strong>ng-bootstrap</strong> project: Angular powered Bootstrap.
@@ -48,7 +48,7 @@ export class App {
 }
 
 @NgModule({
-  imports: [BrowserModule, FormsModule, ReactiveFormsModule, HttpClientModule, NgbModule.forRoot()],
+  imports: [BrowserModule, FormsModule, ReactiveFormsModule, HttpClientModule, NgbModule],
   declarations: [App, ${demoImports}]${needsEntryCmpt ? `,\n  entryComponents: [${entryCmptClass}],` : ','}
   bootstrap: [App]
 })
@@ -119,7 +119,7 @@ function generateConfigJs() {
   return `var ver = {
     ng: '${versions.angular}'
   };
-  
+
   System.config({
   //use typescript for compilation
   transpiler: 'typescript',

--- a/misc/stackblitz-gen.js
+++ b/misc/stackblitz-gen.js
@@ -23,7 +23,7 @@ function generateStackblitzContent(componentName, demoName) {
 <body>
   <form id="mainForm" method="post" action="${stackblitzUrl}">
     <input type="hidden" name="description" value="Example usage of the ${componentName} widget from https://ng-bootstrap.github.io">
-${generateTags(['Angular', 'Bootstrap', 'ng-bootstrap', capitalize(componentName)])}  
+${generateTags(['Angular', 'Bootstrap', 'ng-bootstrap', capitalize(componentName)])}
 
     <input type="hidden" name="files[.angular-cli.json]" value="${he.encode(getStackblitzTemplate('.angular-cli.json'))}">
     <input type="hidden" name="files[index.html]" value="${he.encode(generateIndexHtml())}">
@@ -35,7 +35,7 @@ ${generateTags(['Angular', 'Bootstrap', 'ng-bootstrap', capitalize(componentName
     <input type="hidden" name="files[app/app.component.html]" value="${he.encode(generateAppComponentHtmlContent(componentName, demoName))}">
     <input type="hidden" name="files[app/${fileName}.ts]" value="${he.encode(codeContent)}">
     <input type="hidden" name="files[app/${fileName}.html]" value="${he.encode(markupContent)}">
-    
+
     <input type="hidden" name="dependencies" value="${he.encode(JSON.stringify(generateDependencies()))}">
   </form>
   <script>document.getElementById("mainForm").submit();</script>
@@ -59,7 +59,7 @@ function generateIndexHtml() {
   <body>
     <my-app>loading...</my-app>
   </body>
-  
+
 </html>`;
 }
 
@@ -68,7 +68,7 @@ function generateAppComponentHtmlContent(componentName, demoName) {
 
   return `
 <div class="container-fluid">
-    
+
   <hr>
 
   <p>
@@ -100,10 +100,10 @@ import { AppComponent } from './app.component';
 import { ${demoImports} } from '${demoImport}';
 
 @NgModule({
-  imports: [BrowserModule, FormsModule, ReactiveFormsModule, HttpClientModule, NgbModule.forRoot()], 
+  imports: [BrowserModule, FormsModule, ReactiveFormsModule, HttpClientModule, NgbModule],
   declarations: [AppComponent, ${demoImports}]${needsEntryCmpt ? `,\n  entryComponents: [${entryCmptClass}],` : ','}
   bootstrap: [AppComponent]
-}) 
+})
 export class AppModule {}
 `;
 }

--- a/src/accordion/accordion-config.ts
+++ b/src/accordion/accordion-config.ts
@@ -1,5 +1,4 @@
 import {Injectable} from '@angular/core';
-import {NgbAccordionModule} from './accordion.module';
 
 /**
  * Configuration service for the NgbAccordion component.

--- a/src/accordion/accordion-config.ts
+++ b/src/accordion/accordion-config.ts
@@ -1,11 +1,12 @@
 import {Injectable} from '@angular/core';
+import {NgbAccordionModule} from './accordion.module';
 
 /**
  * Configuration service for the NgbAccordion component.
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the accordions used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbAccordionConfig {
   closeOthers = false;
   type: string;

--- a/src/accordion/accordion.module.ts
+++ b/src/accordion/accordion.module.ts
@@ -11,5 +11,4 @@ const NGB_ACCORDION_DIRECTIVES = [NgbAccordion, NgbPanel, NgbPanelTitle, NgbPane
 
 @NgModule({declarations: NGB_ACCORDION_DIRECTIVES, exports: NGB_ACCORDION_DIRECTIVES, imports: [CommonModule]})
 export class NgbAccordionModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbAccordionModule, providers: [NgbAccordionConfig]}; }
 }

--- a/src/accordion/accordion.spec.ts
+++ b/src/accordion/accordion.spec.ts
@@ -56,7 +56,7 @@ describe('ngb-accordion', () => {
   `;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAccordionModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAccordionModule]});
     TestBed.overrideComponent(TestComponent, {set: {template: html}});
   });
 
@@ -578,7 +578,7 @@ describe('ngb-accordion', () => {
   describe('Custom config', () => {
     let config: NgbAccordionConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbAccordionModule.forRoot()]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbAccordionModule]}); });
 
     beforeEach(inject([NgbAccordionConfig], (c: NgbAccordionConfig) => {
       config = c;
@@ -603,7 +603,7 @@ describe('ngb-accordion', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbAccordionModule.forRoot()], providers: [{provide: NgbAccordionConfig, useValue: config}]});
+          {imports: [NgbAccordionModule], providers: [{provide: NgbAccordionConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/alert/alert-config.ts
+++ b/src/alert/alert-config.ts
@@ -5,7 +5,7 @@ import {Injectable} from '@angular/core';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the alerts used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbAlertConfig {
   dismissible = true;
   type = 'warning';

--- a/src/alert/alert.module.ts
+++ b/src/alert/alert.module.ts
@@ -9,5 +9,4 @@ export {NgbAlertConfig} from './alert-config';
 
 @NgModule({declarations: [NgbAlert], exports: [NgbAlert], imports: [CommonModule], entryComponents: [NgbAlert]})
 export class NgbAlertModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbAlertModule, providers: [NgbAlertConfig]}; }
 }

--- a/src/alert/alert.spec.ts
+++ b/src/alert/alert.spec.ts
@@ -24,8 +24,7 @@ function getCloseButtonIcon(element: HTMLElement): HTMLSpanElement {
 
 describe('ngb-alert', () => {
 
-  beforeEach(
-      () => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAlertModule.forRoot()]}); });
+  beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAlertModule]}); });
 
   it('should initialize inputs with default values', () => {
     const defaultConfig = new NgbAlertConfig();
@@ -95,7 +94,7 @@ describe('ngb-alert', () => {
   describe('Custom config', () => {
     let config: NgbAlertConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbAlertModule.forRoot()]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbAlertModule]}); });
 
     beforeEach(inject([NgbAlertConfig], (c: NgbAlertConfig) => {
       config = c;
@@ -120,7 +119,7 @@ describe('ngb-alert', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbAlertModule.forRoot()], providers: [{provide: NgbAlertConfig, useValue: config}]});
+          {imports: [NgbAlertModule], providers: [{provide: NgbAlertConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/buttons/buttons.module.ts
+++ b/src/buttons/buttons.module.ts
@@ -12,5 +12,4 @@ const NGB_BUTTON_DIRECTIVES = [NgbButtonLabel, NgbCheckBox, NgbRadioGroup, NgbRa
 
 @NgModule({declarations: NGB_BUTTON_DIRECTIVES, exports: NGB_BUTTON_DIRECTIVES})
 export class NgbButtonsModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbButtonsModule, providers: []}; }
 }

--- a/src/carousel/carousel-config.ts
+++ b/src/carousel/carousel-config.ts
@@ -5,7 +5,7 @@ import {Injectable} from '@angular/core';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the carousels used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbCarouselConfig {
   interval = 5000;
   wrap = true;

--- a/src/carousel/carousel.module.ts
+++ b/src/carousel/carousel.module.ts
@@ -9,5 +9,4 @@ export {NgbCarouselConfig} from './carousel-config';
 
 @NgModule({declarations: NGB_CAROUSEL_DIRECTIVES, exports: NGB_CAROUSEL_DIRECTIVES, imports: [CommonModule]})
 export class NgbCarouselModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbCarouselModule, providers: [NgbCarouselConfig]}; }
 }

--- a/src/carousel/carousel.spec.ts
+++ b/src/carousel/carousel.spec.ts
@@ -30,9 +30,7 @@ function expectActiveSlides(nativeEl: HTMLDivElement, active: boolean[]) {
 }
 
 describe('ngb-carousel', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbCarouselModule.forRoot()]});
-  });
+  beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbCarouselModule]}); });
 
   it('should initialize inputs with default values', () => {
     const defaultConfig = new NgbCarouselConfig();
@@ -474,7 +472,7 @@ describe('ngb-carousel', () => {
   describe('Custom config', () => {
     let config: NgbCarouselConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbCarouselModule.forRoot()]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbCarouselModule]}); });
 
     beforeEach(inject([NgbCarouselConfig], (c: NgbCarouselConfig) => {
       config = c;
@@ -502,7 +500,7 @@ describe('ngb-carousel', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbCarouselModule.forRoot()], providers: [{provide: NgbCarouselConfig, useValue: config}]});
+          {imports: [NgbCarouselModule], providers: [{provide: NgbCarouselConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/collapse/collapse.module.ts
+++ b/src/collapse/collapse.module.ts
@@ -5,5 +5,4 @@ export {NgbCollapse} from './collapse';
 
 @NgModule({declarations: [NgbCollapse], exports: [NgbCollapse]})
 export class NgbCollapseModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbCollapseModule, providers: []}; }
 }

--- a/src/datepicker/datepicker-config.ts
+++ b/src/datepicker/datepicker-config.ts
@@ -7,7 +7,7 @@ import {NgbDateStruct} from './ngb-date-struct';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the datepickers used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbDatepickerConfig {
   dayTemplate: TemplateRef<DayTemplateContext>;
   displayMonths = 1;

--- a/src/datepicker/datepicker-day-view.spec.ts
+++ b/src/datepicker/datepicker-day-view.spec.ts
@@ -13,7 +13,7 @@ describe('ngbDatepickerDayView', () => {
 
   beforeEach(() => {
     TestBed.overrideModule(NgbDatepickerModule, {set: {exports: [NgbDatepickerDayView]}});
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule]});
   });
 
   it('should display date', () => {

--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -20,8 +20,7 @@ const createTestNativeCmpt = (html: string) =>
 describe('NgbInputDatepicker', () => {
 
   beforeEach(() => {
-    TestBed.configureTestingModule(
-        {declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot(), FormsModule]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule, FormsModule]});
   });
 
   describe('open, close and toggle', () => {
@@ -691,7 +690,7 @@ describe('NgbInputDatepicker', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         declarations: [TestNativeComponent],
-        imports: [NgbDatepickerModule.forRoot(), FormsModule],
+        imports: [NgbDatepickerModule, FormsModule],
         providers: [{provide: NgbDateAdapter, useClass: NgbDateNativeAdapter}]
       });
     });

--- a/src/datepicker/datepicker-integration.spec.ts
+++ b/src/datepicker/datepicker-integration.spec.ts
@@ -8,9 +8,8 @@ import {NgbDatepickerI18n, NgbDatepickerI18nDefault} from './datepicker-i18n';
 
 describe('ngb-datepicker integration', () => {
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot()]});
-  });
+  beforeEach(
+      () => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule]}); });
 
   it('should allow overriding datepicker calendar', () => {
 

--- a/src/datepicker/datepicker-month-view.spec.ts
+++ b/src/datepicker/datepicker-month-view.spec.ts
@@ -43,7 +43,7 @@ describe('ngb-datepicker-month-view', () => {
 
   beforeEach(() => {
     TestBed.overrideModule(NgbDatepickerModule, {set: {exports: [NgbDatepickerMonthView, NgbDatepickerDayView]}});
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule]});
   });
 
   it('should show/hide weekdays', () => {

--- a/src/datepicker/datepicker-navigation-select.spec.ts
+++ b/src/datepicker/datepicker-navigation-select.spec.ts
@@ -26,7 +26,7 @@ describe('ngb-datepicker-navigation-select', () => {
 
   beforeEach(() => {
     TestBed.overrideModule(NgbDatepickerModule, {set: {exports: [NgbDatepickerNavigationSelect]}});
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule]});
   });
 
   it('should generate month options correctly', () => {

--- a/src/datepicker/datepicker-navigation.spec.ts
+++ b/src/datepicker/datepicker-navigation.spec.ts
@@ -26,7 +26,7 @@ describe('ngb-datepicker-navigation', () => {
   beforeEach(() => {
     TestBed.overrideModule(
         NgbDatepickerModule, {set: {exports: [NgbDatepickerNavigation, NgbDatepickerNavigationSelect]}});
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule]});
   });
 
   it('should toggle navigation select component', () => {

--- a/src/datepicker/datepicker.module.ts
+++ b/src/datepicker/datepicker.module.ts
@@ -38,18 +38,13 @@ export {NgbDateParserFormatter} from './ngb-date-parser-formatter';
   ],
   exports: [NgbDatepicker, NgbInputDatepicker],
   imports: [CommonModule, FormsModule],
-  entryComponents: [NgbDatepicker]
+  entryComponents: [NgbDatepicker],
+  providers: [
+    {provide: NgbCalendar, useClass: NgbCalendarGregorian},
+    {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nDefault},
+    {provide: NgbDateParserFormatter, useClass: NgbDateISOParserFormatter},
+    {provide: NgbDateAdapter, useClass: NgbDateStructAdapter}, NgbFocusTrapFactory, DatePipe
+  ]
 })
 export class NgbDatepickerModule {
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: NgbDatepickerModule,
-      providers: [
-        {provide: NgbCalendar, useClass: NgbCalendarGregorian},
-        {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nDefault},
-        {provide: NgbDateParserFormatter, useClass: NgbDateISOParserFormatter},
-        {provide: NgbDateAdapter, useClass: NgbDateStructAdapter}, NgbDatepickerConfig, NgbFocusTrapFactory, DatePipe
-      ]
-    };
-  }
 }

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -140,7 +140,7 @@ describe('ngb-datepicker', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule(
-        {declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot(), FormsModule, ReactiveFormsModule]});
+        {declarations: [TestComponent], imports: [NgbDatepickerModule, FormsModule, ReactiveFormsModule]});
   });
 
   it('should initialize inputs with provided config', () => {
@@ -1021,7 +1021,7 @@ describe('ngb-datepicker', () => {
   describe('Custom config', () => {
     let config: NgbDatepickerConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbDatepickerModule.forRoot()]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbDatepickerModule]}); });
 
     beforeEach(inject([NgbDatepickerConfig], (c: NgbDatepickerConfig) => {
       config = c;
@@ -1042,7 +1042,7 @@ describe('ngb-datepicker', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbDatepickerModule.forRoot()], providers: [{provide: NgbDatepickerConfig, useValue: config}]});
+          {imports: [NgbDatepickerModule], providers: [{provide: NgbDatepickerConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/dropdown/dropdown-config.ts
+++ b/src/dropdown/dropdown-config.ts
@@ -6,7 +6,7 @@ import {PlacementArray} from '../util/positioning';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the dropdowns used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbDropdownConfig {
   autoClose: boolean | 'outside' | 'inside' = true;
   placement: PlacementArray = 'bottom-left';

--- a/src/dropdown/dropdown.module.ts
+++ b/src/dropdown/dropdown.module.ts
@@ -9,5 +9,4 @@ const NGB_DROPDOWN_DIRECTIVES = [NgbDropdown, NgbDropdownAnchor, NgbDropdownTogg
 
 @NgModule({declarations: NGB_DROPDOWN_DIRECTIVES, exports: NGB_DROPDOWN_DIRECTIVES})
 export class NgbDropdownModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbDropdownModule, providers: [NgbDropdownConfig]}; }
 }

--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -50,7 +50,7 @@ describe('ngb-dropdown', () => {
 
   beforeEach(() => {
     jasmine.addMatchers(jasmineMatchers);
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDropdownModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDropdownModule]});
   });
 
   it('should be closed and down by default', () => {
@@ -245,7 +245,7 @@ describe('ngb-dropdown', () => {
 describe('ngb-dropdown-toggle', () => {
   beforeEach(() => {
     jasmine.addMatchers(jasmineMatchers);
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDropdownModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDropdownModule]});
   });
 
   it('should toggle dropdown on click', () => {
@@ -547,7 +547,7 @@ describe('ngb-dropdown-toggle', () => {
     let config: NgbDropdownConfig;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({imports: [NgbDropdownModule.forRoot()]});
+      TestBed.configureTestingModule({imports: [NgbDropdownModule]});
       TestBed.overrideComponent(TestComponent, {
         set: {
           template: `
@@ -582,7 +582,7 @@ describe('ngb-dropdown-toggle', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbDropdownModule.forRoot()], providers: [{provide: NgbDropdownConfig, useValue: config}]});
+          {imports: [NgbDropdownModule], providers: [{provide: NgbDropdownConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,20 +83,6 @@ const NGB_MODULES = [
   NgbTabsetModule, NgbTimepickerModule, NgbTooltipModule, NgbTypeaheadModule
 ];
 
-@NgModule({
-  imports: [
-    NgbAlertModule.forRoot(), NgbButtonsModule.forRoot(), NgbCollapseModule.forRoot(), NgbProgressbarModule.forRoot(),
-    NgbTooltipModule.forRoot(), NgbTypeaheadModule.forRoot(), NgbAccordionModule.forRoot(), NgbCarouselModule.forRoot(),
-    NgbDatepickerModule.forRoot(), NgbDropdownModule.forRoot(), NgbModalModule.forRoot(), NgbPaginationModule.forRoot(),
-    NgbPopoverModule.forRoot(), NgbProgressbarModule.forRoot(), NgbRatingModule.forRoot(), NgbTabsetModule.forRoot(),
-    NgbTimepickerModule.forRoot(), NgbTooltipModule.forRoot()
-  ],
-  exports: NGB_MODULES
-})
-export class NgbRootModule {
-}
-
 @NgModule({imports: NGB_MODULES, exports: NGB_MODULES})
 export class NgbModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbRootModule}; }
 }

--- a/src/modal/modal-stack.ts
+++ b/src/modal/modal-stack.ts
@@ -17,7 +17,7 @@ import {NgbModalBackdrop} from './modal-backdrop';
 import {NgbModalWindow} from './modal-window';
 import {NgbActiveModal, NgbModalRef} from './modal-ref';
 
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbModalStack {
   private _document: any;
   private _windowAttributes = ['backdrop', 'centered', 'keyboard', 'size', 'windowClass'];

--- a/src/modal/modal.module.ts
+++ b/src/modal/modal.module.ts
@@ -2,7 +2,6 @@ import {NgModule, ModuleWithProviders} from '@angular/core';
 
 import {NgbModalBackdrop} from './modal-backdrop';
 import {NgbModalWindow} from './modal-window';
-import {NgbModalStack} from './modal-stack';
 import {NgbModal} from './modal';
 
 export {NgbModal, NgbModalOptions} from './modal';
@@ -15,5 +14,4 @@ export {ModalDismissReasons} from './modal-dismiss-reasons';
   providers: [NgbModal]
 })
 export class NgbModalModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbModalModule, providers: [NgbModal, NgbModalStack]}; }
 }

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -699,7 +699,7 @@ class TestComponent {
 @NgModule({
   declarations: [TestComponent, CustomInjectorCmpt, DestroyableCmpt, WithActiveModalCmpt],
   exports: [TestComponent, DestroyableCmpt],
-  imports: [CommonModule, NgbModalModule.forRoot()],
+  imports: [CommonModule, NgbModalModule],
   entryComponents: [CustomInjectorCmpt, DestroyableCmpt, WithActiveModalCmpt],
   providers: [SpyService]
 })

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -63,7 +63,7 @@ export interface NgbModalOptions {
  * A service to open modal windows. Creating a modal is straightforward: create a template and pass it as an argument to
  * the "open" method!
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbModal {
   constructor(
       private _moduleCFR: ComponentFactoryResolver, private _injector: Injector, private _modalStack: NgbModalStack) {}

--- a/src/pagination/pagination-config.ts
+++ b/src/pagination/pagination-config.ts
@@ -5,7 +5,7 @@ import {Injectable} from '@angular/core';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the paginations used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbPaginationConfig {
   disabled = false;
   boundaryLinks = false;

--- a/src/pagination/pagination.module.ts
+++ b/src/pagination/pagination.module.ts
@@ -9,5 +9,4 @@ export {NgbPaginationConfig} from './pagination-config';
 
 @NgModule({declarations: [NgbPagination], exports: [NgbPagination], imports: [CommonModule]})
 export class NgbPaginationModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbPaginationModule, providers: [NgbPaginationConfig]}; }
 }

--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -140,9 +140,8 @@ describe('ngb-pagination', () => {
 
   describe('UI logic', () => {
 
-    beforeEach(() => {
-      TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPaginationModule.forRoot()]});
-    });
+    beforeEach(
+        () => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPaginationModule]}); });
 
     it('should render and respond to collectionSize change', () => {
       const html = '<ngb-pagination [collectionSize]="collectionSize" [page]="1"></ngb-pagination>';
@@ -593,7 +592,7 @@ describe('ngb-pagination', () => {
   describe('Custom config', () => {
     let config: NgbPaginationConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbPaginationModule.forRoot()]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbPaginationModule]}); });
 
     beforeEach(inject([NgbPaginationConfig], (c: NgbPaginationConfig) => {
       config = c;
@@ -628,7 +627,7 @@ describe('ngb-pagination', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbPaginationModule.forRoot()], providers: [{provide: NgbPaginationConfig, useValue: config}]});
+          {imports: [NgbPaginationModule], providers: [{provide: NgbPaginationConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/popover/popover-config.ts
+++ b/src/popover/popover-config.ts
@@ -6,7 +6,7 @@ import {PlacementArray} from '../util/positioning';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the popovers used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbPopoverConfig {
   placement: PlacementArray = 'top';
   triggers = 'click';

--- a/src/popover/popover.module.ts
+++ b/src/popover/popover.module.ts
@@ -10,5 +10,4 @@ export {Placement} from '../util/positioning';
 
 @NgModule({declarations: [NgbPopover, NgbPopoverWindow], exports: [NgbPopover], entryComponents: [NgbPopoverWindow]})
 export class NgbPopoverModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbPopoverModule, providers: [NgbPopoverConfig]}; }
 }

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -20,9 +20,7 @@ const createOnPushTestComponent =
     (html: string) => <ComponentFixture<TestOnPushComponent>>createGenericTestComponent(html, TestOnPushComponent);
 
 describe('ngb-popover-window', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPopoverModule.forRoot()]});
-  });
+  beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPopoverModule]}); });
 
   it('should render popover on top by default', () => {
     const fixture = TestBed.createComponent(NgbPopoverWindow);
@@ -48,7 +46,7 @@ describe('ngb-popover', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [TestComponent, TestOnPushComponent, DestroyableCmpt],
-      imports: [NgbPopoverModule.forRoot()],
+      imports: [NgbPopoverModule],
       providers: [SpyService]
     });
   });
@@ -427,9 +425,7 @@ describe('ngb-popover', () => {
   });
 
   describe('triggers', () => {
-    beforeEach(() => {
-      TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPopoverModule.forRoot()]});
-    });
+    beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPopoverModule]}); });
 
     it('should support toggle triggers', () => {
       const fixture = createTestComponent(`<div ngbPopover="Great tip!" triggers="click"></div>`);
@@ -540,7 +536,7 @@ describe('ngb-popover', () => {
     let config: NgbPopoverConfig;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({imports: [NgbPopoverModule.forRoot()]});
+      TestBed.configureTestingModule({imports: [NgbPopoverModule]});
       TestBed.overrideComponent(TestComponent, {set: {template: `<div ngbPopover="Great tip!"></div>`}});
     });
 
@@ -570,7 +566,7 @@ describe('ngb-popover', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbPopoverModule.forRoot()], providers: [{provide: NgbPopoverConfig, useValue: config}]});
+          {imports: [NgbPopoverModule], providers: [{provide: NgbPopoverConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/progressbar/progressbar-config.ts
+++ b/src/progressbar/progressbar-config.ts
@@ -5,7 +5,7 @@ import {Injectable} from '@angular/core';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the progress bars used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbProgressbarConfig {
   max = 100;
   animated = false;

--- a/src/progressbar/progressbar.module.ts
+++ b/src/progressbar/progressbar.module.ts
@@ -9,5 +9,4 @@ export {NgbProgressbarConfig} from './progressbar-config';
 
 @NgModule({declarations: [NgbProgressbar], exports: [NgbProgressbar], imports: [CommonModule]})
 export class NgbProgressbarModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbProgressbarModule, providers: [NgbProgressbarConfig]}; }
 }

--- a/src/progressbar/progressbar.spec.ts
+++ b/src/progressbar/progressbar.spec.ts
@@ -89,9 +89,8 @@ describe('ngb-progressbar', () => {
 
   describe('UI logic', () => {
 
-    beforeEach(() => {
-      TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbProgressbarModule.forRoot()]});
-    });
+    beforeEach(
+        () => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbProgressbarModule]}); });
 
     it('accepts a value and respond to value changes', () => {
       const html = '<ngb-progressbar [value]="value"></ngb-progressbar>';
@@ -219,7 +218,7 @@ describe('ngb-progressbar', () => {
   describe('Custom config', () => {
     let config: NgbProgressbarConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbProgressbarModule.forRoot()]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbProgressbarModule]}); });
 
     beforeEach(inject([NgbProgressbarConfig], (c: NgbProgressbarConfig) => {
       config = c;
@@ -250,7 +249,7 @@ describe('ngb-progressbar', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbProgressbarModule.forRoot()], providers: [{provide: NgbProgressbarConfig, useValue: config}]});
+          {imports: [NgbProgressbarModule], providers: [{provide: NgbProgressbarConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/rating/rating-config.ts
+++ b/src/rating/rating-config.ts
@@ -5,7 +5,7 @@ import {Injectable} from '@angular/core';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the ratings used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbRatingConfig {
   max = 10;
   readonly = false;

--- a/src/rating/rating.module.ts
+++ b/src/rating/rating.module.ts
@@ -9,5 +9,4 @@ export {NgbRatingConfig} from './rating-config';
 
 @NgModule({declarations: [NgbRating], exports: [NgbRating], imports: [CommonModule]})
 export class NgbRatingModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbRatingModule, providers: [NgbRatingConfig]}; }
 }

--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -57,7 +57,7 @@ function getStateText(compiled) {
 describe('ngb-rating', () => {
   beforeEach(() => {
     TestBed.configureTestingModule(
-        {declarations: [TestComponent], imports: [NgbRatingModule.forRoot(), FormsModule, ReactiveFormsModule]});
+        {declarations: [TestComponent], imports: [NgbRatingModule, FormsModule, ReactiveFormsModule]});
   });
 
   it('should initialize inputs with default values', () => {
@@ -672,7 +672,7 @@ describe('ngb-rating', () => {
   describe('Custom config', () => {
     let config: NgbRatingConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbRatingModule.forRoot()]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbRatingModule]}); });
 
     beforeEach(inject([NgbRatingConfig], (c: NgbRatingConfig) => {
       config = c;
@@ -697,7 +697,7 @@ describe('ngb-rating', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbRatingModule.forRoot()], providers: [{provide: NgbRatingConfig, useValue: config}]});
+          {imports: [NgbRatingModule], providers: [{provide: NgbRatingConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/tabset/tabset-config.ts
+++ b/src/tabset/tabset-config.ts
@@ -5,7 +5,7 @@ import {Injectable} from '@angular/core';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the tabsets used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbTabsetConfig {
   justify: 'start' | 'center' | 'end' | 'fill' | 'justified' = 'start';
   orientation: 'horizontal' | 'vertical' = 'horizontal';

--- a/src/tabset/tabset.module.ts
+++ b/src/tabset/tabset.module.ts
@@ -11,5 +11,4 @@ const NGB_TABSET_DIRECTIVES = [NgbTabset, NgbTab, NgbTabContent, NgbTabTitle];
 
 @NgModule({declarations: NGB_TABSET_DIRECTIVES, exports: NGB_TABSET_DIRECTIVES, imports: [CommonModule]})
 export class NgbTabsetModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbTabsetModule, providers: [NgbTabsetConfig]}; }
 }

--- a/src/tabset/tabset.spec.ts
+++ b/src/tabset/tabset.spec.ts
@@ -56,8 +56,7 @@ function getButton(nativeEl: HTMLElement) {
 }
 
 describe('ngb-tabset', () => {
-  beforeEach(
-      () => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTabsetModule.forRoot()]}); });
+  beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTabsetModule]}); });
 
   it('should initialize inputs with default values', () => {
     const defaultConfig = new NgbTabsetConfig();
@@ -541,7 +540,7 @@ describe('ngb-tabset', () => {
   describe('Custom config', () => {
     let config: NgbTabsetConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbTabsetModule.forRoot()]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbTabsetModule]}); });
 
     beforeEach(inject([NgbTabsetConfig], (c: NgbTabsetConfig) => {
       config = c;
@@ -563,7 +562,7 @@ describe('ngb-tabset', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbTabsetModule.forRoot()], providers: [{provide: NgbTabsetConfig, useValue: config}]});
+          {imports: [NgbTabsetModule], providers: [{provide: NgbTabsetConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/timepicker/timepicker-config.ts
+++ b/src/timepicker/timepicker-config.ts
@@ -5,7 +5,7 @@ import {Injectable} from '@angular/core';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the timepickers used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbTimepickerConfig {
   meridian = false;
   spinners = true;

--- a/src/timepicker/timepicker.module.ts
+++ b/src/timepicker/timepicker.module.ts
@@ -10,5 +10,4 @@ export {NgbTimeStruct} from './ngb-time-struct';
 
 @NgModule({declarations: [NgbTimepicker], exports: [NgbTimepicker], imports: [CommonModule]})
 export class NgbTimepickerModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbTimepickerModule, providers: [NgbTimepickerConfig]}; }
 }

--- a/src/timepicker/timepicker.spec.ts
+++ b/src/timepicker/timepicker.spec.ts
@@ -77,7 +77,7 @@ describe('ngb-timepicker', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule(
-        {declarations: [TestComponent], imports: [NgbTimepickerModule.forRoot(), FormsModule, ReactiveFormsModule]});
+        {declarations: [TestComponent], imports: [NgbTimepickerModule, FormsModule, ReactiveFormsModule]});
   });
 
   describe('initialization', () => {
@@ -1125,7 +1125,7 @@ describe('ngb-timepicker', () => {
     let config: NgbTimepickerConfig;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({imports: [NgbTimepickerModule.forRoot()]});
+      TestBed.configureTestingModule({imports: [NgbTimepickerModule]});
       TestBed.overrideComponent(NgbTimepicker, {set: {template: ''}});
     });
 
@@ -1148,7 +1148,7 @@ describe('ngb-timepicker', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbTimepickerModule.forRoot()], providers: [{provide: NgbTimepickerConfig, useValue: config}]});
+          {imports: [NgbTimepickerModule], providers: [{provide: NgbTimepickerConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/tooltip/tooltip-config.ts
+++ b/src/tooltip/tooltip-config.ts
@@ -6,7 +6,7 @@ import {PlacementArray} from '../util/positioning';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the tooltips used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbTooltipConfig {
   placement: PlacementArray = 'top';
   triggers = 'hover';

--- a/src/tooltip/tooltip.module.ts
+++ b/src/tooltip/tooltip.module.ts
@@ -10,5 +10,4 @@ export {Placement} from '../util/positioning';
 
 @NgModule({declarations: [NgbTooltip, NgbTooltipWindow], exports: [NgbTooltip], entryComponents: [NgbTooltipWindow]})
 export class NgbTooltipModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbTooltipModule, providers: [NgbTooltipConfig]}; }
 }

--- a/src/tooltip/tooltip.spec.ts
+++ b/src/tooltip/tooltip.spec.ts
@@ -15,7 +15,7 @@ const createOnPushTestComponent =
     (html: string) => <ComponentFixture<TestOnPushComponent>>createGenericTestComponent(html, TestOnPushComponent);
 
 describe('ngb-tooltip-window', () => {
-  beforeEach(() => { TestBed.configureTestingModule({imports: [NgbTooltipModule.forRoot()]}); });
+  beforeEach(() => { TestBed.configureTestingModule({imports: [NgbTooltipModule]}); });
 
   it('should render tooltip on top by default', () => {
     const fixture = TestBed.createComponent(NgbTooltipWindow);
@@ -37,8 +37,7 @@ describe('ngb-tooltip-window', () => {
 describe('ngb-tooltip', () => {
 
   beforeEach(() => {
-    TestBed.configureTestingModule(
-        {declarations: [TestComponent, TestOnPushComponent], imports: [NgbTooltipModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent, TestOnPushComponent], imports: [NgbTooltipModule]});
   });
 
   function getWindow(element) { return element.querySelector('ngb-tooltip-window'); }
@@ -480,7 +479,7 @@ describe('ngb-tooltip', () => {
     let config: NgbTooltipConfig;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({imports: [NgbTooltipModule.forRoot()]});
+      TestBed.configureTestingModule({imports: [NgbTooltipModule]});
       TestBed.overrideComponent(TestComponent, {set: {template: `<div ngbTooltip="Great tip!"></div>`}});
     });
 
@@ -510,7 +509,7 @@ describe('ngb-tooltip', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbTooltipModule.forRoot()], providers: [{provide: NgbTooltipConfig, useValue: config}]});
+          {imports: [NgbTooltipModule], providers: [{provide: NgbTooltipConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/typeahead/highlight.spec.ts
+++ b/src/typeahead/highlight.spec.ts
@@ -36,7 +36,7 @@ describe('ngb-highlight', () => {
 
   beforeEach(() => {
     TestBed.overrideModule(NgbTypeaheadModule, {set: {exports: [NgbHighlight]}});
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTypeaheadModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTypeaheadModule]});
   });
 
   it('should render highlighted text when there is one match', () => {

--- a/src/typeahead/typeahead-config.ts
+++ b/src/typeahead/typeahead-config.ts
@@ -6,7 +6,7 @@ import {PlacementArray} from '../util/positioning';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the typeaheads used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbTypeaheadConfig {
   container;
   editable = true;

--- a/src/typeahead/typeahead-window.spec.ts
+++ b/src/typeahead/typeahead-window.spec.ts
@@ -14,7 +14,7 @@ describe('ngb-typeahead-window', () => {
 
   beforeEach(() => {
     TestBed.overrideModule(NgbTypeaheadModule, {set: {exports: [NgbTypeaheadWindow]}});
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTypeaheadModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTypeaheadModule]});
   });
 
   describe('display', () => {

--- a/src/typeahead/typeahead.module.ts
+++ b/src/typeahead/typeahead.module.ts
@@ -16,13 +16,8 @@ export {NgbTypeahead, NgbTypeaheadSelectItemEvent} from './typeahead';
   declarations: [NgbTypeahead, NgbHighlight, NgbTypeaheadWindow],
   exports: [NgbTypeahead, NgbHighlight],
   imports: [CommonModule],
-  entryComponents: [NgbTypeaheadWindow]
+  entryComponents: [NgbTypeaheadWindow],
+  providers: [Live, {provide: ARIA_LIVE_DELAY, useValue: DEFAULT_ARIA_LIVE_DELAY}]
 })
 export class NgbTypeaheadModule {
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: NgbTypeaheadModule,
-      providers: [Live, NgbTypeaheadConfig, {provide: ARIA_LIVE_DELAY, useValue: DEFAULT_ARIA_LIVE_DELAY}]
-    };
-  }
 }

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -80,7 +80,7 @@ describe('ngb-typeahead', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [TestComponent, TestOnPushComponent, TestAsyncComponent],
-      imports: [NgbTypeaheadModule.forRoot(), FormsModule, ReactiveFormsModule],
+      imports: [NgbTypeaheadModule, FormsModule, ReactiveFormsModule],
       providers: [{provide: ARIA_LIVE_DELAY, useValue: null}]
     });
   });


### PR DESCRIPTION
With the release of Angular 6, I made a PoC to replace the `.forRoot()` in the import by the new `providedIn` option in the `Injectable`.
https://angular.io/guide/providers#providing-a-service

It's work well, but it's a breaking change, so maybe for the 3.0.