### PR TITLE
fix(demo): NgbdExamplesPage must not be OnPush

### DIFF
--- a/demo/src/app/components/shared/examples-page/examples.component.ts
+++ b/demo/src/app/components/shared/examples-page/examples.component.ts
@@ -1,10 +1,9 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 import { NgbdDemoList } from '../demo-list';
 
 @Component({
-  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ngbd-widget-demo
       *ngFor="let demo of demos"


### PR DESCRIPTION
`NgbdExamplesPage` has been defined to be `ChangeDetectionStrategy.OnPush` on last demos website refactor (#2520).

This breaks some demos. It must *not* be OnPush