### PR TITLE
fix(datepicker): ExpressionChangedAfterItHasBeenCheckedError

### DIFF
--- a/src/datepicker/datepicker-service.spec.ts
+++ b/src/datepicker/datepicker-service.spec.ts
@@ -158,29 +158,22 @@ describe('ngb-datepicker-service', () => {
       expect(getDayCtx(5).disabled).toBe(true);  // 6 MAY
     });
 
-    it(`should rebuild month when 'min/maxDates' change and visible`, () => {
+    it(`should update month when 'min/maxDates' change and visible`, () => {
       // MAY 2017
       service.focus(new NgbDate(2017, 5, 5));
       expect(model.months.length).toBe(1);
       expect(model.minDate).toBeUndefined();
       expect(model.maxDate).toBeUndefined();
 
-      const month = model.months[0];
-      const date = month.weeks[0].days[0].date;
-
       // MIN -> 5 MAY, 2017
       service.minDate = new NgbDate(2017, 5, 5);
       expect(model.months.length).toBe(1);
-      expect(model.months[0]).not.toBe(month);
       expect(getDayCtx(0).disabled).toBe(true);
-      expect(getDay(0).date).not.toBe(date);
 
       // MAX -> 10 MAY, 2017
       service.maxDate = new NgbDate(2017, 5, 10);
       expect(model.months.length).toBe(1);
-      expect(model.months[0]).not.toBe(month);
       expect(model.months[0].weeks[4].days[0].context.disabled).toBe(true);
-      expect(model.months[0].weeks[0].days[0].date).not.toBe(date);
     });
   });
 
@@ -233,18 +226,19 @@ describe('ngb-datepicker-service', () => {
       expect(model.months[0].weekdays[0]).toBe(4);
     });
 
-    it(`should rebuild months when 'firstDayOfWeek' changes`, () => {
+    it(`should update months when 'firstDayOfWeek' changes`, () => {
       service.focus(new NgbDate(2017, 5, 5));
       expect(model.months.length).toBe(1);
       expect(model.firstDayOfWeek).toBe(1);
 
-      const month = model.months[0];
-      const date = month.weeks[0].days[0].date;
+      const oldFirstDate = getDay(0).date.toString();
+      expect(oldFirstDate).toBe('2017-5-1');
 
       service.firstDayOfWeek = 3;
       expect(model.months.length).toBe(1);
-      expect(model.months[0]).not.toBe(month);
-      expect(getDay(0).date).not.toBe(date);
+      expect(model.firstDayOfWeek).toBe(3);
+      const newFirstDate = getDay(0).date.toString();
+      expect(newFirstDate).toBe('2017-4-26');
     });
   });
 
@@ -905,17 +899,16 @@ describe('ngb-datepicker-service', () => {
       expect(day.context.disabled).toBe(true);
     });
 
-    it(`should rebuild months when 'markDisabled changes'`, () => {
+    it(`should update months when 'markDisabled changes'`, () => {
       // MAY 2017
       service.markDisabled = (_) => true;
       service.focus(new NgbDate(2017, 5, 1));
 
-      const month = model.months[0];
-      const date = month.weeks[0].days[0].date;
+      expect(getDay(0).context.disabled).toBe(true);
 
-      service.markDisabled = (_) => true;
-      expect(model.months[0]).not.toBe(month);
-      expect(getDay(0).date).not.toBe(date);
+      service.markDisabled = (_) => false;
+
+      expect(getDay(0).context.disabled).toBe(false);
     });
   });
 

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -366,6 +366,52 @@ describe('ngb-datepicker', () => {
     expect(months.length).toBe(3);
   });
 
+  it('should reuse DOM elements when changing month (single month display)', () => {
+    const fixture = createTestComponent(`<ngb-datepicker [startDate]="date"></ngb-datepicker>`);
+
+    // AUG 2016
+    const oldDates = getDates(fixture.nativeElement);
+    const navigation = getNavigationLinks(fixture.nativeElement);
+    expect(oldDates[0].innerText.trim()).toBe('1');
+
+    // JUL 2016
+    navigation[0].click();
+    fixture.detectChanges();
+
+    const newDates = getDates(fixture.nativeElement);
+    expect(newDates[0].innerText.trim()).toBe('27');
+
+    expect(oldDates).toEqual(newDates);
+  });
+
+  it('should reuse DOM elements when changing month (multiple months display)', () => {
+    const fixture = createTestComponent(`<ngb-datepicker [displayMonths]="2" [startDate]="date"></ngb-datepicker>`);
+
+    // AUG 2016 and SEP 2016
+    const oldDates = getDates(fixture.nativeElement);
+    const oldAugDates = oldDates.slice(0, 42);
+    const oldSepDates = oldDates.slice(42);
+
+    const navigation = getNavigationLinks(fixture.nativeElement);
+    expect(oldAugDates[0].innerText.trim()).toBe('1');
+    expect(oldSepDates[3].innerText.trim()).toBe('1');
+
+    // JUL 2016 and AUG 2016
+    navigation[0].click();
+    fixture.detectChanges();
+
+    const newDates = getDates(fixture.nativeElement);
+    const newJulDates = newDates.slice(0, 42);
+    const newAugDates = newDates.slice(42);
+
+    expect(newJulDates[0].innerText.trim()).toBe('27');
+    expect(newAugDates[0].innerText.trim()).toBe('1');
+
+    // DOM elements were reused:
+    expect(newAugDates).toEqual(oldAugDates);
+    expect(newJulDates).toEqual(oldSepDates);
+  });
+
   it('should switch navigation types', () => {
     const fixture = createTestComponent(`<ngb-datepicker [navigation]="navigation"></ngb-datepicker>`);
 


### PR DESCRIPTION
Reuses data structures in the datepicker data model instead of building new objects each time the user navigates to a different month. As a consequence, DOM elements are no longer destroyed when changing month.

This fixes the following issue which occurred when BrowserAnimationsModule was used: when using the keyboard to navigate from one month to another, the focused element was destroyed during the change detection of the keyboard event, which synchronously triggered the focusout event in Chrome, leading to a change in the data model (and that change is still part of the data model only when BrowserAnimationsModule is used, because that module changes the behavior of Angular to not destroy views and their data model as quickly as when this module is not loaded), and this was causing the ExpressionChangedAfterItHasBeenCheckedError error.

Fixes #2408
