### PR TITLE
chore: make safari versions less restrictive for sauce labs

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -78,13 +78,13 @@ module.exports = function(config) {
         base: 'SauceLabs',
         browserName: 'safari',
         platform: 'macOS 10.12',
-        version: '10.1'
+        version: '10'
       },
       'SL_SAFARI11': {
         base: 'SauceLabs',
         browserName: 'safari',
         platform: 'macOS 10.13',
-        version: '11.0'
+        version: '11'
       },
     },
 


### PR DESCRIPTION
Sauce Labs is failing because of Safari.
Version 11.0 is not available anymore on sauce labs for some reason after the latest mac os update.
Making versions less restrictive