### PR TITLE
fix(demo): carousel displays images in full width on large screens

### DIFF
--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -326,3 +326,9 @@ ngb-datepicker.rtl .ngb-dp-navigation-chevron::before {
   -ms-transform: rotate(45deg);
   margin: 0 0.5rem 0 0;
 }
+
+ngb-carousel {
+  .carousel-item img {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
With the new demo layout, Carousel demo looks a bit broken on very large displays as images which are fetch have an hardcoded width of 900px

PR makes them fit the all space 