### PR TITLE
refactor(datepicker): move 'outsideDays' generation to the service

### DIFF
--- a/demo/src/app/components/datepicker/demos/multiple/datepicker-multiple.html
+++ b/demo/src/app/components/datepicker/demos/multiple/datepicker-multiple.html
@@ -1,5 +1,6 @@
 
-<ngb-datepicker [displayMonths]="displayMonths" [navigation]="navigation" [showWeekNumbers]="showWeekNumbers">
+<ngb-datepicker [displayMonths]="displayMonths" [navigation]="navigation"
+                [showWeekNumbers]="showWeekNumbers" [outsideDays]="outsideDays">
 </ngb-datepicker>
 
 <hr/>
@@ -8,7 +9,7 @@
   <div class="form-group">
     <div class="input-group">
       <input class="form-control" placeholder="yyyy-mm-dd"
-             name="dp" [displayMonths]="displayMonths" [navigation]="navigation"
+             name="dp" [displayMonths]="displayMonths" [navigation]="navigation" [outsideDays]="outsideDays"
              [showWeekNumbers]="showWeekNumbers" ngbDatepicker #d="ngbDatepicker">
       <div class="input-group-append">
         <button class="btn btn-outline-secondary" (click)="d.toggle()" type="button">
@@ -21,7 +22,7 @@
 
 <hr/>
 
-<div class="d-flex">
+<div class="d-flex flex-wrap align-content-between p-2">
   <select class="custom-select" [(ngModel)]="displayMonths">
     <option [ngValue]="1">One month</option>
     <option [ngValue]="2">Two months</option>
@@ -37,6 +38,12 @@
   <select class="custom-select" [(ngModel)]="showWeekNumbers">
     <option [ngValue]="true">Week numbers</option>
     <option [ngValue]="false">No week numbers</option>
+  </select>
+
+  <select class="custom-select" [(ngModel)]="outsideDays">
+    <option value="visible">Visible outside days</option>
+    <option value="hidden">Hidden outside days</option>
+    <option value="collapsed">Collapsed outside days</option>
   </select>
 </div>
 

--- a/demo/src/app/components/datepicker/demos/multiple/datepicker-multiple.ts
+++ b/demo/src/app/components/datepicker/demos/multiple/datepicker-multiple.ts
@@ -5,7 +5,7 @@ import {Component} from '@angular/core';
   templateUrl: './datepicker-multiple.html',
   styles: [`
     select.custom-select {
-      margin-right: 0.5rem;
+      margin: 0.5rem 0.5rem 0 0;
       width: auto;
     }
   `]
@@ -15,4 +15,5 @@ export class NgbdDatepickerMultiple {
   displayMonths = 2;
   navigation = 'select';
   showWeekNumbers = false;
+  outsideDays = 'visible';
 }

--- a/src/datepicker/datepicker-month-view.ts
+++ b/src/datepicker/datepicker-month-view.ts
@@ -1,5 +1,5 @@
 import {Component, Input, TemplateRef, Output, EventEmitter} from '@angular/core';
-import {MonthViewModel, DayViewModel, WeekViewModel} from './datepicker-view-model';
+import {MonthViewModel, DayViewModel} from './datepicker-view-model';
 import {NgbDate} from './ngb-date';
 import {NgbDatepickerI18n} from './datepicker-i18n';
 import {DayTemplateContext} from './datepicker-day-template-context';
@@ -48,14 +48,14 @@ import {DayTemplateContext} from './datepicker-day-template-context';
       </div>
     </div>
     <ng-template ngFor let-week [ngForOf]="month.weeks">
-      <div *ngIf="!isCollapsed(week)" class="ngb-dp-week" role="row">
+      <div *ngIf="!week.collapsed" class="ngb-dp-week" role="row">
         <div *ngIf="showWeekNumbers" class="ngb-dp-week-number small text-muted">{{ week.number }}</div>
         <div *ngFor="let day of week.days" (click)="doSelect(day)" class="ngb-dp-day" role="gridcell"
           [class.disabled]="day.context.disabled"
           [tabindex]="day.tabindex"
-          [class.hidden]="isHidden(day)"
+          [class.hidden]="day.hidden"
           [attr.aria-label]="day.ariaLabel">
-          <ng-template [ngIf]="!isHidden(day)">
+          <ng-template [ngIf]="!day.hidden">
             <ng-template [ngTemplateOutlet]="dayTemplate" [ngTemplateOutletContext]="day.context"></ng-template>
           </ng-template>
         </div>
@@ -66,7 +66,6 @@ import {DayTemplateContext} from './datepicker-day-template-context';
 export class NgbDatepickerMonthView {
   @Input() dayTemplate: TemplateRef<DayTemplateContext>;
   @Input() month: MonthViewModel;
-  @Input() outsideDays: 'visible' | 'hidden' | 'collapsed';
   @Input() showWeekdays;
   @Input() showWeekNumbers;
 
@@ -75,17 +74,8 @@ export class NgbDatepickerMonthView {
   constructor(public i18n: NgbDatepickerI18n) {}
 
   doSelect(day: DayViewModel) {
-    if (!day.context.disabled && !this.isHidden(day)) {
+    if (!day.context.disabled && !day.hidden) {
       this.select.emit(NgbDate.from(day.date));
     }
-  }
-
-  isCollapsed(week: WeekViewModel) {
-    return this.outsideDays === 'collapsed' && week.days[0].date.month !== this.month.number &&
-        week.days[week.days.length - 1].date.month !== this.month.number;
-  }
-
-  isHidden(day: DayViewModel) {
-    return (this.outsideDays === 'hidden' || this.outsideDays === 'collapsed') && this.month.number !== day.date.month;
   }
 }

--- a/src/datepicker/datepicker-service.ts
+++ b/src/datepicker/datepicker-service.ts
@@ -33,6 +33,7 @@ export class NgbDatepickerService {
     focusVisible: false,
     months: [],
     navigation: 'select',
+    outsideDays: 'visible',
     prevDisabled: false,
     nextDisabled: false,
     selectBoxes: {years: [], months: []},
@@ -95,6 +96,12 @@ export class NgbDatepickerService {
     }
   }
 
+  set outsideDays(outsideDays: 'visible' | 'collapsed' | 'hidden') {
+    if (this._state.outsideDays !== outsideDays) {
+      this._nextState({outsideDays});
+    }
+  }
+
   constructor(private _calendar: NgbCalendar, private _i18n: NgbDatepickerI18n) {}
 
   focus(date: NgbDate) {
@@ -149,25 +156,34 @@ export class NgbDatepickerService {
   }
 
   private _patchContexts(state: DatepickerViewModel) {
+    const {months, displayMonths, selectedDate, focusDate, focusVisible, disabled, outsideDays} = state;
     state.months.forEach(month => {
       month.weeks.forEach(week => {
         week.days.forEach(day => {
 
           // patch focus flag
-          if (state.focusDate) {
-            day.context.focused = state.focusDate.equals(day.date) && state.focusVisible;
+          if (focusDate) {
+            day.context.focused = focusDate.equals(day.date) && focusVisible;
           }
 
-          day.tabindex =
-              (!state.disabled && day.date.equals(state.focusDate) && state.focusDate.month === month.number) ? 0 : -1;
+          // calculating tabindex
+          day.tabindex = !disabled && day.date.equals(focusDate) && focusDate.month === month.number ? 0 : -1;
+
           // override context disabled
-          if (state.disabled === true) {
+          if (disabled === true) {
             day.context.disabled = true;
           }
 
           // patch selection flag
-          if (state.selectedDate !== undefined) {
-            day.context.selected = state.selectedDate !== null && state.selectedDate.equals(day.date);
+          if (selectedDate !== undefined) {
+            day.context.selected = selectedDate !== null && selectedDate.equals(day.date);
+          }
+
+          // visibility
+          if (month.number !== day.date.month) {
+            day.hidden = outsideDays === 'hidden' || outsideDays === 'collapsed' ||
+                (displayMonths > 1 && day.date.after(months[0].firstDate) &&
+                 day.date.before(months[displayMonths - 1].lastDate))
           }
         });
       });
@@ -219,7 +235,7 @@ export class NgbDatepickerService {
     // rebuilding months
     if (startDate) {
       const forceRebuild = 'firstDayOfWeek' in patch || 'markDisabled' in patch || 'minDate' in patch ||
-          'maxDate' in patch || 'disabled' in patch;
+          'maxDate' in patch || 'disabled' in patch || 'outsideDays' in patch;
 
       const months = buildMonths(this._calendar, startDate, state, this._i18n, forceRebuild);
 

--- a/src/datepicker/datepicker-tools.ts
+++ b/src/datepicker/datepicker-tools.ts
@@ -104,7 +104,7 @@ export function buildMonths(
 
 export function buildMonth(
     calendar: NgbCalendar, date: NgbDate, state: DatepickerViewModel, i18n: NgbDatepickerI18n): MonthViewModel {
-  const {minDate, maxDate, firstDayOfWeek, markDisabled} = state;
+  const {minDate, maxDate, firstDayOfWeek, markDisabled, outsideDays} = state;
   const month:
       MonthViewModel = {firstDate: null, lastDate: null, number: date.month, year: date.year, weeks: [], weekdays: []};
 
@@ -145,19 +145,23 @@ export function buildMonth(
         date: newDate,
         context: {
           date: {year: newDate.year, month: newDate.month, day: newDate.day},
-          currentMonth: month.number,
-          disabled: disabled,
+          currentMonth: month.number, disabled,
           focused: false,
           selected: false
         },
-        tabindex: -1, ariaLabel
+        tabindex: -1, ariaLabel,
+        hidden: false
       });
 
       date = nextDate;
     }
 
+    // marking week as collapsed
+    const collapsed = outsideDays === 'collapsed' && days[0].date.month !== month.number &&
+        days[days.length - 1].date.month !== month.number;
+
     month.weeks.push(
-        {number: calendar.getWeekNumber(days.map(day => NgbDate.from(day.date)), firstDayOfWeek), days: days});
+        {number: calendar.getWeekNumber(days.map(day => NgbDate.from(day.date)), firstDayOfWeek), days, collapsed});
   }
 
   return month;

--- a/src/datepicker/datepicker-view-model.ts
+++ b/src/datepicker/datepicker-view-model.ts
@@ -8,12 +8,14 @@ export type DayViewModel = {
   date: NgbDate,
   context: DayTemplateContext,
   tabindex: number,
-  ariaLabel: string
+  ariaLabel: string,
+  hidden: boolean
 }
 
 export type WeekViewModel = {
   number: number,
-  days: DayViewModel[]
+  days: DayViewModel[],
+  collapsed: boolean
 }
 
 export type MonthViewModel = {
@@ -39,6 +41,7 @@ export type DatepickerViewModel = {
   minDate?: NgbDate,
   months: MonthViewModel[],
   navigation: 'select' | 'arrows' | 'none',
+  outsideDays: 'visible' | 'collapsed' | 'hidden',
   prevDisabled: boolean,
   nextDisabled: boolean,
   selectBoxes: {

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -383,20 +383,6 @@ describe('ngb-datepicker', () => {
     expect(fixture.debugElement.query(By.directive(NgbDatepickerNavigation))).toBeNull();
   });
 
-  it('should override outside days to "hidden" if there are multiple months displayed', () => {
-    const fixture = createTestComponent(
-        `<ngb-datepicker [displayMonths]="displayMonths" [outsideDays]="'collapsed'"></ngb-datepicker>`);
-
-
-    let months = fixture.debugElement.queryAll(By.directive(NgbDatepickerMonthView));
-    expect(months[0].componentInstance.outsideDays).toBe('collapsed');
-
-    fixture.componentInstance.displayMonths = 2;
-    fixture.detectChanges();
-    months = fixture.debugElement.queryAll(By.directive(NgbDatepickerMonthView));
-    expect(months[0].componentInstance.outsideDays).toBe('hidden');
-  });
-
   it('should toggle month names display for a single month', () => {
     const fixture = createTestComponent(
         `<ngb-datepicker [startDate]="date" [displayMonths]="1" [navigation]="navigation"></ngb-datepicker>`);

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -137,7 +137,6 @@ export interface NgbDatepickerNavigateEvent {
             [dayTemplate]="dayTemplate || dt"
             [showWeekdays]="showWeekdays"
             [showWeekNumbers]="showWeekNumbers"
-            [outsideDays]="(displayMonths === 1 ? outsideDays : 'hidden')"
             (select)="onDateSelect($event)">
           </ngb-datepicker-month-view>
         </div>
@@ -299,14 +298,14 @@ export class NgbDatepicker implements OnDestroy,
 
   ngOnInit() {
     if (this.model === undefined) {
-      ['displayMonths', 'markDisabled', 'firstDayOfWeek', 'navigation', 'minDate', 'maxDate'].forEach(
+      ['displayMonths', 'markDisabled', 'firstDayOfWeek', 'navigation', 'minDate', 'maxDate', 'outsideDays'].forEach(
           input => this._service[input] = this[input]);
       this.navigateTo(this.startDate);
     }
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    ['displayMonths', 'markDisabled', 'firstDayOfWeek', 'navigation', 'minDate', 'maxDate']
+    ['displayMonths', 'markDisabled', 'firstDayOfWeek', 'navigation', 'minDate', 'maxDate', 'outsideDays']
         .filter(input => input in changes)
         .forEach(input => this._service[input] = this[input]);
 


### PR DESCRIPTION
The last in series of moving logic from components to the service and utility functions