### PR TITLE
feat(modal): add 'moduleCFR' option

### DIFF
--- a/src/modal/modal-stack.ts
+++ b/src/modal/modal-stack.ts
@@ -38,7 +38,8 @@ export class NgbModalStack {
     }
 
     const activeModal = new NgbActiveModal();
-    const contentRef = this._getContentRef(moduleCFR, options.injector || contentInjector, content, activeModal);
+    const contentRef =
+        this._getContentRef(options.moduleCFR || moduleCFR, options.injector || contentInjector, content, activeModal);
 
     let backdropCmptRef: ComponentRef<NgbModalBackdrop> =
         options.backdrop !== false ? this._attachBackdrop(containerEl) : null;

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -42,6 +42,11 @@ export interface NgbModalOptions {
   keyboard?: boolean;
 
   /**
+   * ComponentFactoryResolver to use for modal content.
+   */
+  moduleCFR?: ComponentFactoryResolver;
+
+  /**
    * Size of a new modal window.
    */
   size?: 'sm' | 'lg';


### PR DESCRIPTION
Enable consumers to use NgModal service with lazy loaded module.

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [] added/updated any applicable API documentation.
 - [] added/updated any applicable demos.


Using lazy loaded modules creates a separate ComponentFactoryResolver for that module.  Injecting NgModal service, into a shared services caused NgModal to use the root Component Factory Resolver. As such entryComponents used by lazy loaded modules have to be added to the root module. Increasing main.js bundle size.

This feature allows for passing in a ComponetFactoryResolver (i.e the one create for the lazy loaded module), so you can declare entryComponents on the modules that use them. Decrease main.js bundle size.