### PR TITLE
chore: warn about deprecations and remove 'forRoot()' from tests

### DIFF
--- a/src/accordion/accordion.spec.ts
+++ b/src/accordion/accordion.spec.ts
@@ -60,7 +60,7 @@ describe('ngb-accordion', () => {
   `;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAccordionModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAccordionModule]});
     TestBed.overrideComponent(TestComponent, {set: {template: html}});
   });
 
@@ -547,7 +547,7 @@ describe('ngb-accordion', () => {
   describe('Custom config', () => {
     let config: NgbAccordionConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbAccordionModule.forRoot()]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbAccordionModule]}); });
 
     beforeEach(inject([NgbAccordionConfig], (c: NgbAccordionConfig) => {
       config = c;
@@ -572,7 +572,7 @@ describe('ngb-accordion', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbAccordionModule.forRoot()], providers: [{provide: NgbAccordionConfig, useValue: config}]});
+          {imports: [NgbAccordionModule], providers: [{provide: NgbAccordionConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/alert/alert.spec.ts
+++ b/src/alert/alert.spec.ts
@@ -24,8 +24,7 @@ function getCloseButtonIcon(element: HTMLElement): HTMLSpanElement {
 
 describe('ngb-alert', () => {
 
-  beforeEach(
-      () => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAlertModule.forRoot()]}); });
+  beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAlertModule]}); });
 
   it('should initialize inputs with default values', () => {
     const defaultConfig = new NgbAlertConfig();
@@ -116,7 +115,7 @@ describe('ngb-alert', () => {
   describe('Custom config', () => {
     let config: NgbAlertConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbAlertModule.forRoot()]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbAlertModule]}); });
 
     beforeEach(inject([NgbAlertConfig], (c: NgbAlertConfig) => {
       config = c;
@@ -141,7 +140,7 @@ describe('ngb-alert', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbAlertModule.forRoot()], providers: [{provide: NgbAlertConfig, useValue: config}]});
+          {imports: [NgbAlertModule], providers: [{provide: NgbAlertConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/carousel/carousel.spec.ts
+++ b/src/carousel/carousel.spec.ts
@@ -31,8 +31,7 @@ function expectActiveSlides(nativeEl: HTMLDivElement, active: boolean[]) {
 
 describe('ngb-carousel', () => {
   beforeEach(() => {
-    TestBed.configureTestingModule(
-        {declarations: [TestComponent, TestComponentOnPush], imports: [NgbCarouselModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent, TestComponentOnPush], imports: [NgbCarouselModule]});
   });
 
   it('should initialize inputs with default values', () => {
@@ -574,7 +573,7 @@ describe('ngb-carousel', () => {
   describe('Custom config', () => {
     let config: NgbCarouselConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbCarouselModule.forRoot()]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbCarouselModule]}); });
 
     beforeEach(inject([NgbCarouselConfig], (c: NgbCarouselConfig) => {
       config = c;
@@ -611,7 +610,7 @@ describe('ngb-carousel', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbCarouselModule.forRoot()], providers: [{provide: NgbCarouselConfig, useValue: config}]});
+          {imports: [NgbCarouselModule], providers: [{provide: NgbCarouselConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -25,8 +25,7 @@ function dispatchKeyUpEvent(key: Key) {
 describe('NgbInputDatepicker', () => {
 
   beforeEach(() => {
-    TestBed.configureTestingModule(
-        {declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot(), FormsModule]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule, FormsModule]});
   });
 
   describe('open, close and toggle', () => {
@@ -812,7 +811,7 @@ describe('NgbInputDatepicker', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         declarations: [TestNativeComponent],
-        imports: [NgbDatepickerModule.forRoot(), FormsModule],
+        imports: [NgbDatepickerModule, FormsModule],
         providers: [{provide: NgbDateAdapter, useClass: NgbDateNativeAdapter}]
       });
     });

--- a/src/datepicker/datepicker-integration.spec.ts
+++ b/src/datepicker/datepicker-integration.spec.ts
@@ -8,9 +8,8 @@ import {NgbDatepickerI18n, NgbDatepickerI18nDefault} from './datepicker-i18n';
 
 describe('ngb-datepicker integration', () => {
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot()]});
-  });
+  beforeEach(
+      () => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule]}); });
 
   it('should allow overriding datepicker calendar', () => {
 

--- a/src/datepicker/datepicker-month-view.spec.ts
+++ b/src/datepicker/datepicker-month-view.spec.ts
@@ -43,7 +43,7 @@ describe('ngb-datepicker-month-view', () => {
 
   beforeEach(() => {
     TestBed.overrideModule(NgbDatepickerModule, {set: {exports: [NgbDatepickerMonthView, NgbDatepickerDayView]}});
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule]});
   });
 
   it('should show/hide weekdays', () => {

--- a/src/datepicker/datepicker-navigation-select.spec.ts
+++ b/src/datepicker/datepicker-navigation-select.spec.ts
@@ -25,7 +25,7 @@ describe('ngb-datepicker-navigation-select', () => {
 
   beforeEach(() => {
     TestBed.overrideModule(NgbDatepickerModule, {set: {exports: [NgbDatepickerNavigationSelect]}});
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule]});
   });
 
   it('should generate month options correctly', () => {

--- a/src/datepicker/datepicker-navigation.spec.ts
+++ b/src/datepicker/datepicker-navigation.spec.ts
@@ -26,7 +26,7 @@ describe('ngb-datepicker-navigation', () => {
   beforeEach(() => {
     TestBed.overrideModule(
         NgbDatepickerModule, {set: {exports: [NgbDatepickerNavigation, NgbDatepickerNavigationSelect]}});
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDatepickerModule]});
   });
 
   it('should toggle navigation select component', () => {

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -140,7 +140,7 @@ describe('ngb-datepicker', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule(
-        {declarations: [TestComponent], imports: [NgbDatepickerModule.forRoot(), FormsModule, ReactiveFormsModule]});
+        {declarations: [TestComponent], imports: [NgbDatepickerModule, FormsModule, ReactiveFormsModule]});
   });
 
   it('should initialize inputs with provided config', () => {
@@ -1053,7 +1053,7 @@ describe('ngb-datepicker', () => {
   describe('Custom config', () => {
     let config: NgbDatepickerConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbDatepickerModule.forRoot()]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbDatepickerModule]}); });
 
     beforeEach(inject([NgbDatepickerConfig], (c: NgbDatepickerConfig) => {
       config = c;
@@ -1074,7 +1074,7 @@ describe('ngb-datepicker', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbDatepickerModule.forRoot()], providers: [{provide: NgbDatepickerConfig, useValue: config}]});
+          {imports: [NgbDatepickerModule], providers: [{provide: NgbDatepickerConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -53,7 +53,7 @@ describe('ngb-dropdown', () => {
 
   beforeEach(() => {
     jasmine.addMatchers(jasmineMatchers);
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDropdownModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDropdownModule]});
   });
 
   it('should be closed and down by default', () => {
@@ -248,8 +248,7 @@ describe('ngb-dropdown', () => {
 describe('ngb-dropdown-toggle', () => {
   beforeEach(() => {
     jasmine.addMatchers(jasmineMatchers);
-    TestBed.configureTestingModule(
-        {declarations: [TestComponent, TestClickCloseOnPush], imports: [NgbDropdownModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent, TestClickCloseOnPush], imports: [NgbDropdownModule]});
   });
 
   it('should toggle dropdown on click', () => {
@@ -611,7 +610,7 @@ describe('ngb-dropdown-toggle', () => {
     let config: NgbDropdownConfig;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({imports: [NgbDropdownModule.forRoot()]});
+      TestBed.configureTestingModule({imports: [NgbDropdownModule]});
       TestBed.overrideComponent(TestComponent, {
         set: {
           template: `
@@ -646,7 +645,7 @@ describe('ngb-dropdown-toggle', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbDropdownModule.forRoot()], providers: [{provide: NgbDropdownConfig, useValue: config}]});
+          {imports: [NgbDropdownModule], providers: [{provide: NgbDropdownConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,16 +93,6 @@ const NGB_MODULES = [
   NgbTabsetModule, NgbTimepickerModule, NgbTooltipModule, NgbTypeaheadModule
 ];
 
-/**
- * NgbRootModule is no longer necessary, you can simply import NgbModule
- * Will be removed in 4.0.0.
- *
- * @deprecated 3.0.0
- */
-@NgModule({imports: [NGB_MODULES], exports: NGB_MODULES})
-export class NgbRootModule {
-}
-
 @NgModule({imports: NGB_MODULES, exports: NGB_MODULES})
 export class NgbModule {
   /**
@@ -111,5 +101,5 @@ export class NgbModule {
    *
    * @deprecated 3.0.0
    */
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbRootModule}; }
+  static forRoot(): ModuleWithProviders { return {ngModule: NgbModule}; }
 }

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -757,7 +757,7 @@ class TestComponent {
 @NgModule({
   declarations: [TestComponent, CustomInjectorCmpt, DestroyableCmpt, WithActiveModalCmpt],
   exports: [TestComponent, DestroyableCmpt],
-  imports: [CommonModule, NgbModalModule.forRoot()],
+  imports: [CommonModule, NgbModalModule],
   entryComponents: [CustomInjectorCmpt, DestroyableCmpt, WithActiveModalCmpt],
   providers: [SpyService]
 })

--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -140,9 +140,8 @@ describe('ngb-pagination', () => {
 
   describe('UI logic', () => {
 
-    beforeEach(() => {
-      TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPaginationModule.forRoot()]});
-    });
+    beforeEach(
+        () => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPaginationModule]}); });
 
     it('should render and respond to collectionSize change', () => {
       const html = '<ngb-pagination [collectionSize]="collectionSize" [page]="1"></ngb-pagination>';
@@ -593,7 +592,7 @@ describe('ngb-pagination', () => {
   describe('Custom config', () => {
     let config: NgbPaginationConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbPaginationModule.forRoot()]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbPaginationModule]}); });
 
     beforeEach(inject([NgbPaginationConfig], (c: NgbPaginationConfig) => {
       config = c;
@@ -628,7 +627,7 @@ describe('ngb-pagination', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbPaginationModule.forRoot()], providers: [{provide: NgbPaginationConfig, useValue: config}]});
+          {imports: [NgbPaginationModule], providers: [{provide: NgbPaginationConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -26,9 +26,7 @@ const createOnPushTestComponent =
     (html: string) => <ComponentFixture<TestOnPushComponent>>createGenericTestComponent(html, TestOnPushComponent);
 
 describe('ngb-popover-window', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPopoverModule.forRoot()]});
-  });
+  beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPopoverModule]}); });
 
   it('should render popover on top by default', () => {
     const fixture = TestBed.createComponent(NgbPopoverWindow);
@@ -66,7 +64,7 @@ describe('ngb-popover', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [TestComponent, TestOnPushComponent, DestroyableCmpt],
-      imports: [NgbPopoverModule.forRoot()],
+      imports: [NgbPopoverModule],
       providers: [SpyService]
     });
   });
@@ -469,9 +467,7 @@ describe('ngb-popover', () => {
   });
 
   describe('triggers', () => {
-    beforeEach(() => {
-      TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPopoverModule.forRoot()]});
-    });
+    beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPopoverModule]}); });
 
     it('should support toggle triggers', () => {
       const fixture = createTestComponent(`<div ngbPopover="Great tip!" triggers="click"></div>`);
@@ -579,9 +575,7 @@ describe('ngb-popover', () => {
   });
 
   describe('autoClose', () => {
-    beforeEach(() => {
-      TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPopoverModule.forRoot()]});
-    });
+    beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPopoverModule]}); });
 
     it('should not close when autoClose is false', fakeAsync(() => {
          const fixture = createTestComponent(`
@@ -790,7 +784,7 @@ describe('ngb-popover', () => {
     let config: NgbPopoverConfig;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({imports: [NgbPopoverModule.forRoot()]});
+      TestBed.configureTestingModule({imports: [NgbPopoverModule]});
       TestBed.overrideComponent(TestComponent, {set: {template: `<div ngbPopover="Great tip!"></div>`}});
     });
 
@@ -823,7 +817,7 @@ describe('ngb-popover', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbPopoverModule.forRoot()], providers: [{provide: NgbPopoverConfig, useValue: config}]});
+          {imports: [NgbPopoverModule], providers: [{provide: NgbPopoverConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/progressbar/progressbar.spec.ts
+++ b/src/progressbar/progressbar.spec.ts
@@ -89,9 +89,8 @@ describe('ngb-progressbar', () => {
 
   describe('UI logic', () => {
 
-    beforeEach(() => {
-      TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbProgressbarModule.forRoot()]});
-    });
+    beforeEach(
+        () => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbProgressbarModule]}); });
 
     it('accepts a value and respond to value changes', () => {
       const html = '<ngb-progressbar [value]="value"></ngb-progressbar>';
@@ -219,7 +218,7 @@ describe('ngb-progressbar', () => {
   describe('Custom config', () => {
     let config: NgbProgressbarConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbProgressbarModule.forRoot()]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbProgressbarModule]}); });
 
     beforeEach(inject([NgbProgressbarConfig], (c: NgbProgressbarConfig) => {
       config = c;
@@ -250,7 +249,7 @@ describe('ngb-progressbar', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbProgressbarModule.forRoot()], providers: [{provide: NgbProgressbarConfig, useValue: config}]});
+          {imports: [NgbProgressbarModule], providers: [{provide: NgbProgressbarConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -49,7 +49,7 @@ function getStateText(compiled) {
 describe('ngb-rating', () => {
   beforeEach(() => {
     TestBed.configureTestingModule(
-        {declarations: [TestComponent], imports: [NgbRatingModule.forRoot(), FormsModule, ReactiveFormsModule]});
+        {declarations: [TestComponent], imports: [NgbRatingModule, FormsModule, ReactiveFormsModule]});
   });
 
   it('should initialize inputs with default values', () => {
@@ -664,7 +664,7 @@ describe('ngb-rating', () => {
   describe('Custom config', () => {
     let config: NgbRatingConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbRatingModule.forRoot()]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbRatingModule]}); });
 
     beforeEach(inject([NgbRatingConfig], (c: NgbRatingConfig) => {
       config = c;
@@ -689,7 +689,7 @@ describe('ngb-rating', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbRatingModule.forRoot()], providers: [{provide: NgbRatingConfig, useValue: config}]});
+          {imports: [NgbRatingModule], providers: [{provide: NgbRatingConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/tabset/tabset.spec.ts
+++ b/src/tabset/tabset.spec.ts
@@ -56,8 +56,7 @@ function getButton(nativeEl: HTMLElement) {
 }
 
 describe('ngb-tabset', () => {
-  beforeEach(
-      () => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTabsetModule.forRoot()]}); });
+  beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTabsetModule]}); });
 
   it('should initialize inputs with default values', () => {
     const defaultConfig = new NgbTabsetConfig();
@@ -553,7 +552,7 @@ describe('ngb-tabset', () => {
   describe('Custom config', () => {
     let config: NgbTabsetConfig;
 
-    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbTabsetModule.forRoot()]}); });
+    beforeEach(() => { TestBed.configureTestingModule({imports: [NgbTabsetModule]}); });
 
     beforeEach(inject([NgbTabsetConfig], (c: NgbTabsetConfig) => {
       config = c;
@@ -575,7 +574,7 @@ describe('ngb-tabset', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbTabsetModule.forRoot()], providers: [{provide: NgbTabsetConfig, useValue: config}]});
+          {imports: [NgbTabsetModule], providers: [{provide: NgbTabsetConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/timepicker/timepicker.spec.ts
+++ b/src/timepicker/timepicker.spec.ts
@@ -79,7 +79,7 @@ describe('ngb-timepicker', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule(
-        {declarations: [TestComponent], imports: [NgbTimepickerModule.forRoot(), FormsModule, ReactiveFormsModule]});
+        {declarations: [TestComponent], imports: [NgbTimepickerModule, FormsModule, ReactiveFormsModule]});
   });
 
   describe('initialization', () => {
@@ -1127,7 +1127,7 @@ describe('ngb-timepicker', () => {
     let config: NgbTimepickerConfig;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({imports: [NgbTimepickerModule.forRoot()]});
+      TestBed.configureTestingModule({imports: [NgbTimepickerModule]});
       TestBed.overrideComponent(NgbTimepicker, {set: {template: ''}});
     });
 
@@ -1150,7 +1150,7 @@ describe('ngb-timepicker', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbTimepickerModule.forRoot()], providers: [{provide: NgbTimepickerConfig, useValue: config}]});
+          {imports: [NgbTimepickerModule], providers: [{provide: NgbTimepickerConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {
@@ -1303,7 +1303,7 @@ describe('ngb-timepicker', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         declarations: [TestComponent],
-        imports: [NgbTimepickerModule.forRoot(), FormsModule],
+        imports: [NgbTimepickerModule, FormsModule],
         providers: [{provide: NgbTimeAdapter, useClass: StringTimeAdapter}]
       });
     });

--- a/src/tooltip/tooltip.spec.ts
+++ b/src/tooltip/tooltip.spec.ts
@@ -21,7 +21,7 @@ const createOnPushTestComponent =
     (html: string) => <ComponentFixture<TestOnPushComponent>>createGenericTestComponent(html, TestOnPushComponent);
 
 describe('ngb-tooltip-window', () => {
-  beforeEach(() => { TestBed.configureTestingModule({imports: [NgbTooltipModule.forRoot()]}); });
+  beforeEach(() => { TestBed.configureTestingModule({imports: [NgbTooltipModule]}); });
 
   it('should render tooltip on top by default', () => {
     const fixture = TestBed.createComponent(NgbTooltipWindow);
@@ -43,8 +43,7 @@ describe('ngb-tooltip-window', () => {
 describe('ngb-tooltip', () => {
 
   beforeEach(() => {
-    TestBed.configureTestingModule(
-        {declarations: [TestComponent, TestOnPushComponent], imports: [NgbTooltipModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent, TestOnPushComponent], imports: [NgbTooltipModule]});
   });
 
   function getWindow(element) { return element.querySelector('ngb-tooltip-window'); }
@@ -483,9 +482,7 @@ describe('ngb-tooltip', () => {
   });
 
   describe('autoClose', () => {
-    beforeEach(() => {
-      TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTooltipModule.forRoot()]});
-    });
+    beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTooltipModule]}); });
 
     it('should not close when autoClose is false', fakeAsync(() => {
          const fixture = createTestComponent(`
@@ -694,7 +691,7 @@ describe('ngb-tooltip', () => {
     let config: NgbTooltipConfig;
 
     beforeEach(() => {
-      TestBed.configureTestingModule({imports: [NgbTooltipModule.forRoot()]});
+      TestBed.configureTestingModule({imports: [NgbTooltipModule]});
       TestBed.overrideComponent(TestComponent, {set: {template: `<div ngbTooltip="Great tip!"></div>`}});
     });
 
@@ -724,7 +721,7 @@ describe('ngb-tooltip', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule(
-          {imports: [NgbTooltipModule.forRoot()], providers: [{provide: NgbTooltipConfig, useValue: config}]});
+          {imports: [NgbTooltipModule], providers: [{provide: NgbTooltipConfig, useValue: config}]});
     });
 
     it('should initialize inputs with provided config as provider', () => {

--- a/src/typeahead/highlight.spec.ts
+++ b/src/typeahead/highlight.spec.ts
@@ -36,7 +36,7 @@ describe('ngb-highlight', () => {
 
   beforeEach(() => {
     TestBed.overrideModule(NgbTypeaheadModule, {set: {exports: [NgbHighlight]}});
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTypeaheadModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTypeaheadModule]});
   });
 
   it('should render highlighted text when there is one match', () => {

--- a/src/typeahead/typeahead-window.spec.ts
+++ b/src/typeahead/typeahead-window.spec.ts
@@ -14,7 +14,7 @@ describe('ngb-typeahead-window', () => {
 
   beforeEach(() => {
     TestBed.overrideModule(NgbTypeaheadModule, {set: {exports: [NgbTypeaheadWindow]}});
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTypeaheadModule.forRoot()]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTypeaheadModule]});
   });
 
   describe('display', () => {

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -73,7 +73,7 @@ describe('ngb-typeahead', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [TestComponent, TestOnPushComponent, TestAsyncComponent],
-      imports: [NgbTypeaheadModule.forRoot(), FormsModule, ReactiveFormsModule],
+      imports: [NgbTypeaheadModule, FormsModule, ReactiveFormsModule],
       providers: [{provide: ARIA_LIVE_DELAY, useValue: null}]
     });
   });

--- a/tslint.json
+++ b/tslint.json
@@ -9,6 +9,9 @@
       "check-space"
     ],
     "curly": true,
+    "deprecation": {
+      "severity": "warning"
+    },
     "eofline": true,
     "forin": true,
     "import-blacklist": [


### PR DESCRIPTION
- removes deprecated `.forRoot()` from tests
- turns on linter warning about deprecations