### PR TITLE
fix(modal): adjust modal background to avoid shifting

### DIFF
--- a/src/modal/modal-stack.ts
+++ b/src/modal/modal-stack.ts
@@ -12,6 +12,7 @@ import {
 
 import {ContentRef} from '../util/popup';
 import {isDefined, isString} from '../util/util';
+import {Scrollbar} from '../util/scrollbar';
 
 import {NgbModalBackdrop} from './modal-backdrop';
 import {NgbModalWindow} from './modal-window';
@@ -19,19 +20,19 @@ import {NgbActiveModal, NgbModalRef} from './modal-ref';
 
 @Injectable()
 export class NgbModalStack {
-  private _document: any;
   private _windowAttributes = ['ariaLabelledBy', 'backdrop', 'centered', 'keyboard', 'size', 'windowClass'];
   private _backdropAttributes = ['backdropClass'];
 
   constructor(
       private _applicationRef: ApplicationRef, private _injector: Injector,
-      private _componentFactoryResolver: ComponentFactoryResolver, @Inject(DOCUMENT) document) {
-    this._document = document;
-  }
+      private _componentFactoryResolver: ComponentFactoryResolver, @Inject(DOCUMENT) private _document,
+      private _scrollbar: Scrollbar) {}
 
   open(moduleCFR: ComponentFactoryResolver, contentInjector: Injector, content: any, options): NgbModalRef {
     const containerEl =
         isDefined(options.container) ? this._document.querySelector(options.container) : this._document.body;
+
+    const revertPaddingForScrollbar = this._scrollbar.compensateScrollbar();
 
     if (!containerEl) {
       throw new Error(`The specified modal container "${options.container || 'body'}" was not found in the DOM.`);
@@ -45,6 +46,7 @@ export class NgbModalStack {
     let windowCmptRef: ComponentRef<NgbModalWindow> = this._attachWindowComponent(containerEl, contentRef);
     let ngbModalRef: NgbModalRef = new NgbModalRef(windowCmptRef, contentRef, backdropCmptRef, options.beforeDismiss);
 
+    ngbModalRef.result.then(revertPaddingForScrollbar, revertPaddingForScrollbar);
     activeModal.close = (result: any) => { ngbModalRef.close(result); };
     activeModal.dismiss = (reason: any) => { ngbModalRef.dismiss(reason); };
 

--- a/src/modal/modal.module.ts
+++ b/src/modal/modal.module.ts
@@ -4,6 +4,7 @@ import {NgbModalBackdrop} from './modal-backdrop';
 import {NgbModalWindow} from './modal-window';
 import {NgbModalStack} from './modal-stack';
 import {NgbModal} from './modal';
+import {Scrollbar} from '../util/scrollbar';
 
 export {NgbModal, NgbModalOptions} from './modal';
 export {NgbModalRef, NgbActiveModal} from './modal-ref';
@@ -15,5 +16,7 @@ export {ModalDismissReasons} from './modal-dismiss-reasons';
   providers: [NgbModal]
 })
 export class NgbModalModule {
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbModalModule, providers: [NgbModal, NgbModalStack]}; }
+  static forRoot(): ModuleWithProviders {
+    return {ngModule: NgbModalModule, providers: [NgbModal, NgbModalStack, Scrollbar]};
+  }
 }

--- a/src/util/scrollbar.ts
+++ b/src/util/scrollbar.ts
@@ -1,0 +1,47 @@
+import {Injectable, Inject} from '@angular/core';
+import {DOCUMENT} from '@angular/platform-browser';
+
+import {isDefined} from './util';
+
+
+
+@Injectable()
+export class Scrollbar {
+  constructor(@Inject(DOCUMENT) private _document) {}
+
+  compensateScrollbar() {
+    if (!this.isScrollbarPresent()) {
+      return () => {};
+    }
+    const scrollbarWidth = this.getScrollbarWidth();
+    return this.adjustElementForScrollbar(scrollbarWidth);
+  }
+
+  adjustElementForScrollbar(scrollbarWidth: number) {
+    const element = this._document.body;
+    const userSetPadding = element.style.paddingRight;
+    const paddingAmount = parseFloat(window.getComputedStyle(element)['padding-right']);
+    element.style['padding-right'] = `${paddingAmount + scrollbarWidth}px`;
+    return () => element.style['padding-right'] = userSetPadding;
+  }
+
+  isScrollbarPresent(): boolean {
+    const element = this._document.body;
+    const rect = element.getBoundingClientRect();
+    return rect.left + rect.right < window.innerWidth;
+  }
+
+  getScrollbarWidth(): number {
+    const document = this._document;
+    const element = document.body;
+
+    const measurer = document.createElement('div');
+    measurer.className = 'modal-scrollbar-measure';
+
+    element.appendChild(measurer);
+    const scrollbarWidth = measurer.getBoundingClientRect().width - measurer.clientWidth;
+    element.removeChild(measurer);
+
+    return scrollbarWidth;
+  }
+}


### PR DESCRIPTION
Shifting potentially occurs when a scrollbar present on the container disappears once the modal opens.

The solution is taken from Bootstrap itself.

fixex #641 

Remaining:

- tests
