### PR TITLE
demo(datepicker): fix css selectors for Chrome and Firefox

### DIFF
--- a/demo/src/app/components/datepicker/overview/demo/datepicker-overview-demo.component.ts
+++ b/demo/src/app/components/datepicker/overview/demo/datepicker-overview-demo.component.ts
@@ -71,11 +71,11 @@ const after = (one: NgbDateStruct, two: NgbDateStruct) =>
       color: white;
       background-color: coral;
     }
-    .range:not(.holiday,.weekend), .custom-day:not(.weekend,.holiday):hover {
+    .range:not(.holiday):not(.weekend), .custom-day:not(.weekend):not(.holiday):hover {
       background-color: rgb(2, 117, 216);
       color: white;
     }
-    .faded:not(.holiday,.weekend) {
+    .faded:not(.holiday):not(.weekend) {
       background-color: rgba(2, 117, 216, 0.5);
     }
   `],

--- a/demo/src/app/components/datepicker/overview/index.ts
+++ b/demo/src/app/components/datepicker/overview/index.ts
@@ -1,2 +1,2 @@
 export * from './datepicker-overview.component';
-export * from './demo/detepicker-overview-demo.component';
+export * from './demo/datepicker-overview-demo.component';


### PR DESCRIPTION
It was rendered correctly only in Safari previously. 
Also fixed a typo in the filename.