### PR TITLE
Doc/ngb highlight

### DIFF
--- a/demo/src/app/components/typeahead/demos/template/typeahead-template.html
+++ b/demo/src/app/components/typeahead/demos/template/typeahead-template.html
@@ -1,8 +1,10 @@
-<p>A typeahead example that uses custom template for results display and uses object as a model</p>
+<p>A typeahead example that uses a custom template for results display, an object as the model,
+  and the highlight directive to highlight the term inside the custom template.
+</p>
 
 <ng-template #rt let-r="result" let-t="term">
-  <img [src]="'https://upload.wikimedia.org/wikipedia/commons/thumb/' + r['flag']" width="16">
-  {{ r.name}}
+  <img [src]="'https://upload.wikimedia.org/wikipedia/commons/thumb/' + r['flag']" class="mr-1" style="width: 16px">
+  <ngb-highlight [result]="r.name" [term]="t"></ngb-highlight>
 </ng-template>
 
 <label for="typeahead-template">Search for a state:</label>

--- a/demo/src/app/components/typeahead/typeahead.component.ts
+++ b/demo/src/app/components/typeahead/typeahead.component.ts
@@ -8,6 +8,7 @@ import {DEMO_SNIPPETS} from './demos';
       <ngbd-api-docs directive="NgbTypeahead"></ngbd-api-docs>
       <ngbd-api-docs-class type="NgbTypeaheadSelectItemEvent"></ngbd-api-docs-class>
       <ngbd-api-docs-class type="ResultTemplateContext"></ngbd-api-docs-class>
+      <ngbd-api-docs directive="NgbHighlight"></ngbd-api-docs>
       <ngbd-api-docs-config type="NgbTypeaheadConfig"></ngbd-api-docs-config>
       <ngbd-example-box demoTitle="Simple Typeahead" [snippets]="snippets" component="typeahead" demo="basic">
         <ngbd-typeahead-basic></ngbd-typeahead-basic>

--- a/src/typeahead/highlight.ts
+++ b/src/typeahead/highlight.ts
@@ -1,6 +1,10 @@
 import {Component, Input, OnChanges, ChangeDetectionStrategy, SimpleChanges} from '@angular/core';
 import {regExpEscape, toString} from '../util/util';
 
+/**
+ * Directive that can be used inside a custom result template in order to highlight the term inside the text of the
+ * result
+ */
 @Component({
   selector: 'ngb-highlight',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -16,8 +20,19 @@ import {regExpEscape, toString} from '../util/util';
 export class NgbHighlight implements OnChanges {
   parts: string[];
 
+  /**
+   * The CSS class of the span elements wrapping the term inside the result
+   */
   @Input() highlightClass = 'ngb-highlight';
+
+  /**
+   * The result text to display. If the term is found inside this text, it's highlighted
+   */
   @Input() result: string;
+
+  /**
+   * The searched term
+   */
   @Input() term: string;
 
   ngOnChanges(changes: SimpleChanges) {

--- a/src/typeahead/highlight.ts
+++ b/src/typeahead/highlight.ts
@@ -9,7 +9,7 @@ import {regExpEscape, toString} from '../util/util';
   selector: 'ngb-highlight',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `<ng-template ngFor [ngForOf]="parts" let-part let-isOdd="odd">` +
-      `<span *ngIf="isOdd" class="{{highlightClass}}">{{part}}</span><ng-template [ngIf]="!isOdd">{{part}}</ng-template>` +
+      `<span *ngIf="isOdd; else even" [class]="highlightClass">{{part}}</span><ng-template #even>{{part}}</ng-template>` +
       `</ng-template>`,  // template needs to be formatted in a certain way so we don't add empty text nodes
   styles: [`
     .ngb-highlight {


### PR DESCRIPTION
I noticed that the `NgbHighlight` directive is exported from the ng-bootstrap module, but not documented. 
This PR thus adds documentation for this directive and shows how to use it in the *custom template* demo of `NgbTypeahead`.

A second commit also makes a tiny refactoring of the template of the directive.

If the directive was not documented on purpose, because it's intended to leave it private in a future release, then I think it would be better to document it, but to deprecate it and thus make it clear that it shouldn't be used. But I'm not sure why making it private would be desirable. Anyway, in that case, the second commit can be cherry-picked.

----

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
