### PR TITLE
feat(typeahead): configurable autocomplete attribute

### DIFF
--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -847,6 +847,14 @@ describe('ngb-typeahead', () => {
       expect(input.getAttribute('autocapitalize')).toBe('off');
       expect(input.getAttribute('autocorrect')).toBe('off');
     });
+
+    it('should have configurable autocomplete attribute', () => {
+      const fixture =
+          createTestComponent('<input type="text" [ngbTypeahead]="findObjects" autocomplete="ignored-123456"/>');
+      const input = getNativeInput(fixture.nativeElement);
+
+      expect(input.getAttribute('autocomplete')).toBe('ignored-123456');
+    });
   });
 
   describe('accessibility', () => {

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -67,7 +67,7 @@ let nextWindowId = 0;
     '[class.open]': 'isPopupOpen()',
     '(document:click)': 'onDocumentClick($event)',
     '(keydown)': 'handleKeyDown($event)',
-    'autocomplete': 'off',
+    '[autocomplete]': 'autocomplete',
     'autocapitalize': 'off',
     'autocorrect': 'off',
     'role': 'combobox',
@@ -89,6 +89,12 @@ export class NgbTypeahead implements ControlValueAccessor,
   private _windowRef: ComponentRef<NgbTypeaheadWindow>;
   private _zoneSubscription: any;
 
+  /**
+   * Value for the configurable autocomplete attribute.
+   * Defaults to 'off' to disable the native browser autocomplete, but this standard value does not seem
+   * to be always correctly taken into account.
+   */
+  @Input() autocomplete = 'off';
 
   /**
    * A selector specifying the element the tooltip should be appended to.


### PR DESCRIPTION
This PR makes the autocomplete attribute in the typeahead configurable. It allows to fix issue #2194.
