### PR TITLE
chore: fix umd bundle name for plunker

### DIFF
--- a/misc/plunk-gen.js
+++ b/misc/plunk-gen.js
@@ -154,7 +154,7 @@ function generateConfigJs() {
     'tslib': 'npm:tslib/tslib.js',
     'typescript': 'npm:typescript@${versions.typescript}/lib/typescript.js',
 
-    '@ng-bootstrap/ng-bootstrap': 'npm:@ng-bootstrap/ng-bootstrap@${versions.ngBootstrap}/bundles/ng-bootstrap.js'
+    '@ng-bootstrap/ng-bootstrap': 'npm:@ng-bootstrap/ng-bootstrap@${versions.ngBootstrap}/bundles/ng-bootstrap.umd.js'
   },
   packages: {
     app: {


### PR DESCRIPTION
After the migration to CLI, bundle name has changed to from `bundles/ng-bootstrap.js` to `bundles/ng-bootstrap.umd.js`