### PR TITLE
feat(tabset): bind tabs to routes

### DIFF
--- a/demo/src/app/components/tabset/demos/router/tabset-router.html
+++ b/demo/src/app/components/tabset/demos/router/tabset-router.html
@@ -1,0 +1,31 @@
+<p>In order to easily synchronize the <code>&lt;ngb-tabset&gt;</code> with the Angular router, some directives are provided in the
+  <code>NgbTabsetRoutingModule</code> module, which is not in the main entry point of ng-bootstrap (to avoid adding a general dependency
+  on the Angular router).</p>
+<p>The <code>NgbTabsetRoutingModule</code> module has to be imported from <code>'@ng-bootstrap/ng-bootstrap/tabset/routing'</code>.</p>
+<p>All child <code>&lt;ngb-tab&gt;</code> elements must be linked with a route using the standard
+  <a href="https://angular.io/api/router/RouterLink#description">routerLink</a> directive.</p>
+<p>The corresponding routes have to be defined in the configuration of the Angular router.</p>
+<p>The <code>&lt;ngb-tabset&gt;</code> should only be used on those configured routes. If no child <code>&lt;ngb-tab&gt;</code> element matches,
+  the <code>&lt;ngb-tabset&gt;</code> will not change the active tab (and if there is no active tab, the default behavior of the normal
+  <code>&lt;ngb-tabset&gt;</code> component is to select the first tab).</p>
+<p>The content of the tabs can be defined either in the corresponding <code>&lt;ng-template ngbTabContent&gt;</code> elements, or as the
+component property defined in the router configuration (if the <code>&lt;router-outlet&gt;</code> element is included in the page).</p>
+
+<ngb-tabset routerControlled>
+  <ngb-tab title="First" routerLink="firstTab" fragment="router">
+    <ng-template ngbTabContent>
+      First content
+    </ng-template>
+  </ngb-tab>
+  <ngb-tab title="Second" routerLink="secondTab" fragment="router">
+    <ng-template ngbTabContent>
+      Second content
+    </ng-template>
+  </ngb-tab>
+  <ngb-tab routerLink="thirdTab" fragment="router">
+    <ng-template ngbTabTitle>Third</ng-template>
+    <ng-template ngbTabContent>
+      Third content
+    </ng-template>
+  </ngb-tab>
+</ngb-tabset>

--- a/demo/src/app/components/tabset/demos/router/tabset-router.ts
+++ b/demo/src/app/components/tabset/demos/router/tabset-router.ts
@@ -1,0 +1,7 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'ngbd-tabset-router',
+  templateUrl: './tabset-router.html'
+})
+export class NgbdTabsetRouter { }

--- a/demo/src/app/components/tabset/tabset.module.ts
+++ b/demo/src/app/components/tabset/tabset.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 
 import { NgbdSharedModule } from '../../shared';
+import { NgbTabsetRoutingModule } from '@ng-bootstrap/ng-bootstrap/tabset/routing';
 import { ComponentWrapper } from '../../shared/component-wrapper/component-wrapper.component';
 import { NgbdComponentsSharedModule, NgbdDemoList } from '../shared';
 import { NgbdApiPage } from '../shared/api-page/api.component';
@@ -11,12 +12,14 @@ import { NgbdTabsetJustify } from './demos/justify/tabset-justify';
 import { NgbdTabsetOrientation } from './demos/orientation/tabset-orientation';
 import { NgbdTabsetPills } from './demos/pills/tabset-pills';
 import { NgbdTabsetPreventchange } from './demos/preventchange/tabset-preventchange';
+import { NgbdTabsetRouter } from './demos/router/tabset-router';
 import { NgbdTabsetSelectbyid } from './demos/selectbyid/tabset-selectbyid';
 
 const DEMO_DIRECTIVES = [
   NgbdTabsetBasic,
   NgbdTabsetPills,
   NgbdTabsetPreventchange,
+  NgbdTabsetRouter,
   NgbdTabsetSelectbyid,
   NgbdTabsetConfig,
   NgbdTabsetJustify,
@@ -60,6 +63,12 @@ const DEMOS = {
     code: require('!!raw-loader!./demos/orientation/tabset-orientation'),
     markup: require('!!raw-loader!./demos/orientation/tabset-orientation.html')
   },
+  router: {
+    title: 'Router',
+    type: NgbdTabsetRouter,
+    code: require('!!raw-loader!./demos/router/tabset-router'),
+    markup: require('!!raw-loader!./demos/router/tabset-router.html')
+  },
   config: {
     title: 'Global configuration of tabs',
     type: NgbdTabsetConfig,
@@ -74,7 +83,14 @@ export const ROUTES = [
     path: '',
     component: ComponentWrapper,
     children: [
-      { path: 'examples', component: NgbdExamplesPage },
+      {
+        path: 'examples',
+        component: NgbdExamplesPage, children: [
+          {path: 'firstTab', children: []},
+          {path: 'secondTab', children: []},
+          {path: 'thirdTab', children: []}
+        ]
+      },
       { path: 'api', component: NgbdApiPage }
     ]
   }
@@ -83,7 +99,8 @@ export const ROUTES = [
 @NgModule({
   imports: [
     NgbdSharedModule,
-    NgbdComponentsSharedModule
+    NgbdComponentsSharedModule,
+    NgbTabsetRoutingModule
   ],
   declarations: DEMO_DIRECTIVES,
   entryComponents: DEMO_DIRECTIVES

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -4,7 +4,8 @@
     "baseUrl": "./",
     "outDir": "temp",
     "paths": {
-      "@ng-bootstrap/ng-bootstrap": ["../src/index"]
+      "@ng-bootstrap/ng-bootstrap": ["../src/index"],
+      "@ng-bootstrap/ng-bootstrap/tabset/routing": ["../src/tabset/routing"]
     }
   },
   "include": [

--- a/src/tabset/routing/index.spec.ts
+++ b/src/tabset/routing/index.spec.ts
@@ -1,0 +1,95 @@
+import {TestBed, ComponentFixture, inject, fakeAsync, tick} from '@angular/core/testing';
+import {RouterTestingModule} from '@angular/router/testing';
+import {Location} from '@angular/common';
+import {Router} from '@angular/router';
+import {createGenericTestComponent} from '../../test/common';
+
+import {Component} from '@angular/core';
+
+import {NgbTabsetModule} from '../tabset.module';
+import {NgbTabsetRoutingModule} from '.';
+
+const createTestComponent = (html: string) =>
+    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
+
+const getTabTitles = (nativeEl: HTMLElement) => Array.prototype.slice.apply(nativeEl.querySelectorAll('.nav-link'));
+const mapToHref = (items: HTMLElement[]) => items.map(item => item.getAttribute('href'));
+const mapToActive = (items: HTMLElement[]) => items.map(item => item.classList.contains('active'));
+
+describe('ngb-tabset-routing', () => {
+
+  let fixture: ComponentFixture<TestComponent>;
+  let router: Router;
+  let location: Location;
+
+  beforeEach(fakeAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [
+        NgbTabsetModule.forRoot(),
+        RouterTestingModule.withRoutes(
+            [{path: 'firstTab', children: []}, {path: 'secondTab', children: []}, {path: 'thirdTab', children: []}]),
+        NgbTabsetRoutingModule
+      ]
+    });
+    fixture = createTestComponent(`
+        <ngb-tabset routerControlled>
+          <ngb-tab title="first tab" routerLink="firstTab" preserveFragment></ngb-tab>
+          <ngb-tab title="second tab" routerLink="secondTab" preserveFragment></ngb-tab>
+          <ngb-tab title="third tab" routerLink="thirdTab" preserveFragment></ngb-tab>
+        </ngb-tabset>
+      `);
+    router = TestBed.get(Router);
+    location = TestBed.get(Location);
+    location.go('/secondTab');
+    router.initialNavigation();
+    tick(1);
+    fixture.detectChanges();
+  }));
+
+  it('should initially have the right hrefs and active tab', () => {
+    const titles = getTabTitles(fixture.nativeElement);
+    expect(location.path()).toBe('/secondTab');
+    expect(mapToHref(titles)).toEqual(['/firstTab', '/secondTab', '/thirdTab']);
+    expect(mapToActive(titles)).toEqual([false, true, false]);
+  });
+
+  it('should change the active tab depending on the url', fakeAsync(() => {
+       const titles = getTabTitles(fixture.nativeElement);
+
+       location.go('/thirdTab');
+       tick(1);
+       fixture.detectChanges();
+
+       expect(location.path()).toBe('/thirdTab');
+       expect(mapToHref(titles)).toEqual(['/firstTab', '/secondTab', '/thirdTab']);
+       expect(mapToActive(titles)).toEqual([false, false, true]);
+     }));
+
+  it('should navigate when clicking on a tab', fakeAsync(() => {
+       const titles = getTabTitles(fixture.nativeElement);
+       titles[2].click();
+       tick(1);
+       fixture.detectChanges();
+
+       expect(location.path()).toBe('/thirdTab');
+       expect(mapToHref(titles)).toEqual(['/firstTab', '/secondTab', '/thirdTab']);
+       expect(mapToActive(titles)).toEqual([false, false, true]);
+     }));
+
+
+  it('should update the href on navigation', fakeAsync(() => {
+       location.go('/secondTab#withHash');
+       tick(1);
+       fixture.detectChanges();
+
+       const titles = getTabTitles(fixture.nativeElement);
+       expect(location.path()).toBe('/secondTab#withHash');
+       expect(mapToHref(titles)).toEqual(['/firstTab#withHash', '/secondTab#withHash', '/thirdTab#withHash']);
+       expect(mapToActive(titles)).toEqual([false, true, false]);
+     }));
+});
+
+@Component({selector: 'test-cmp', template: ''})
+class TestComponent {
+}

--- a/src/tabset/routing/index.ts
+++ b/src/tabset/routing/index.ts
@@ -1,0 +1,146 @@
+import {
+  Directive,
+  OnInit,
+  OnDestroy,
+  QueryList,
+  Input,
+  NgModule,
+  ContentChildren,
+  OnChanges,
+  AfterContentInit
+} from '@angular/core';
+import {NgbTabsetModule, NgbTabset, NgbTabChangeEvent, NgbTab} from '@ng-bootstrap/ng-bootstrap';
+import {RouterModule, RouterLink, Router, NavigationEnd} from '@angular/router';
+import {LocationStrategy, CommonModule} from '@angular/common';
+import {Subscription, of, merge, BehaviorSubject, concat} from 'rxjs';
+import {switchMap, filter, map} from 'rxjs/operators';
+
+/**
+ * The NgbTabWithRoute directive allows to link an ngb-tab element with a route.
+ * When this directive is used, the href property of the tab is automatically set based on the route.
+ */
+@Directive({selector: 'ngb-tab[routerLink]'})
+export class NgbTabWithRoute implements OnInit, OnDestroy, OnChanges {
+  private _subscription: Subscription;
+
+  /**
+   * routerLink property from the routerLink directive, cf https://angular.io/api/router/RouterLink#routerLink
+   */
+  @Input() routerLink;
+
+  /**
+   * preserveQueryParams property from the routerLink directive, cf
+   * https://angular.io/api/router/RouterLink#preserveQueryParams
+   */
+  @Input() preserveQueryParams;
+
+  /**
+   * queryParams property from the routerLink directive, cf https://angular.io/api/router/RouterLink#queryParams
+   */
+  @Input() queryParams;
+
+  /**
+   * fragment property from the routerLink directive, cf https://angular.io/api/router/RouterLink#fragment
+   */
+  @Input() fragment;
+
+  /**
+   * queryParamsHandling property from the routerLink directive, cf
+   * https://angular.io/api/router/RouterLink#queryParamsHandling
+   */
+  @Input() queryParamsHandling;
+
+  /**
+   * preserveFragment property from the routerLink directive, cf
+   * https://angular.io/api/router/RouterLink#preserveFragment
+   */
+  @Input() preserveFragment;
+
+  /**
+   * skipLocationChange property from the routerLink directive, cf
+   * https://angular.io/api/router/RouterLink#skipLocationChange
+   */
+  @Input() skipLocationChange;
+
+  /**
+   * Whether the url has to match exactly to make the tab active
+   * (when 'exact' is false, a route will also be considered active when a child root is active).
+   */
+  @Input() exact = false;
+
+  public active = new BehaviorSubject(false);
+
+  constructor(
+      public tabRef: NgbTab, public routerLinkRef: RouterLink, public router: Router,
+      public locationStrategy: LocationStrategy) {}
+
+  ngOnInit() {
+    this._update();
+    this._subscription = this.router.events.subscribe(event => {
+      if (event instanceof NavigationEnd) {
+        this._update();
+      }
+    });
+  }
+
+  ngOnChanges() { this._update(); }
+
+  ngOnDestroy() { this._subscription.unsubscribe(); }
+
+  private _update() {
+    const urlTree = this.routerLinkRef.urlTree;
+    this.tabRef.href = this.locationStrategy.prepareExternalUrl(this.router.serializeUrl(urlTree));
+    const newActive = this.router.isActive(urlTree, this.exact);
+    if (newActive !== this.active.value) {
+      this.active.next(newActive);
+    }
+  }
+}
+
+/**
+ * The NgbRouterControlledTabset directive synchronizes an ngb-tabset element with the Angular router, so that clicking
+ * on a tab triggers navigation and any navigation in the router triggers an update of the active tab.
+ */
+@Directive({selector: 'ngb-tabset[routerControlled]'})
+export class NgbRouterControlledTabset implements AfterContentInit, OnInit, OnDestroy {
+  @ContentChildren(NgbTabWithRoute) tabs: QueryList<NgbTabWithRoute>;
+
+  private _tabsetTabChange: Subscription;
+  private _activeChanged: Subscription;
+
+  constructor(public tabset: NgbTabset) {}
+
+  ngOnInit() {
+    this._tabsetTabChange = this.tabset.tabChange.subscribe((event: NgbTabChangeEvent) => {
+      const selectedTab = this.tabs.find(tab => tab.tabRef.id === event.nextId);
+      if (selectedTab) {
+        event.preventDefault();
+        selectedTab.routerLinkRef.onClick();
+      }
+    });
+  }
+
+  ngOnDestroy() {
+    this._tabsetTabChange.unsubscribe();
+    this._activeChanged.unsubscribe();
+  }
+
+  ngAfterContentInit() {
+    this._activeChanged =
+        concat(of(null), this.tabs.changes)
+            .pipe(
+                switchMap(
+                    () => merge(...this.tabs.map(tab => tab.active.pipe(filter(active => active), map(() => tab))))))
+            .subscribe(activeTab => this.tabset.activeId = activeTab.tabRef.id);
+  }
+}
+
+const NGB_TABSET_ROUTING_DIRECTIVES = [NgbTabWithRoute, NgbRouterControlledTabset];
+
+@NgModule({
+  declarations: NGB_TABSET_ROUTING_DIRECTIVES,
+  exports: NGB_TABSET_ROUTING_DIRECTIVES,
+  imports: [CommonModule, NgbTabsetModule, RouterModule]
+})
+export class NgbTabsetRoutingModule {
+}

--- a/src/tabset/routing/package.json
+++ b/src/tabset/routing/package.json
@@ -1,0 +1,7 @@
+{
+  "ngPackage": {
+    "lib": {
+      "entryFile": "./index.ts"
+    }
+  }
+}

--- a/src/tabset/tabset.spec.ts
+++ b/src/tabset/tabset.spec.ts
@@ -197,6 +197,16 @@ describe('ngb-tabset', () => {
     expect(childTitle).not.toContain('parent');
   });
 
+  it('should use the provided href on the tab title', () => {
+    const fixture = createTestComponent(`
+      <ngb-tabset>
+        <ngb-tab title="foo" href="/my-href"><ng-template ngbTabContent>Foo</ng-template></ngb-tab>
+        <ngb-tab title="bar"><ng-template ngbTabContent>Bar</ng-template></ngb-tab>
+      </ngb-tabset>
+    `);
+    const titles = getTabTitles(fixture.nativeElement);
+    expect(titles[0].getAttribute('href')).toBe('/my-href');
+  });
 
   it('should not crash for empty tabsets', () => {
     const fixture = createTestComponent(`<ngb-tabset activeId="2"></ngb-tabset>`);

--- a/src/tabset/tabset.ts
+++ b/src/tabset/tabset.ts
@@ -5,7 +5,6 @@ import {
   QueryList,
   Directive,
   TemplateRef,
-  ContentChild,
   AfterContentChecked,
   Output,
   EventEmitter
@@ -47,6 +46,10 @@ export class NgbTab {
    * Allows toggling disabled state of a given state. Disabled tabs can't be selected.
    */
   @Input() disabled = false;
+  /**
+   * href attribute to use in the tab title anchor.
+   */
+  @Input() href = '';
 
   titleTpl: NgbTabTitle | null;
   contentTpl: NgbTabContent | null;
@@ -94,7 +97,7 @@ export interface NgbTabChangeEvent {
     <ul [class]="'nav nav-' + type + (orientation == 'horizontal'?  ' ' + justifyClass : ' flex-column')" role="tablist">
       <li class="nav-item" *ngFor="let tab of tabs">
         <a [id]="tab.id" class="nav-link" [class.active]="tab.id === activeId" [class.disabled]="tab.disabled"
-          href (click)="!!select(tab.id)" role="tab" [attr.tabindex]="(tab.disabled ? '-1': undefined)"
+          [href]="tab.href" (click)="!!select(tab.id)" role="tab" [attr.tabindex]="(tab.disabled ? '-1': undefined)"
           [attr.aria-controls]="(!destroyOnHide || tab.id === activeId ? tab.id + '-panel' : null)"
           [attr.aria-expanded]="tab.id === activeId" [attr.aria-disabled]="tab.disabled">
           {{tab.title}}<ng-template [ngTemplateOutlet]="tab.titleTpl?.templateRef"></ng-template>

--- a/src/tsconfig.spec.json
+++ b/src/tsconfig.spec.json
@@ -5,7 +5,10 @@
     "types": [
       "jasmine",
       "node"
-    ]
+    ],
+    "paths": {
+      "@ng-bootstrap/ng-bootstrap": ["src/index"]
+    }
   },
   "files": [
     "./test.ts"


### PR DESCRIPTION
This PR is a suggestion to solve the issue raised in #1632. It allows to easily bind tabs to routes by taking into account the `routerLink` directives on `<ngb-tab>` elements.

For this to work, the new `NgbTabsetRoutingModule` module has to be included in the application and the `routerControlled` attribute has to be defined on the `<ngb-tabset>` element.

Also, the corresponding routes have to be defined in the configuration of the router.
The content of the tabs can be defined either in the corresponding `<ng-template ngbTabContent>` elements, or as the `component` property defined in the router configuration (if the  `<router-outlet>` element is included in the page).

Here is an example:
```html
<ngb-tabset routerControlled>
  <ngb-tab title="First" routerLink="firstTab">
    <ng-template ngbTabContent>
      First content
    </ng-template>
  </ngb-tab>
  <ngb-tab title="Second" routerLink="secondTab">
    <ng-template ngbTabContent>
      Second content
    </ng-template>
  </ngb-tab>
  <ngb-tab routerLink="thirdTab">
    <ng-template ngbTabTitle>Third</ng-template>
    <ng-template ngbTabContent>
      Third content
    </ng-template>
  </ngb-tab>
</ngb-tabset>
```

Note that `NgbTabsetRoutingModule` is a separate module in a different entry point (`"@ng-bootstrap/ng-bootstrap/tabset/routing"`) because it depends on `@angular/router` (and the main entry point does not have this dependency).

Note that this PR also adds an `href` input on `<ngb-tab>` elements, which can be used when `routerControlled` is not set on `<ngb-tabset>` in order to set the `href` used on the tab title anchor.

---

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
