### PR TITLE
demo(timepicker): don't use ngModel and FormControl simultaneously

### DIFF
--- a/demo/src/app/components/timepicker/demos/validation/timepicker-validation.html
+++ b/demo/src/app/components/timepicker/demos/validation/timepicker-validation.html
@@ -1,7 +1,7 @@
 <p>Illustrates custom validation, you have to select time between 12:00 and 13:59</p>
 
 <div class="form-group">
-  <ngb-timepicker [(ngModel)]="time" [formControl]="ctrl" required></ngb-timepicker>
+  <ngb-timepicker [formControl]="ctrl" required></ngb-timepicker>
   <div *ngIf="ctrl.valid" class="small form-text text-success">Great choice</div>
   <div class="small form-text text-danger" *ngIf="!ctrl.valid">
     <div *ngIf="ctrl.errors['required']">Select some time during lunchtime</div>
@@ -11,4 +11,4 @@
 </div>
 
 <hr>
-<pre>Selected time: {{time | json}}</pre>
+<pre>Selected time: {{ctrl.value | json}}</pre>

--- a/demo/src/app/components/timepicker/demos/validation/timepicker-validation.ts
+++ b/demo/src/app/components/timepicker/demos/validation/timepicker-validation.ts
@@ -6,7 +6,6 @@ import {FormControl} from '@angular/forms';
   templateUrl: './timepicker-validation.html'
 })
 export class NgbdTimepickerValidation {
-  time;
 
   ctrl = new FormControl('', (control: FormControl) => {
     const value = control.value;


### PR DESCRIPTION
Fixes the deprecation in Angular 6:

```
    It looks like you're using ngModel on the same form field as formControl. 
    Support for using the ngModel input property and ngModelChange event with 
    reactive form directives has been deprecated in Angular v6 and will be removed 
    in Angular v7.
    
    For more information on this, see our API docs here:
    https://angular.io/api/forms/FormControlDirective#use-with-ngmodel
```