### PR TITLE
feat(typeahead): clear input on blur and dismiss (non editable)

### DIFF
--- a/demo/src/app/components/typeahead/demos/basic/typeahead-basic.html
+++ b/demo/src/app/components/typeahead/demos/basic/typeahead-basic.html
@@ -5,7 +5,12 @@ A typeahead example that gets values from a static <code>string[]</code>
   <li>limits to 10 results</li>
 </ul>
 
-<label for="typeahead-basic">Search for a state:</label>
-<input id="typeahead-basic" type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search"/>
+<p><label for="typeahead-basic-editable">Search for a state (editable):</label></p>
+<pre>Model: {{ modelEditable | json }}</pre>
+<p><input id="typeahead-basic-editable" type="text" class="form-control" [(ngModel)]="modelEditable" [ngbTypeahead]="search"/></p>
+
+<p><label for="typeahead-basic-non-editable">Search for a state (non-editable):</label></p>
+<pre>Model: {{ modelNonEditable | json }}</pre>
+<p><input id="typeahead-basic-non-editable" type="text" class="form-control" [(ngModel)]="modelNonEditable" [ngbTypeahead]="search" [editable]="false"/></p>
+
 <hr>
-<pre>Model: {{ model | json }}</pre>

--- a/demo/src/app/components/typeahead/demos/basic/typeahead-basic.ts
+++ b/demo/src/app/components/typeahead/demos/basic/typeahead-basic.ts
@@ -17,7 +17,8 @@ const states = ['Alabama', 'Alaska', 'American Samoa', 'Arizona', 'Arkansas', 'C
   styles: [`.form-control { width: 300px; }`]
 })
 export class NgbdTypeaheadBasic {
-  public model: any;
+  public modelEditable: any;
+  public modelNonEditable: any;
 
   search = (text$: Observable<string>) =>
     text$.pipe(

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -732,6 +732,122 @@ describe('ngb-typeahead', () => {
        }));
   });
 
+  describe('input clearing when invalid', () => {
+    it('should clear input on dismiss when not editable', async(async() => {
+         const fixture = createTestComponent(
+             `<input type="text" [(ngModel)]="model" [ngbTypeahead]="findAnywhere" [editable]="false"/>`);
+         fixture.detectChanges();
+         const compiled = fixture.nativeElement;
+         const inputEl = getNativeInput(compiled);
+
+         await fixture.whenStable();
+         changeInput(compiled, 'on');
+         fixture.detectChanges();
+         expectWindowResults(compiled, ['+one', 'one more']);
+
+         const event = createKeyDownEvent(Key.Escape);
+         getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+         fixture.detectChanges();
+         expect(inputEl.value).toBe('');
+         expect(fixture.componentInstance.model).toBeUndefined();
+       }));
+
+    it('should not clear input on dismiss when editable', async(async() => {
+         const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="findAnywhere"/>`);
+         fixture.detectChanges();
+         const compiled = fixture.nativeElement;
+         const inputEl = getNativeInput(compiled);
+
+         await fixture.whenStable();
+         changeInput(compiled, 'on');
+         fixture.detectChanges();
+         expectWindowResults(compiled, ['+one', 'one more']);
+
+         const event = createKeyDownEvent(Key.Escape);
+         getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+         fixture.detectChanges();
+         expect(inputEl.value).toBe('on');
+         expect(fixture.componentInstance.model).toBe('on');
+       }));
+
+    it('should clear input on blur when changed and not editable', async(async() => {
+         const fixture = createTestComponent(
+             `<input type="text" [(ngModel)]="model" [ngbTypeahead]="findAnywhere" [editable]="false"/>`);
+         fixture.detectChanges();
+         const compiled = fixture.nativeElement;
+         const inputEl = getNativeInput(compiled);
+
+         // select an item
+         changeInput(compiled, 'on');
+         fixture.detectChanges();
+         expectWindowResults(compiled, ['+one', 'one more']);
+
+         getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
+         fixture.detectChanges();
+         expect(getWindow(compiled)).toBeNull();
+         expectInputValue(compiled, 'one');
+         expect(fixture.componentInstance.model).toBe('one');
+
+         // change input
+         changeInput(compiled, 'on');
+         fixture.detectChanges();
+         expectInputValue(compiled, 'on');
+         expect(fixture.componentInstance.model).toBeUndefined();
+         blurInput(compiled);
+         expect(inputEl.value).toBe('');
+       }));
+
+    it('should not clear input on blur when not changed and not editable', async(async() => {
+         const fixture = createTestComponent(
+             `<input type="text" [(ngModel)]="model" [ngbTypeahead]="findAnywhere" [editable]="false"/>`);
+         fixture.detectChanges();
+         const compiled = fixture.nativeElement;
+         const inputEl = getNativeInput(compiled);
+
+         // select an item
+         changeInput(compiled, 'on');
+         fixture.detectChanges();
+         expectWindowResults(compiled, ['+one', 'one more']);
+
+         getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
+         fixture.detectChanges();
+         expect(getWindow(compiled)).toBeNull();
+         expectInputValue(compiled, 'one');
+         expect(fixture.componentInstance.model).toBe('one');
+
+         // change input
+         blurInput(compiled);
+         expect(inputEl.value).toBe('one');
+         expect(fixture.componentInstance.model).toBe('one');
+       }));
+
+    it('should not clear input on blur when changed and editable', async(async() => {
+         const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="findAnywhere"/>`);
+         fixture.detectChanges();
+         const compiled = fixture.nativeElement;
+         const inputEl = getNativeInput(compiled);
+
+         // select an item
+         changeInput(compiled, 'on');
+         fixture.detectChanges();
+         expectWindowResults(compiled, ['+one', 'one more']);
+
+         getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
+         fixture.detectChanges();
+         expect(getWindow(compiled)).toBeNull();
+         expectInputValue(compiled, 'one');
+         expect(fixture.componentInstance.model).toBe('one');
+
+         // change input
+         changeInput(compiled, 'on');
+         fixture.detectChanges();
+         expectInputValue(compiled, 'on');
+         expect(fixture.componentInstance.model).toBe('on');
+         blurInput(compiled);
+         expect(inputEl.value).toBe('on');
+       }));
+  });
+
   describe('container', () => {
 
     it('should be appended to the element matching the selector passed to "container"', () => {


### PR DESCRIPTION
Clear input on blur and popup dismiss when not editable, and when content doesn't match current model anymore.

close #1276

