### PR TITLE
fix(datepicker): simplify focus trap with observables

### DIFF
--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -643,6 +643,33 @@ describe('NgbInputDatepicker', () => {
     });
   });
 
+  describe('focus', () => {
+
+    it('should re-focus elements inside the datepicker', () => {
+      const fixture = createTestCmpt(`
+          <input ngbDatepicker #d="ngbDatepicker">
+          <button id="open-button" (click)="open(d)">Open</button>
+          <button id="outside-button">Outside button</button>
+      `);
+
+      // open
+      fixture.nativeElement.querySelector('#open-button').click();
+      fixture.detectChanges();
+      const firstDay = fixture.nativeElement.querySelector('div.ngb-dp-day[tabindex="0"]');
+      expect(document.activeElement).toBe(firstDay);
+
+      // bring focus outside
+      const outsideButton = fixture.nativeElement.querySelector('#outside-button');
+      outsideButton.focus();
+      expect(document.activeElement).toBe(outsideButton);
+      expect(document.activeElement).not.toBe(firstDay);
+
+      // click somewhere inside (week day header)
+      fixture.nativeElement.querySelector('.ngb-dp-weekday').click();
+      expect(document.activeElement).toBe(firstDay);
+    });
+  });
+
   describe('container', () => {
 
     it('should be appended to the element matching the selector passed to "container"', () => {

--- a/src/datepicker/datepicker.module.ts
+++ b/src/datepicker/datepicker.module.ts
@@ -1,7 +1,6 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule, DatePipe} from '@angular/common';
 import {FormsModule} from '@angular/forms';
-import {NgbFocusTrapFactory} from '../util/focus-trap';
 import {NgbDatepicker, NgbDatepickerNavigateEvent} from './datepicker';
 import {NgbDatepickerMonthView} from './datepicker-month-view';
 import {NgbDatepickerNavigation} from './datepicker-navigation';
@@ -48,7 +47,7 @@ export class NgbDatepickerModule {
         {provide: NgbCalendar, useClass: NgbCalendarGregorian},
         {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nDefault},
         {provide: NgbDateParserFormatter, useClass: NgbDateISOParserFormatter},
-        {provide: NgbDateAdapter, useClass: NgbDateStructAdapter}, NgbDatepickerConfig, NgbFocusTrapFactory, DatePipe
+        {provide: NgbDateAdapter, useClass: NgbDateStructAdapter}, NgbDatepickerConfig, DatePipe
       ]
     };
   }

--- a/src/util/focus-trap.ts
+++ b/src/util/focus-trap.ts
@@ -1,129 +1,56 @@
-import {DOCUMENT} from '@angular/common';
-import {Inject, Injectable, NgZone} from '@angular/core';
+import {fromEvent, Observable} from 'rxjs/index';
+import {filter, map, takeUntil, withLatestFrom} from 'rxjs/operators';
+
+enum Key {
+  Tab = 9
+}
 
 const FOCUSABLE_ELEMENTS_SELECTOR = [
   'a[href]', 'button:not([disabled])', 'input:not([disabled]):not([type="hidden"])', 'select:not([disabled])',
   'textarea:not([disabled])', '[contenteditable]', '[tabindex]:not([tabindex="-1"])'
 ].join(', ');
 
-enum DIRECTION {
-  BACKWARD,
-  FORWARD
+/**
+ * Returns first and last focusable elements inside of a given element based on specific CSS selector
+ */
+function getFocusableBoundaryElements(element: HTMLElement): HTMLElement[] {
+  const list: NodeListOf<HTMLElement> = element.querySelectorAll(FOCUSABLE_ELEMENTS_SELECTOR);
+  return [list[0], list[list.length - 1]];
 }
 
 /**
- * Class that enforce the browser focus to be trapped inside a DOM element.
+ * Function that enforces browser focus to be trapped inside a DOM element.
  *
- * The implementation is rather simple, the class add a `focusin` listener on the document with capture phase.
- * Any focus event will then be caught, and therefore the class will only allow the one for elements contained inside
- * it's own element.
+ * Works only for clicks inside the element and navigation with 'Tab', ignoring clicks outside of the element
  *
- * In case the element is not contained, the class will determine which new element has to be focused based on the `tab`
- * navigation direction.
- *
- * Should not be used directly. Use only via {@link NgbFocusTrapFactory}
+ * @param element The element around which focus will be trapped inside
+ * @param stopFocusTrap$ The observable stream. When completed the focus trap will clean up listeners
+ * and free internal resources
  */
-export class NgbFocusTrap {
-  private _removeDocumentListener;
-  private _direction: DIRECTION = DIRECTION.FORWARD;
-  private _endOfDocument: HTMLElement | null = null;
+export const ngbFocusTrap = (element: HTMLElement, stopFocusTrap$: Observable<any>) => {
+  // last focused element
+  const lastFocusedElement$ =
+      fromEvent<FocusEvent>(element, 'focusin').pipe(takeUntil(stopFocusTrap$), map(e => e.target));
 
-  /**
-   * Guess the next focusable element.
-   * Computation is based on specific CSS selector and [tab] navigation direction
-   */
-  private get focusableElement(): HTMLElement {
-    const list: NodeListOf<HTMLElement> = this._element.querySelectorAll(FOCUSABLE_ELEMENTS_SELECTOR);
-    return this._direction === DIRECTION.BACKWARD ? list[list.length - 1] : list[0];
-  }
+  // 'tab' / 'shift+tab' stream
+  fromEvent<KeyboardEvent>(element, 'keydown')
+      .pipe(takeUntil(stopFocusTrap$), filter(e => e.which === Key.Tab), withLatestFrom(lastFocusedElement$))
+      .subscribe(([tabEvent, focusedElement]) => {
+        const[first, last] = getFocusableBoundaryElements(element);
 
-  /**
-   * @param _element The element around which focus will be trapped inside
-   * @param autofocus Initially put the focus on specific element with a `ngbFocustrap` attribute. Will also remenber
-   * and restore any previously focused element on destroy.
-   * @param _document Document on which `focusin` and `keydown.TAB` events are listened
-   * @param _ngZone The zone Angular is running in
-   */
-  constructor(private _element: HTMLElement, autofocus: boolean, private _document: Document, private _ngZone: NgZone) {
-    this._enforceFocus = this._enforceFocus.bind(this);
-    this._detectDirection = this._detectDirection.bind(this);
+        if (focusedElement === first && tabEvent.shiftKey) {
+          last.focus();
+          tabEvent.preventDefault();
+        }
 
-    const eod = this._endOfDocument = this._document.createElement('i');
-    eod.className = 'ngb-focustrap-eod';
-    eod.tabIndex = 0;
-    this._document.body.appendChild(eod);
-
-    this._ngZone.runOutsideAngular(() => {
-      this._document.addEventListener('focusin', this._enforceFocus, true);
-      this._document.addEventListener('keydown', this._detectDirection);
-
-      this._removeDocumentListener = () => {
-        this._document.removeEventListener('focusin', this._enforceFocus, true);
-        this._document.removeEventListener('keydown', this._detectDirection);
-      }
-    });
-
-    if (autofocus === true) {
-      this._focusInitial();
-    }
-  }
-
-  /** Detect if incoming focus event should be prevented or not */
-  private _enforceFocus(event) {
-    const {target} = event;
-    if (this._document !== target && this._element !== target && !this._element.contains(target)) {
-      this._ngZone.run(() => {
-        const element = this.focusableElement;
-        if (element) {
-          element.focus();
-          event.stopPropagation();
+        if (focusedElement === last && !tabEvent.shiftKey) {
+          first.focus();
+          tabEvent.preventDefault();
         }
       });
-    }
-  }
 
-  /** Event handler detecting current `tab` navigation direction */
-  private _detectDirection(event) {
-    const {shiftKey, key} = event;
-    if (key === 'Tab') {
-      this._direction = shiftKey ? DIRECTION.BACKWARD : DIRECTION.FORWARD;
-    }
-  }
-
-  /** Try to set focus on the first found element that has an ngbAutofocus attribute */
-  private _focusInitial() {
-    const element = this._element.querySelector('[ngbAutofocus]') as HTMLElement;
-    if (element) {
-      element.focus();
-    }
-  }
-
-  /**
-   * Destroys the focustrap by removing all event listeners set on document.
-   *
-   * Eventually put the focus back on the previously focused element at the time
-   * focustrap has been initialized.
-   */
-  destroy() {
-    this._removeDocumentListener();
-    this._document.body.removeChild(this._endOfDocument);
-  }
-}
-
-/**
- * Factory service to easily create a `NgbFocusTrap` instance on an element
- */
-@Injectable()
-export class NgbFocusTrapFactory {
-  constructor(@Inject(DOCUMENT) private _document: Document, private _ngZone: NgZone) {}
-
-  /**
-   * Create an instance of {@link NgbFocusTrap} and return it
-   * @param element HTMLElement to trap focus inside
-   * @param autofocus Whether the focustrap should automatically move focus into the trapped element upon
-   * initialization and return focus to the previous activeElement upon destruction.
-   */
-  create(element: HTMLElement, autofocus = false): NgbFocusTrap {
-    return new NgbFocusTrap(element, autofocus, this._document, this._ngZone);
-  }
-}
+  // inside click
+  fromEvent(element, 'click')
+      .pipe(takeUntil(stopFocusTrap$), withLatestFrom(lastFocusedElement$), map(arr => arr[1] as HTMLElement))
+      .subscribe(lastFocusedElement => lastFocusedElement.focus());
+};


### PR DESCRIPTION
Refactor existing implementation of the focus trap: handle only inside clicks and tab navigation. It doesn't steal outside focus anymore

Fixes #2406
Fixes #2390
Fixes #2372 (one more time)