### PR TITLE
feat(datepicker): use generic date model <D> for all public APIs

### DIFF
--- a/src/datepicker/adapters/ngb-date-adapter.ts
+++ b/src/datepicker/adapters/ngb-date-adapter.ts
@@ -8,17 +8,17 @@ import {NgbDateStruct} from '../ngb-date-struct';
  * but you can provide another implementation to use an alternative format, ie for using with native Date Object.
  */
 @Injectable()
-export abstract class NgbDateAdapter<T> {
+export abstract class NgbDateAdapter<D> {
   /**
    * Converts user-model date into an NgbDateStruct for internal use in the library
    */
-  abstract fromModel(value: T): NgbDateStruct;
+  abstract fromModel(value: D): NgbDateStruct;
 
   /**
    * Converts internal date value NgbDateStruct to user-model date
    * The returned type is suposed to be of the same type as fromModel() input-value param
    */
-  abstract toModel(date: NgbDateStruct): T;
+  abstract toModel(date: NgbDateStruct): D;
 }
 
 @Injectable()

--- a/src/datepicker/adapters/ngb-date-native-adapter.spec.ts
+++ b/src/datepicker/adapters/ngb-date-native-adapter.spec.ts
@@ -34,7 +34,7 @@ describe('ngb-date-native model adapter', () => {
     });
 
     it('should convert a valid date',
-       () => { expect(adapter.toModel({year: 2016, month: 10, day: 15})).toEqual(new Date(2016, 9, 15)); });
+       () => { expect(adapter.toModel({year: 2016, month: 10, day: 15})).toEqual(new Date(2016, 9, 15, 12)); });
   });
 
 });

--- a/src/datepicker/adapters/ngb-date-native-adapter.ts
+++ b/src/datepicker/adapters/ngb-date-native-adapter.ts
@@ -10,6 +10,6 @@ export class NgbDateNativeAdapter extends NgbDateAdapter<Date> {
   }
 
   toModel(date: NgbDateStruct): Date {
-    return date && date.year && date.month ? new Date(date.year, date.month - 1, date.day) : null;
+    return date && date.year && date.month ? new Date(date.year, date.month - 1, date.day, 12) : null;
   }
 }

--- a/src/datepicker/datepicker-config.ts
+++ b/src/datepicker/datepicker-config.ts
@@ -8,13 +8,13 @@ import {NgbDateStruct} from './ngb-date-struct';
  * order to provide default values for all the datepickers used in the application.
  */
 @Injectable()
-export class NgbDatepickerConfig {
-  dayTemplate: TemplateRef<DayTemplateContext>;
+export class NgbDatepickerConfig<D = NgbDateStruct> {
+  dayTemplate: TemplateRef<DayTemplateContext<D>>;
   displayMonths = 1;
   firstDayOfWeek = 1;
-  markDisabled: (date: NgbDateStruct, current: {year: number, month: number}) => boolean;
-  minDate: NgbDateStruct;
-  maxDate: NgbDateStruct;
+  markDisabled: (date: D, current: {year: number, month: number}) => boolean;
+  minDate: D;
+  maxDate: D;
   navigation: 'select' | 'arrows' | 'none' = 'select';
   outsideDays: 'visible' | 'collapsed' | 'hidden' = 'visible';
   showWeekdays = true;

--- a/src/datepicker/datepicker-day-template-context.ts
+++ b/src/datepicker/datepicker-day-template-context.ts
@@ -2,7 +2,7 @@ import {NgbDateStruct} from './ngb-date-struct';
 /**
  * Context for the datepicker 'day' template in case you want to override the default one
  */
-export interface DayTemplateContext {
+export interface DayTemplateContext<D = NgbDateStruct> {
   /**
    * Month currently displayed by the datepicker
    */
@@ -11,7 +11,7 @@ export interface DayTemplateContext {
   /**
    * Date that corresponds to the template
    */
-  date: NgbDateStruct;
+  date: D;
 
   /**
    * True if current date is disabled

--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -2,7 +2,7 @@ import {TestBed, ComponentFixture, fakeAsync, tick} from '@angular/core/testing'
 import {By} from '@angular/platform-browser';
 import {createGenericTestComponent} from '../test/common';
 
-import {Component, Injectable} from '@angular/core';
+import {Component} from '@angular/core';
 import {FormsModule, NgForm} from '@angular/forms';
 
 import {Key} from '../util/key';
@@ -11,12 +11,7 @@ import {NgbInputDatepicker} from './datepicker-input';
 import {NgbDatepicker} from './datepicker';
 import {NgbDateStruct} from './ngb-date-struct';
 import {NgbDate} from './ngb-date';
-
-const createTestCmpt = (html: string) =>
-    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
-
-const createTestNativeCmpt = (html: string) =>
-    createGenericTestComponent(html, TestNativeComponent) as ComponentFixture<TestNativeComponent>;
+import {ADAPTERS, SupportedDate} from '../test/datepicker/common';
 
 function dispatchKeyUpEvent(key: Key) {
   const event = document.createEvent('KeyboardEvent') as any;
@@ -26,897 +21,845 @@ function dispatchKeyUpEvent(key: Key) {
   document.dispatchEvent(event);
 }
 
-describe('NgbInputDatepicker', () => {
+ADAPTERS.forEach(adapter => {
 
-  beforeEach(() => {
-    TestBed.configureTestingModule(
-        {declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot(), FormsModule]});
-  });
+  const createTestCmpt = (html: string) =>
+      createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
-  describe('open, close and toggle', () => {
+  const fromStruct = (date: NgbDateStruct): SupportedDate =>
+      (adapter.instance as NgbDateAdapter<SupportedDate>).toModel(date);
 
-    it('should allow controlling datepicker popup from outside', () => {
-      const fixture = createTestCmpt(`
+  describe(`NgbInputDatepicker (${adapter.type.name})`, () => {
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        declarations: [TestComponent],
+        imports: [NgbDatepickerModule.forRoot(), FormsModule],
+        providers: [{provide: NgbDateAdapter, useClass: adapter.type}]
+      });
+    });
+
+    describe('open, close and toggle', () => {
+
+      it('should allow controlling datepicker popup from outside', () => {
+        const fixture = createTestCmpt(`
           <input ngbDatepicker #d="ngbDatepicker">
           <button [ngbDatepickerToggle]="d" (click)="open(d)">Open</button>
           <button [ngbDatepickerToggle]="d" (click)="close(d)">Close</button>
           <button [ngbDatepickerToggle]="d" (click)="toggle(d)">Toggle</button>`);
 
-      const buttons = fixture.nativeElement.querySelectorAll('button');
+        const buttons = fixture.nativeElement.querySelectorAll('button');
 
-      buttons[0].click();  // open
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+        buttons[0].click();  // open
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
 
-      buttons[1].click();  // close
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
+        buttons[1].click();  // close
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
 
-      buttons[2].click();  // toggle
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+        buttons[2].click();  // toggle
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
 
-      buttons[2].click();  // toggle
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
-    });
+        buttons[2].click();  // toggle
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
+      });
 
-    it('should support the "position" option',
-       () => { createTestCmpt(`<input ngbDatepicker #d="ngbDatepicker" [placement]="'bottom-right'">`); });
+      it('should support the "position" option',
+         () => { createTestCmpt(`<input ngbDatepicker #d="ngbDatepicker" [placement]="'bottom-right'">`); });
 
-    it('should focus the datepicker after opening', () => {
-      const fixture = createTestCmpt(`
+      it('should focus the datepicker after opening', () => {
+        const fixture = createTestCmpt(`
           <input ngbDatepicker #d="ngbDatepicker">
           <button [ngbDatepickerToggle]="d" (click)="open(d)">Open</button>
       `);
 
-      // open
-      const button = fixture.nativeElement.querySelector('button');
-      button.click();
-      fixture.detectChanges();
-      expect(document.activeElement).toBe(fixture.nativeElement.querySelector('div.ngb-dp-day[tabindex="0"]'));
-    });
+        // open
+        const button = fixture.nativeElement.querySelector('button');
+        button.click();
+        fixture.detectChanges();
+        expect(document.activeElement).toBe(fixture.nativeElement.querySelector('div.ngb-dp-day[tabindex="0"]'));
+      });
 
-    it('should close datepicker on ESC key', () => {
-      const fixture = createTestCmpt(`
+      it('should close datepicker on ESC key', () => {
+        const fixture = createTestCmpt(`
           <input ngbDatepicker #d="ngbDatepicker">
           <button [ngbDatepickerToggle]="d" (click)="open(d)">Open</button>`);
 
-      // open
-      const button = fixture.nativeElement.querySelector('button');
-      button.click();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+        // open
+        const button = fixture.nativeElement.querySelector('button');
+        button.click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
 
-      // dispatch escape
-      dispatchKeyUpEvent(Key.Escape);
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
-    });
+        // dispatch escape
+        dispatchKeyUpEvent(Key.Escape);
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
+      });
 
-    it('should not close datepicker when clicking on input element', () => {
-      const fixture = createTestCmpt(`
+      it('should not close datepicker when clicking on input element', () => {
+        const fixture = createTestCmpt(`
           <input ngbDatepicker #d="ngbDatepicker">
           <button [ngbDatepickerToggle]="d" (click)="open(d)">Open</button>
           <button id="outside-button">Outside button</button>
       `);
 
-      // open
-      const button = fixture.nativeElement.querySelector('button');
-      button.click();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+        // open
+        const button = fixture.nativeElement.querySelector('button');
+        button.click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
 
-      // click on input
-      const input = fixture.nativeElement.querySelector('input[ngbDatepicker]');
-      input.click();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
-    });
+        // click on input
+        const input = fixture.nativeElement.querySelector('input[ngbDatepicker]');
+        input.click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+      });
 
-    it('should not close datepicker when clicking elements with [ngbDatepickerToggle]', () => {
-      const fixture = createTestCmpt(`
+      it('should not close datepicker when clicking elements with [ngbDatepickerToggle]', () => {
+        const fixture = createTestCmpt(`
           <input ngbDatepicker #d="ngbDatepicker">
           <button [ngbDatepickerToggle]="d" (click)="open(d)">Open</button>
           <button [ngbDatepickerToggle]="d" id="outside-button">Outside button</button>
       `);
 
-      // open
-      const button = fixture.nativeElement.querySelector('button');
-      button.click();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+        // open
+        const button = fixture.nativeElement.querySelector('button');
+        button.click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
 
-      // click outside
-      const outsideButton = fixture.nativeElement.querySelector('#outside-button');
-      outsideButton.click();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
-    });
+        // click outside
+        const outsideButton = fixture.nativeElement.querySelector('#outside-button');
+        outsideButton.click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+      });
 
-    it('should not close datepicker when clicking elements added with "registerClickableElement()"', () => {
-      const fixture = createTestCmpt(`
+      it('should not close datepicker when clicking elements added with "registerClickableElement()"', () => {
+        const fixture = createTestCmpt(`
           <input ngbDatepicker #d="ngbDatepicker">
           <button [ngbDatepickerToggle]="d" (click)="d.registerClickableElement(b1); open(d); d.registerClickableElement(b2);">Open</button>
           <button #b1 id="outside-button1">Outside button</button>
           <button #b2 id="outside-button2">Outside button</button>
       `);
 
-      // open
-      const button = fixture.nativeElement.querySelector('button');
-      button.click();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+        // open
+        const button = fixture.nativeElement.querySelector('button');
+        button.click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
 
-      // click outside 1
-      const outsideButton1 = fixture.nativeElement.querySelector('#outside-button1');
-      outsideButton1.click();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+        // click outside 1
+        const outsideButton1 = fixture.nativeElement.querySelector('#outside-button1');
+        outsideButton1.click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
 
-      // click outside 2
-      const outsideButton2 = fixture.nativeElement.querySelector('#outside-button2');
-      outsideButton2.click();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
-    });
+        // click outside 2
+        const outsideButton2 = fixture.nativeElement.querySelector('#outside-button2');
+        outsideButton2.click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+      });
 
-    it('should close datepicker on date selection and outside click', () => {
-      const fixture = createTestCmpt(`
+      it('should close datepicker on date selection and outside click', () => {
+        const fixture = createTestCmpt(`
           <input ngbDatepicker #d="ngbDatepicker">
           <button [ngbDatepickerToggle]="d" (click)="open(d)">Open</button>
           <button id="outside-button">Outside button</button>
       `);
 
-      // open
-      const button = fixture.nativeElement.querySelector('button');
-      button.click();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+        // open
+        const button = fixture.nativeElement.querySelector('button');
+        button.click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
 
-      // select
-      const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
-      dp.select.emit();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
+        // select
+        const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+        dp.select.emit();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
 
-      // open
-      button.click();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+        // open
+        button.click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
 
-      // click outside
-      const outsideButton = fixture.nativeElement.querySelector('#outside-button');
-      outsideButton.click();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
-    });
+        // click outside
+        const outsideButton = fixture.nativeElement.querySelector('#outside-button');
+        outsideButton.click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
+      });
 
-    it(`should not close datepicker if 'autoClose' set to 'false'`, () => {
-      const fixture = createTestCmpt(`
+      it(`should not close datepicker if 'autoClose' set to 'false'`, () => {
+        const fixture = createTestCmpt(`
           <input ngbDatepicker #d="ngbDatepicker" [autoClose]="false">
           <button [ngbDatepickerToggle]="d" (click)="open(d)">Open</button>
           <button id="outside-button">Outside button</button>
       `);
 
-      // open
-      const button = fixture.nativeElement.querySelector('button');
-      button.click();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+        // open
+        const button = fixture.nativeElement.querySelector('button');
+        button.click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
 
-      // select
-      const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
-      dp.select.emit();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+        // select
+        const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+        dp.select.emit();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
 
-      // click outside
-      const outsideButton = fixture.nativeElement.querySelector('#outside-button');
-      outsideButton.click();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
-    });
+        // click outside
+        const outsideButton = fixture.nativeElement.querySelector('#outside-button');
+        outsideButton.click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+      });
 
-    it(`should close datepicker only on date selection if 'autoClose' set to 'inside'`, () => {
-      const fixture = createTestCmpt(`
+      it(`should close datepicker only on date selection if 'autoClose' set to 'inside'`, () => {
+        const fixture = createTestCmpt(`
           <input ngbDatepicker #d="ngbDatepicker" autoClose="inside">
           <button [ngbDatepickerToggle]="d" (click)="open(d)">Open</button>
           <button id="outside-button">Outside button</button>
       `);
 
-      // open
-      const button = fixture.nativeElement.querySelector('button');
-      button.click();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+        // open
+        const button = fixture.nativeElement.querySelector('button');
+        button.click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
 
-      // click outside
-      const outsideButton = fixture.nativeElement.querySelector('#outside-button');
-      outsideButton.click();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+        // click outside
+        const outsideButton = fixture.nativeElement.querySelector('#outside-button');
+        outsideButton.click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
 
-      // select
-      const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
-      dp.select.emit();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
-    });
+        // select
+        const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+        dp.select.emit();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
+      });
 
-    it(`should close datepicker only on outside click if 'autoClose' set to 'outside'`, () => {
-      const fixture = createTestCmpt(`
+      it(`should close datepicker only on outside click if 'autoClose' set to 'outside'`, () => {
+        const fixture = createTestCmpt(`
           <input ngbDatepicker #d="ngbDatepicker" autoClose="outside">
           <button [ngbDatepickerToggle]="d" (click)="open(d)">Open</button>
           <button id="outside-button">Outside button</button>
       `);
 
-      // open
-      const button = fixture.nativeElement.querySelector('button');
-      button.click();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+        // open
+        const button = fixture.nativeElement.querySelector('button');
+        button.click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
 
-      // select
-      const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
-      dp.select.emit();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+        // select
+        const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+        dp.select.emit();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
 
-      // click outside
-      const outsideButton = fixture.nativeElement.querySelector('#outside-button');
-      outsideButton.click();
-      fixture.detectChanges();
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
-    });
-  });
-
-  describe('ngModel interactions', () => {
-
-    it('should format bound date as ISO (by default) in the input field', fakeAsync(() => {
-         const fixture = createTestCmpt(`<input ngbDatepicker [ngModel]="date">`);
-         const input = fixture.nativeElement.querySelector('input');
-
-         fixture.componentInstance.date = {year: 2016, month: 10, day: 10};
-         fixture.detectChanges();
-         tick();
-         expect(input.value).toBe('2016-10-10');
-
-         fixture.componentInstance.date = {year: 2016, month: 10, day: 15};
-         fixture.detectChanges();
-         tick();
-         expect(input.value).toBe('2016-10-15');
-       }));
-
-    it('should parse user-entered date as ISO (by default)', () => {
-      const fixture = createTestCmpt(`<input ngbDatepicker [(ngModel)]="date">`);
-      const inputDebugEl = fixture.debugElement.query(By.css('input'));
-
-      inputDebugEl.triggerEventHandler('input', {target: {value: '2016-09-10'}});
-      expect(fixture.componentInstance.date).toEqual({year: 2016, month: 9, day: 10});
+        // click outside
+        const outsideButton = fixture.nativeElement.querySelector('#outside-button');
+        outsideButton.click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
+      });
     });
 
-    it('should set only valid dates', fakeAsync(() => {
-         const fixture = createTestCmpt(`<input ngbDatepicker [ngModel]="date">`);
-         const input = fixture.nativeElement.querySelector('input');
+    describe('ngModel interactions', () => {
 
-         fixture.componentInstance.date = <any>{};
-         fixture.detectChanges();
-         tick();
-         expect(input.value).toBe('');
+      it('should format bound date as ISO (by default) in the input field', fakeAsync(() => {
+           const fixture = createTestCmpt(`<input ngbDatepicker [ngModel]="date">`);
+           const input = fixture.nativeElement.querySelector('input');
 
-         fixture.componentInstance.date = null;
-         fixture.detectChanges();
-         tick();
-         expect(input.value).toBe('');
+           fixture.componentInstance.date = fromStruct({year: 2016, month: 10, day: 10});
+           fixture.detectChanges();
+           tick();
+           expect(input.value).toBe('2016-10-10');
 
-         fixture.componentInstance.date = <any>new Date();
-         fixture.detectChanges();
-         tick();
-         expect(input.value).toBe('');
+           fixture.componentInstance.date = fromStruct({year: 2016, month: 10, day: 15});
+           fixture.detectChanges();
+           tick();
+           expect(input.value).toBe('2016-10-15');
+         }));
 
-         fixture.componentInstance.date = undefined;
-         fixture.detectChanges();
-         tick();
-         expect(input.value).toBe('');
+      it('should parse user-entered date as ISO (by default)', () => {
+        const fixture = createTestCmpt(`<input ngbDatepicker [(ngModel)]="date">`);
+        const inputDebugEl = fixture.debugElement.query(By.css('input'));
 
-         fixture.componentInstance.date = new NgbDate(300000, 1, 1);
-         fixture.detectChanges();
-         tick();
-         expect(input.value).toBe('');
+        inputDebugEl.triggerEventHandler('input', {target: {value: '2016-09-10'}});
+        expect(fixture.componentInstance.date).toEqual(fromStruct({year: 2016, month: 9, day: 10}));
+      });
 
-         fixture.componentInstance.date = new NgbDate(2017, 2, null);
-         fixture.detectChanges();
-         tick();
-         expect(input.value).toBe('');
+      it('should set only valid dates', fakeAsync(() => {
+           const fixture = createTestCmpt(`<input ngbDatepicker [ngModel]="date">`);
+           const input = fixture.nativeElement.querySelector('input');
 
-         fixture.componentInstance.date = new NgbDate(2017, null, 5);
-         fixture.detectChanges();
-         tick();
-         expect(input.value).toBe('');
+           fixture.componentInstance.date = <any>{};
+           fixture.detectChanges();
+           tick();
+           expect(input.value).toBe('');
 
-         fixture.componentInstance.date = new NgbDate(null, 2, 5);
-         fixture.detectChanges();
-         tick();
-         expect(input.value).toBe('');
+           fixture.componentInstance.date = null;
+           fixture.detectChanges();
+           tick();
+           expect(input.value).toBe('');
 
-         fixture.componentInstance.date = new NgbDate(<any>'2017', <any>'03', <any>'10');
-         fixture.detectChanges();
-         tick();
-         expect(input.value).toBe('');
-       }));
+           fixture.componentInstance.date = undefined;
+           fixture.detectChanges();
+           tick();
+           expect(input.value).toBe('');
 
-    it('should propagate disabled state', fakeAsync(() => {
-         const fixture = createTestCmpt(`
+           fixture.componentInstance.date = fromStruct({year: 300000, month: 1, day: 1});
+           fixture.detectChanges();
+           tick();
+           expect(input.value).toBe('');
+         }));
+
+      it('should propagate disabled state', fakeAsync(() => {
+           const fixture = createTestCmpt(`
         <input ngbDatepicker [(ngModel)]="date" #d="ngbDatepicker" [disabled]="isDisabled">
         <button [ngbDatepickerToggle]="d" (click)="open(d)">Open</button>`);
-         fixture.componentInstance.isDisabled = true;
-         fixture.detectChanges();
+           fixture.componentInstance.isDisabled = true;
+           fixture.detectChanges();
 
-         const button = fixture.nativeElement.querySelector('button');
-         const input = fixture.nativeElement.querySelector('input');
+           const button = fixture.nativeElement.querySelector('button');
+           const input = fixture.nativeElement.querySelector('input');
 
-         button.click();  // open
-         tick();
-         fixture.detectChanges();
-         const buttonInDatePicker = fixture.nativeElement.querySelector('ngb-datepicker button');
+           button.click();  // open
+           tick();
+           fixture.detectChanges();
+           const buttonInDatePicker = fixture.nativeElement.querySelector('ngb-datepicker button');
 
-         expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
-         expect(input.disabled).toBeTruthy();
-         expect(buttonInDatePicker.disabled).toBeTruthy();
+           expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+           expect(input.disabled).toBeTruthy();
+           expect(buttonInDatePicker.disabled).toBeTruthy();
 
-         const dayElements = fixture.nativeElement.querySelectorAll('ngb-datepicker-month-view .ngb-dp-day');
-         expect(dayElements[1]).toHaveCssClass('disabled');
-         expect(dayElements[11]).toHaveCssClass('disabled');
-         expect(dayElements[21]).toHaveCssClass('disabled');
+           const dayElements = fixture.nativeElement.querySelectorAll('ngb-datepicker-month-view .ngb-dp-day');
+           expect(dayElements[1]).toHaveCssClass('disabled');
+           expect(dayElements[11]).toHaveCssClass('disabled');
+           expect(dayElements[21]).toHaveCssClass('disabled');
 
-         fixture.componentInstance.isDisabled = false;
-         fixture.detectChanges();
-         tick();
-         fixture.detectChanges();
+           fixture.componentInstance.isDisabled = false;
+           fixture.detectChanges();
+           tick();
+           fixture.detectChanges();
 
-         expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
-         expect(input.disabled).toBeFalsy();
-         expect(buttonInDatePicker.disabled).toBeFalsy();
+           expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+           expect(input.disabled).toBeFalsy();
+           expect(buttonInDatePicker.disabled).toBeFalsy();
 
-         const dayElements2 = fixture.nativeElement.querySelectorAll('ngb-datepicker-month-view .ngb-dp-day');
-         expect(dayElements2[1]).not.toHaveCssClass('disabled');
-         expect(dayElements2[11]).not.toHaveCssClass('disabled');
-         expect(dayElements2[21]).not.toHaveCssClass('disabled');
-       }));
+           const dayElements2 = fixture.nativeElement.querySelectorAll('ngb-datepicker-month-view .ngb-dp-day');
+           expect(dayElements2[1]).not.toHaveCssClass('disabled');
+           expect(dayElements2[11]).not.toHaveCssClass('disabled');
+           expect(dayElements2[21]).not.toHaveCssClass('disabled');
+         }));
 
-    it('should propagate disabled state without form control', () => {
-      const fixture = createTestCmpt(`
+      it('should propagate disabled state without form control', () => {
+        const fixture = createTestCmpt(`
         <input ngbDatepicker #d="ngbDatepicker" [disabled]="isDisabled">
         <button [ngbDatepickerToggle]="d" (click)="open(d)">Open</button>`);
-      fixture.componentInstance.isDisabled = true;
-      fixture.detectChanges();
+        fixture.componentInstance.isDisabled = true;
+        fixture.detectChanges();
 
-      const button = fixture.nativeElement.querySelector('button');
-      const input = fixture.nativeElement.querySelector('input');
+        const button = fixture.nativeElement.querySelector('button');
+        const input = fixture.nativeElement.querySelector('input');
 
-      expect(input.disabled).toBeTruthy();
+        expect(input.disabled).toBeTruthy();
 
-      button.click();  // open
-      fixture.detectChanges();
-      const buttonInDatePicker = fixture.nativeElement.querySelector('ngb-datepicker button');
+        button.click();  // open
+        fixture.detectChanges();
+        const buttonInDatePicker = fixture.nativeElement.querySelector('ngb-datepicker button');
 
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
-      expect(input.disabled).toBeTruthy();
-      expect(buttonInDatePicker.disabled).toBeTruthy();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+        expect(input.disabled).toBeTruthy();
+        expect(buttonInDatePicker.disabled).toBeTruthy();
 
-      const dayElements = fixture.nativeElement.querySelectorAll('ngb-datepicker-month-view .ngb-dp-day');
-      expect(dayElements[1]).toHaveCssClass('disabled');
-      expect(dayElements[11]).toHaveCssClass('disabled');
-      expect(dayElements[21]).toHaveCssClass('disabled');
+        const dayElements = fixture.nativeElement.querySelectorAll('ngb-datepicker-month-view .ngb-dp-day');
+        expect(dayElements[1]).toHaveCssClass('disabled');
+        expect(dayElements[11]).toHaveCssClass('disabled');
+        expect(dayElements[21]).toHaveCssClass('disabled');
 
-      fixture.componentInstance.isDisabled = false;
-      fixture.detectChanges();
+        fixture.componentInstance.isDisabled = false;
+        fixture.detectChanges();
 
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
-      expect(input.disabled).toBeFalsy();
-      expect(buttonInDatePicker.disabled).toBeFalsy();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).not.toBeNull();
+        expect(input.disabled).toBeFalsy();
+        expect(buttonInDatePicker.disabled).toBeFalsy();
 
-      const dayElements2 = fixture.nativeElement.querySelectorAll('ngb-datepicker-month-view .ngb-dp-day');
-      expect(dayElements2[1]).not.toHaveCssClass('disabled');
-      expect(dayElements2[11]).not.toHaveCssClass('disabled');
-      expect(dayElements2[21]).not.toHaveCssClass('disabled');
-    });
+        const dayElements2 = fixture.nativeElement.querySelectorAll('ngb-datepicker-month-view .ngb-dp-day');
+        expect(dayElements2[1]).not.toHaveCssClass('disabled');
+        expect(dayElements2[11]).not.toHaveCssClass('disabled');
+        expect(dayElements2[21]).not.toHaveCssClass('disabled');
+      });
 
-    it('should propagate touched state on (blur)', fakeAsync(() => {
-         const fixture = createTestCmpt(`<input ngbDatepicker [(ngModel)]="date">`);
-         const inputDebugEl = fixture.debugElement.query(By.css('input'));
+      it('should propagate touched state on (blur)', fakeAsync(() => {
+           const fixture = createTestCmpt(`<input ngbDatepicker [(ngModel)]="date">`);
+           const inputDebugEl = fixture.debugElement.query(By.css('input'));
 
-         expect(inputDebugEl.classes['ng-touched']).toBeFalsy();
+           expect(inputDebugEl.classes['ng-touched']).toBeFalsy();
 
-         inputDebugEl.triggerEventHandler('blur', {});
-         tick();
-         fixture.detectChanges();
+           inputDebugEl.triggerEventHandler('blur', {});
+           tick();
+           fixture.detectChanges();
 
-         expect(inputDebugEl.classes['ng-touched']).toBeTruthy();
-       }));
+           expect(inputDebugEl.classes['ng-touched']).toBeTruthy();
+         }));
 
-    it('should propagate touched state when setting a date', fakeAsync(() => {
-         const fixture = createTestCmpt(`
+      it('should propagate touched state when setting a date', fakeAsync(() => {
+           const fixture = createTestCmpt(`
       <input ngbDatepicker [(ngModel)]="date" #d="ngbDatepicker">
       <button [ngbDatepickerToggle]="d" (click)="open(d)">Open</button>`);
 
-         const buttonDebugEl = fixture.debugElement.query(By.css('button'));
-         const inputDebugEl = fixture.debugElement.query(By.css('input'));
-
-         expect(inputDebugEl.classes['ng-touched']).toBeFalsy();
-
-         buttonDebugEl.triggerEventHandler('click', {});  // open
-         inputDebugEl.triggerEventHandler('change', {target: {value: '2016-09-10'}});
-         tick();
-         fixture.detectChanges();
-
-         expect(inputDebugEl.classes['ng-touched']).toBeTruthy();
-       }));
-  });
-
-  describe('manual data entry', () => {
-
-    it('should reformat value entered by a user when it is valid', fakeAsync(() => {
-         const fixture = createTestCmpt(`<input ngbDatepicker (ngModelChange)="date">`);
-         const inputDebugEl = fixture.debugElement.query(By.css('input'));
-
-         inputDebugEl.triggerEventHandler('change', {target: {value: '2016-9-1'}});
-         tick();
-         fixture.detectChanges();
-
-         expect(inputDebugEl.nativeElement.value).toBe('2016-09-01');
-       }));
-
-    it('should retain value entered by a user if it is not valid', fakeAsync(() => {
-         const fixture = createTestCmpt(`<input ngbDatepicker (ngModelChange)="date">`);
-         const inputDebugEl = fixture.debugElement.query(By.css('input'));
-
-         inputDebugEl.nativeElement.value = '2016-09-aa';
-         inputDebugEl.triggerEventHandler('change', {target: {value: inputDebugEl.nativeElement.value}});
-         tick();
-         fixture.detectChanges();
-
-         expect(inputDebugEl.nativeElement.value).toBe('2016-09-aa');
-       }));
-
-  });
-
-  describe('validation', () => {
-
-    describe('values set from model', () => {
-
-      it('should not return errors for valid model', fakeAsync(() => {
-           const fixture = createTestCmpt(
-               `<form><input ngbDatepicker [ngModel]="{year: 2017, month: 04, day: 04}" name="dp"></form>`);
-           const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
-
-           fixture.detectChanges();
-           tick();
-           expect(form.control.valid).toBeTruthy();
-           expect(form.control.hasError('ngbDate', ['dp'])).toBeFalsy();
-         }));
-
-      it('should not return errors for empty model', fakeAsync(() => {
-           const fixture = createTestCmpt(`<form><input ngbDatepicker [ngModel]="date" name="dp"></form>`);
-           const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
-
-           fixture.detectChanges();
-           tick();
-           expect(form.control.valid).toBeTruthy();
-         }));
-
-      it('should return "invalid" errors for invalid model', fakeAsync(() => {
-           const fixture = createTestCmpt(`<form><input ngbDatepicker [ngModel]="5" name="dp"></form>`);
-           const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
-
-           fixture.detectChanges();
-           tick();
-           expect(form.control.invalid).toBeTruthy();
-           expect(form.control.getError('ngbDate', ['dp']).invalid).toBe(5);
-         }));
-
-      it('should return "requiredBefore" errors for dates before minimal date', fakeAsync(() => {
-           const fixture = createTestCmpt(`<form>
-          <input ngbDatepicker [ngModel]="{year: 2017, month: 04, day: 04}" [minDate]="{year: 2017, month: 6, day: 4}" name="dp">
-        </form>`);
-           const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
-
-           fixture.detectChanges();
-           tick();
-           expect(form.control.invalid).toBeTruthy();
-           expect(form.control.getError('ngbDate', ['dp']).requiredBefore).toEqual({year: 2017, month: 6, day: 4});
-         }));
-
-      it('should return "requiredAfter" errors for dates after maximal date', fakeAsync(() => {
-           const fixture = createTestCmpt(`<form>
-          <input ngbDatepicker [ngModel]="{year: 2017, month: 04, day: 04}" [maxDate]="{year: 2017, month: 2, day: 4}" name="dp">
-        </form>`);
-           const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
-
-           fixture.detectChanges();
-           tick();
-           expect(form.control.invalid).toBeTruthy();
-           expect(form.control.getError('ngbDate', ['dp']).requiredAfter).toEqual({year: 2017, month: 2, day: 4});
-         }));
-
-      it('should update validity status when model changes', fakeAsync(() => {
-           const fixture = createTestCmpt(`<form><input ngbDatepicker [ngModel]="date" name="dp"></form>`);
-           const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
-
-           fixture.componentRef.instance.date = <any>'invalid';
-           fixture.detectChanges();
-           tick();
-           expect(form.control.invalid).toBeTruthy();
-
-           fixture.componentRef.instance.date = {year: 2015, month: 7, day: 3};
-           fixture.detectChanges();
-           tick();
-           expect(form.control.valid).toBeTruthy();
-         }));
-
-      it('should update validity status when minDate changes', fakeAsync(() => {
-           const fixture = createTestCmpt(`<form>
-          <input ngbDatepicker [ngModel]="{year: 2017, month: 2, day: 4}" [minDate]="date" name="dp">
-        </form>`);
-           const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
-
-           fixture.detectChanges();
-           tick();
-           expect(form.control.valid).toBeTruthy();
-
-           fixture.componentRef.instance.date = {year: 2018, month: 7, day: 3};
-           fixture.detectChanges();
-           tick();
-           expect(form.control.invalid).toBeTruthy();
-         }));
-
-      it('should update validity status when maxDate changes', fakeAsync(() => {
-           const fixture = createTestCmpt(`<form>
-          <input ngbDatepicker [ngModel]="{year: 2017, month: 2, day: 4}" [maxDate]="date" name="dp">
-        </form>`);
-           const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
-
-           fixture.detectChanges();
-           tick();
-           expect(form.control.valid).toBeTruthy();
-
-           fixture.componentRef.instance.date = {year: 2015, month: 7, day: 3};
-           fixture.detectChanges();
-           tick();
-           expect(form.control.invalid).toBeTruthy();
-         }));
-
-      it('should update validity for manually entered dates', fakeAsync(() => {
-           const fixture = createTestCmpt(`<form><input ngbDatepicker [(ngModel)]="date" name="dp"></form>`);
+           const buttonDebugEl = fixture.debugElement.query(By.css('button'));
            const inputDebugEl = fixture.debugElement.query(By.css('input'));
-           const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
 
-           inputDebugEl.triggerEventHandler('input', {target: {value: '2016-09-10'}});
-           fixture.detectChanges();
-           tick();
-           expect(form.control.valid).toBeTruthy();
+           expect(inputDebugEl.classes['ng-touched']).toBeFalsy();
 
-           inputDebugEl.triggerEventHandler('input', {target: {value: 'invalid'}});
-           fixture.detectChanges();
-           tick();
-           expect(form.control.invalid).toBeTruthy();
-         }));
-
-      it('should consider empty strings as valid', fakeAsync(() => {
-           const fixture = createTestCmpt(`<form><input ngbDatepicker [(ngModel)]="date" name="dp"></form>`);
-           const inputDebugEl = fixture.debugElement.query(By.css('input'));
-           const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
-
+           buttonDebugEl.triggerEventHandler('click', {});  // open
            inputDebugEl.triggerEventHandler('change', {target: {value: '2016-09-10'}});
-           fixture.detectChanges();
            tick();
-           expect(form.control.valid).toBeTruthy();
+           fixture.detectChanges();
 
-           inputDebugEl.triggerEventHandler('change', {target: {value: ''}});
-           fixture.detectChanges();
-           tick();
-           expect(form.control.valid).toBeTruthy();
+           expect(inputDebugEl.classes['ng-touched']).toBeTruthy();
          }));
     });
 
-  });
+    describe('manual data entry', () => {
 
-  describe('options', () => {
+      it('should reformat value entered by a user when it is valid', fakeAsync(() => {
+           const fixture = createTestCmpt(`<input ngbDatepicker (ngModelChange)="date">`);
+           const inputDebugEl = fixture.debugElement.query(By.css('input'));
 
-    it('should propagate the "dayTemplate" option', () => {
-      const fixture = createTestCmpt(`<ng-template #t></ng-template><input ngbDatepicker [dayTemplate]="t">`);
-      const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
+           inputDebugEl.triggerEventHandler('change', {target: {value: '2016-9-1'}});
+           tick();
+           fixture.detectChanges();
 
-      dpInput.open();
-      fixture.detectChanges();
+           expect(inputDebugEl.nativeElement.value).toBe('2016-09-01');
+         }));
 
-      const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
-      expect(dp.dayTemplate).toBeDefined();
+      it('should retain value entered by a user if it is not valid', fakeAsync(() => {
+           const fixture = createTestCmpt(`<input ngbDatepicker (ngModelChange)="date">`);
+           const inputDebugEl = fixture.debugElement.query(By.css('input'));
+
+           inputDebugEl.nativeElement.value = '2016-09-aa';
+           inputDebugEl.triggerEventHandler('change', {target: {value: inputDebugEl.nativeElement.value}});
+           tick();
+           fixture.detectChanges();
+
+           expect(inputDebugEl.nativeElement.value).toBe('2016-09-aa');
+         }));
+
     });
 
-    it('should propagate the "displayMonths" option', () => {
-      const fixture = createTestCmpt(`<input ngbDatepicker [displayMonths]="3">`);
-      const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
+    describe('validation', () => {
 
-      dpInput.open();
-      fixture.detectChanges();
+      describe('values set from model', () => {
 
-      const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
-      expect(dp.displayMonths).toBe(3);
+        it('should not return errors for valid model', fakeAsync(() => {
+             const fixture = createTestCmpt(
+                 `<form><input ngbDatepicker [ngModel]="fromStruct({year: 2017, month: 04, day: 04})" name="dp"></form>`);
+             const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
+
+             fixture.detectChanges();
+             tick();
+             expect(form.control.valid).toBeTruthy();
+             expect(form.control.hasError('ngbDate', ['dp'])).toBeFalsy();
+           }));
+
+        it('should not return errors for empty model', fakeAsync(() => {
+             const fixture = createTestCmpt(`<form><input ngbDatepicker [ngModel]="date" name="dp"></form>`);
+             const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
+
+             fixture.detectChanges();
+             tick();
+             expect(form.control.valid).toBeTruthy();
+           }));
+
+        it('should return "invalid" errors for invalid model', fakeAsync(() => {
+             const fixture = createTestCmpt(`<form><input ngbDatepicker [ngModel]="5" name="dp"></form>`);
+             const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
+
+             fixture.detectChanges();
+             tick();
+             expect(form.control.invalid).toBeTruthy();
+             expect(form.control.getError('ngbDate', ['dp']).invalid).toBe(5);
+           }));
+
+        it('should return "requiredBefore" errors for dates before minimal date', fakeAsync(() => {
+             const fixture = createTestCmpt(`<form>
+          <input ngbDatepicker [ngModel]="fromStruct({year: 2017, month: 04, day: 04})"
+          [minDate]="fromStruct({year: 2017, month: 6, day: 4})" name="dp">
+        </form>`);
+             const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
+
+             fixture.detectChanges();
+             tick();
+             expect(form.control.invalid).toBeTruthy();
+             expect(form.control.getError('ngbDate', ['dp']).requiredBefore)
+                 .toEqual(fromStruct({year: 2017, month: 6, day: 4}));
+           }));
+
+        it('should return "requiredAfter" errors for dates after maximal date', fakeAsync(() => {
+             const fixture = createTestCmpt(`<form>
+          <input ngbDatepicker [ngModel]="fromStruct({year: 2017, month: 04, day: 04})"
+          [maxDate]="fromStruct({year: 2017, month: 2, day: 4})" name="dp">
+        </form>`);
+             const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
+
+             fixture.detectChanges();
+             tick();
+             expect(form.control.invalid).toBeTruthy();
+             expect(form.control.getError('ngbDate', ['dp']).requiredAfter)
+                 .toEqual(fromStruct({year: 2017, month: 2, day: 4}));
+           }));
+
+        it('should update validity status when model changes', fakeAsync(() => {
+             const fixture = createTestCmpt(`<form><input ngbDatepicker [ngModel]="date" name="dp"></form>`);
+             const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
+
+             fixture.componentRef.instance.date = <any>'invalid';
+             fixture.detectChanges();
+             tick();
+             expect(form.control.invalid).toBeTruthy();
+
+             fixture.componentRef.instance.date = fromStruct({year: 2015, month: 7, day: 3});
+             fixture.detectChanges();
+             tick();
+             expect(form.control.valid).toBeTruthy();
+           }));
+
+        it('should update validity status when minDate changes', fakeAsync(() => {
+             const fixture = createTestCmpt(`<form>
+          <input ngbDatepicker [ngModel]="fromStruct({year: 2017, month: 2, day: 4})" [minDate]="date" name="dp">
+        </form>`);
+             const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
+
+             fixture.detectChanges();
+             tick();
+             expect(form.control.valid).toBeTruthy();
+
+             fixture.componentRef.instance.date = fromStruct({year: 2018, month: 7, day: 3});
+             fixture.detectChanges();
+             tick();
+             expect(form.control.invalid).toBeTruthy();
+           }));
+
+        it('should update validity status when maxDate changes', fakeAsync(() => {
+             const fixture = createTestCmpt(`<form>
+          <input ngbDatepicker [ngModel]="fromStruct({year: 2017, month: 2, day: 4})" [maxDate]="date" name="dp">
+        </form>`);
+             const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
+
+             fixture.detectChanges();
+             tick();
+             expect(form.control.valid).toBeTruthy();
+
+             fixture.componentRef.instance.date = fromStruct({year: 2015, month: 7, day: 3});
+             fixture.detectChanges();
+             tick();
+             expect(form.control.invalid).toBeTruthy();
+           }));
+
+        it('should update validity for manually entered dates', fakeAsync(() => {
+             const fixture = createTestCmpt(`<form><input ngbDatepicker [(ngModel)]="date" name="dp"></form>`);
+             const inputDebugEl = fixture.debugElement.query(By.css('input'));
+             const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
+
+             inputDebugEl.triggerEventHandler('input', {target: {value: '2016-09-10'}});
+             fixture.detectChanges();
+             tick();
+             expect(form.control.valid).toBeTruthy();
+
+             inputDebugEl.triggerEventHandler('input', {target: {value: 'invalid'}});
+             fixture.detectChanges();
+             tick();
+             expect(form.control.invalid).toBeTruthy();
+           }));
+
+        it('should consider empty strings as valid', fakeAsync(() => {
+             const fixture = createTestCmpt(`<form><input ngbDatepicker [(ngModel)]="date" name="dp"></form>`);
+             const inputDebugEl = fixture.debugElement.query(By.css('input'));
+             const form = fixture.debugElement.query(By.directive(NgForm)).injector.get(NgForm);
+
+             inputDebugEl.triggerEventHandler('change', {target: {value: '2016-09-10'}});
+             fixture.detectChanges();
+             tick();
+             expect(form.control.valid).toBeTruthy();
+
+             inputDebugEl.triggerEventHandler('change', {target: {value: ''}});
+             fixture.detectChanges();
+             tick();
+             expect(form.control.valid).toBeTruthy();
+           }));
+      });
+
     });
 
-    it('should propagate the "firstDayOfWeek" option', () => {
-      const fixture = createTestCmpt(`<input ngbDatepicker [firstDayOfWeek]="5">`);
-      const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
+    describe('options', () => {
 
-      dpInput.open();
-      fixture.detectChanges();
+      it('should propagate the "dayTemplate" option', () => {
+        const fixture = createTestCmpt(`<ng-template #t></ng-template><input ngbDatepicker [dayTemplate]="t">`);
+        const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
 
-      const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
-      expect(dp.firstDayOfWeek).toBe(5);
-    });
+        dpInput.open();
+        fixture.detectChanges();
 
-    it('should propagate the "markDisabled" option', () => {
-      const fixture = createTestCmpt(`<input ngbDatepicker [markDisabled]="noop">`);
-      const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
+        const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+        expect(dp.dayTemplate).toBeDefined();
+      });
 
-      dpInput.open();
-      fixture.detectChanges();
+      it('should propagate the "displayMonths" option', () => {
+        const fixture = createTestCmpt(`<input ngbDatepicker [displayMonths]="3">`);
+        const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
 
-      const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
-      expect(dp.markDisabled).toBeDefined();
-    });
+        dpInput.open();
+        fixture.detectChanges();
 
-    it('should propagate the "minDate" option', () => {
-      const fixture = createTestCmpt(`<input ngbDatepicker [minDate]="{year: 2016, month: 9, day: 13}">`);
-      const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
+        const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+        expect(dp.displayMonths).toBe(3);
+      });
 
-      dpInput.open();
-      fixture.detectChanges();
+      it('should propagate the "firstDayOfWeek" option', () => {
+        const fixture = createTestCmpt(`<input ngbDatepicker [firstDayOfWeek]="5">`);
+        const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
 
-      const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
-      expect(dp.minDate).toEqual({year: 2016, month: 9, day: 13});
-    });
+        dpInput.open();
+        fixture.detectChanges();
 
-    it('should propagate the "maxDate" option', () => {
-      const fixture = createTestCmpt(`<input ngbDatepicker [maxDate]="{year: 2016, month: 9, day: 13}">`);
-      const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
+        const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+        expect(dp.firstDayOfWeek).toBe(5);
+      });
 
-      dpInput.open();
-      fixture.detectChanges();
+      it('should propagate the "markDisabled" option', () => {
+        const fixture = createTestCmpt(`<input ngbDatepicker [markDisabled]="noop">`);
+        const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
 
-      const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
-      expect(dp.maxDate).toEqual({year: 2016, month: 9, day: 13});
-    });
+        dpInput.open();
+        fixture.detectChanges();
 
-    it('should propagate the "outsideDays" option', () => {
-      const fixture = createTestCmpt(`<input ngbDatepicker outsideDays="collapsed">`);
-      const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
+        const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+        expect(dp.markDisabled).toBeDefined();
+      });
 
-      dpInput.open();
-      fixture.detectChanges();
+      it('should propagate the "minDate" option', () => {
+        const fixture = createTestCmpt(`<input ngbDatepicker [minDate]="fromStruct({year: 2016, month: 9, day: 13})">`);
+        const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
 
-      const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
-      expect(dp.outsideDays).toEqual('collapsed');
-    });
+        dpInput.open();
+        fixture.detectChanges();
 
-    it('should propagate the "navigation" option', () => {
-      const fixture = createTestCmpt(`<input ngbDatepicker navigation="none">`);
-      const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
+        const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+        expect(dp.minDate).toEqual(fromStruct({year: 2016, month: 9, day: 13}));
+      });
 
-      dpInput.open();
-      fixture.detectChanges();
+      it('should propagate the "maxDate" option', () => {
+        const fixture = createTestCmpt(`<input ngbDatepicker [maxDate]="fromStruct({year: 2016, month: 9, day: 13})">`);
+        const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
 
-      const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
-      expect(dp.navigation).toBe('none');
-    });
+        dpInput.open();
+        fixture.detectChanges();
 
-    it('should propagate the "showWeekdays" option', () => {
-      const fixture = createTestCmpt(`<input ngbDatepicker [showWeekdays]="true">`);
-      const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
+        const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+        expect(dp.maxDate).toEqual(fromStruct({year: 2016, month: 9, day: 13}));
+      });
 
-      dpInput.open();
-      fixture.detectChanges();
+      it('should propagate the "outsideDays" option', () => {
+        const fixture = createTestCmpt(`<input ngbDatepicker outsideDays="collapsed">`);
+        const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
 
-      const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
-      expect(dp.showWeekdays).toBeTruthy();
-    });
+        dpInput.open();
+        fixture.detectChanges();
 
-    it('should propagate the "showWeekNumbers" option', () => {
-      const fixture = createTestCmpt(`<input ngbDatepicker [showWeekNumbers]="true">`);
-      const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
+        const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+        expect(dp.outsideDays).toEqual('collapsed');
+      });
 
-      dpInput.open();
-      fixture.detectChanges();
+      it('should propagate the "navigation" option', () => {
+        const fixture = createTestCmpt(`<input ngbDatepicker navigation="none">`);
+        const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
 
-      const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
-      expect(dp.showWeekNumbers).toBeTruthy();
-    });
+        dpInput.open();
+        fixture.detectChanges();
 
-    it('should propagate the "startDate" option', () => {
-      const fixture = createTestCmpt(`<input ngbDatepicker [startDate]="{year: 2016, month: 9}">`);
-      const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
+        const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+        expect(dp.navigation).toBe('none');
+      });
 
-      dpInput.open();
-      fixture.detectChanges();
+      it('should propagate the "showWeekdays" option', () => {
+        const fixture = createTestCmpt(`<input ngbDatepicker [showWeekdays]="true">`);
+        const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
 
-      const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
-      expect(dp.startDate).toEqual({year: 2016, month: 9});
-    });
+        dpInput.open();
+        fixture.detectChanges();
 
-    it('should propagate model as "startDate" option when "startDate" not provided', fakeAsync(() => {
-         const fixture = createTestCmpt(`<input ngbDatepicker [ngModel]="{year: 2016, month: 9, day: 13}">`);
-         const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
+        const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+        expect(dp.showWeekdays).toBeTruthy();
+      });
 
-         tick();
-         fixture.detectChanges();
-         dpInput.open();
-         fixture.detectChanges();
+      it('should propagate the "showWeekNumbers" option', () => {
+        const fixture = createTestCmpt(`<input ngbDatepicker [showWeekNumbers]="true">`);
+        const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
 
-         const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
-         expect(dp.startDate).toEqual(NgbDate.from({year: 2016, month: 9, day: 13}));
-       }));
+        dpInput.open();
+        fixture.detectChanges();
 
-    it('should relay the "navigate" event', () => {
-      const fixture =
-          createTestCmpt(`<input ngbDatepicker [startDate]="{year: 2016, month: 9}" (navigate)="onNavigate($event)">`);
-      const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
+        const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+        expect(dp.showWeekNumbers).toBeTruthy();
+      });
 
-      spyOn(fixture.componentInstance, 'onNavigate');
+      it('should propagate the "startDate" option', () => {
+        const fixture = createTestCmpt(`<input ngbDatepicker [startDate]="{year: 2016, month: 9}">`);
+        const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
 
-      dpInput.open();
-      fixture.detectChanges();
-      expect(fixture.componentInstance.onNavigate).toHaveBeenCalledWith({current: null, next: {year: 2016, month: 9}});
+        dpInput.open();
+        fixture.detectChanges();
 
-      const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
-      dp.navigateTo({year: 2018, month: 4});
-      expect(fixture.componentInstance.onNavigate)
-          .toHaveBeenCalledWith({current: {year: 2016, month: 9}, next: {year: 2018, month: 4}});
-    });
+        const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+        expect(dp.startDate).toEqual({year: 2016, month: 9});
+      });
 
-    it('should emit both "dateSelect" and "onModelChange" events', () => {
-      const fixture = createTestCmpt(`
+      it('should propagate model as "startDate" option when "startDate" not provided', fakeAsync(() => {
+           const fixture =
+               createTestCmpt(`<input ngbDatepicker [ngModel]="fromStruct({year: 2016, month: 9, day: 13})">`);
+           const dpInput =
+               fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
+
+           tick();
+           fixture.detectChanges();
+           dpInput.open();
+           fixture.detectChanges();
+
+           const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+           expect(dp.startDate).toEqual(NgbDate.from({year: 2016, month: 9, day: 13}));
+         }));
+
+      it('should relay the "navigate" event', () => {
+        const fixture = createTestCmpt(
+            `<input ngbDatepicker [startDate]="{year: 2016, month: 9}" (navigate)="onNavigate($event)">`);
+        const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
+
+        spyOn(fixture.componentInstance, 'onNavigate');
+
+        dpInput.open();
+        fixture.detectChanges();
+        expect(fixture.componentInstance.onNavigate)
+            .toHaveBeenCalledWith({current: null, next: {year: 2016, month: 9}});
+
+        const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+        dp.navigateTo({year: 2018, month: 4});
+        expect(fixture.componentInstance.onNavigate)
+            .toHaveBeenCalledWith({current: {year: 2016, month: 9}, next: {year: 2018, month: 4}});
+      });
+
+      it('should emit both "dateSelect" and "onModelChange" events', () => {
+        const fixture = createTestCmpt(`
           <input ngbDatepicker ngModel [startDate]="{year: 2018, month: 3}"
           (ngModelChange)="onModelChange($event)" (dateSelect)="onDateSelect($event)">`);
 
-      const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
-      spyOn(fixture.componentInstance, 'onDateSelect');
-      spyOn(fixture.componentInstance, 'onModelChange');
+        const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
+        spyOn(fixture.componentInstance, 'onDateSelect');
+        spyOn(fixture.componentInstance, 'onModelChange');
 
-      // open
-      dpInput.open();
-      fixture.detectChanges();
+        // open
+        dpInput.open();
+        fixture.detectChanges();
 
-      // click on a date
-      fixture.nativeElement.querySelectorAll('.ngb-dp-day')[3].click();  // 1 MAR 2018
-      fixture.detectChanges();
-      expect(fixture.componentInstance.onDateSelect).toHaveBeenCalledTimes(1);
-      expect(fixture.componentInstance.onModelChange).toHaveBeenCalledTimes(1);
+        // click on a date
+        fixture.nativeElement.querySelectorAll('.ngb-dp-day')[3].click();  // 1 MAR 2018
+        fixture.detectChanges();
+        expect(fixture.componentInstance.onDateSelect).toHaveBeenCalledTimes(1);
+        expect(fixture.componentInstance.onModelChange).toHaveBeenCalledTimes(1);
 
-      // open again
-      dpInput.open();
-      fixture.detectChanges();
+        // open again
+        dpInput.open();
+        fixture.detectChanges();
 
-      // click the same date
-      fixture.nativeElement.querySelectorAll('.ngb-dp-day')[3].click();  // 1 MAR 2018
-      fixture.detectChanges();
-      expect(fixture.componentInstance.onDateSelect).toHaveBeenCalledTimes(2);
-      expect(fixture.componentInstance.onModelChange).toHaveBeenCalledTimes(1);
+        // click the same date
+        fixture.nativeElement.querySelectorAll('.ngb-dp-day')[3].click();  // 1 MAR 2018
+        fixture.detectChanges();
+        expect(fixture.componentInstance.onDateSelect).toHaveBeenCalledTimes(2);
+        expect(fixture.componentInstance.onModelChange).toHaveBeenCalledTimes(1);
 
-      expect(fixture.componentInstance.onDateSelect).toHaveBeenCalledWith({year: 2018, month: 3, day: 1});
-      expect(fixture.componentInstance.onModelChange).toHaveBeenCalledWith({year: 2018, month: 3, day: 1});
+        expect(fixture.componentInstance.onDateSelect).toHaveBeenCalledWith(fromStruct({year: 2018, month: 3, day: 1}));
+        expect(fixture.componentInstance.onModelChange)
+            .toHaveBeenCalledWith(fromStruct({year: 2018, month: 3, day: 1}));
+      });
     });
-  });
 
-  describe('container', () => {
+    describe('container', () => {
 
-    it('should be appended to the element matching the selector passed to "container"', () => {
-      const selector = 'body';
-      const fixture = createTestCmpt(`
+      it('should be appended to the element matching the selector passed to "container"', () => {
+        const selector = 'body';
+        const fixture = createTestCmpt(`
           <input ngbDatepicker #d="ngbDatepicker" container="${selector}">
           <button [ngbDatepickerToggle]="d" (click)="open(d)">Open</button>
       `);
 
-      // open date-picker
-      const button = fixture.nativeElement.querySelector('button');
-      button.click();
-      fixture.detectChanges();
+        // open date-picker
+        const button = fixture.nativeElement.querySelector('button');
+        button.click();
+        fixture.detectChanges();
 
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
-      expect(document.querySelector(selector).querySelector('ngb-datepicker')).not.toBeNull();
-    });
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
+        expect(document.querySelector(selector).querySelector('ngb-datepicker')).not.toBeNull();
+      });
 
-    it('should properly destroy datepicker window when the "container" option is used', () => {
-      const selector = 'body';
-      const fixture = createTestCmpt(`
+      it('should properly destroy datepicker window when the "container" option is used', () => {
+        const selector = 'body';
+        const fixture = createTestCmpt(`
           <input ngbDatepicker #d="ngbDatepicker" container="${selector}">
           <button [ngbDatepickerToggle]="d" (click)="open(d)">Open</button>
           <button [ngbDatepickerToggle]="d" (click)="close(d)">Close</button>
       `);
 
-      // open date-picker
-      const buttons = fixture.nativeElement.querySelectorAll('button');
-      buttons[0].click();  // open button
-      fixture.detectChanges();
+        // open date-picker
+        const buttons = fixture.nativeElement.querySelectorAll('button');
+        buttons[0].click();  // open button
+        fixture.detectChanges();
 
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
-      expect(document.querySelector(selector).querySelector('ngb-datepicker')).not.toBeNull();
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
+        expect(document.querySelector(selector).querySelector('ngb-datepicker')).not.toBeNull();
 
-      // close date-picker
-      buttons[1].click();  // close button
-      fixture.detectChanges();
+        // close date-picker
+        buttons[1].click();  // close button
+        fixture.detectChanges();
 
-      expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
-      expect(document.querySelector(selector).querySelector('ngb-datepicker')).toBeNull();
-    });
-  });
-
-  describe('Native adapter', () => {
-
-    beforeEach(() => {
-      TestBed.configureTestingModule({
-        declarations: [TestNativeComponent],
-        imports: [NgbDatepickerModule.forRoot(), FormsModule],
-        providers: [{provide: NgbDateAdapter, useClass: NgbDateNativeAdapter}]
+        expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
+        expect(document.querySelector(selector).querySelector('ngb-datepicker')).toBeNull();
       });
     });
-
-    it('should format bound date as ISO (by default) in the input field', fakeAsync(() => {
-         const fixture = createTestNativeCmpt(`<input ngbDatepicker [ngModel]="date">`);
-         const input = fixture.nativeElement.querySelector('input');
-
-         fixture.componentInstance.date = new Date(2018, 0, 3);
-         fixture.detectChanges();
-         tick();
-         expect(input.value).toBe('2018-01-03');
-
-         fixture.componentInstance.date = new Date(2018, 10, 13);
-         fixture.detectChanges();
-         tick();
-         expect(input.value).toBe('2018-11-13');
-       }));
-
-    it('should parse user-entered date as ISO (by default)', () => {
-      const fixture = createTestNativeCmpt(`<input ngbDatepicker [(ngModel)]="date">`);
-      const inputDebugEl = fixture.debugElement.query(By.css('input'));
-
-      inputDebugEl.triggerEventHandler('input', {target: {value: '2018-01-03'}});
-      expect(fixture.componentInstance.date).toEqual(new Date(2018, 0, 3));
-    });
   });
-});
 
-@Injectable()
-class NgbDateNativeAdapter extends NgbDateAdapter<Date> {
-  fromModel(date: Date): NgbDateStruct {
-    return (date && date.getFullYear) ? {year: date.getFullYear(), month: date.getMonth() + 1, day: date.getDate()} :
-                                        null;
+  @Component({selector: 'test-cmp', template: ''})
+  class TestComponent {
+    fromStruct = fromStruct;
+
+    date: SupportedDate;
+    isDisabled;
+
+    onNavigate() {}
+
+    onDateSelect() {}
+
+    onModelChange() {}
+
+    open(d: NgbInputDatepicker) { d.open(); }
+
+    close(d: NgbInputDatepicker) { d.close(); }
+
+    toggle(d: NgbInputDatepicker) { d.toggle(); }
+
+    noop() {}
   }
-
-  toModel(date: NgbDateStruct): Date { return date ? new Date(date.year, date.month - 1, date.day) : null; }
-}
-
-@Component({selector: 'test-native-cmp', template: ''})
-class TestNativeComponent {
-  date: Date;
-}
-
-@Component({selector: 'test-cmp', template: ''})
-class TestComponent {
-  date: NgbDateStruct;
-  isDisabled;
-
-  onNavigate() {}
-
-  onDateSelect() {}
-
-  onModelChange() {}
-
-  open(d: NgbInputDatepicker) { d.open(); }
-
-  close(d: NgbInputDatepicker) { d.close(); }
-
-  toggle(d: NgbInputDatepicker) { d.toggle(); }
-
-  noop() {}
-}
+});

--- a/src/datepicker/datepicker-month-view.ts
+++ b/src/datepicker/datepicker-month-view.ts
@@ -64,7 +64,7 @@ import {DayTemplateContext} from './datepicker-day-template-context';
   `
 })
 export class NgbDatepickerMonthView {
-  @Input() dayTemplate: TemplateRef<DayTemplateContext>;
+  @Input() dayTemplate: TemplateRef<DayTemplateContext<any>>;
   @Input() month: MonthViewModel;
   @Input() showWeekdays;
   @Input() showWeekNumbers;

--- a/src/datepicker/datepicker-service.spec.ts
+++ b/src/datepicker/datepicker-service.spec.ts
@@ -7,6 +7,7 @@ import {DatepickerViewModel} from './datepicker-view-model';
 import {NgbDateStruct} from './ngb-date-struct';
 import {NgbDatepickerI18n, NgbDatepickerI18nDefault} from './datepicker-i18n';
 import {DatePipe} from '@angular/common';
+import {NgbDateAdapter, NgbDateStructAdapter} from './adapters/ngb-date-adapter';
 
 describe('ngb-datepicker-service', () => {
 
@@ -27,7 +28,8 @@ describe('ngb-datepicker-service', () => {
     TestBed.configureTestingModule({
       providers: [
         NgbDatepickerService, {provide: NgbCalendar, useClass: NgbCalendarGregorian},
-        {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nDefault}, DatePipe
+        {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nDefault},
+        {provide: NgbDateAdapter, useClass: NgbDateStructAdapter}, DatePipe
       ]
     });
 

--- a/src/datepicker/datepicker-service.ts
+++ b/src/datepicker/datepicker-service.ts
@@ -19,6 +19,7 @@ import {
 
 import {filter} from 'rxjs/operators';
 import {NgbDatepickerI18n} from './datepicker-i18n';
+import {NgbDateAdapter} from './adapters/ngb-date-adapter';
 
 @Injectable()
 export class NgbDatepickerService {
@@ -102,7 +103,8 @@ export class NgbDatepickerService {
     }
   }
 
-  constructor(private _calendar: NgbCalendar, private _i18n: NgbDatepickerI18n) {}
+  constructor(
+      private _calendar: NgbCalendar, private _i18n: NgbDatepickerI18n, private _dateAdapter: NgbDateAdapter<any>) {}
 
   focus(date: NgbDate) {
     if (!this._state.disabled && this._calendar.isValid(date) && isChangedDate(this._state.focusDate, date)) {
@@ -115,7 +117,7 @@ export class NgbDatepickerService {
   }
 
   focusSelect() {
-    if (isDateSelectable(this._state.focusDate, this._state)) {
+    if (isDateSelectable(this._state.focusDate, this._state, this._dateAdapter)) {
       this.select(this._state.focusDate, {emitEvent: true});
     }
   }
@@ -134,7 +136,7 @@ export class NgbDatepickerService {
         this._nextState({selectedDate});
       }
 
-      if (options.emitEvent && isDateSelectable(selectedDate, this._state)) {
+      if (options.emitEvent && isDateSelectable(selectedDate, this._state, this._dateAdapter)) {
         this._select$.next(selectedDate);
       }
     }
@@ -237,7 +239,7 @@ export class NgbDatepickerService {
       const forceRebuild = 'firstDayOfWeek' in patch || 'markDisabled' in patch || 'minDate' in patch ||
           'maxDate' in patch || 'disabled' in patch || 'outsideDays' in patch;
 
-      const months = buildMonths(this._calendar, startDate, state, this._i18n, forceRebuild);
+      const months = buildMonths(this._calendar, startDate, state, this._i18n, this._dateAdapter, forceRebuild);
 
       // updating months and boundary dates
       state.months = months;
@@ -245,7 +247,7 @@ export class NgbDatepickerService {
       state.lastDate = months.length > 0 ? months[months.length - 1].lastDate : undefined;
 
       // reset selected date if 'markDisabled' returns true
-      if ('selectedDate' in patch && !isDateSelectable(state.selectedDate, state)) {
+      if ('selectedDate' in patch && !isDateSelectable(state.selectedDate, state, this._dateAdapter)) {
         state.selectedDate = null;
       }
 

--- a/src/datepicker/datepicker-tools.spec.ts
+++ b/src/datepicker/datepicker-tools.spec.ts
@@ -14,6 +14,8 @@ import {TestBed} from '@angular/core/testing';
 import {DatepickerViewModel, NgbMarkDisabled, MonthViewModel} from './datepicker-view-model';
 import {NgbDatepickerI18n, NgbDatepickerI18nDefault} from './datepicker-i18n';
 import {DatePipe} from '@angular/common';
+import {NgbDateStruct} from './ngb-date-struct';
+import {NgbDateAdapter, NgbDateStructAdapter} from './adapters/ngb-date-adapter';
 
 describe(`datepicker-tools`, () => {
 
@@ -77,16 +79,19 @@ describe(`datepicker-tools`, () => {
 
     let calendar: NgbCalendar;
     let i18n: NgbDatepickerI18n;
+    let dateAdapter: NgbDateAdapter<NgbDateStruct>;
 
     beforeAll(() => {
       TestBed.configureTestingModule({
         providers: [
           {provide: NgbCalendar, useClass: NgbCalendarGregorian},
-          {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nDefault}, DatePipe
+          {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nDefault},
+          {provide: NgbDateAdapter, useClass: NgbDateStructAdapter}, DatePipe
         ]
       });
       calendar = TestBed.get(NgbCalendar);
       i18n = TestBed.get(NgbDatepickerI18n);
+      dateAdapter = TestBed.get(NgbDateAdapter);
     });
 
     // TODO: this should be automated somehow, ex. generate next 10 years or something
@@ -124,7 +129,8 @@ describe(`datepicker-tools`, () => {
     months.forEach(refMonth => {
       it(`should build month (${refMonth.date.year} - ${refMonth.date.month}) correctly`, () => {
 
-        let month = buildMonth(calendar, refMonth.date, { firstDayOfWeek: 1 } as DatepickerViewModel, i18n);
+        let month =
+            buildMonth(calendar, refMonth.date, { firstDayOfWeek: 1 } as DatepickerViewModel, i18n, dateAdapter);
 
         expect(month).toBeTruthy();
         expect(month.year).toEqual(refMonth.date.year);
@@ -153,8 +159,9 @@ describe(`datepicker-tools`, () => {
       const markDisabled: NgbMarkDisabled = (date) => date.day === 2;
 
       // MAY 2017
-      let month = buildMonth(
-          calendar, new NgbDate(2017, 5, 5), { firstDayOfWeek: 1, markDisabled } as DatepickerViewModel, i18n);
+      let month = buildMonth(calendar, new NgbDate(2017, 5, 5), {
+        firstDayOfWeek: 1, markDisabled
+      } as DatepickerViewModel, i18n, dateAdapter);
 
       // 2 MAY - disabled
       expect(month.weeks[0].days[0].context.disabled).toBe(false);
@@ -174,10 +181,10 @@ describe(`datepicker-tools`, () => {
         maxDate: new NgbDate(2017, 5, 10),
         markDisabled: mock.markDisabled
       } as DatepickerViewModel;
-      buildMonth(calendar, new NgbDate(2017, 5, 5), state, i18n);
+      buildMonth(calendar, new NgbDate(2017, 5, 5), state, i18n, dateAdapter);
 
       // called one time, because it should be used only inside min-max range
-      expect(mock.markDisabled).toHaveBeenCalledWith(new NgbDate(2017, 5, 10), {year: 2017, month: 5});
+      expect(mock.markDisabled).toHaveBeenCalledWith({year: 2017, month: 5, day: 10}, {year: 2017, month: 5});
       expect(mock.markDisabled).toHaveBeenCalledTimes(1);
     });
 
@@ -186,7 +193,7 @@ describe(`datepicker-tools`, () => {
 
       // MAY 2017
       let state = { firstDayOfWeek: 1, minDate: new NgbDate(2017, 5, 3), markDisabled } as DatepickerViewModel;
-      const month = buildMonth(calendar, new NgbDate(2017, 5, 5), state, i18n);
+      const month = buildMonth(calendar, new NgbDate(2017, 5, 5), state, i18n, dateAdapter);
 
       // MIN = 2, so 1-2 MAY - disabled
       expect(month.weeks[0].days[0].context.disabled).toBe(true);
@@ -200,7 +207,7 @@ describe(`datepicker-tools`, () => {
 
       // MAY 2017
       let state = { firstDayOfWeek: 1, maxDate: new NgbDate(2017, 5, 2), markDisabled } as DatepickerViewModel;
-      const month = buildMonth(calendar, new NgbDate(2017, 5, 5), state, i18n);
+      const month = buildMonth(calendar, new NgbDate(2017, 5, 5), state, i18n, dateAdapter);
 
       // MAX = 2, so 3-4 MAY - disabled
       expect(month.weeks[0].days[0].context.disabled).toBe(false);
@@ -211,12 +218,14 @@ describe(`datepicker-tools`, () => {
 
     it(`should rotate days of the week`, () => {
       // SUN = 7
-      let month = buildMonth(calendar, new NgbDate(2017, 5, 5), { firstDayOfWeek: 7 } as DatepickerViewModel, i18n);
+      let month = buildMonth(
+          calendar, new NgbDate(2017, 5, 5), { firstDayOfWeek: 7 } as DatepickerViewModel, i18n, dateAdapter);
       expect(month.weekdays).toEqual([7, 1, 2, 3, 4, 5, 6]);
       expect(month.weeks[0].days[0].date).toEqual(new NgbDate(2017, 4, 30));
 
       // WED = 3
-      month = buildMonth(calendar, new NgbDate(2017, 5, 5), { firstDayOfWeek: 3 } as DatepickerViewModel, i18n);
+      month = buildMonth(
+          calendar, new NgbDate(2017, 5, 5), { firstDayOfWeek: 3 } as DatepickerViewModel, i18n, dateAdapter);
       expect(month.weekdays).toEqual([3, 4, 5, 6, 7, 1, 2]);
       expect(month.weeks[0].days[0].date).toEqual(new NgbDate(2017, 4, 26));
     });
@@ -226,25 +235,29 @@ describe(`datepicker-tools`, () => {
 
     let calendar: NgbCalendar;
     let i18n: NgbDatepickerI18n;
+    let dateAdapter: NgbDateAdapter<NgbDateStruct>;
+
 
     beforeAll(() => {
       TestBed.configureTestingModule({
         providers: [
           {provide: NgbCalendar, useClass: NgbCalendarGregorian},
-          {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nDefault}, DatePipe
+          {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nDefault},
+          {provide: NgbDateAdapter, useClass: NgbDateStructAdapter}, DatePipe
         ]
       });
       calendar = TestBed.get(NgbCalendar);
       i18n = TestBed.get(NgbDatepickerI18n);
+      dateAdapter = TestBed.get(NgbDateAdapter);
     });
 
     it(`should generate 'displayMonths' number of months`, () => {
       let state = { displayMonths: 1, firstDayOfWeek: 1, months: [] } as DatepickerViewModel;
-      let months = buildMonths(calendar, new NgbDate(2017, 5, 5), state, i18n, false);
+      let months = buildMonths(calendar, new NgbDate(2017, 5, 5), state, i18n, dateAdapter, false);
       expect(months.length).toBe(1);
 
       state.displayMonths = 2;
-      months = buildMonths(calendar, new NgbDate(2017, 5, 5), state, i18n, false);
+      months = buildMonths(calendar, new NgbDate(2017, 5, 5), state, i18n, dateAdapter, false);
       expect(months.length).toBe(2);
     });
 
@@ -309,25 +322,25 @@ describe(`datepicker-tools`, () => {
 
     it(`should reuse the same data structure (force = false)`, () => {
       let state = { displayMonths: 1, firstDayOfWeek: 1, months: [] } as DatepickerViewModel;
-      let months = buildMonths(calendar, new NgbDate(2017, 5, 5), state, i18n, false);
+      let months = buildMonths(calendar, new NgbDate(2017, 5, 5), state, i18n, dateAdapter, false);
       expect(months).toBe(state.months);
       expect(months.length).toBe(1);
       let monthsStructure = storeMonthsDataStructure(months);
 
-      months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, false);
+      months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, dateAdapter, false);
       expect(months).toBe(state.months);
       expect(months.length).toBe(1);
       expect(storeMonthsDataStructure(months))['toHaveTheSameMonthDataStructureAs'](monthsStructure);
 
       state.displayMonths = 2;
-      months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, false);
+      months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, dateAdapter, false);
       expect(months).toBe(state.months);
       expect(months.length).toBe(2);
       monthsStructure.push(...storeMonthsDataStructure([months[1]]));
       expect(storeMonthsDataStructure(months))['toHaveTheSameMonthDataStructureAs'](monthsStructure);
 
       // next month
-      months = buildMonths(calendar, new NgbDate(2018, 6, 5), state, i18n, false);
+      months = buildMonths(calendar, new NgbDate(2018, 6, 5), state, i18n, dateAdapter, false);
       expect(months).toBe(state.months);
       expect(months.length).toBe(2);
       // the structures should be swapped:
@@ -335,7 +348,7 @@ describe(`datepicker-tools`, () => {
       expect(storeMonthsDataStructure(months))['toHaveTheSameMonthDataStructureAs'](monthsStructure);
 
       // previous month
-      months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, false);
+      months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, dateAdapter, false);
       expect(months).toBe(state.months);
       expect(months.length).toBe(2);
       // the structures should be swapped (again):
@@ -343,35 +356,35 @@ describe(`datepicker-tools`, () => {
       expect(storeMonthsDataStructure(months))['toHaveTheSameMonthDataStructureAs'](monthsStructure);
 
       state.displayMonths = 5;
-      months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, false);
+      months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, dateAdapter, false);
       expect(months).toBe(state.months);
       expect(months.length).toBe(5);
       monthsStructure.push(...storeMonthsDataStructure(months.slice(2)));
       expect(storeMonthsDataStructure(months))['toHaveTheSameMonthDataStructureAs'](monthsStructure);
 
       // go to two months after, the 3 last months are reused as is
-      months = buildMonths(calendar, new NgbDate(2018, 7, 5), state, i18n, false);
+      months = buildMonths(calendar, new NgbDate(2018, 7, 5), state, i18n, dateAdapter, false);
       expect(months).toBe(state.months);
       expect(months.length).toBe(5);
       monthsStructure.unshift(...monthsStructure.splice(2, 3));
       expect(storeMonthsDataStructure(months))['toHaveTheSameMonthDataStructureAs'](monthsStructure);
 
       // go to two months before, the 3 first months are reused as is
-      months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, false);
+      months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, dateAdapter, false);
       expect(months).toBe(state.months);
       expect(months.length).toBe(5);
       monthsStructure.push(...monthsStructure.splice(0, 3));
       expect(storeMonthsDataStructure(months))['toHaveTheSameMonthDataStructureAs'](monthsStructure);
 
       // completely change the dates, nothing is shifted in monthsStructure
-      months = buildMonths(calendar, new NgbDate(2018, 10, 5), state, i18n, false);
+      months = buildMonths(calendar, new NgbDate(2018, 10, 5), state, i18n, dateAdapter, false);
       expect(months).toBe(state.months);
       expect(months.length).toBe(5);
       expect(storeMonthsDataStructure(months))['toHaveTheSameMonthDataStructureAs'](monthsStructure);
 
       // keep 2 months
       state.displayMonths = 2;
-      months = buildMonths(calendar, new NgbDate(2018, 11, 5), state, i18n, false);
+      months = buildMonths(calendar, new NgbDate(2018, 11, 5), state, i18n, dateAdapter, false);
       expect(months).toBe(state.months);
       expect(months.length).toBe(2);
       monthsStructure = monthsStructure.slice(1, 3);
@@ -380,63 +393,63 @@ describe(`datepicker-tools`, () => {
 
     it(`should reuse the same data structure (force = true)`, () => {
       let state = { displayMonths: 1, firstDayOfWeek: 1, months: [] } as DatepickerViewModel;
-      let months = buildMonths(calendar, new NgbDate(2017, 5, 5), state, i18n, true);
+      let months = buildMonths(calendar, new NgbDate(2017, 5, 5), state, i18n, dateAdapter, true);
       expect(months).toBe(state.months);
       expect(months.length).toBe(1);
       let monthsStructure = storeMonthsDataStructure(months);
 
-      months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, true);
+      months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, dateAdapter, true);
       expect(months).toBe(state.months);
       expect(months.length).toBe(1);
       expect(storeMonthsDataStructure(months))['toHaveTheSameMonthDataStructureAs'](monthsStructure);
 
       state.displayMonths = 2;
-      months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, true);
+      months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, dateAdapter, true);
       expect(months).toBe(state.months);
       expect(months.length).toBe(2);
       monthsStructure.push(...storeMonthsDataStructure([months[1]]));
       expect(storeMonthsDataStructure(months))['toHaveTheSameMonthDataStructureAs'](monthsStructure);
 
       // next month
-      months = buildMonths(calendar, new NgbDate(2018, 6, 5), state, i18n, true);
+      months = buildMonths(calendar, new NgbDate(2018, 6, 5), state, i18n, dateAdapter, true);
       expect(months).toBe(state.months);
       expect(months.length).toBe(2);
       expect(storeMonthsDataStructure(months))['toHaveTheSameMonthDataStructureAs'](monthsStructure);
 
       // previous month
-      months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, true);
+      months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, dateAdapter, true);
       expect(months).toBe(state.months);
       expect(months.length).toBe(2);
       expect(storeMonthsDataStructure(months))['toHaveTheSameMonthDataStructureAs'](monthsStructure);
 
       state.displayMonths = 5;
-      months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, true);
+      months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, dateAdapter, true);
       expect(months).toBe(state.months);
       expect(months.length).toBe(5);
       monthsStructure.push(...storeMonthsDataStructure(months.slice(2)));
       expect(storeMonthsDataStructure(months))['toHaveTheSameMonthDataStructureAs'](monthsStructure);
 
       // go to two months after
-      months = buildMonths(calendar, new NgbDate(2018, 7, 5), state, i18n, true);
+      months = buildMonths(calendar, new NgbDate(2018, 7, 5), state, i18n, dateAdapter, true);
       expect(months).toBe(state.months);
       expect(months.length).toBe(5);
       expect(storeMonthsDataStructure(months))['toHaveTheSameMonthDataStructureAs'](monthsStructure);
 
       // go to two months before
-      months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, true);
+      months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, dateAdapter, true);
       expect(months).toBe(state.months);
       expect(months.length).toBe(5);
       expect(storeMonthsDataStructure(months))['toHaveTheSameMonthDataStructureAs'](monthsStructure);
 
       // completely change the dates
-      months = buildMonths(calendar, new NgbDate(2018, 10, 5), state, i18n, true);
+      months = buildMonths(calendar, new NgbDate(2018, 10, 5), state, i18n, dateAdapter, true);
       expect(months).toBe(state.months);
       expect(months.length).toBe(5);
       expect(storeMonthsDataStructure(months))['toHaveTheSameMonthDataStructureAs'](monthsStructure);
 
       // keep 2 months
       state.displayMonths = 2;
-      months = buildMonths(calendar, new NgbDate(2018, 11, 5), state, i18n, true);
+      months = buildMonths(calendar, new NgbDate(2018, 11, 5), state, i18n, dateAdapter, true);
       expect(months).toBe(state.months);
       expect(months.length).toBe(2);
       monthsStructure = monthsStructure.slice(0, 2);
@@ -503,44 +516,46 @@ describe(`datepicker-tools`, () => {
 
   describe(`isDateSelectable()`, () => {
 
+    const adapter = new NgbDateStructAdapter();
+
     // disabling 15th of any month
     const markDisabled: NgbMarkDisabled = (date, month) => date.day === 15;
 
     it(`should return false if date is invalid`, () => {
       let state = { disabled: false } as DatepickerViewModel;
-      expect(isDateSelectable(null, state)).toBeFalsy();
-      expect(isDateSelectable(undefined, state)).toBeFalsy();
+      expect(isDateSelectable(null, state, adapter)).toBeFalsy();
+      expect(isDateSelectable(undefined, state, adapter)).toBeFalsy();
     });
 
     it(`should return false if datepicker is disabled`, () => {
       let state = { disabled: true } as DatepickerViewModel;
-      expect(isDateSelectable(new NgbDate(2016, 11, 10), state)).toBeFalsy();
-      expect(isDateSelectable(new NgbDate(2017, 11, 10), state)).toBeFalsy();
-      expect(isDateSelectable(new NgbDate(2018, 11, 10), state)).toBeFalsy();
+      expect(isDateSelectable(new NgbDate(2016, 11, 10), state, adapter)).toBeFalsy();
+      expect(isDateSelectable(new NgbDate(2017, 11, 10), state, adapter)).toBeFalsy();
+      expect(isDateSelectable(new NgbDate(2018, 11, 10), state, adapter)).toBeFalsy();
     });
 
     it(`should take into account markDisabled values`, () => {
       let state = { disabled: false, markDisabled } as DatepickerViewModel;
-      expect(isDateSelectable(new NgbDate(2016, 11, 15), state)).toBeFalsy();
-      expect(isDateSelectable(new NgbDate(2017, 11, 15), state)).toBeFalsy();
-      expect(isDateSelectable(new NgbDate(2018, 11, 15), state)).toBeFalsy();
+      expect(isDateSelectable(new NgbDate(2016, 11, 15), state, adapter)).toBeFalsy();
+      expect(isDateSelectable(new NgbDate(2017, 11, 15), state, adapter)).toBeFalsy();
+      expect(isDateSelectable(new NgbDate(2018, 11, 15), state, adapter)).toBeFalsy();
     });
 
     it(`should take into account minDate values`, () => {
       let state = { disabled: false, minDate: new NgbDate(2018, 11, 10) } as DatepickerViewModel;
-      expect(isDateSelectable(new NgbDate(2017, 11, 10), state)).toBeFalsy();
+      expect(isDateSelectable(new NgbDate(2017, 11, 10), state, adapter)).toBeFalsy();
     });
 
     it(`should take into account maxDate values`, () => {
       let state = { disabled: false, maxDate: new NgbDate(2016, 11, 10) } as DatepickerViewModel;
-      expect(isDateSelectable(new NgbDate(2017, 11, 10), state)).toBeFalsy();
+      expect(isDateSelectable(new NgbDate(2017, 11, 10), state, adapter)).toBeFalsy();
     });
 
     it(`should return true for normal values`, () => {
       let state = { disabled: false } as DatepickerViewModel;
-      expect(isDateSelectable(new NgbDate(2016, 11, 10), state)).toBeTruthy();
-      expect(isDateSelectable(new NgbDate(2017, 11, 10), state)).toBeTruthy();
-      expect(isDateSelectable(new NgbDate(2018, 11, 10), state)).toBeTruthy();
+      expect(isDateSelectable(new NgbDate(2016, 11, 10), state, adapter)).toBeTruthy();
+      expect(isDateSelectable(new NgbDate(2017, 11, 10), state, adapter)).toBeTruthy();
+      expect(isDateSelectable(new NgbDate(2018, 11, 10), state, adapter)).toBeTruthy();
     });
   });
 

--- a/src/datepicker/datepicker-view-model.ts
+++ b/src/datepicker/datepicker-view-model.ts
@@ -1,12 +1,11 @@
 import {NgbDate} from './ngb-date';
-import {NgbDateStruct} from './ngb-date-struct';
 import {DayTemplateContext} from './datepicker-day-template-context';
 
-export type NgbMarkDisabled = (date: NgbDateStruct, current: {year: number, month: number}) => boolean;
+export type NgbMarkDisabled = (date: any, current: {year: number, month: number}) => boolean;
 
 export type DayViewModel = {
   date: NgbDate,
-  context: DayTemplateContext,
+  context: DayTemplateContext<any>,
   tabindex: number,
   ariaLabel: string,
   hidden: boolean

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -103,7 +103,7 @@ export interface NgbDatepickerNavigateEvent {
   template: `
     <ng-template #dt let-date="date" let-currentMonth="currentMonth" let-selected="selected" let-disabled="disabled" let-focused="focused">
       <div ngbDatepickerDayView
-        [date]="date"
+        [date]="dateAdapter.fromModel(date)"
         [currentMonth]="currentMonth"
         [selected]="selected"
         [disabled]="disabled"
@@ -145,8 +145,8 @@ export interface NgbDatepickerNavigateEvent {
   `,
   providers: [NGB_DATEPICKER_VALUE_ACCESSOR, NgbDatepickerService, NgbDatepickerKeyMapService]
 })
-export class NgbDatepicker implements OnDestroy,
-    OnChanges, OnInit, ControlValueAccessor {
+export class NgbDatepicker<D = NgbDateStruct>
+    implements OnDestroy, OnChanges, OnInit, ControlValueAccessor {
   model: DatepickerViewModel;
 
   private _subscription: Subscription;
@@ -154,7 +154,7 @@ export class NgbDatepicker implements OnDestroy,
   /**
    * Reference for the custom template for the day display
    */
-  @Input() dayTemplate: TemplateRef<DayTemplateContext>;
+  @Input() dayTemplate: TemplateRef<DayTemplateContext<D>>;
 
   /**
    * Number of months to display
@@ -170,17 +170,17 @@ export class NgbDatepicker implements OnDestroy,
    * Callback to mark a given date as disabled.
    * 'Current' contains the month that will be displayed in the view
    */
-  @Input() markDisabled: (date: NgbDateStruct, current: {year: number, month: number}) => boolean;
+  @Input() markDisabled: (date: D, current: {year: number, month: number}) => boolean;
 
   /**
    * Max date for the navigation. If not provided, 'year' select box will display 10 years after current month
    */
-  @Input() maxDate: NgbDateStruct;
+  @Input() maxDate: D;
 
   /**
    * Min date for the navigation. If not provided, 'year' select box will display 10 years before current month
    */
-  @Input() minDate: NgbDateStruct;
+  @Input() minDate: D;
 
   /**
    * Navigation type: `select` (default with select boxes for month and year), `arrows`
@@ -222,21 +222,22 @@ export class NgbDatepicker implements OnDestroy,
    * An event fired when user selects a date using keyboard or mouse.
    * The payload of the event is currently selected NgbDateStruct.
    */
-  @Output() select = new EventEmitter<NgbDateStruct>();
+  @Output() select = new EventEmitter<D>();
 
   onChange = (_: any) => {};
   onTouched = () => {};
 
   constructor(
       private _keyMapService: NgbDatepickerKeyMapService, public _service: NgbDatepickerService,
-      private _calendar: NgbCalendar, public i18n: NgbDatepickerI18n, config: NgbDatepickerConfig,
+      private _calendar: NgbCalendar, public i18n: NgbDatepickerI18n, config: NgbDatepickerConfig<D>,
       private _cd: ChangeDetectorRef, private _elementRef: ElementRef<HTMLElement>,
-      private _ngbDateAdapter: NgbDateAdapter<any>, private _ngZone: NgZone) {
+      public dateAdapter: NgbDateAdapter<D>, private _ngZone: NgZone) {
     ['dayTemplate', 'displayMonths', 'firstDayOfWeek', 'markDisabled', 'minDate', 'maxDate', 'navigation',
      'outsideDays', 'showWeekdays', 'showWeekNumbers', 'startDate']
         .forEach(input => this[input] = config[input]);
 
-    this._selectSubscription = _service.select$.subscribe(date => { this.select.emit(date.toStruct()); });
+    this._selectSubscription =
+        _service.select$.subscribe(date => { this.select.emit(this.dateAdapter.toModel(date)); });
 
     this._subscription = _service.model$.subscribe(model => {
       const newDate = model.firstDate;
@@ -251,7 +252,7 @@ export class NgbDatepicker implements OnDestroy,
       // handling selection change
       if (isChangedDate(newSelectedDate, oldSelectedDate)) {
         this.onTouched();
-        this.onChange(this._ngbDateAdapter.toModel(newSelectedDate));
+        this.onChange(this.dateAdapter.toModel(newSelectedDate));
       }
 
       // handling focus change
@@ -298,16 +299,28 @@ export class NgbDatepicker implements OnDestroy,
 
   ngOnInit() {
     if (this.model === undefined) {
-      ['displayMonths', 'markDisabled', 'firstDayOfWeek', 'navigation', 'minDate', 'maxDate', 'outsideDays'].forEach(
+      ['displayMonths', 'firstDayOfWeek', 'navigation', 'outsideDays', 'markDisabled'].forEach(
           input => this._service[input] = this[input]);
+
+      this._service.minDate = this.dateAdapter.fromModel(this.minDate);
+      this._service.maxDate = this.dateAdapter.fromModel(this.maxDate);
+
       this.navigateTo(this.startDate);
     }
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    ['displayMonths', 'markDisabled', 'firstDayOfWeek', 'navigation', 'minDate', 'maxDate', 'outsideDays']
+    ['displayMonths', 'firstDayOfWeek', 'navigation', 'outsideDays', 'markDisabled']
         .filter(input => input in changes)
         .forEach(input => this._service[input] = this[input]);
+
+    if ('minDate' in changes) {
+      this._service.minDate = this.dateAdapter.fromModel(this.minDate);
+    }
+
+    if ('maxDate' in changes) {
+      this._service.maxDate = this.dateAdapter.fromModel(this.maxDate);
+    }
 
     if ('startDate' in changes) {
       this.navigateTo(this.startDate);
@@ -342,5 +355,5 @@ export class NgbDatepicker implements OnDestroy,
 
   showFocus(focusVisible: boolean) { this._service.focusVisible = focusVisible; }
 
-  writeValue(value) { this._service.select(NgbDate.from(this._ngbDateAdapter.fromModel(value))); }
+  writeValue(value) { this._service.select(NgbDate.from(this.dateAdapter.fromModel(value))); }
 }

--- a/src/test/datepicker/common.ts
+++ b/src/test/datepicker/common.ts
@@ -1,3 +1,7 @@
+import {NgbDateNativeAdapter} from '../../datepicker/adapters/ngb-date-native-adapter';
+import {NgbDateStruct} from '../../datepicker/ngb-date-struct';
+import {NgbDateStructAdapter} from '../../datepicker/adapters/ngb-date-adapter';
+
 export function getNavigationLinks(element: HTMLElement): HTMLElement[] {
   return <HTMLElement[]>Array.from(element.querySelectorAll('button'));
 }
@@ -9,3 +13,10 @@ export function getMonthSelect(element: HTMLElement): HTMLSelectElement {
 export function getYearSelect(element: HTMLElement): HTMLSelectElement {
   return element.querySelectorAll('select')[1] as HTMLSelectElement;
 }
+
+export type SupportedDate = Date | NgbDateStruct;
+
+export const ADAPTERS = [
+  {type: NgbDateStructAdapter, instance: new NgbDateStructAdapter()},
+  {type: NgbDateNativeAdapter, instance: new NgbDateNativeAdapter()}
+];


### PR DESCRIPTION
Note: check 'hide whitespaces changes' in the diff view when looking at changes in `datepicker.spec.ts`

---

BREAKING CHANGE: all public datepicker APIs now use generic type <D> for the date model.

If you're using any kind of adapter with the datepicker (ex. `NgbDateNativeAdapter`), now all of the following public datepicker APIs will use your date model <D> and not `NgbDateStruct` as previously:

```typescript
class NgbDatepicker<D> {
  @Input() markDisabled: (date: D, current: {year: number, month: number}) => boolean;
  @Input() maxDate: D;
  @Input() minDate: D;
  @Output() select = new EventEmitter<D>();
}

class NgbInputDatepicker<D> {
  @Input() markDisabled: (date: D, current: {year: number, month: number}) => boolean;
  @Input() maxDate: D;
  @Input() minDate: D;
  @Output() dateSelect = new EventEmitter<D>();
}

class NgbDatepickerConfig<D> {
  markDisabled: (date: D, current: {year: number, month: number}) => boolean;
  minDate: D;
  maxDate: D;
}

interface DayTemplateContext<D> {
  date: D;
}
```

Fixes #1979