### PR TITLE
refactor: specify _document type

### DIFF
--- a/src/modal/modal-stack.ts
+++ b/src/modal/modal-stack.ts
@@ -29,7 +29,7 @@ export class NgbModalStack {
   private _activeWindowCmptHasChanged = new Subject();
 
   constructor(
-      private _applicationRef: ApplicationRef, private _injector: Injector, @Inject(DOCUMENT) private _document,
+      private _applicationRef: ApplicationRef, private _injector: Injector, @Inject(DOCUMENT) private _document: any,
       private _scrollBar: ScrollBar, private _rendererFactory: RendererFactory2) {
     // Trap focus on active WindowCmpt
     this._activeWindowCmptHasChanged.subscribe(() => {

--- a/src/modal/modal-window.ts
+++ b/src/modal/modal-window.ts
@@ -31,7 +31,6 @@ import {ModalDismissReasons} from './modal-dismiss-reasons';
 })
 export class NgbModalWindow implements OnInit,
     AfterViewInit, OnDestroy {
-  private _document: any;
   private _elWithFocus: Element;  // element that is focused prior to modal opening
 
   @Input() ariaLabelledBy: string;
@@ -43,7 +42,7 @@ export class NgbModalWindow implements OnInit,
 
   @Output('dismiss') dismissEvent = new EventEmitter();
 
-  constructor(@Inject(DOCUMENT) document, private _elRef: ElementRef<HTMLElement>) { this._document = document; }
+  constructor(@Inject(DOCUMENT) private _document: any, private _elRef: ElementRef<HTMLElement>) {}
 
   backdropClick($event): void {
     if (this.backdrop === true && this._elRef.nativeElement === $event.target) {

--- a/src/util/scrollbar.ts
+++ b/src/util/scrollbar.ts
@@ -19,7 +19,7 @@ export type CompensationReverter = () => void;
  */
 @Injectable({providedIn: 'root'})
 export class ScrollBar {
-  constructor(@Inject(DOCUMENT) private _document) {}
+  constructor(@Inject(DOCUMENT) private _document: any) {}
 
   /**
    * Detects if a scrollbar is present and if yes, already compensates for its


### PR DESCRIPTION
Minor change for the sake of consistency. Now all `@Inject(DOCUMENT)` injections in constructor look the same.