### PR TITLE
chore: extract and display generic type info in the API

### DIFF
--- a/demo/src/app/components/shared/api-docs/api-docs-class.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs-class.component.html
@@ -8,7 +8,9 @@
     >
       <img src="img/link-symbol.svg" alt="Anchor link to: {{apiDocs.className}}"/>
     </a>
-    {{apiDocs.className}}
+    <span>
+      {{apiDocs.className}}<span class="text-muted font-weight-light" *ngIf="apiDocs.typeParameter">&lt;{{apiDocs.typeParameter}}&gt;</span>
+    </span>
     <a
       class="github-link"
       (click)="trackSourceClick()"

--- a/demo/src/app/components/shared/api-docs/api-docs-config.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs-config.component.html
@@ -9,7 +9,9 @@
     >
       <img src="img/link-symbol.svg" alt="Anchor link to: {{apiDocs.className}}"/>
     </a>
-    {{apiDocs.className}}
+    <span>
+      {{apiDocs.className}}<span class="text-muted font-weight-light" *ngIf="apiDocs.typeParameter">&lt;{{apiDocs.typeParameter}}&gt;</span>
+    </span>
     <a
       class="github-link"
       href="https://github.com/ng-bootstrap/ng-bootstrap/tree/master/{{apiDocs.fileName}}"

--- a/demo/src/app/components/shared/api-docs/api-docs.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs.component.html
@@ -7,7 +7,9 @@
     >
       <img src="img/link-symbol.svg" alt="Anchor link to: {{apiDocs.className}}"/>
     </a>
-    <span>{{apiDocs.className}}</span>
+    <span>
+      {{apiDocs.className}}<span class="text-muted font-weight-light" *ngIf="apiDocs.typeParameter">&lt;{{apiDocs.typeParameter}}&gt;</span>
+    </span>
     <a
       class="github-link"
       (click)="trackSourceClick()"

--- a/demo/src/app/components/shared/api-docs/api-docs.model.ts
+++ b/demo/src/app/components/shared/api-docs/api-docs.model.ts
@@ -1,5 +1,6 @@
 export interface ClassDesc {
   type: string;
+  typeParameter: string;
   fileName: string;
   className: string;
   description: string;

--- a/misc/api-doc-test-cases/type-parameters.ts
+++ b/misc/api-doc-test-cases/type-parameters.ts
@@ -1,0 +1,19 @@
+import {Component, Injectable} from '@angular/core';
+
+@Component({})
+export class NoParameterComponent {}
+
+@Component({})
+export class ParameterComponent<C> {}
+
+@Injectable()
+export interface NoParameterInterface {}
+
+@Injectable()
+export interface ParameterInterface<I = NoParameterInterface> {}
+
+@Injectable()
+export class NoParameterService {}
+
+@Injectable()
+export class ParameterService<S = number> {}

--- a/misc/api-doc.spec.js
+++ b/misc/api-doc.spec.js
@@ -253,4 +253,14 @@ describe('APIDocVisitor', function() {
     expect(docs.NgbDirective.methods[0].since).toEqual({version: '2.0.0', description: ''});
   });
 
+  it('should extract class and interface type parameters', function() {
+    var docs = apiDoc(['misc/api-doc-test-cases/type-parameters.ts']);
+
+    expect(docs.NoParameterComponent.typeParameter).toBeUndefined();
+    expect(docs.ParameterComponent.typeParameter).toEqual('C');
+    expect(docs.NoParameterInterface.typeParameter).toBeUndefined();
+    expect(docs.ParameterInterface.typeParameter).toEqual('I = NoParameterInterface');
+    expect(docs.NoParameterService.typeParameter).toBeUndefined();
+    expect(docs.ParameterService.typeParameter).toEqual('S = number');
+  });
 });


### PR DESCRIPTION
Allow extracting things like:

```typescript
class NgbDatepicker<T = NgbDateStruct> {
}

interface NgbDateAdapter<T> {
}
```

To be displayed like this:

![screen shot 2018-07-05 at 12 22 09](https://user-images.githubusercontent.com/8074436/42322396-9bfec63c-805c-11e8-9a85-a81219dc16c0.png)

![screen shot 2018-07-05 at 12 22 23](https://user-images.githubusercontent.com/8074436/42322403-a55c36e2-805c-11e8-9150-3ba26c15c3d3.png)