### PR TITLE
feat(datepicker): close datepicker popup on ESC from anywhere

### DIFF
--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -17,6 +17,18 @@ const createTestCmpt = (html: string) =>
 const createTestNativeCmpt = (html: string) =>
     createGenericTestComponent(html, TestNativeComponent) as ComponentFixture<TestNativeComponent>;
 
+enum Key {
+  Escape = 27
+}
+
+function dispatchKeyUpEvent(key: Key) {
+  const event = document.createEvent('KeyboardEvent') as any;
+  let initEventFn = (event.initKeyEvent || event.initKeyboardEvent).bind(event);
+  initEventFn('keyup', true, true, window, 0, 0, 0, 0, 0, key);
+  Object.defineProperties(event, {which: {get: () => key}});
+  document.dispatchEvent(event);
+}
+
 describe('NgbInputDatepicker', () => {
 
   beforeEach(() => {
@@ -66,6 +78,22 @@ describe('NgbInputDatepicker', () => {
       button.click();
       fixture.detectChanges();
       expect(document.activeElement).toBe(fixture.nativeElement.querySelector('div.ngb-dp-day[tabindex="0"]'));
+    });
+
+    it('should close datepicker on ESC key', () => {
+      const fixture = createTestCmpt(`
+          <input ngbDatepicker #d="ngbDatepicker">
+          <button (click)="open(d)">Open</button>`);
+
+      // open
+      const button = fixture.nativeElement.querySelector('button');
+      button.click();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+
+      // dispatch escape
+      dispatchKeyUpEvent(Key.Escape);
+      expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
     });
 
     it('should close datepicker on date selection', () => {

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -13,9 +13,11 @@ import {
   Output,
   OnChanges,
   OnDestroy,
-  SimpleChanges
+  SimpleChanges,
+  Inject
 } from '@angular/core';
 import {AbstractControl, ControlValueAccessor, Validator, NG_VALUE_ACCESSOR, NG_VALIDATORS} from '@angular/forms';
+import {DOCUMENT} from '@angular/common';
 
 import {NgbDate} from './ngb-date';
 import {NgbDatepicker, NgbDatepickerNavigateEvent} from './datepicker';
@@ -29,7 +31,8 @@ import {NgbDateAdapter} from './ngb-date-adapter';
 import {NgbCalendar} from './ngb-calendar';
 import {NgbDatepickerService} from './datepicker-service';
 
-import {Subject} from 'rxjs';
+import {Subject, fromEvent} from 'rxjs';
+import {filter, takeUntil} from 'rxjs/operators';
 
 const NGB_DATEPICKER_VALUE_ACCESSOR = {
   provide: NG_VALUE_ACCESSOR,
@@ -43,6 +46,10 @@ const NGB_DATEPICKER_VALIDATOR = {
   multi: true
 };
 
+enum Key {
+  Escape = 27
+}
+
 /**
  * A directive that makes it possible to have datepickers on input fields.
  * Manages integration with the input field itself (data entry) and ngModel (validation etc.).
@@ -53,7 +60,6 @@ const NGB_DATEPICKER_VALIDATOR = {
   host: {
     '(input)': 'manualDateChange($event.target.value)',
     '(change)': 'manualDateChange($event.target.value, true)',
-    '(keyup.esc)': 'close()',
     '(blur)': 'onBlur()',
     '[disabled]': 'disabled'
   },
@@ -185,7 +191,7 @@ export class NgbInputDatepicker implements OnChanges,
       private _parserFormatter: NgbDateParserFormatter, private _elRef: ElementRef<HTMLInputElement>,
       private _vcRef: ViewContainerRef, private _renderer: Renderer2, private _cfr: ComponentFactoryResolver,
       ngZone: NgZone, private _service: NgbDatepickerService, private _calendar: NgbCalendar,
-      private _ngbDateAdapter: NgbDateAdapter<any>) {
+      private _ngbDateAdapter: NgbDateAdapter<any>, @Inject(DOCUMENT) private _document: any) {
     this._zoneSubscription = ngZone.onStable.subscribe(() => {
       if (this._cRef) {
         positionElements(
@@ -271,6 +277,11 @@ export class NgbInputDatepicker implements OnChanges,
       ngbFocusTrap(this._cRef.location.nativeElement, this._closed$);
 
       this._cRef.instance.focus();
+
+      // closing on ESC
+      fromEvent<KeyboardEvent>(this._document, 'keyup')
+          .pipe(takeUntil(this._closed$), filter(e => e.which === Key.Escape))
+          .subscribe(() => this.close());
     }
   }
 


### PR DESCRIPTION
- sets up handlers when datepicker is open
- removes handlers when datepicker closes
- listens on the document, not on the input