### PR TITLE
feat(popover): Do not render .popover-header node if title is not set

### DIFF
--- a/src/popover/popover.module.ts
+++ b/src/popover/popover.module.ts
@@ -1,4 +1,5 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
+import {CommonModule} from '@angular/common';
 
 import {NgbPopover, NgbPopoverWindow} from './popover';
 import {NgbPopoverConfig} from './popover-config';
@@ -8,7 +9,12 @@ export {NgbPopover} from './popover';
 export {NgbPopoverConfig} from './popover-config';
 export {Placement} from '../util/positioning';
 
-@NgModule({declarations: [NgbPopover, NgbPopoverWindow], exports: [NgbPopover], entryComponents: [NgbPopoverWindow]})
+@NgModule({
+  imports: [CommonModule],
+  declarations: [NgbPopover, NgbPopoverWindow],
+  exports: [NgbPopover],
+  entryComponents: [NgbPopoverWindow]
+})
 export class NgbPopoverModule {
   static forRoot(): ModuleWithProviders { return {ngModule: NgbPopoverModule, providers: [NgbPopoverConfig]}; }
 }

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -35,6 +35,13 @@ describe('ngb-popover-window', () => {
     expect(fixture.nativeElement.querySelector('.popover-header').textContent).toBe('Test title');
   });
 
+  it('should not render popover title node if title is not set', () => {
+    const fixture = TestBed.createComponent(NgbPopoverWindow);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.popover-header')).toBeNull();
+  });
+
   it('should position popovers as requested', () => {
     const fixture = TestBed.createComponent(NgbPopoverWindow);
     fixture.componentInstance.placement = 'left';

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -36,7 +36,10 @@ let nextId = 0;
   },
   template: `
     <div class="arrow"></div>
-    <h3 class="popover-header">{{title}}</h3><div class="popover-body"><ng-content></ng-content></div>`,
+    <h3 class="popover-header" *ngIf="title">{{title}}</h3>
+    <div class="popover-body">
+      <ng-content></ng-content>
+    </div>`,
   styles: [`
     :host.bs-popover-top .arrow, :host.bs-popover-bottom .arrow {
       left: 50%;


### PR DESCRIPTION
Do not render .popover-header (title) node if title is not set, because if it has some styling applied (margin or padding), UI will not look good.

Closes #2454
