### PR TITLE
fix(typeahead): add hover class instead of active class on mouseover

### DIFF
--- a/src/test/typeahead/common.ts
+++ b/src/test/typeahead/common.ts
@@ -19,10 +19,10 @@ export function expectResults(nativeEl: HTMLElement, resultsDef: string[]): void
     let classIndicator = resultDef.charAt(0);
 
     if (classIndicator === '+') {
-      expect(pages[i]).toHaveCssClass('active');
+      expect(pages[i]).toHaveCssClass('hover');
       expect(normalizeText(pages[i].textContent)).toEqual(resultDef.substr(1));
     } else {
-      expect(pages[i]).not.toHaveCssClass('active');
+      expect(pages[i]).not.toHaveCssClass('hover');
       expect(normalizeText(pages[i].textContent)).toEqual(resultDef);
     }
   }

--- a/src/typeahead/typeahead-window.ts
+++ b/src/typeahead/typeahead-window.ts
@@ -28,7 +28,7 @@ export interface ResultTemplateContext {
     <ng-template ngFor [ngForOf]="results" let-result let-idx="index">
       <button type="button" class="dropdown-item" role="option"
         [id]="id + '-' + idx"
-        [class.active]="idx === activeIdx"
+        [class.hover]="idx === activeIdx"
         (mouseenter)="markActive(idx)"
         (click)="select(result)">
           <ng-template [ngTemplateOutlet]="resultTemplate || rt"


### PR DESCRIPTION
Current behavior for typeahead does not align with CSS standards. mouseenter effectively adds the "active" class to elements when it should add the "hover" class.

From https://www.w3.org/TR/selectors-3/#pseudo-classes:

- The :hover pseudo-class applies while the user designates an element with a pointing device, but does not necessarily activate it. For example, a visual user agent could apply this pseudo-class when the cursor (mouse pointer) hovers over a box generated by the element. User agents that do not support interactive media do not have to support this pseudo-class. Some conforming user agents that support interactive media may not be able to support this pseudo-class (e.g., a pen device that does not detect hovering).

- The :active pseudo-class applies while an element is being activated by the user. For example, between the times the user presses the mouse button and releases it. On systems with more than one mouse button, :active applies only to the primary or primary activation button (typically the "left" mouse button), and any aliases thereof.