### PR TITLE
fix(dropdown): close dropdown correctly inside the OnPush component

### DIFF
--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -1,12 +1,10 @@
-import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
+import {ComponentFixture, inject, TestBed} from '@angular/core/testing';
 import {createGenericTestComponent, createKeyEvent} from '../test/common';
 import {Key} from '../util/key';
 
-import {Component} from '@angular/core';
-import {By} from '@angular/platform-browser';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 import {NgbDropdownModule} from './dropdown.module';
-import {NgbDropdown} from './dropdown';
 import {NgbDropdownConfig} from './dropdown-config';
 
 const createTestComponent = (html: string) =>
@@ -250,7 +248,8 @@ describe('ngb-dropdown', () => {
 describe('ngb-dropdown-toggle', () => {
   beforeEach(() => {
     jasmine.addMatchers(jasmineMatchers);
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDropdownModule.forRoot()]});
+    TestBed.configureTestingModule(
+        {declarations: [TestComponent, TestClickCloseOnPush], imports: [NgbDropdownModule.forRoot()]});
   });
 
   it('should toggle dropdown on click', () => {
@@ -316,10 +315,42 @@ describe('ngb-dropdown-toggle', () => {
     const compiled = fixture.nativeElement;
     const buttonEl = compiled.querySelector('button');
 
-    fixture.detectChanges();
     expect(compiled).toBeShown();
 
     buttonEl.click();
+    fixture.detectChanges();
+    expect(compiled).not.toBeShown();
+  });
+
+  it('should close on inside click, outside click and escape when inside the OnPush component', () => {
+    const fixture = createTestComponent(`<test-click-close-on-push></test-click-close-on-push>`);
+    const compiled = fixture.nativeElement;
+    const toggleEl = compiled.querySelector('button');
+    const outsideEl = compiled.querySelector('.outside');
+    const insideEl = compiled.querySelector('.inside');
+
+    const reopen = () => {
+      toggleEl.click();
+      fixture.detectChanges();
+      expect(compiled).toBeShown();
+    };
+
+    // inside click
+    insideEl.click();
+    fixture.detectChanges();
+    expect(compiled).not.toBeShown();
+
+
+    // outside click
+    reopen();
+    outsideEl.click();
+    fixture.detectChanges();
+    expect(compiled).not.toBeShown();
+
+
+    // escape
+    reopen();
+    document.dispatchEvent(createFakeEscapeKeyUpEvent());
     fixture.detectChanges();
     expect(compiled).not.toBeShown();
   });
@@ -336,7 +367,6 @@ describe('ngb-dropdown-toggle', () => {
     const compiled = fixture.nativeElement;
     const buttonEl = compiled.querySelector('button');
 
-    fixture.detectChanges();
     expect(compiled).toBeShown();
 
     const evt = document.createEvent('MouseEvent');
@@ -358,7 +388,6 @@ describe('ngb-dropdown-toggle', () => {
     const compiled = fixture.nativeElement;
     let buttonEl = compiled.querySelector('button');
 
-    fixture.detectChanges();
     expect(compiled).toBeShown();
 
     buttonEl.click();
@@ -367,85 +396,76 @@ describe('ngb-dropdown-toggle', () => {
   });
 
   describe('escape closing', () => {
+
     it('should close on ESC from anywhere', () => {
       const fixture = createTestComponent(`
-          <div ngbDropdown [autoClose]="true">
+          <div ngbDropdown [open]="true" [autoClose]="true">
               <button ngbDropdownToggle>Toggle dropdown</button>
               <div ngbDropdownMenu></div>
           </div>`);
-      const compiled = fixture.nativeElement;
 
-      compiled.querySelector('button').click();
-      fixture.detectChanges();
+      const compiled = fixture.nativeElement;
       expect(compiled).toBeShown();
 
       document.dispatchEvent(createFakeEscapeKeyUpEvent());
       fixture.detectChanges();
-
       expect(compiled).not.toBeShown();
     });
+
     it('should close on ESC from the toggling button', () => {
       const fixture = createTestComponent(`
-        <div ngbDropdown [autoClose]="true">
+        <div ngbDropdown [open]="true" [autoClose]="true">
             <button ngbDropdownToggle>Toggle dropdown</button>
             <div ngbDropdownMenu></div>
         </div>`);
       const compiled = fixture.nativeElement;
       const buttonElement = compiled.querySelector('button');
 
-      buttonElement.click();
-      fixture.detectChanges();
       expect(compiled).toBeShown();
 
       buttonElement.dispatchEvent(createFakeEscapeKeyUpEvent());
       fixture.detectChanges();
-
       expect(compiled).not.toBeShown();
     });
 
     it('should not close on ESC from the toggling button if autoClose is set to false', () => {
       const fixture = createTestComponent(`
-        <div ngbDropdown [autoClose]="false">
+        <div ngbDropdown [open]="true" [autoClose]="false">
             <button ngbDropdownToggle>Toggle dropdown</button>
             <div ngbDropdownMenu></div>
         </div>`);
       const compiled = fixture.nativeElement;
       const buttonElement = compiled.querySelector('button');
 
-      buttonElement.click();
-      fixture.detectChanges();
       expect(compiled).toBeShown();
 
       buttonElement.dispatchEvent(createFakeEscapeKeyUpEvent());
       fixture.detectChanges();
+      expect(compiled).toBeShown();
 
-      const expectation = expect(compiled);
-      expectation.toBeShown();
       buttonElement.click();
       fixture.detectChanges();
-      expectation.not.toBeShown();
+      expect(compiled).not.toBeShown();
     });
+
     it('should not close on ESC from anywhere if autoClose is set to false', () => {
       const fixture = createTestComponent(`
-          <div ngbDropdown [autoClose]="false">
+          <div ngbDropdown [open]="true" [autoClose]="false">
               <button ngbDropdownToggle>Toggle dropdown</button>
               <div ngbDropdownMenu></div>
           </div>`);
       const compiled = fixture.nativeElement;
       const buttonElement = compiled.querySelector('button');
 
-      buttonElement.click();
-      fixture.detectChanges();
       expect(compiled).toBeShown();
 
       document.dispatchEvent(createFakeEscapeKeyUpEvent());
       fixture.detectChanges();
+      expect(compiled).toBeShown();
 
-      const expectation = expect(compiled);
-      expectation.toBeShown();
       buttonElement.click();
       fixture.detectChanges();
-      expectation.not.toBeShown();
+      expect(compiled).not.toBeShown();
     });
   });
 
@@ -462,7 +482,6 @@ describe('ngb-dropdown-toggle', () => {
     const compiled = fixture.nativeElement;
     const linkEl = compiled.querySelector('a');
 
-    fixture.detectChanges();
     expect(compiled).toBeShown();
 
     linkEl.click();
@@ -483,7 +502,6 @@ describe('ngb-dropdown-toggle', () => {
     const compiled = fixture.nativeElement;
     const linkEl = compiled.querySelector('a');
 
-    fixture.detectChanges();
     expect(compiled).toBeShown();
 
     linkEl.click();
@@ -545,7 +563,6 @@ describe('ngb-dropdown-toggle', () => {
       const buttonEl = compiled.querySelector('button');
       const linkEl = compiled.querySelector('a');
 
-      fixture.detectChanges();
       expect(compiled).toBeShown();
 
       // remains open on item click
@@ -575,7 +592,6 @@ describe('ngb-dropdown-toggle', () => {
       const buttonEl = compiled.querySelector('#outside');
       const linkEl = compiled.querySelector('a');
 
-      fixture.detectChanges();
       expect(compiled).toBeShown();
 
       // remains open on outside click
@@ -659,4 +675,20 @@ class TestComponent {
     this.stateChanges.push($event);
     this.isOpen = $event;
   }
+}
+
+@Component({
+  selector: 'test-click-close-on-push',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div ngbDropdown [open]="true">
+      <button ngbDropdownToggle>Toggle dropdown</button>
+      <div ngbDropdownMenu>
+        <a class="dropdown-item inside">Action</a>
+      </div>
+    </div>
+    <button class="outside">Outside</button>
+  `
+})
+class TestClickCloseOnPush {
 }


### PR DESCRIPTION
* fixes a regression introduced in 2.2.1: click handler didn't mark component as dirty
* cleans up click handler correctly
* removes unnecessary checks in tests

Fixes #2559
