### PR TITLE
chore: deprecate '.forRoot()' in all modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,31 +47,28 @@ npm install --save @ng-bootstrap/ng-bootstrap
 Once installed you need to import our main module:
 ```js
 import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
-```
-The only remaining part is to list the imported module in your application module. The exact method will be slightly
-different for the root (top-level) module for which you should end up with the code similar to (notice `NgbModule.forRoot()`):
-```js
-import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 
 @NgModule({
-  declarations: [AppComponent, ...],
-  imports: [NgbModule.forRoot(), ...],  
-  bootstrap: [AppComponent]
+  ...
+  imports: [NgbModule, ...],
+  ...
 })
-export class AppModule {
+export class YourAppModule {
 }
 ```
 
-Other modules in your application can simply import `NgbModule`:
+Alternatively you could only import modules with components you need, ex. pagination and alert. 
+The resulting bundle will be smaller in this case.
 
 ```js
-import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
+import {NgbPaginationModule, NgbAlertModule} from '@ng-bootstrap/ng-bootstrap';
 
 @NgModule({
-  declarations: [OtherComponent, ...],
-  imports: [NgbModule, ...], 
+  ...
+  imports: [NgbPaginationModule, NgbAlertModule, ...],
+  ...
 })
-export class OtherModule {
+export class YourAppModule {
 }
 ```
 

--- a/demo/src/app/getting-started/getting-started.component.html
+++ b/demo/src/app/getting-started/getting-started.component.html
@@ -63,17 +63,10 @@
 
   <p>Once installed you need to import our main module.</p>
 
-  <ngbd-code [code]="codeImport" lang="typescript"></ngbd-code>
-
-  <p>
-    The only remaining part is to list the imported module in your root module and any additional application modules that make use
-    of the components in this library. The exact method will be slightly different for the root (top-level) module for which you
-    should end up with the code similar to (notice <code>NgbModule.forRoot()</code>):
-  </p>
-
   <ngbd-code [code]="codeRoot" lang="typescript"></ngbd-code>
 
-  <p>Other modules in your application can simply import <code>NgbModule</code>:</p>
+  <p>Alternatively you could only import modules with components you need, ex. pagination and alert.
+    The resulting bundle will be smaller in this case.</p>
 
   <ngbd-code [code]="codeOther" lang="typescript"></ngbd-code>
   <br>

--- a/demo/src/app/getting-started/getting-started.component.ts
+++ b/demo/src/app/getting-started/getting-started.component.ts
@@ -8,27 +8,26 @@ export class GettingStarted {
 
   codeInstall = `npm install --save @ng-bootstrap/ng-bootstrap`;
 
-  codeImport = `import {NgbModule} from '@ng-bootstrap/ng-bootstrap';`;
-
   codeRoot = `
 import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 
 @NgModule({
-  declarations: [AppComponent, ...],
-  imports: [NgbModule.forRoot(), ...],
-  bootstrap: [AppComponent]
+  ...
+  imports: [NgbModule, ...],
+  ...
 })
-export class AppModule {
+export class YourAppModule {
 }`;
 
   codeOther = `
-import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
+import {NgbPaginationModule, NgbAlertModule} from '@ng-bootstrap/ng-bootstrap';
 
 @NgModule({
-  declarations: [OtherComponent, ...],
-  imports: [NgbModule, ...]
+  ...
+  imports: [NgbPaginationModule, NgbAlertModule, ...],
+  ...
 })
-export class OtherModule {
+export class YourAppModule {
 }`;
 
   codeSystem = `

--- a/src/accordion/accordion-config.ts
+++ b/src/accordion/accordion-config.ts
@@ -5,7 +5,7 @@ import {Injectable} from '@angular/core';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the accordions used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbAccordionConfig {
   closeOthers = false;
   type: string;

--- a/src/accordion/accordion.module.ts
+++ b/src/accordion/accordion.module.ts
@@ -1,8 +1,7 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
-import {NgbAccordion, NgbPanel, NgbPanelTitle, NgbPanelContent, NgbPanelChangeEvent} from './accordion';
-import {NgbAccordionConfig} from './accordion-config';
+import {NgbAccordion, NgbPanel, NgbPanelTitle, NgbPanelContent} from './accordion';
 
 export {NgbAccordion, NgbPanel, NgbPanelTitle, NgbPanelContent, NgbPanelChangeEvent} from './accordion';
 export {NgbAccordionConfig} from './accordion-config';
@@ -11,5 +10,11 @@ const NGB_ACCORDION_DIRECTIVES = [NgbAccordion, NgbPanel, NgbPanelTitle, NgbPane
 
 @NgModule({declarations: NGB_ACCORDION_DIRECTIVES, exports: NGB_ACCORDION_DIRECTIVES, imports: [CommonModule]})
 export class NgbAccordionModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbAccordionModule, providers: [NgbAccordionConfig]}; }
+  /**
+   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
+   * Will be removed in 4.0.0.
+   *
+   * @deprecated 3.0.0
+   */
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbAccordionModule}; }
 }

--- a/src/alert/alert-config.ts
+++ b/src/alert/alert-config.ts
@@ -5,7 +5,7 @@ import {Injectable} from '@angular/core';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the alerts used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbAlertConfig {
   dismissible = true;
   type = 'warning';

--- a/src/alert/alert.module.ts
+++ b/src/alert/alert.module.ts
@@ -2,12 +2,17 @@ import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NgbAlert} from './alert';
-import {NgbAlertConfig} from './alert-config';
 
 export {NgbAlert} from './alert';
 export {NgbAlertConfig} from './alert-config';
 
 @NgModule({declarations: [NgbAlert], exports: [NgbAlert], imports: [CommonModule], entryComponents: [NgbAlert]})
 export class NgbAlertModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbAlertModule, providers: [NgbAlertConfig]}; }
+  /**
+   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
+   * Will be removed in 4.0.0.
+   *
+   * @deprecated 3.0.0
+   */
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbAlertModule}; }
 }

--- a/src/buttons/buttons.module.ts
+++ b/src/buttons/buttons.module.ts
@@ -12,5 +12,11 @@ const NGB_BUTTON_DIRECTIVES = [NgbButtonLabel, NgbCheckBox, NgbRadioGroup, NgbRa
 
 @NgModule({declarations: NGB_BUTTON_DIRECTIVES, exports: NGB_BUTTON_DIRECTIVES})
 export class NgbButtonsModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbButtonsModule, providers: []}; }
+  /**
+   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
+   * Will be removed in 4.0.0.
+   *
+   * @deprecated 3.0.0
+   */
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbButtonsModule}; }
 }

--- a/src/carousel/carousel-config.ts
+++ b/src/carousel/carousel-config.ts
@@ -5,7 +5,7 @@ import {Injectable} from '@angular/core';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the carousels used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbCarouselConfig {
   interval = 5000;
   wrap = true;

--- a/src/carousel/carousel.module.ts
+++ b/src/carousel/carousel.module.ts
@@ -1,13 +1,18 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
-import {NGB_CAROUSEL_DIRECTIVES, NgbSlideEvent} from './carousel';
-import {NgbCarouselConfig} from './carousel-config';
+import {NGB_CAROUSEL_DIRECTIVES} from './carousel';
 
 export {NgbCarousel, NgbSlide, NgbSlideEvent} from './carousel';
 export {NgbCarouselConfig} from './carousel-config';
 
 @NgModule({declarations: NGB_CAROUSEL_DIRECTIVES, exports: NGB_CAROUSEL_DIRECTIVES, imports: [CommonModule]})
 export class NgbCarouselModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbCarouselModule, providers: [NgbCarouselConfig]}; }
+  /**
+   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
+   * Will be removed in 4.0.0.
+   *
+   * @deprecated 3.0.0
+   */
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbCarouselModule}; }
 }

--- a/src/collapse/collapse.module.ts
+++ b/src/collapse/collapse.module.ts
@@ -5,5 +5,11 @@ export {NgbCollapse} from './collapse';
 
 @NgModule({declarations: [NgbCollapse], exports: [NgbCollapse]})
 export class NgbCollapseModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbCollapseModule, providers: []}; }
+  /**
+   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
+   * Will be removed in 4.0.0.
+   *
+   * @deprecated 3.0.0
+   */
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbCollapseModule}; }
 }

--- a/src/datepicker/datepicker-config.ts
+++ b/src/datepicker/datepicker-config.ts
@@ -7,7 +7,7 @@ import {NgbDateStruct} from './ngb-date-struct';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the datepickers used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbDatepickerConfig {
   dayTemplate: TemplateRef<DayTemplateContext>;
   displayMonths = 1;

--- a/src/datepicker/datepicker.module.ts
+++ b/src/datepicker/datepicker.module.ts
@@ -1,7 +1,7 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule, DatePipe} from '@angular/common';
 import {FormsModule} from '@angular/forms';
-import {NgbDatepicker, NgbDatepickerNavigateEvent} from './datepicker';
+import {NgbDatepicker} from './datepicker';
 import {NgbDatepickerMonthView} from './datepicker-month-view';
 import {NgbDatepickerNavigation} from './datepicker-navigation';
 import {NgbInputDatepicker} from './datepicker-input';
@@ -9,12 +9,9 @@ import {NgbDatepickerToggle} from './datepicker-toggle';
 import {NgbDatepickerDayView} from './datepicker-day-view';
 import {NgbDatepickerI18n, NgbDatepickerI18nDefault} from './datepicker-i18n';
 import {NgbCalendar, NgbCalendarGregorian} from './ngb-calendar';
-import {NgbCalendarIslamicCivil} from './hijri/ngb-calendar-islamic-civil';
-import {NgbCalendarIslamicUmalqura} from './hijri/ngb-calendar-islamic-umalqura';
 import {NgbDateParserFormatter, NgbDateISOParserFormatter} from './ngb-date-parser-formatter';
 import {NgbDateAdapter, NgbDateStructAdapter} from './adapters/ngb-date-adapter';
 import {NgbDatepickerNavigationSelect} from './datepicker-navigation-select';
-import {NgbDatepickerConfig} from './datepicker-config';
 
 export {NgbDatepicker, NgbDatepickerNavigateEvent} from './datepicker';
 export {NgbInputDatepicker} from './datepicker-input';
@@ -40,18 +37,20 @@ export {NgbDateParserFormatter} from './ngb-date-parser-formatter';
   ],
   exports: [NgbDatepicker, NgbInputDatepicker, NgbDatepickerToggle],
   imports: [CommonModule, FormsModule],
+  providers: [
+    {provide: NgbCalendar, useClass: NgbCalendarGregorian},
+    {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nDefault},
+    {provide: NgbDateParserFormatter, useClass: NgbDateISOParserFormatter},
+    {provide: NgbDateAdapter, useClass: NgbDateStructAdapter}, DatePipe
+  ],
   entryComponents: [NgbDatepicker]
 })
 export class NgbDatepickerModule {
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: NgbDatepickerModule,
-      providers: [
-        {provide: NgbCalendar, useClass: NgbCalendarGregorian},
-        {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nDefault},
-        {provide: NgbDateParserFormatter, useClass: NgbDateISOParserFormatter},
-        {provide: NgbDateAdapter, useClass: NgbDateStructAdapter}, NgbDatepickerConfig, DatePipe
-      ]
-    };
-  }
+  /**
+   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
+   * Will be removed in 4.0.0.
+   *
+   * @deprecated 3.0.0
+   */
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbDatepickerModule}; }
 }

--- a/src/dropdown/dropdown-config.ts
+++ b/src/dropdown/dropdown-config.ts
@@ -6,7 +6,7 @@ import {PlacementArray} from '../util/positioning';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the dropdowns used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbDropdownConfig {
   autoClose: boolean | 'outside' | 'inside' = true;
   placement: PlacementArray = 'bottom-left';

--- a/src/dropdown/dropdown.module.ts
+++ b/src/dropdown/dropdown.module.ts
@@ -1,6 +1,5 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 import {NgbDropdown, NgbDropdownAnchor, NgbDropdownToggle, NgbDropdownMenu} from './dropdown';
-import {NgbDropdownConfig} from './dropdown-config';
 
 export {NgbDropdown, NgbDropdownToggle, NgbDropdownMenu} from './dropdown';
 export {NgbDropdownConfig} from './dropdown-config';
@@ -9,5 +8,11 @@ const NGB_DROPDOWN_DIRECTIVES = [NgbDropdown, NgbDropdownAnchor, NgbDropdownTogg
 
 @NgModule({declarations: NGB_DROPDOWN_DIRECTIVES, exports: NGB_DROPDOWN_DIRECTIVES})
 export class NgbDropdownModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbDropdownModule, providers: [NgbDropdownConfig]}; }
+  /**
+   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
+   * Will be removed in 4.0.0.
+   *
+   * @deprecated 3.0.0
+   */
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbDropdownModule}; }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,20 +92,23 @@ const NGB_MODULES = [
   NgbTabsetModule, NgbTimepickerModule, NgbTooltipModule, NgbTypeaheadModule
 ];
 
-@NgModule({
-  imports: [
-    NgbAlertModule.forRoot(), NgbButtonsModule.forRoot(), NgbCollapseModule.forRoot(), NgbProgressbarModule.forRoot(),
-    NgbTooltipModule.forRoot(), NgbTypeaheadModule.forRoot(), NgbAccordionModule.forRoot(), NgbCarouselModule.forRoot(),
-    NgbDatepickerModule.forRoot(), NgbDropdownModule.forRoot(), NgbModalModule.forRoot(), NgbPaginationModule.forRoot(),
-    NgbPopoverModule.forRoot(), NgbProgressbarModule.forRoot(), NgbRatingModule.forRoot(), NgbTabsetModule.forRoot(),
-    NgbTimepickerModule.forRoot(), NgbTooltipModule.forRoot()
-  ],
-  exports: NGB_MODULES
-})
+/**
+ * NgbRootModule is no longer necessary, you can simply import NgbModule
+ * Will be removed in 4.0.0.
+ *
+ * @deprecated 3.0.0
+ */
+@NgModule({imports: [NGB_MODULES], exports: NGB_MODULES})
 export class NgbRootModule {
 }
 
 @NgModule({imports: NGB_MODULES, exports: NGB_MODULES})
 export class NgbModule {
+  /**
+   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
+   * Will be removed in 4.0.0.
+   *
+   * @deprecated 3.0.0
+   */
   static forRoot(): ModuleWithProviders { return {ngModule: NgbRootModule}; }
 }

--- a/src/modal/modal-stack.ts
+++ b/src/modal/modal-stack.ts
@@ -18,7 +18,7 @@ import {NgbModalBackdrop} from './modal-backdrop';
 import {NgbModalWindow} from './modal-window';
 import {NgbActiveModal, NgbModalRef} from './modal-ref';
 
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbModalStack {
   private _windowAttributes = ['ariaLabelledBy', 'backdrop', 'centered', 'keyboard', 'size', 'windowClass'];
   private _backdropAttributes = ['backdropClass'];

--- a/src/modal/modal.module.ts
+++ b/src/modal/modal.module.ts
@@ -2,21 +2,19 @@ import {NgModule, ModuleWithProviders} from '@angular/core';
 
 import {NgbModalBackdrop} from './modal-backdrop';
 import {NgbModalWindow} from './modal-window';
-import {NgbModalStack} from './modal-stack';
 import {NgbModal} from './modal';
-import {ScrollBar} from '../util/scrollbar';
 
 export {NgbModal, NgbModalOptions} from './modal';
 export {NgbModalRef, NgbActiveModal} from './modal-ref';
 export {ModalDismissReasons} from './modal-dismiss-reasons';
 
-@NgModule({
-  declarations: [NgbModalBackdrop, NgbModalWindow],
-  entryComponents: [NgbModalBackdrop, NgbModalWindow],
-  providers: [NgbModal]
-})
+@NgModule({declarations: [NgbModalBackdrop, NgbModalWindow], entryComponents: [NgbModalBackdrop, NgbModalWindow]})
 export class NgbModalModule {
-  static forRoot(): ModuleWithProviders {
-    return {ngModule: NgbModalModule, providers: [NgbModal, NgbModalStack, ScrollBar]};
-  }
+  /**
+   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
+   * Will be removed in 4.0.0.
+   *
+   * @deprecated 3.0.0
+   */
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbModalModule}; }
 }

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -71,7 +71,7 @@ export interface NgbModalOptions {
  * A service to open modal windows. Creating a modal is straightforward: create a template and pass it as an argument to
  * the "open" method!
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbModal {
   constructor(
       private _moduleCFR: ComponentFactoryResolver, private _injector: Injector, private _modalStack: NgbModalStack) {}

--- a/src/pagination/pagination-config.ts
+++ b/src/pagination/pagination-config.ts
@@ -5,7 +5,7 @@ import {Injectable} from '@angular/core';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the paginations used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbPaginationConfig {
   disabled = false;
   boundaryLinks = false;

--- a/src/pagination/pagination.module.ts
+++ b/src/pagination/pagination.module.ts
@@ -2,12 +2,17 @@ import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NgbPagination} from './pagination';
-import {NgbPaginationConfig} from './pagination-config';
 
 export {NgbPagination} from './pagination';
 export {NgbPaginationConfig} from './pagination-config';
 
 @NgModule({declarations: [NgbPagination], exports: [NgbPagination], imports: [CommonModule]})
 export class NgbPaginationModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbPaginationModule, providers: [NgbPaginationConfig]}; }
+  /**
+   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
+   * Will be removed in 4.0.0.
+   *
+   * @deprecated 3.0.0
+   */
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbPaginationModule}; }
 }

--- a/src/popover/popover-config.ts
+++ b/src/popover/popover-config.ts
@@ -6,7 +6,7 @@ import {PlacementArray} from '../util/positioning';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the popovers used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbPopoverConfig {
   placement: PlacementArray = 'top';
   triggers = 'click';

--- a/src/popover/popover.module.ts
+++ b/src/popover/popover.module.ts
@@ -1,8 +1,6 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 
 import {NgbPopover, NgbPopoverWindow} from './popover';
-import {NgbPopoverConfig} from './popover-config';
-import {Placement} from '../util/positioning';
 
 export {NgbPopover} from './popover';
 export {NgbPopoverConfig} from './popover-config';
@@ -10,5 +8,11 @@ export {Placement} from '../util/positioning';
 
 @NgModule({declarations: [NgbPopover, NgbPopoverWindow], exports: [NgbPopover], entryComponents: [NgbPopoverWindow]})
 export class NgbPopoverModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbPopoverModule, providers: [NgbPopoverConfig]}; }
+  /**
+   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
+   * Will be removed in 4.0.0.
+   *
+   * @deprecated 3.0.0
+   */
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbPopoverModule}; }
 }

--- a/src/progressbar/progressbar-config.ts
+++ b/src/progressbar/progressbar-config.ts
@@ -5,7 +5,7 @@ import {Injectable} from '@angular/core';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the progress bars used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbProgressbarConfig {
   max = 100;
   animated = false;

--- a/src/progressbar/progressbar.module.ts
+++ b/src/progressbar/progressbar.module.ts
@@ -2,12 +2,17 @@ import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NgbProgressbar} from './progressbar';
-import {NgbProgressbarConfig} from './progressbar-config';
 
 export {NgbProgressbar} from './progressbar';
 export {NgbProgressbarConfig} from './progressbar-config';
 
 @NgModule({declarations: [NgbProgressbar], exports: [NgbProgressbar], imports: [CommonModule]})
 export class NgbProgressbarModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbProgressbarModule, providers: [NgbProgressbarConfig]}; }
+  /**
+   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
+   * Will be removed in 4.0.0.
+   *
+   * @deprecated 3.0.0
+   */
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbProgressbarModule}; }
 }

--- a/src/rating/rating-config.ts
+++ b/src/rating/rating-config.ts
@@ -5,7 +5,7 @@ import {Injectable} from '@angular/core';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the ratings used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbRatingConfig {
   max = 10;
   readonly = false;

--- a/src/rating/rating.module.ts
+++ b/src/rating/rating.module.ts
@@ -1,6 +1,5 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {NgbRatingConfig} from './rating-config';
 
 import {NgbRating} from './rating';
 
@@ -9,5 +8,11 @@ export {NgbRatingConfig} from './rating-config';
 
 @NgModule({declarations: [NgbRating], exports: [NgbRating], imports: [CommonModule]})
 export class NgbRatingModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbRatingModule, providers: [NgbRatingConfig]}; }
+  /**
+   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
+   * Will be removed in 4.0.0.
+   *
+   * @deprecated 3.0.0
+   */
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbRatingModule}; }
 }

--- a/src/tabset/tabset-config.ts
+++ b/src/tabset/tabset-config.ts
@@ -5,7 +5,7 @@ import {Injectable} from '@angular/core';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the tabsets used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbTabsetConfig {
   justify: 'start' | 'center' | 'end' | 'fill' | 'justified' = 'start';
   orientation: 'horizontal' | 'vertical' = 'horizontal';

--- a/src/tabset/tabset.module.ts
+++ b/src/tabset/tabset.module.ts
@@ -1,8 +1,7 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
-import {NgbTabset, NgbTab, NgbTabContent, NgbTabTitle, NgbTabChangeEvent} from './tabset';
-import {NgbTabsetConfig} from './tabset-config';
+import {NgbTabset, NgbTab, NgbTabContent, NgbTabTitle} from './tabset';
 
 export {NgbTabset, NgbTab, NgbTabContent, NgbTabTitle, NgbTabChangeEvent} from './tabset';
 export {NgbTabsetConfig} from './tabset-config';
@@ -11,5 +10,11 @@ const NGB_TABSET_DIRECTIVES = [NgbTabset, NgbTab, NgbTabContent, NgbTabTitle];
 
 @NgModule({declarations: NGB_TABSET_DIRECTIVES, exports: NGB_TABSET_DIRECTIVES, imports: [CommonModule]})
 export class NgbTabsetModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbTabsetModule, providers: [NgbTabsetConfig]}; }
+  /**
+   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
+   * Will be removed in 4.0.0.
+   *
+   * @deprecated 3.0.0
+   */
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbTabsetModule}; }
 }

--- a/src/timepicker/timepicker-config.ts
+++ b/src/timepicker/timepicker-config.ts
@@ -5,7 +5,7 @@ import {Injectable} from '@angular/core';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the timepickers used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbTimepickerConfig {
   meridian = false;
   spinners = true;

--- a/src/timepicker/timepicker.module.ts
+++ b/src/timepicker/timepicker.module.ts
@@ -2,7 +2,6 @@ import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NgbTimepicker} from './timepicker';
-import {NgbTimepickerConfig} from './timepicker-config';
 import {NgbTimeAdapter, NgbTimeStructAdapter} from './ngb-time-adapter';
 
 export {NgbTimepicker} from './timepicker';
@@ -10,12 +9,18 @@ export {NgbTimepickerConfig} from './timepicker-config';
 export {NgbTimeStruct} from './ngb-time-struct';
 export {NgbTimeAdapter} from './ngb-time-adapter';
 
-@NgModule({declarations: [NgbTimepicker], exports: [NgbTimepicker], imports: [CommonModule]})
+@NgModule({
+  declarations: [NgbTimepicker],
+  exports: [NgbTimepicker],
+  imports: [CommonModule],
+  providers: [{provide: NgbTimeAdapter, useClass: NgbTimeStructAdapter}]
+})
 export class NgbTimepickerModule {
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: NgbTimepickerModule,
-      providers: [NgbTimepickerConfig, {provide: NgbTimeAdapter, useClass: NgbTimeStructAdapter}]
-    };
-  }
+  /**
+   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
+   * Will be removed in 4.0.0.
+   *
+   * @deprecated 3.0.0
+   */
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbTimepickerModule}; }
 }

--- a/src/tooltip/tooltip-config.ts
+++ b/src/tooltip/tooltip-config.ts
@@ -6,7 +6,7 @@ import {PlacementArray} from '../util/positioning';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the tooltips used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbTooltipConfig {
   placement: PlacementArray = 'top';
   triggers = 'hover';

--- a/src/tooltip/tooltip.module.ts
+++ b/src/tooltip/tooltip.module.ts
@@ -1,8 +1,6 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 
 import {NgbTooltip, NgbTooltipWindow} from './tooltip';
-import {NgbTooltipConfig} from './tooltip-config';
-import {Placement} from '../util/positioning';
 
 export {NgbTooltipConfig} from './tooltip-config';
 export {NgbTooltip} from './tooltip';
@@ -10,5 +8,10 @@ export {Placement} from '../util/positioning';
 
 @NgModule({declarations: [NgbTooltip, NgbTooltipWindow], exports: [NgbTooltip], entryComponents: [NgbTooltipWindow]})
 export class NgbTooltipModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbTooltipModule, providers: [NgbTooltipConfig]}; }
+  /**
+   * No need in forRoot anymore with tree-shakeable services
+   *
+   * @deprecated 3.0.0
+   */
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbTooltipModule}; }
 }

--- a/src/typeahead/typeahead-config.ts
+++ b/src/typeahead/typeahead-config.ts
@@ -6,7 +6,7 @@ import {PlacementArray} from '../util/positioning';
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the typeaheads used in the application.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class NgbTypeaheadConfig {
   container;
   editable = true;

--- a/src/typeahead/typeahead.module.ts
+++ b/src/typeahead/typeahead.module.ts
@@ -3,9 +3,7 @@ import {CommonModule} from '@angular/common';
 
 import {NgbHighlight} from './highlight';
 import {NgbTypeaheadWindow} from './typeahead-window';
-import {NgbTypeahead, NgbTypeaheadSelectItemEvent} from './typeahead';
-import {NgbTypeaheadConfig} from './typeahead-config';
-import {Live, ARIA_LIVE_DELAY, DEFAULT_ARIA_LIVE_DELAY} from './../util/accessibility/live';
+import {NgbTypeahead} from './typeahead';
 
 export {NgbHighlight} from './highlight';
 export {NgbTypeaheadWindow} from './typeahead-window';
@@ -19,10 +17,11 @@ export {NgbTypeahead, NgbTypeaheadSelectItemEvent} from './typeahead';
   entryComponents: [NgbTypeaheadWindow]
 })
 export class NgbTypeaheadModule {
-  static forRoot(): ModuleWithProviders {
-    return {
-      ngModule: NgbTypeaheadModule,
-      providers: [Live, NgbTypeaheadConfig, {provide: ARIA_LIVE_DELAY, useValue: DEFAULT_ARIA_LIVE_DELAY}]
-    };
-  }
+  /**
+   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
+   * Will be removed in 4.0.0.
+   *
+   * @deprecated 3.0.0
+   */
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbTypeaheadModule}; }
 }

--- a/src/util/accessibility/live.ts
+++ b/src/util/accessibility/live.ts
@@ -6,9 +6,11 @@ import {DOCUMENT} from '@angular/common';
 // usefulness (and default value) of delay documented in Material's CDK
 // https://github.com/angular/material2/blob/6405da9b8e8532a7e5c854c920ee1815c275d734/src/cdk/a11y/live-announcer/live-announcer.ts#L50
 export type ARIA_LIVE_DELAY_TYPE = number | null;
-export const ARIA_LIVE_DELAY = new InjectionToken<ARIA_LIVE_DELAY_TYPE>('live announcer delay');
-export const DEFAULT_ARIA_LIVE_DELAY: ARIA_LIVE_DELAY_TYPE = 100;
-
+export const ARIA_LIVE_DELAY = new InjectionToken<ARIA_LIVE_DELAY_TYPE>(
+    'live announcer delay', {providedIn: 'root', factory: ARIA_LIVE_DELAY_FACTORY});
+export function ARIA_LIVE_DELAY_FACTORY(): number {
+  return 100;
+}
 
 
 function getLiveElement(document: any, lazyCreate = false): HTMLElement | null {
@@ -31,7 +33,7 @@ function getLiveElement(document: any, lazyCreate = false): HTMLElement | null {
 
 
 
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class Live implements OnDestroy {
   constructor(@Inject(DOCUMENT) private _document: any, @Inject(ARIA_LIVE_DELAY) private _delay: any) {}
 

--- a/src/util/scrollbar.ts
+++ b/src/util/scrollbar.ts
@@ -17,7 +17,7 @@ export type CompensationReverter = () => void;
  * It allows to compensate the lack of a vertical scrollbar by adding an
  * equivalent padding on the right of the body, and to remove this compensation.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class ScrollBar {
   constructor(@Inject(DOCUMENT) private _document) {}
 


### PR DESCRIPTION
Alternative to #2363
Contains only deprecations and documentation updates
We should deprecate it in 2.2.0 and remove in 3.0.0

We should also keep #2363 to only actually remove `.forRoot()` and  update BREAKING CHANGES.
I think I even would have opened a separate PR to update our own code (tests + demo)