### PR TITLE
fix(accordion): the markup should follow the boostrap one

### DIFF
--- a/src/accordion/accordion.spec.ts
+++ b/src/accordion/accordion.spec.ts
@@ -16,7 +16,7 @@ function getPanels(element: HTMLElement): HTMLDivElement[] {
 }
 
 function getPanelsContent(element: HTMLElement): HTMLDivElement[] {
-  return <HTMLDivElement[]>Array.from(element.querySelectorAll('.card > .card-body'));
+  return <HTMLDivElement[]>Array.from(element.querySelectorAll('.card > .collapse'));
 }
 
 function getPanelsTitle(element: HTMLElement): HTMLButtonElement[] {

--- a/src/accordion/accordion.ts
+++ b/src/accordion/accordion.ts
@@ -123,8 +123,10 @@ export interface NgbPanelChangeEvent {
           </h5>
         </div>
         <div id="{{panel.id}}" role="tabpanel" [attr.aria-labelledby]="panel.id + '-header'"
-             class="card-body collapse" [class.show]="panel.isOpen" *ngIf="!destroyOnHide || panel.isOpen">
-             <ng-template [ngTemplateOutlet]="panel.contentTpl?.templateRef"></ng-template>
+             class="collapse" [class.show]="panel.isOpen" *ngIf="!destroyOnHide || panel.isOpen">
+          <div class="card-body">
+               <ng-template [ngTemplateOutlet]="panel.contentTpl?.templateRef"></ng-template>
+          </div>
         </div>
       </div>
     </ng-template>


### PR DESCRIPTION
Following the bootstrap example: https://getbootstrap.com/docs/4.1/components/collapse/#accordion-example

The card-body is inside the collapse element. It can be useful for animation.