### PR TITLE
fix(datepicker): fix select width with bootsrap 4.1

### DIFF
--- a/src/datepicker/datepicker-navigation-select.ts
+++ b/src/datepicker/datepicker-navigation-select.ts
@@ -11,6 +11,7 @@ import {NgbDatepickerI18n} from './datepicker-i18n';
       display: flex;
       display: -ms-flexbox;
       -ms-flex: 1 1 auto;
+      width: 100%;
       padding: 0 0.5rem;
       font-size: 0.875rem;
       height: 1.85rem;


### PR DESCRIPTION
Following the change in BS 4.1: https://github.com/twbs/bootstrap/blame/f81f419b22949d2bf0f4d346891be44724109135/scss/_forms.scss#L307

Selects are collapsed if inside the `.form-inline`:

![screen shot 2018-06-08 at 15 18 48](https://user-images.githubusercontent.com/8074436/41160256-5ef92684-6b2f-11e8-973a-a3d2bc55fe44.png)
