### PR TITLE
fix(progressbar): add missing i18n id specifier

### DIFF
--- a/src/progressbar/progressbar.ts
+++ b/src/progressbar/progressbar.ts
@@ -13,7 +13,7 @@ import {NgbProgressbarConfig} from './progressbar-config';
       <div class="progress-bar{{type ? ' bg-' + type : ''}}{{animated ? ' progress-bar-animated' : ''}}{{striped ?
     ' progress-bar-striped' : ''}}" role="progressbar" [style.width.%]="getPercentValue()"
     [attr.aria-valuenow]="getValue()" aria-valuemin="0" [attr.aria-valuemax]="max">
-        <span *ngIf="showValue" i18n="ngb.progressbar.value">{{getPercentValue()}}%</span><ng-content></ng-content>
+        <span *ngIf="showValue" i18n="@@ngb.progressbar.value">{{getPercentValue()}}%</span><ng-content></ng-content>
       </div>
     </div>
   `


### PR DESCRIPTION
The id was picked up as description by the angular cli, which resulted in a random id:

```xlf
<trans-unit id="04d611d19c117c60c9e14d0a04399a027184bc77" datatype="html">
    <source><x id="INTERPOLATION" equiv-text="{{getPercentValue()}}"/>%</source>
    <context-group purpose="location">
      <context context-type="sourcefile">../node_modules/@ng-bootstrap/ng-bootstrap/progressbar/progressbar.d.ts</context>
      <context context-type="linenumber">6</context>
    </context-group>
    <note priority="1" from="description">ngb.progressbar.value</note>
</trans-unit>
```