### PR TITLE
feat(tooltip): add openDelay and closeDelay

### DIFF
--- a/demo/src/app/components/popover/demos/delay/popover-delay.html
+++ b/demo/src/app/components/popover/demos/delay/popover-delay.html
@@ -1,0 +1,16 @@
+<p>
+  When using non-manual triggers, you can control the delay to open and close the popover through the <code>openDelay</code> and
+  <code>closeDelay</code> properties. Note that the <code>autoClose</code> feature does not use the close delay, it closes the popover immediately.
+</p>
+
+<button type="button" class="btn btn-outline-secondary mr-2"
+  ngbPopover="You see, I show up after 300ms and disappear after 500ms!"
+  [openDelay]="300" [closeDelay]="500" triggers="mouseenter:mouseleave">
+  Hover 300ms here
+</button>
+
+<button type="button" class="btn btn-outline-secondary mr-2"
+  ngbPopover="You see, I show up after 1s and disappear after 2s!"
+  [openDelay]="1000" [closeDelay]="2000" triggers="mouseenter:mouseleave">
+  Hover 1s here
+</button>

--- a/demo/src/app/components/popover/demos/delay/popover-delay.ts
+++ b/demo/src/app/components/popover/demos/delay/popover-delay.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'ngbd-popover-delay',
+  templateUrl: './popover-delay.html'
+})
+export class NgbdPopoverDelay {
+}

--- a/demo/src/app/components/popover/popover.module.ts
+++ b/demo/src/app/components/popover/popover.module.ts
@@ -10,6 +10,7 @@ import { NgbdPopoverBasic } from './demos/basic/popover-basic';
 import { NgbdPopoverConfig } from './demos/config/popover-config';
 import { NgbdPopoverContainer } from './demos/container/popover-container';
 import { NgbdPopoverCustomclass } from './demos/customclass/popover-customclass';
+import { NgbdPopoverDelay } from './demos/delay/popover-delay';
 import { NgbdPopoverTplcontent } from './demos/tplcontent/popover-tplcontent';
 import { NgbdPopoverTplwithcontext } from './demos/tplwithcontext/popover-tplwithcontext';
 import { NgbdPopoverTriggers } from './demos/triggers/popover-triggers';
@@ -24,6 +25,7 @@ const DEMO_DIRECTIVES = [
   NgbdPopoverVisibility,
   NgbdPopoverContainer,
   NgbdPopoverCustomclass,
+  NgbdPopoverDelay,
   NgbdPopoverConfig
 ];
 
@@ -57,6 +59,12 @@ const DEMOS = {
     type: NgbdPopoverTplwithcontext,
     code: require('!!raw-loader!./demos/tplwithcontext/popover-tplwithcontext'),
     markup: require('!!raw-loader!./demos/tplwithcontext/popover-tplwithcontext.html')
+  },
+  delay: {
+    title: 'Open and close delays',
+    type: NgbdPopoverDelay,
+    code: require('!!raw-loader!./demos/delay/popover-delay'),
+    markup: require('!!raw-loader!./demos/delay/popover-delay.html')
   },
   visibility: {
     title: 'Popover visibility events',

--- a/demo/src/app/components/tooltip/demos/delay/tooltip-delay.html
+++ b/demo/src/app/components/tooltip/demos/delay/tooltip-delay.html
@@ -1,0 +1,15 @@
+<p>
+  When using non-manual triggers, you can control the delay to open and close the tooltip through the <code>openDelay</code> and
+  <code>closeDelay</code> properties. Note that the <code>autoClose</code> feature does not use the close delay, it closes the tooltip immediately.
+</p>
+
+<button type="button" class="btn btn-outline-secondary mr-2"
+  ngbTooltip="You see, I show up after 300ms and disappear after 500ms!"
+  [openDelay]="300" [closeDelay]="500">
+  Hover 300ms here
+</button>
+<button type="button" class="btn btn-outline-secondary mr-2"
+  ngbTooltip="You see, I show up after 1s and disappear after 2s!"
+  [openDelay]="1000" [closeDelay]="2000">
+  Hover 1s here
+</button>

--- a/demo/src/app/components/tooltip/demos/delay/tooltip-delay.ts
+++ b/demo/src/app/components/tooltip/demos/delay/tooltip-delay.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'ngbd-tooltip-delay',
+  templateUrl: './tooltip-delay.html'
+})
+export class NgbdTooltipDelay {
+}

--- a/demo/src/app/components/tooltip/tooltip.module.ts
+++ b/demo/src/app/components/tooltip/tooltip.module.ts
@@ -10,6 +10,7 @@ import { NgbdTooltipBasic } from './demos/basic/tooltip-basic';
 import { NgbdTooltipConfig } from './demos/config/tooltip-config';
 import { NgbdTooltipContainer } from './demos/container/tooltip-container';
 import { NgbdTooltipCustomclass } from './demos/customclass/tooltip-customclass';
+import { NgbdTooltipDelay } from './demos/delay/tooltip-delay';
 import { NgbdTooltipTplcontent } from './demos/tplcontent/tooltip-tplcontent';
 import { NgbdTooltipTplwithcontext } from './demos/tplwithcontext/tooltip-tplwithcontext';
 import { NgbdTooltipTriggers } from './demos/triggers/tooltip-triggers';
@@ -18,6 +19,7 @@ const DEMO_DIRECTIVES = [
   NgbdTooltipBasic,
   NgbdTooltipContainer,
   NgbdTooltipCustomclass,
+  NgbdTooltipDelay,
   NgbdTooltipTplcontent,
   NgbdTooltipTriggers,
   NgbdTooltipAutoclose,
@@ -55,6 +57,12 @@ const DEMOS = {
     type: NgbdTooltipTplwithcontext,
     code: require('!!raw-loader!./demos/tplwithcontext/tooltip-tplwithcontext'),
     markup: require('!!raw-loader!./demos/tplwithcontext/tooltip-tplwithcontext.html')
+  },
+  delay: {
+    title: 'Open and close delays',
+    type: NgbdTooltipDelay,
+    code: require('!!raw-loader!./demos/delay/tooltip-delay'),
+    markup: require('!!raw-loader!./demos/delay/tooltip-delay.html')
   },
   container: {
     title: 'Append tooltip in the body',

--- a/src/popover/popover-config.spec.ts
+++ b/src/popover/popover-config.spec.ts
@@ -10,5 +10,7 @@ describe('ngb-popover-config', () => {
     expect(config.container).toBeUndefined();
     expect(config.disablePopover).toBe(false);
     expect(config.popoverClass).toBeUndefined();
+    expect(config.openDelay).toBe(0);
+    expect(config.closeDelay).toBe(0);
   });
 });

--- a/src/popover/popover-config.ts
+++ b/src/popover/popover-config.ts
@@ -14,4 +14,6 @@ export class NgbPopoverConfig {
   container: string;
   disablePopover = false;
   popoverClass: string;
+  openDelay = 0;
+  closeDelay = 0;
 }

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -109,6 +109,14 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
    */
   @Input() popoverClass: string;
   /**
+   * Delay (in ms) before opening the popover after a non-manual opening trigger.
+   */
+  @Input() openDelay: number;
+  /**
+   * Delay (in ms) before closing the popover after a non-manual closing trigger.
+   */
+  @Input() closeDelay: number;
+  /**
    * Emits an event when the popover is shown
    */
   @Output() shown = new EventEmitter();
@@ -142,6 +150,8 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
     this.container = config.container;
     this.disablePopover = config.disablePopover;
     this.popoverClass = config.popoverClass;
+    this.openDelay = config.openDelay;
+    this.closeDelay = config.closeDelay;
     this._popupService = new PopupService<NgbPopoverWindow>(
         NgbPopoverWindow, injector, viewContainerRef, _renderer, componentFactoryResolver);
 
@@ -213,8 +223,8 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
 
   ngOnInit() {
     this._unregisterListenersFn = listenToTriggers(
-        this._renderer, this._elementRef.nativeElement, this.triggers, this.open.bind(this), this.close.bind(this),
-        this.toggle.bind(this));
+        this._renderer, this._elementRef.nativeElement, this.triggers, this.isOpen.bind(this), this.open.bind(this),
+        this.close.bind(this), +this.openDelay, +this.closeDelay);
   }
 
   ngOnChanges(changes: SimpleChanges) {

--- a/src/tooltip/tooltip-config.spec.ts
+++ b/src/tooltip/tooltip-config.spec.ts
@@ -10,5 +10,7 @@ describe('ngb-tooltip-config', () => {
     expect(config.container).toBeUndefined();
     expect(config.disableTooltip).toBe(false);
     expect(config.tooltipClass).toBeUndefined();
+    expect(config.openDelay).toBe(0);
+    expect(config.closeDelay).toBe(0);
   });
 });

--- a/src/tooltip/tooltip-config.ts
+++ b/src/tooltip/tooltip-config.ts
@@ -14,4 +14,6 @@ export class NgbTooltipConfig {
   container: string;
   disableTooltip = false;
   tooltipClass: string;
+  openDelay = 0;
+  closeDelay = 0;
 }

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -89,6 +89,14 @@ export class NgbTooltip implements OnInit, OnDestroy {
    */
   @Input() tooltipClass: string;
   /**
+   * Delay (in ms) before opening the tooltip after a non-manual opening trigger.
+   */
+  @Input() openDelay: number;
+  /**
+   * Delay (in ms) before closing the tooltip after a non-manual closing trigger.
+   */
+  @Input() closeDelay: number;
+  /**
    * Emits an event when the tooltip is shown
    */
   @Output() shown = new EventEmitter();
@@ -114,6 +122,8 @@ export class NgbTooltip implements OnInit, OnDestroy {
     this.container = config.container;
     this.disableTooltip = config.disableTooltip;
     this.tooltipClass = config.tooltipClass;
+    this.openDelay = config.openDelay;
+    this.closeDelay = config.closeDelay;
     this._popupService = new PopupService<NgbTooltipWindow>(
         NgbTooltipWindow, injector, viewContainerRef, _renderer, componentFactoryResolver);
 
@@ -197,8 +207,8 @@ export class NgbTooltip implements OnInit, OnDestroy {
 
   ngOnInit() {
     this._unregisterListenersFn = listenToTriggers(
-        this._renderer, this._elementRef.nativeElement, this.triggers, this.open.bind(this), this.close.bind(this),
-        this.toggle.bind(this));
+        this._renderer, this._elementRef.nativeElement, this.triggers, this.isOpen.bind(this), this.open.bind(this),
+        this.close.bind(this), +this.openDelay, +this.closeDelay);
   }
 
   ngOnDestroy() {

--- a/src/util/triggers.spec.ts
+++ b/src/util/triggers.spec.ts
@@ -1,4 +1,6 @@
-import {parseTriggers} from './triggers';
+import {fakeAsync, tick} from '@angular/core/testing';
+import {Subject, Subscription, Observable} from 'rxjs';
+import {parseTriggers, triggerDelay} from './triggers';
 
 describe('triggers', () => {
 
@@ -84,5 +86,151 @@ describe('triggers', () => {
       }).toThrow(`Triggers parse error: manual trigger can\'t be mixed with other triggers`);
     });
 
+  });
+
+  describe('triggerDelay', () => {
+    let subject$: Subject<boolean>;
+    let delayed$: Observable<boolean>;
+    let open: boolean;
+    let subscription: Subscription;
+    let spy: jasmine.Spy;
+
+    beforeEach(() => {
+      subject$ = new Subject();
+      spy = jasmine.createSpy('listener', (newValue) => open = newValue).and.callThrough();
+      delayed$ = subject$.asObservable().pipe(triggerDelay(5000, 1000, () => open));
+      subscription = delayed$.subscribe(spy);
+    });
+
+    afterEach(() => {
+      if (subscription) {
+        subscription.unsubscribe();
+        subscription = null;
+      }
+    });
+
+    it('delays open', fakeAsync(() => {
+         open = false;
+         subject$.next(true);
+         tick(4999);
+         expect(spy).not.toHaveBeenCalled();
+         tick(2);
+         expect(spy).toHaveBeenCalledWith(true);
+         tick(100000);
+         expect(spy.calls.count()).toBe(1);
+       }));
+
+    it('cancels open if it is already done through another way', fakeAsync(() => {
+         open = false;
+         subject$.next(true);
+         tick(4999);
+         expect(spy).not.toHaveBeenCalled();
+         open = true;
+         tick(2);
+         expect(spy).not.toHaveBeenCalled();
+         tick(100000);
+         expect(spy.calls.count()).toBe(0);
+       }));
+
+    it('delays close', fakeAsync(() => {
+         open = true;
+         subject$.next(false);
+         tick(999);
+         expect(spy).not.toHaveBeenCalled();
+         tick(2);
+         expect(spy).toHaveBeenCalledWith(false);
+         tick(100000);
+         expect(spy.calls.count()).toBe(1);
+       }));
+
+    it('cancels close if it is already done through another way', fakeAsync(() => {
+         open = true;
+         subject$.next(false);
+         tick(999);
+         expect(spy).not.toHaveBeenCalled();
+         open = false;
+         tick(2);
+         expect(spy).not.toHaveBeenCalled();
+         tick(100000);
+         expect(spy.calls.count()).toBe(0);
+       }));
+
+    it('ignores extra open during openDelay', fakeAsync(() => {
+         open = false;
+         subject$.next(true);
+         tick(200);
+         subject$.next(true);
+         tick(100);
+         subject$.next(true);
+         tick(200);
+         tick(4499);
+         expect(spy).not.toHaveBeenCalled();
+         tick(2);
+         expect(spy).toHaveBeenCalledWith(true);
+         tick(100000);
+         expect(spy.calls.count()).toBe(1);
+       }));
+
+    it('ignores extra close during closeDelay', fakeAsync(() => {
+         open = true;
+         subject$.next(false);
+         tick(200);
+         subject$.next(false);
+         tick(100);
+         subject$.next(false);
+         tick(200);
+         tick(499);
+         expect(spy).not.toHaveBeenCalled();
+         tick(2);
+         expect(spy).toHaveBeenCalledWith(false);
+         tick(100000);
+         expect(spy.calls.count()).toBe(1);
+       }));
+
+    it('cancels open when receiving close during openDelay', fakeAsync(() => {
+         open = false;
+         subject$.next(true);
+         tick(4999);
+         subject$.next(false);
+         tick(100000);
+         expect(spy).not.toHaveBeenCalled();
+       }));
+
+    it('cancels close when receiving open during closeDelay', fakeAsync(() => {
+         open = true;
+         subject$.next(false);
+         tick(999);
+         subject$.next(true);
+         tick(100000);
+         expect(spy).not.toHaveBeenCalled();
+       }));
+
+    it('closes during openDelay if opened through another way', fakeAsync(() => {
+         open = false;
+         subject$.next(true);
+         tick(4999);
+         open = true;
+         subject$.next(false);
+         tick(999);
+         expect(spy).not.toHaveBeenCalled();
+         tick(2);
+         expect(spy).toHaveBeenCalledWith(false);
+         tick(100000);
+         expect(spy.calls.count()).toBe(1);
+       }));
+
+    it('opens during closeDelay if closed through another way', fakeAsync(() => {
+         open = true;
+         subject$.next(false);
+         tick(999);
+         open = false;
+         subject$.next(true);
+         tick(4999);
+         expect(spy).not.toHaveBeenCalled();
+         tick(2);
+         expect(spy).toHaveBeenCalledWith(true);
+         tick(100000);
+         expect(spy.calls.count()).toBe(1);
+       }));
   });
 });


### PR DESCRIPTION
This PR is an implementation of the feature requested in #1052.
It adds the `triggerOpenDelay` and `triggerCloseDelay` properties on the `tooltip` and `popover` components.

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.

Notes:
- **The API documentation will have to be updated for the new properties to include the `@since` keyword with the right version number.**