### PR TITLE
fix(live): use a single DOM element for Live Announcer

### DIFF
--- a/src/util/accessibility/live.spec.ts
+++ b/src/util/accessibility/live.spec.ts
@@ -5,15 +5,14 @@ import {Live, ARIA_LIVE_DELAY} from './live';
 
 
 
-function getLiveElement(): Element {
-  return document.body.querySelector('[aria-live]');
+function getLiveElement(): Element | null {
+  return document.body.querySelector('#ngb-live');
 }
 
 
 
 describe('LiveAnnouncer', () => {
   let live: Live;
-  let liveElement: Element;
   let fixture: ComponentFixture<TestComponent>;
 
   const say = () => { fixture.debugElement.query(By.css('button')).nativeElement.click(); };
@@ -26,15 +25,14 @@ describe('LiveAnnouncer', () => {
 
     beforeEach(inject([Live], (_live: Live) => {
       live = _live;
-      liveElement = getLiveElement();
       fixture = TestBed.createComponent(TestComponent);
     }));
 
     it('should correctly update the text message', () => {
       say();
+      const liveElement = getLiveElement();
       expect(liveElement.textContent).toBe('test');
-
-      live.ngOnDestroy();
+      expect(liveElement.id).toBe('ngb-live');
     });
 
     it('should remove the used element from the DOM on destroy', () => {

--- a/src/util/accessibility/live.ts
+++ b/src/util/accessibility/live.ts
@@ -11,15 +11,20 @@ export const DEFAULT_ARIA_LIVE_DELAY: ARIA_LIVE_DELAY_TYPE = 100;
 
 
 
-function createLiveElement(document): HTMLElement {
-  const element = document.createElement('div');
+function getLiveElement(document: any, lazyCreate = false): HTMLElement | null {
+  let element = document.body.querySelector('#ngb-live') as HTMLElement;
 
-  element.setAttribute('aria-live', 'polite');
-  element.setAttribute('aria-atomic', 'true');
+  if (element == null && lazyCreate) {
+    element = document.createElement('div');
 
-  element.classList.add('sr-only');
+    element.setAttribute('id', 'ngb-live');
+    element.setAttribute('aria-live', 'polite');
+    element.setAttribute('aria-atomic', 'true');
 
-  document.body.appendChild(element);
+    element.classList.add('sr-only');
+
+    document.body.appendChild(element);
+  }
 
   return element;
 }
@@ -28,16 +33,17 @@ function createLiveElement(document): HTMLElement {
 
 @Injectable()
 export class Live implements OnDestroy {
-  private _element: HTMLElement;
+  constructor(@Inject(DOCUMENT) private _document: any, @Inject(ARIA_LIVE_DELAY) private _delay: any) {}
 
-  constructor(@Inject(DOCUMENT) document: any, @Inject(ARIA_LIVE_DELAY) private _delay: ARIA_LIVE_DELAY_TYPE) {
-    this._element = createLiveElement(document);
+  ngOnDestroy() {
+    const element = getLiveElement(this._document);
+    if (element) {
+      element.parentElement.removeChild(element);
+    }
   }
 
-  ngOnDestroy() { this._element.parentElement.removeChild(this._element); }
-
-  say(message: string): void {
-    const element = this._element;
+  say(message: string) {
+    const element = getLiveElement(this._document, true);
     const delay = this._delay;
 
     element.textContent = '';


### PR DESCRIPTION
An attempt to lazily create and reuse `aria-live` element for the live announcer

- test execution order doesn't matter anymore
- multiple ng-bootstrap modules will use a single DOM element
- `ARIA_LIVE_DELAY_TYPE` → `any` for SSR

cc @ymeine 