### PR TITLE
fix(datepicker): prevent focustrap to restore focus on destroy

### DIFF
--- a/src/util/focus-trap.spec.ts
+++ b/src/util/focus-trap.spec.ts
@@ -48,7 +48,7 @@ describe('ngbFocusTrap', () => {
     });
   });
 
-  it('should save/restore focused element when autofocus is set', () => {
+  it('should focus element decorated with ngbAutofocus when created', () => {
     TestBed.configureTestingModule({
       declarations: [TestComponent, FocusTrapComponent],
       providers: [NgbFocusTrapFactory, {provide: Autofocus, useValue: true}]
@@ -71,7 +71,7 @@ describe('ngbFocusTrap', () => {
     // let's destroy the focustrap (removing <focus-trapped>)
     instance.show = false;
     fixture.detectChanges();
-    expect(document.activeElement).toBe(initial);
+    expect(document.activeElement).not.toBe(button);
   });
 });
 

--- a/src/util/focus-trap.ts
+++ b/src/util/focus-trap.ts
@@ -26,7 +26,6 @@ enum DIRECTION {
 export class NgbFocusTrap {
   private _removeDocumentListener;
   private _direction: DIRECTION = DIRECTION.FORWARD;
-  private _previouslyFocused: HTMLElement | null = null;
   private _endOfDocument: HTMLElement | null = null;
 
   /**
@@ -65,7 +64,6 @@ export class NgbFocusTrap {
     });
 
     if (autofocus === true) {
-      this._previouslyFocused = document.activeElement as HTMLElement;
       this._focusInitial();
     }
   }
@@ -109,9 +107,6 @@ export class NgbFocusTrap {
   destroy() {
     this._removeDocumentListener();
     this._document.body.removeChild(this._endOfDocument);
-    if (this._previouslyFocused) {
-      this._previouslyFocused.focus();
-    }
   }
 }
 


### PR DESCRIPTION
With this fix, focustrap on datepicker will no longer remember element focused prior initialization, and thus won't try to set it back on destroy.

fixes #2372