### PR TITLE
feat(datepicker): NgbDateNativeUTCAdapter

### DIFF
--- a/src/datepicker/adapters/ngb-date-native-utc-adapter.spec.ts
+++ b/src/datepicker/adapters/ngb-date-native-utc-adapter.spec.ts
@@ -1,0 +1,40 @@
+import {NgbDateNativeUTCAdapter} from './ngb-date-native-utc-adapter';
+
+describe('ngb-date-native-utc model adapter', () => {
+  let adapter: NgbDateNativeUTCAdapter;
+
+  beforeEach(() => { adapter = new NgbDateNativeUTCAdapter(); });
+
+  describe('fromModel', () => {
+
+    it('should convert invalid and incomplete values to null', () => {
+      expect(adapter.fromModel(null)).toBeNull();
+      expect(adapter.fromModel(undefined)).toBeNull();
+      expect(adapter.fromModel(<any>'')).toBeNull();
+      expect(adapter.fromModel(<any>'s')).toBeNull();
+      expect(adapter.fromModel(<any>2)).toBeNull();
+      expect(adapter.fromModel(<any>{})).toBeNull();
+      expect(adapter.fromModel(<any>{year: 2017, month: 10})).toBeNull();
+    });
+
+    it('should convert valid date',
+       () => { expect(adapter.fromModel(new Date(Date.UTC(2016, 4, 1)))).toEqual({year: 2016, month: 5, day: 1}); });
+  });
+
+  describe('toModel', () => {
+
+    it('should convert invalid and incomplete values to null', () => {
+      expect(adapter.toModel(null)).toBeNull();
+      expect(adapter.toModel(undefined)).toBeNull();
+      expect(adapter.toModel(<any>'')).toBeNull();
+      expect(adapter.toModel(<any>'s')).toBeNull();
+      expect(adapter.toModel(<any>2)).toBeNull();
+      expect(adapter.toModel(<any>{})).toBeNull();
+      expect(adapter.toModel(<any>new Date())).toBeNull();
+    });
+
+    it('should convert a valid date',
+       () => { expect(adapter.toModel({year: 2016, month: 10, day: 15})).toEqual(new Date(Date.UTC(2016, 9, 15))); });
+  });
+
+});

--- a/src/datepicker/adapters/ngb-date-native-utc-adapter.ts
+++ b/src/datepicker/adapters/ngb-date-native-utc-adapter.ts
@@ -1,0 +1,16 @@
+import {Injectable} from '@angular/core';
+import {NgbDateAdapter} from './ngb-date-adapter';
+import {NgbDateStruct} from '../ngb-date-struct';
+
+@Injectable()
+export class NgbDateNativeUTCAdapter extends NgbDateAdapter<Date> {
+  fromModel(date: Date): NgbDateStruct {
+    return (date && date.getUTCFullYear) ?
+        {year: date.getUTCFullYear(), month: date.getUTCMonth() + 1, day: date.getUTCDate()} :
+        null;
+  }
+
+  toModel(date: NgbDateStruct): Date {
+    return date && date.year && date.month ? new Date(Date.UTC(date.year, date.month - 1, date.day)) : null;
+  }
+}

--- a/src/datepicker/datepicker.module.ts
+++ b/src/datepicker/datepicker.module.ts
@@ -23,6 +23,7 @@ export {NgbDateStruct} from './ngb-date-struct';
 export {NgbDate} from './ngb-date';
 export {NgbDateAdapter} from './adapters/ngb-date-adapter';
 export {NgbDateNativeAdapter} from './adapters/ngb-date-native-adapter';
+export {NgbDateNativeUTCAdapter} from './adapters/ngb-date-native-utc-adapter';
 export {NgbDateParserFormatter} from './ngb-date-parser-formatter';
 export {NgbCalendarPersian} from './jalali/ngb-calendar-persian';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ export {
   NgbDateParserFormatter,
   NgbDateAdapter,
   NgbDateNativeAdapter,
+  NgbDateNativeUTCAdapter,
   NgbDatepicker,
   NgbInputDatepicker
 } from './datepicker/datepicker.module';


### PR DESCRIPTION
This PR implements a new adapter for the datepicker model which is very similar to `NgbDateNativeAdapter` with one difference: it uses the UTC date instead of the local date, as requested in #2631.

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
