### PR TITLE
demo: datepicker overview page

### DIFF
--- a/demo/src/app/app.routing.ts
+++ b/demo/src/app/app.routing.ts
@@ -20,9 +20,9 @@ import {
   NgbdTooltip,
   NgbdTypeahead
 } from './components';
-import {DEFAULT_TAB} from './shared/component-wrapper/component-wrapper.component';
 
-const DEFAULT_API_PATH = {path: '', pathMatch: 'full', redirectTo: DEFAULT_TAB};
+const DEFAULT_API_PATH = {path: '', pathMatch: 'full', redirectTo: 'examples'};
+const DEFAULT_API_PATH_OVERVIEW = {path: '', pathMatch: 'full', redirectTo: 'overview'};
 
 const componentRoutes = [{
     path: 'components/accordion',
@@ -57,7 +57,7 @@ const componentRoutes = [{
   }, {
     path: 'components/datepicker',
     children: [
-      DEFAULT_API_PATH,
+      DEFAULT_API_PATH_OVERVIEW,
       {path: ':tab', component: NgbdDatepicker}
     ]
   }, {

--- a/demo/src/app/components/datepicker/datepicker.component.ts
+++ b/demo/src/app/components/datepicker/datepicker.component.ts
@@ -5,6 +5,9 @@ import {DEMO_SNIPPETS} from './demos';
   selector: 'ngbd-datepicker',
   template: `
     <ngbd-component-wrapper component="Datepicker">
+      <ngbd-overview>
+        <ngbd-datepicker-overview></ngbd-datepicker-overview>
+      </ngbd-overview>
       <ngbd-api-docs directive="NgbDatepicker"></ngbd-api-docs>
       <ngbd-api-docs directive="NgbInputDatepicker"></ngbd-api-docs>
       <ngbd-api-docs-class type="NgbDateStruct"></ngbd-api-docs-class>

--- a/demo/src/app/components/datepicker/index.ts
+++ b/demo/src/app/components/datepicker/index.ts
@@ -4,11 +4,12 @@ import {NgModule} from '@angular/core';
 import {NgbdSharedModule} from '../../shared';
 import {NgbdComponentsSharedModule} from '../shared';
 import {NgbdDatepicker} from './datepicker.component';
+import {NgbdDatepickerOverviewComponent, NgbdDatepickerOverviewDemoComponent} from './overview';
 import {DEMO_DIRECTIVES} from './demos';
 
 @NgModule({
   imports: [NgbdSharedModule, NgbdComponentsSharedModule],
   exports: [NgbdDatepicker],
-  declarations: [NgbdDatepicker, ...DEMO_DIRECTIVES],
+  declarations: [NgbdDatepicker, ...DEMO_DIRECTIVES, NgbdDatepickerOverviewComponent, NgbdDatepickerOverviewDemoComponent],
 })
 export class NgbdDatepickerModule {}

--- a/demo/src/app/components/datepicker/overview/datepicker-overview.component.html
+++ b/demo/src/app/components/datepicker/overview/datepicker-overview.component.html
@@ -1,0 +1,426 @@
+<p>
+  Datepicker will help you with date selection.
+  It can be used either inline with <code>NgbDatepicker</code> component or as a
+  popup on any input element with <code>NgbInputDatepicker</code> directive.
+  It also comes with the list of services to do formatting, calendars and i18n.
+</p>
+<p>
+  We try to keep API of our components simple, but introduce extension points,
+  so you could enrich and reuse them.
+
+  Here is a short example of the vacation range picker that displays holidays with tooltips
+  and disables weekends.
+</p>
+
+<ngbd-datepicker-demo-overview class="d-block my-4"></ngbd-datepicker-demo-overview>
+
+<p>
+  To understand the concepts behind the datepicker, here are some topics to look at:
+</p>
+<ol>
+  <li><a [routerLink]="" fragment="basic-usage">Basic usage</a></li>
+  <li><a [routerLink]="" fragment="getting-date">Getting/setting a date</a></li>
+  <li><a [routerLink]="" fragment="navigation">Moving around</a></li>
+  <li><a [routerLink]="" fragment="date-model">Date model and format</a></li>
+  <li><a [routerLink]="" fragment="day-template">Day display customization</a></li>
+  <li><a [routerLink]="" fragment="limiting-dates">Disabling and limiting dates</a></li>
+  <li><a [routerLink]="" fragment="range">Range selection</a></li>
+  <li><a [routerLink]="" fragment="calendars">Alternative calendars</a></li>
+  <li><a [routerLink]="" fragment="i18n">Internationalization</a></li>
+  <li><a [routerLink]="" fragment="keyboard-shortcuts">Keyboard shortcuts</a></li>
+</ol>
+
+
+
+<!-- BASIC USAGE -->
+<section>
+  <h2>
+    <a class="title-fragment" [routerLink]="" fragment="basic-usage" ngbdFragment>
+      <img src="img/link-symbol.svg" />
+    </a>
+    Basic Usage
+  </h2>
+
+  <p>
+    Datepicker can be used either inline or inside of the popup.
+  </p>
+  <p>
+    In the example below the template variable <code>#d</code> will point
+    to the instance of the <code>NgbDatepicker</code> component in the first case.
+    In the second it will point to the instance of the <code>NgbInputDatepicker</code>
+    directive that will handle the popup containing inline datepicker.
+  </p>
+
+  <ngbd-code lang="html" [code]="snippets.basic"></ngbd-code>
+
+  <p>
+    See the <a routerLink="../api" fragment="NgbDatepicker">NgbDatepicker API</a>
+    and the <a routerLink="../api" fragment="NgbInputDatepicker">NgbInputDatepicker API</a>
+    for details on all available inputs, outputs and methods.
+
+    You can customize the number of displayed months, the way navigation
+    between months and years looks like, week numbers, etc.
+  </p>
+
+  <p>
+    If you have a very specific case of the datepicker popup,
+    you could always create you own one and use the inline datepicker inside.
+  </p>
+
+  <h4>Handling the popup</h4>
+
+  <p>
+    It's up to you do decide when the datepicker popup should be opened and closed.
+    The API contains <code>.open()</code>, <code>.close()</code> and <code>.toggle()</code>
+    methods.
+  </p>
+
+  <p>
+    By default the popup element is attached after the input in the DOM.
+    You have also the option of attaching it to the document body by setting the
+    <code>[container]</code> input to <code>'body'</code>
+  </p>
+
+  <ngbd-code lang="html" [code]="snippets.popup"></ngbd-code>
+
+  <p>
+    The popup will be closed when pressing the <code>Escape</code> key and when
+    a date is selected via keyboard or mouse.
+    It can stay open after date selection if you set <code>[autoClose]</code> input to <code>false</code>
+  </p>
+</section>
+
+
+
+<!-- GETTING / SETTING A DATE -->
+<section>
+  <h2>
+    <a class="title-fragment" [routerLink]="" fragment="getting-date" ngbdFragment>
+      <img src="img/link-symbol.svg" />
+    </a>
+    Getting/setting a date
+  </h2>
+
+  <p>
+    You have several ways of knowing when user selects a date. The date is selected
+    either by clicking on it, pressing <code>Space</code> or <code>Enter</code>,
+    typing text in the input or programmatically.
+  </p>
+
+  <p>
+    Datepicker is integrated with Angular forms and works with both reactive
+    and template-driven forms. So you could use <code>[(ngModel)]</code>,
+    <code>[formControl]</code>, <code>formControlName</code>, etc. Using
+    <code>ngModel</code> will allow you both to get and set selected value.
+  </p>
+
+  <p>
+    The model, however, will NOT be a native javascript date,
+    see the following section for more info.
+  </p>
+
+  <ngbd-code lang="html" [code]="snippets.form"></ngbd-code>
+
+  <p>
+    Alternatively you could use the <code>(dateSelect)</code> or <code>(select)</code> outputs.
+    The difference from <code>ngModel</code> is that outputs will continue emitting the same value,
+    if user clicks on the same date. <code>NgModel</code> will do it only once.
+  </p>
+
+  <ngbd-code lang="html" [code]="snippets.selection"></ngbd-code>
+</section>
+
+
+
+<!-- MOVING AROUND-->
+<section>
+  <h2>
+    <a class="title-fragment" [routerLink]="" fragment="navigation" ngbdFragment>
+      <img src="img/link-symbol.svg" />
+    </a>
+    Moving around
+  </h2>
+
+  <p>
+    Date selection and navigation are two different things.
+    You might have a date selected in January, but August currently displayed.
+  </p>
+
+  <p>
+    Datepicker fully supports keyboard navigation and screen readers. You can navigate
+    between controls using <code>Tab</code> (focus will be trapped in the popup), move
+    date focus with arrow keys, home, page up/down and use <code>Shift</code> modifier
+    for faster navigation.
+  </p>
+
+  <p>
+    From the API, you could tell datepicker to open a specific month initially
+    via the <code>[startDate]</code> input or via the <code>.navigateTo()</code> method
+  </p>
+
+  <ngbd-code lang="html" [code]="snippets.navigation"></ngbd-code>
+</section>
+
+
+
+<!-- DISABLING/LIMITING DATES-->
+<section>
+  <h2>
+    <a class="title-fragment" [routerLink]="" fragment="limiting-dates" ngbdFragment>
+      <img src="img/link-symbol.svg" />
+    </a>
+    Disabling and limiting dates
+  </h2>
+
+  <p>
+    You can limit the dates available for navigation and selection using
+    <code>[minDate]</code> and <code>[maxDate]</code> inputs. If you don't specify
+    any of them, you'll have infinite navigation and the year select box
+    will display [-10, +10] years from currently visible month.
+  </p>
+
+  <p>
+    If you want to disable some dates for selection (ex. weekends), you have to
+    provide the <code>[markDisabled]</code> function that will mark certain dates
+    not selectable. It will be called for each newly visible day when you navigate
+    between months.
+  </p>
+
+  <ngbd-code style="position: relative; top: 0.25rem" lang="typescript" [code]="snippets.disablingTS"></ngbd-code>
+  <ngbd-code style="position: relative; bottom: 0.25rem" lang="html" [code]="snippets.disablingHTML"></ngbd-code>
+</section>
+
+
+
+<!-- DATE MODEL-->
+<section>
+  <h2>
+    <a class="title-fragment" [routerLink]="" fragment="date-model" ngbdFragment>
+      <img src="img/link-symbol.svg" />
+    </a>
+    Date model and format
+  </h2>
+
+  <ngb-alert [dismissible]="false">
+    Note: this should change in the near future with using native <code>Date</code>
+    for all public APIs
+  </ngb-alert>
+
+  <p>
+    Datepicker uses <code>NgbDateStruct</code> as a model and not the native
+    <code>Date</code> object. It's a simple data structure with 3 fields.
+    Also note that months start with 1 (as in ISO 8601).
+  </p>
+
+  <ngbd-code lang="typescript" [code]="snippets.dateStruct"></ngbd-code>
+
+  <p>
+    You can tell datepicker to use the native javascript date adapter (bundled with ng-bootstrap) as in the
+    <a routerLink="../examples" fragment="adapter">custom date adapter example</a>. For now
+    the adapter works only for the form integration, so for instance <code>(ngModelChange)</code>
+    will return a native date object. All other APIs continue to use <code>NgbDateStruct</code>
+  </p>
+
+  <p>
+    You can also create your own adapters if necessary by extending and implementing the
+    <code>NgbDateAdapter</code> methods.
+  </p>
+
+  <ngbd-code lang="typescript" [code]="snippets.adapter"></ngbd-code>
+
+  <h4>Input date parsing and formatting</h4>
+
+  <p>
+    In the case of the <code>NgbInputDatepicker</code> you should be able to parse
+    and format the text entered in the input. This is not as easy task as it seems,
+    because you have to account for various formats and locales.
+    For now internally there is a service that does default formatting using ISO 8601 format.
+  </p>
+
+  <ngbd-code lang="typescript" [code]="snippets.formatter"></ngbd-code>
+
+  <p>
+    If the entered input value is invalid, the form model will contain the entered text.
+  </p>
+
+</section>
+
+
+
+<!-- DAY CUSTOMIZATION-->
+<section>
+  <h2>
+    <a class="title-fragment" [routerLink]="" fragment="day-template" ngbdFragment>
+      <img src="img/link-symbol.svg" />
+    </a>
+    Day display customization
+  </h2>
+
+  <p>
+    You can completely replace how each date is rendered by providing a custom template
+    and rendering anything you want inside. You'll get a date context available inside
+    the template with info on whether current date is disabled, selected, focused, etc.
+  </p>
+
+  <p>
+    For more info on what is provided in the template context,
+    see the <a routerLink="../api" fragment="DayTemplateContext">DayTemplateContext API</a>
+  </p>
+
+  <ngbd-code lang="html" [code]="snippets.dayTemplate"></ngbd-code>
+</section>
+
+
+
+<!-- RANGE SELECTION -->
+<section>
+  <h2>
+    <a class="title-fragment" [routerLink]="" fragment="range" ngbdFragment>
+      <img src="img/link-symbol.svg" />
+    </a>
+    Range selection
+  </h2>
+
+  <p>
+    The datepicker model is a single date, however you still can implement range selection
+    functionality. With <code>(select)</code> and <code>(dateSelect)</code> outputs you'll know
+    which dates are being selected and with the <code>[dayTemplate]</code> input
+    you can customize the way any particular date looks.
+    If you want to use the <code>NgbDatepickerInput</code>, you can also tell the popup
+    to stay open by tuning the <code>[autoClose]</code> input.
+    Check the <a routerLink="../examples" fragment="range">range selection example</a>
+    and the initial demo on this page for more details.
+  </p>
+
+  <p>
+    If you can't use the <code>NgbDatepickerInput</code> directive, you should
+    create your own popup and use <code>NgbDatepicker</code> inside of it. In this case
+    we'll handle everything related to date selection and navigation for you and you can create
+    a completely customized popup with any data model you want.
+  </p>
+</section>
+
+
+
+<!-- CALENDARS -->
+<section>
+  <h2>
+    <a class="title-fragment" [routerLink]="" fragment="calendars" ngbdFragment>
+      <img src="img/link-symbol.svg" />
+    </a>
+    Alternative calendars
+  </h2>
+
+  <p>
+    Internally datepicker uses <code>NgbCalendar</code> implementation for the Gregorian
+    calendar. This could be extended to support and calendar that has notion of days, months and years.
+  </p>
+
+  <p>For instance, there are other Islamic calendar implementations available:</p>
+  <ul>
+    <li><code>NgbCalendarIslamicCivil</code></li>
+    <li><code>NgbCalendarIslamicUmalqura</code></li>
+    <li><code>NgbCalendarHijri</code></li>
+  </ul>
+
+  <p>
+    To use any of them, simply provide a different calendar implementation
+  </p>
+
+  <ngbd-code lang="typescript" [code]="snippets.calendars"></ngbd-code>
+
+</section>
+
+
+
+<!-- I18N -->
+<section>
+  <h2>
+    <a class="title-fragment" [routerLink]="" fragment="i18n" ngbdFragment>
+      <img src="img/link-symbol.svg" />
+    </a>
+    Internationalization
+  </h2>
+
+  <p>
+    Since the 2.0.0 release datepicker will use the
+    <a href="https://angular.io/guide/i18n#setting-up-the-locale-of-your-app">application locale</a>
+    if it is present to get translations of weekdays and month names. The internal service that does
+    translation is called <code>NgbDatepickerI18n</code> and you could provide your own implementation
+    if necessary.
+  </p>
+
+  <ngbd-code lang="typescript" [code]="snippets.i18n"></ngbd-code>
+
+  <p>
+    The next/previous button labels can be translated using the standard Angular i18n
+    mechanism. For example, previous month label is extracted under <code>the ngb.datepicker.previous-month</code>
+    name.
+  </p>
+</section>
+
+
+
+<!-- Keyboard -->
+<section>
+  <h2>
+    <a class="title-fragment" [routerLink]="" fragment="keyboard-shortcuts" ngbdFragment>
+      <img src="img/link-symbol.svg" />
+    </a>
+    Keyboard shortcuts
+  </h2>
+
+  <table class="table mt-4">
+    <tbody>
+      <tr>
+        <td><code>Space / Enter</code></td>
+        <td>Selects currently focused date if it is not disabled</td>
+      </tr>
+      <tr>
+        <td><code>Escape</code></td>
+        <td>Closes the datepicker popup (unless <code>[autoClose]</code> is false)</td>
+      </tr>
+      <tr>
+        <td><code>Arrow(Up|Down|Left|Right)</code></td>
+        <td>Moves day focus inside the months view</td>
+      </tr>
+      <tr>
+        <td><code>Shift + Arrow(Up|Down|Left|Right)</code></td>
+        <td>Selects currently focused date (if it is not disabled)</td>
+      </tr>
+      <tr>
+        <td><code>Home</code></td>
+        <td>Moves focus to the the first day of currently opened first month</td>
+      </tr>
+      <tr>
+        <td><code>End</code></td>
+        <td>Moves focus to the the last day of currently opened last month</td>
+      </tr>
+      <tr>
+        <td><code>Shift + Home</code></td>
+        <td>Moves focus to the <code>minDate</code> (if set)</td>
+      </tr>
+      <tr>
+        <td><code>Shift + End</code></td>
+        <td>Moves focus to the <code>maxDate</code> (if set)</td>
+      </tr>
+      <tr>
+        <td><code>PageDown</code></td>
+        <td>Moves focus to the previous month</td>
+      </tr>
+      <tr>
+        <td><code>PageUp</code></td>
+        <td>Moves focus to the next month</td>
+      </tr>
+      <tr>
+        <td><code>Shift + PageDown</code></td>
+        <td>Moves focus to the previous year</td>
+      </tr>
+      <tr>
+        <td><code>Shift + PageUp</code></td>
+        <td>Moves focus to the next year</td>
+      </tr>
+    </tbody>
+  </table>
+
+</section>

--- a/demo/src/app/components/datepicker/overview/datepicker-overview.component.ts
+++ b/demo/src/app/components/datepicker/overview/datepicker-overview.component.ts
@@ -1,0 +1,96 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {NgbDateParserFormatter, NgbDateStruct} from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+  selector: 'ngbd-datepicker-overview',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './datepicker-overview.component.html'
+})
+
+export class NgbdDatepickerOverviewComponent {
+  snippets = {
+    basic: `
+<!-- 1. inline datepicker -->
+<ngb-datepicker #d></ngb-datepicker>
+
+<!-- 2. datepicker in the popup -->
+<input type="text" ngbDatepicker #d="ngbDatepicker"/>
+`,
+    popup: `
+<input type="text" ngbDatepicker #d="ngbDatepicker"/>
+<button (click)="d.toggle()">Toggle</button>
+`,
+    form: `
+<input type="text" ngbDatepicker [(ngModel)]="date"/>
+`,
+    selection: `
+<!-- inline -->
+<ngb-datepicker (select)="onDateSelect($event)"></ngb-datepicker>
+
+<!-- in the popup -->
+<input type="text" ngbDatepicker (dateSelect)="onDateSelect($event)"/>
+`,
+    navigation: `
+<ngb-datepicker #d [startDate]="{year: 1789, month: 7}"></ngb-datepicker>
+<button (click)="d.navigateTo({year: 2048, month: 1})">Goto JAN 2048</button>
+`,
+    dateStruct: `
+const date: NgbDateStruct = { day: 14, month: 7, year: 1789 }; // July, 14 1789
+`,
+    adapter: `
+@Injectable()
+export abstract class NgbDateAdapter<T> {
+  abstract fromModel(value: T): NgbDateStruct; // from your model -> internal model
+  abstract toModel(date: NgbDateStruct): T; // from internal model -> your mode
+}
+
+// create your own if necessary
+providers: [{provide: NgbDateAdapter, useClass: YourOwnDateAdapter}]
+
+// native adapter is bundled with library
+providers: [{provide: NgbDateAdapter, useClass: NgbDateNativeAdapter}]
+`,
+    formatter: `
+@Injectable()
+export abstract class NgbDateParserFormatter {
+  abstract parse(value: string): NgbDateStruct; // from input -> internal model
+  abstract format(date: NgbDateStruct): string; // from internal model -> string
+}
+
+// create your own if necessary
+providers: [{provide: NgbDateParserFormatter, useClass: YourOwnParserFormatter}]
+`,
+    dayTemplate: `
+<ng-template #t let-date="date">
+	{{ date.day }}
+</ng-template>
+
+<ngbDatepicker [dayTemplate]=“t”/>
+`,
+  disablingTS: `
+// disable the 13th of each month
+const isDisabled = (date: NgbDateStruct, current: {month: number}) => day.date === 13;
+`,
+  disablingHTML: `
+<ngb-datepicker [minDate]="{year: 2010, month: 1, day, 1}"
+                [maxDate]="{year: 2048, month 12, day, 31}"
+                [markDisabled]="isDisabled">
+</ngb-datepicker>
+`,
+  calendars: `
+providers: [{provide: NgbCalendar, useClass: NgbCalendarHijri}]
+`,
+  i18n: `
+@Injectable()
+export abstract class NgbDatepickerI18n {
+  abstract getWeekdayShortName(weekday: number): string;
+  abstract getMonthShortName(month: number): string;
+  abstract getMonthFullName(month: number): string;
+  abstract getDayAriaLabel(date: NgbDateStruct): string;
+}
+
+// provide your own if necessary
+providers: [{provide: NgbDatepickerI18n, useClass: YourOwnDatepickerI18n}]
+`
+  }
+}

--- a/demo/src/app/components/datepicker/overview/demo/detepicker-overview-demo.component.ts
+++ b/demo/src/app/components/datepicker/overview/demo/detepicker-overview-demo.component.ts
@@ -1,0 +1,159 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {NgbDateAdapter, NgbDateNativeAdapter, NgbDateStruct, NgbCalendar} from '@ng-bootstrap/ng-bootstrap';
+
+// This will go away with moving model to native JS date
+const equals = (one: NgbDateStruct, two: NgbDateStruct) =>
+  one && two && two.year === one.year && two.month === one.month && two.day === one.day;
+
+const before = (one: NgbDateStruct, two: NgbDateStruct) =>
+  !one || !two ? false : one.year === two.year ? one.month === two.month ? one.day === two.day
+    ? false : one.day < two.day : one.month < two.month : one.year < two.year;
+
+const after = (one: NgbDateStruct, two: NgbDateStruct) =>
+  !one || !two ? false : one.year === two.year ? one.month === two.month ? one.day === two.day
+    ? false : one.day > two.day : one.month > two.month : one.year > two.year;
+
+@Component({
+  selector: 'ngbd-datepicker-demo-overview',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="mb-3">
+      <h5>Vacations </h5>
+      <p>
+        from
+        <b>{{ toNativeDate(fromDate) | date: 'mediumDate' }}</b>
+        to
+        <b>{{ toNativeDate(toDate ? toDate : hoveredDate) | date: 'mediumDate' }}</b>
+      </p>
+    </div>
+
+    <ng-template #dayTemplate let-date="date" let-focused="focused"
+                 let-currentMonth="currentMonth" let-disabled="disabled">
+
+      <span class="custom-day" [ngbTooltip]="getTooltip(date)" container="body"
+            [class.holiday]="!!isHoliday(date)"
+            [class.weekend]="isWeekend(date)"
+            [class.range]="isRange(date)"
+            [class.faded]="isHovered(date) || isInside(date)"
+            (mouseenter)="hoveredDate = date"
+            (mouseleave)="hoveredDate = null">
+        {{ date.day }}
+      </span>
+    </ng-template>
+
+    <ngb-datepicker
+      (select)="onDateSelection($event)"
+      [dayTemplate]="dayTemplate"
+      [markDisabled]="markDisabled"
+      [showWeekNumbers]="true"
+      outsideDays="hidden"
+      [displayMonths]="2">
+    </ngb-datepicker>
+  `,
+  styles: [`
+    .custom-day {
+      text-align: center;
+      display: inline-block;
+      width: 2rem;
+      height: 2rem;
+      line-height: 2rem;
+    }
+    .custom-day:hover {
+      background-color: #e6e6e6;
+    }
+    .weekend {
+      color: #bbbbbb;
+    }
+    .weekend:hover {
+      background-color: transparent;
+    }
+    .holiday, .holiday.weekend, .holiday:hover {
+      color: white;
+      background-color: coral;
+    }
+    .range:not(.holiday,.weekend), .custom-day:not(.weekend,.holiday):hover {
+      background-color: rgb(2, 117, 216);
+      color: white;
+    }
+    .faded:not(.holiday,.weekend) {
+      background-color: rgba(2, 117, 216, 0.5);
+    }
+  `],
+})
+
+export class NgbdDatepickerOverviewDemoComponent {
+
+  hoveredDate: NgbDateStruct;
+
+  fromDate: NgbDateStruct;
+  toDate: NgbDateStruct;
+
+  holidays: {month, day, text}[] = [
+    {month: 1, day: 1, text: 'New Years Day'},
+    {month: 3, day: 30, text: 'Good Friday (hi, Alsace!)'},
+    {month: 5, day: 1, text: 'Labour Day'},
+    {month: 5, day: 5, text: 'V-E Day'},
+    {month: 7, day: 14, text: 'Bastille Day'},
+    {month: 8, day: 15, text: 'Assumption Day'},
+    {month: 11, day: 1, text: 'All Saints Day'},
+    {month: 11, day: 11, text: 'Armistice Day'},
+    {month: 12, day: 25, text: 'Christmas Day'}
+  ];
+
+  constructor(private calendar: NgbCalendar) {
+    this.markDisabled = this.markDisabled.bind(this);
+    this.fromDate = this.getFirstAvailableDate(calendar.getToday());
+    this.toDate = this.getFirstAvailableDate(calendar.getNext(calendar.getToday(), 'd', 15));
+  }
+
+  isWeekend(date: NgbDateStruct) {
+    const d = this.toNativeDate(date);
+    return d.getDay() === 0 || d.getDay() === 6;
+  }
+
+  isHoliday(date: NgbDateStruct): string {
+    const holiday = this.holidays.find(h => h.day === date.day && h.month === date.month);
+    return holiday ? holiday.text : '';
+  }
+
+  markDisabled(date: NgbDateStruct, current: {month: number}) {
+    return this.isHoliday(date) || (this.isWeekend(date) && date.month === current.month);
+  }
+
+  onDateSelection(date: NgbDateStruct) {
+    if (!this.fromDate && !this.toDate) {
+      this.fromDate = date;
+    } else if (this.fromDate && !this.toDate && (after(date, this.fromDate) || equals(date, this.fromDate))) {
+      this.toDate = date;
+    } else {
+      this.toDate = null;
+      this.fromDate = date;
+    }
+  }
+
+  getTooltip(date: NgbDateStruct) {
+    const holidayTooltip = this.isHoliday(date);
+
+    if (holidayTooltip) {
+      return holidayTooltip;
+    } else if (this.isRange(date) && !this.isWeekend(date)) {
+      return 'Vacations!';
+    } else {
+      return '';
+    }
+  }
+
+  getFirstAvailableDate(date): NgbDateStruct {
+    while (this.isWeekend(date) || this.isHoliday(date)) {
+      date = this.calendar.getNext(date, 'd', 1);
+    }
+    return date;
+  }
+
+  toNativeDate = (date: NgbDateStruct) => date ? new Date(date.year, date.month - 1, date.day, 12) : null;
+  isRange = date => this.isFrom(date) || this.isTo(date) || this.isInside(date) || this.isHovered(date);
+  isHovered = date => this.fromDate && !this.toDate && this.hoveredDate && after(date, this.fromDate) && before(date, this.hoveredDate);
+  isInside = date => after(date, this.fromDate) && before(date, this.toDate);
+  isFrom = date => equals(date, this.fromDate);
+  isTo = date => equals(date, this.toDate);
+}

--- a/demo/src/app/components/datepicker/overview/index.ts
+++ b/demo/src/app/components/datepicker/overview/index.ts
@@ -1,0 +1,2 @@
+export * from './datepicker-overview.component';
+export * from './demo/detepicker-overview-demo.component';

--- a/demo/src/app/components/shared/index.ts
+++ b/demo/src/app/components/shared/index.ts
@@ -1,16 +1,20 @@
 import {NgModule} from '@angular/core';
 
 import {NgbdSharedModule} from '../../shared';
-import {ExampleBoxComponent} from './example-box/example-box.component';
-import {NgbdApiDocs} from './api-docs/api-docs.component';
-import {NgbdApiDocsBadge} from './api-docs/api-docs-badge.component';
-import {NgbdApiDocsClass} from './api-docs/api-docs-class.component';
-import {NgbdApiDocsConfig} from './api-docs/api-docs-config.component';
-import {NgbdFragment} from './fragment/fragment.directive';
+import {ExampleBoxComponent} from './example-box';
+import {NgbdApiDocs, NgbdApiDocsBadge, NgbdApiDocsClass, NgbdApiDocsConfig} from './api-docs';
+import {NgbdFragment} from './fragment';
+import {NgbdOverviewComponent} from './overview';
 
 @NgModule({
   imports: [NgbdSharedModule],
-  declarations: [ExampleBoxComponent, NgbdApiDocsBadge, NgbdApiDocs, NgbdApiDocsClass, NgbdApiDocsConfig, NgbdFragment],
-  exports: [ExampleBoxComponent, NgbdApiDocsBadge, NgbdApiDocs, NgbdApiDocsClass, NgbdApiDocsConfig, NgbdFragment]
+  declarations: [
+    ExampleBoxComponent, NgbdApiDocsBadge, NgbdApiDocs, NgbdApiDocsClass, NgbdApiDocsConfig,
+    NgbdFragment, NgbdOverviewComponent
+  ],
+  exports: [
+    ExampleBoxComponent, NgbdApiDocsBadge, NgbdApiDocs, NgbdApiDocsClass, NgbdApiDocsConfig,
+    NgbdFragment, NgbdOverviewComponent
+  ]
 })
 export class NgbdComponentsSharedModule {}

--- a/demo/src/app/components/shared/overview/index.ts
+++ b/demo/src/app/components/shared/overview/index.ts
@@ -1,0 +1,1 @@
+export * from './overview.component';

--- a/demo/src/app/components/shared/overview/overview.component.ts
+++ b/demo/src/app/components/shared/overview/overview.component.ts
@@ -1,0 +1,18 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {Analytics} from '../../../shared/analytics/analytics';
+
+@Component({
+  selector: 'ngbd-overview',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="overview-component">
+      <ng-content></ng-content>
+    </div>
+  `,
+})
+
+export class NgbdOverviewComponent {
+
+  constructor(private _analytics: Analytics) {
+  }
+}

--- a/demo/src/app/shared/component-wrapper/component-wrapper.component.html
+++ b/demo/src/app/shared/component-wrapper/component-wrapper.component.html
@@ -21,7 +21,6 @@
         id="doc-nav"
         [ngbCollapse]="sidebarCollapsed"
         class="d-lg-block my-3 collpase sidebar"
-        [activeTab]="activeTab"
       ></ngbd-side-nav>
     </div>
 
@@ -30,7 +29,7 @@
         <h1 class="mb-4 mr-auto mr-md-none">{{ component }}</h1>
 
         <ul class="nav nav-tabs px-4 px-lg-5 content-tabset" [class.justify-content-start]="isLargeScreenOrLess" [class.justify-content-end]="isSmallScreenOrLess">
-          <li class="nav-item" *ngIf="hasOverview">
+          <li class="nav-item" *ngIf="overview">
             <a
               class="nav-link"
               [class.active]="activeTab === 'overview'"
@@ -69,6 +68,10 @@
           [ngSwitch]="activeTab"
           class="col-12 col-xl-9 px-md-0 pr-xl-4"
         >
+          <ng-container *ngSwitchCase="'overview'">
+            <ng-content select="ngbd-overview"></ng-content>
+          </ng-container>
+
           <ng-container *ngSwitchCase="'examples'">
             <ng-content select="ngbd-example-box"></ng-content>
             <div class="examples-legend">

--- a/demo/src/app/shared/component-wrapper/component-wrapper.component.ts
+++ b/demo/src/app/shared/component-wrapper/component-wrapper.component.ts
@@ -1,11 +1,11 @@
-import {Component, Input, ContentChildren, OnInit, NgZone} from '@angular/core';
+import {Component, ContentChild, ContentChildren, Input, NgZone} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
 
 import {ExampleBoxComponent} from '../../components/shared/example-box';
 import {NgbdApiDocs, NgbdApiDocsClass, NgbdApiDocsConfig} from '../../components/shared/api-docs';
+import {NgbdOverviewComponent} from '../../components/shared/overview';
 
-export const DEFAULT_TAB = 'examples';
-const VALID_TABS = [DEFAULT_TAB, 'api'];
+const VALID_TABS = ['overview', 'examples', 'api'];
 
 @Component({selector: 'ngbd-component-wrapper', templateUrl: './component-wrapper.component.html'})
 export class ComponentWrapper {
@@ -20,8 +20,7 @@ export class ComponentWrapper {
 
   sidebarCollapsed = true;
 
-  // TODO: change to @ContentChild(OverviewBoxComponent) when implemented
-  hasOverview = false;
+  @ContentChild(NgbdOverviewComponent) overview;
 
   @ContentChildren(ExampleBoxComponent) demos;
 
@@ -40,7 +39,7 @@ export class ComponentWrapper {
       if (VALID_TABS.indexOf(tab) !== -1) {
         this.activeTab = tab;
       } else {
-        this.router.navigate(['..', DEFAULT_TAB], {relativeTo: this.route});
+        this.router.navigate(['..'], {relativeTo: this.route});
       }
       document.body.scrollIntoView();
     });

--- a/demo/src/app/shared/side-nav/side-nav.component.html
+++ b/demo/src/app/shared/side-nav/side-nav.component.html
@@ -10,9 +10,9 @@
     <ul class="nav flex-column">
       <li
         *ngFor="let component of components"
-        [class.active]="isActive(['/components', component.toLowerCase(), activeTab])"
+        [class.active]="isActive(['/components', component.toLowerCase()], false)"
       >
-        <a class="toc-link" [routerLink]="['/components', component.toLowerCase(), activeTab]">{{ component }}</a>
+        <a class="toc-link" [routerLink]="['/components', component.toLowerCase()]">{{ component }}</a>
       </li>
     </ul>
   </div>

--- a/demo/src/app/shared/side-nav/side-nav.component.ts
+++ b/demo/src/app/shared/side-nav/side-nav.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input} from '@angular/core';
+import {Component} from '@angular/core';
 import {Router} from '@angular/router';
 
 export const componentsList = [
@@ -11,7 +11,6 @@ export const componentsList = [
   templateUrl: './side-nav.component.html',
 })
 export class SideNavComponent {
-  @Input() activeTab: String;
   components = componentsList;
 
   constructor(private router: Router) {}

--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -161,11 +161,12 @@ header.title {
 }
 
 
-div.api-doc-component {
+div.api-doc-component,
+div.overview-component {
   margin-bottom: 3rem;
 
-  > h2,
-  > h3 {
+  h2,
+  h3 {
     .github-link {
       transition: opacity 0.5s;
       opacity: 0.3;


### PR DESCRIPTION
First overview page for the demo site:
- new overview component
- datepicker overview component and demo
- change in routing behavior → not remembering active tab id anymore as it will cause issues with switching between components with and without overview. So, `/datepicker` → redirect to `/datepicker/overview` and `/alert` → redirect to `/alert/examples`

Closes #2102

<details>
 <summary>See a very long overview screenshot here</summary>

![screen shot 2018-06-27 at 17 42 22](https://user-images.githubusercontent.com/8074436/41984939-370041f0-7a32-11e8-873b-13ac9bdc184f.png)

</details> 