### PR TITLE
feat(pagination): add class to be able customize the look

### DIFF
--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -38,6 +38,23 @@ function expectPages(nativeEl: HTMLElement, pagesDef: string[]): void {
         expect(pages[i].querySelector('a').hasAttribute('tabindex')).toBeFalsy();
       }
     }
+    if (normalizeText(pages[i].textContent) === '...') {
+      expect(pages[i]).toHaveCssClass('ngb-pagination-ellipsis');
+    } else {
+      expect(pages[i]).not.toHaveCssClass('ngb-pagination-ellipsis');
+    }
+    if (normalizeText(pages[i].textContent) === '«') {
+      expect(pages[i]).toHaveCssClass('ngb-pagination-previous');
+    }
+    if (normalizeText(pages[i].textContent) === '»') {
+      expect(pages[i]).toHaveCssClass('ngb-pagination-next');
+    }
+    if (normalizeText(pages[i].textContent) === '««') {
+      expect(pages[i]).toHaveCssClass('ngb-pagination-first');
+    }
+    if (normalizeText(pages[i].textContent) === '»»') {
+      expect(pages[i]).toHaveCssClass('ngb-pagination-last');
+    }
   }
 }
 

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -11,7 +11,7 @@ import {NgbPaginationConfig} from './pagination-config';
   host: {'role': 'navigation'},
   template: `
     <ul [class]="'pagination' + (size ? ' pagination-' + size : '')">
-      <li *ngIf="boundaryLinks" class="page-item"
+      <li *ngIf="boundaryLinks" class="page-item ngb-pagination-first"
         [class.disabled]="!hasPrevious() || disabled">
         <a aria-label="First" i18n-aria-label="@@ngb.pagination.first-aria" class="page-link" href
           (click)="!!selectPage(1)" [attr.tabindex]="(hasPrevious() ? null : '-1')">
@@ -19,7 +19,7 @@ import {NgbPaginationConfig} from './pagination-config';
         </a>
       </li>
 
-      <li *ngIf="directionLinks" class="page-item"
+      <li *ngIf="directionLinks" class="page-item ngb-pagination-previous"
         [class.disabled]="!hasPrevious() || disabled">
         <a aria-label="Previous" i18n-aria-label="@@ngb.pagination.previous-aria" class="page-link" href
           (click)="!!selectPage(page-1)" [attr.tabindex]="(hasPrevious() ? null : '-1')">
@@ -27,21 +27,21 @@ import {NgbPaginationConfig} from './pagination-config';
         </a>
       </li>
       <li *ngFor="let pageNumber of pages" class="page-item" [class.active]="pageNumber === page"
-        [class.disabled]="isEllipsis(pageNumber) || disabled">
+        [class.disabled]="isEllipsis(pageNumber) || disabled" [class.ngb-pagination-ellipsis]="isEllipsis(pageNumber)">
         <a *ngIf="isEllipsis(pageNumber)" class="page-link">...</a>
         <a *ngIf="!isEllipsis(pageNumber)" class="page-link" href (click)="!!selectPage(pageNumber)">
           {{pageNumber}}
           <span *ngIf="pageNumber === page" class="sr-only">(current)</span>
         </a>
       </li>
-      <li *ngIf="directionLinks" class="page-item" [class.disabled]="!hasNext() || disabled">
+      <li *ngIf="directionLinks" class="page-item ngb-pagination-next" [class.disabled]="!hasNext() || disabled">
         <a aria-label="Next" i18n-aria-label="@@ngb.pagination.next-aria" class="page-link" href
           (click)="!!selectPage(page+1)" [attr.tabindex]="(hasNext() ? null : '-1')">
           <span aria-hidden="true" i18n="@@ngb.pagination.next">&raquo;</span>
         </a>
       </li>
 
-      <li *ngIf="boundaryLinks" class="page-item" [class.disabled]="!hasNext() || disabled">
+      <li *ngIf="boundaryLinks" class="page-item ngb-pagination-last" [class.disabled]="!hasNext() || disabled">
         <a aria-label="Last" i18n-aria-label="@@ngb.pagination.last-aria" class="page-link" href
           (click)="!!selectPage(pageCount)" [attr.tabindex]="(hasNext() ? null : '-1')">
           <span aria-hidden="true" i18n="@@ngb.pagination.last">&raquo;&raquo;</span>


### PR DESCRIPTION

Closes  #899

(Lint was not passing without changing the radix for the rating...)
I changed view encapsulation to none, because if we add some style in the pagination feature then the encapsulation does not allow to use the class to custom the inner content of the li (and this is what we want here).