### PR TITLE
feat(typeahead): Add a closeOnSelect property to typeahead

### DIFF
--- a/src/typeahead/typeahead-config.ts
+++ b/src/typeahead/typeahead-config.ts
@@ -12,5 +12,6 @@ export class NgbTypeaheadConfig {
   editable = true;
   focusFirst = true;
   showHint = false;
+  closeOnSelect = true;
   placement: PlacementArray = 'bottom-left';
 }

--- a/src/typeahead/typeahead-window.ts
+++ b/src/typeahead/typeahead-window.ts
@@ -1,4 +1,4 @@
-import {Component, Input, Output, EventEmitter, TemplateRef, OnInit} from '@angular/core';
+import {Component, Input, Output, EventEmitter, TemplateRef, OnInit, ElementRef} from '@angular/core';
 
 import {toString} from '../util/util';
 
@@ -79,9 +79,13 @@ export class NgbTypeaheadWindow implements OnInit {
 
   @Output('activeChange') activeChangeEvent = new EventEmitter();
 
+  constructor(private _elementRef: ElementRef) {}
+
   hasActive() { return this.activeIdx > -1 && this.activeIdx < this.results.length; }
 
   getActive() { return this.results[this.activeIdx]; }
+
+  isEventFrom($event) { return this._elementRef.nativeElement.contains($event.target); }
 
   markActive(activeIdx: number) {
     this.activeIdx = activeIdx;

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -833,6 +833,44 @@ describe('ngb-typeahead', () => {
        }));
   });
 
+  describe('keep dropdown open on item select', () => {
+
+    it('should keep dropdown window open after selecting on an dropdown item', () => {
+      const fixture =
+          createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find" [closeOnSelect]="false"/>`);
+
+      // clicking selected
+      changeInput(fixture.nativeElement, 'o');
+      fixture.detectChanges();
+      getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
+      fixture.detectChanges();
+      expect(getWindow(fixture.nativeElement)).not.toBeNull();
+
+      const enterEvent = createKeyDownEvent(Key.Enter);
+      getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+      fixture.detectChanges();
+      expect(getWindow(fixture.nativeElement)).not.toBeNull();
+
+      const tabEvent = createKeyDownEvent(Key.Enter);
+      getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+      fixture.detectChanges();
+      expect(getWindow(fixture.nativeElement)).not.toBeNull();
+    });
+
+    it('should close dropdown window when click on document', () => {
+      const fixture =
+          createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find" [closeOnSelect]="false"/>`);
+
+      // clicking selected
+      changeInput(fixture.nativeElement, 'o');
+      fixture.detectChanges();
+
+      fixture.nativeElement.click();
+      fixture.detectChanges();
+      expect(getWindow(fixture.nativeElement)).toBeNull();
+    });
+  });
+
   describe('container', () => {
 
     it('should be appended to the element matching the selector passed to "container"', () => {

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -113,6 +113,11 @@ export class NgbTypeahead implements ControlValueAccessor,
   @Input() focusFirst: boolean;
 
   /**
+   * A flag indication whether to close the popup after selecting an item
+   */
+  @Input() closeOnSelect: boolean;
+
+  /**
    * A function to convert a given value into string to display in the input field
    */
   @Input() inputFormatter: (value: any) => string;
@@ -166,6 +171,7 @@ export class NgbTypeahead implements ControlValueAccessor,
     this.focusFirst = config.focusFirst;
     this.showHint = config.showHint;
     this.placement = config.placement;
+    this.closeOnSelect = config.closeOnSelect;
 
     this._valueChanges = fromEvent<Event>(_elementRef.nativeElement, 'input')
                              .pipe(map($event => ($event.target as HTMLInputElement).value));
@@ -218,7 +224,7 @@ export class NgbTypeahead implements ControlValueAccessor,
   }
 
   onDocumentClick(event) {
-    if (event.target !== this._elementRef.nativeElement) {
+    if (event.target !== this._elementRef.nativeElement && this._isEventFromMenu(event)) {
       this.dismissPopup();
     }
   }
@@ -268,7 +274,9 @@ export class NgbTypeahead implements ControlValueAccessor,
             event.stopPropagation();
             this._selectResult(result);
           }
-          this._closePopup();
+          if (this.closeOnSelect) {
+            this._closePopup();
+          }
           break;
         case Key.Escape:
           event.preventDefault();
@@ -312,7 +320,9 @@ export class NgbTypeahead implements ControlValueAccessor,
 
   private _selectResultClosePopup(result: any) {
     this._selectResult(result);
-    this._closePopup();
+    if (this.closeOnSelect) {
+      this._closePopup();
+    }
   }
 
   private _showHint() {
@@ -373,4 +383,6 @@ export class NgbTypeahead implements ControlValueAccessor,
     }
     this._subscription = null;
   }
+
+  private _isEventFromMenu($event) { return this._windowRef ? !this._windowRef.instance.isEventFrom($event) : false; }
 }


### PR DESCRIPTION
Used to determine whether to close the dropdown after selection.

Resolves #2397.

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [] added/updated any applicable API documentation.
 - [] added/updated any applicable demos.
