### PR TITLE
feat(modal): implicit context for template based modal

### DIFF
--- a/demo/src/app/components/modal/demos/basic/modal-basic.html
+++ b/demo/src/app/components/modal/demos/basic/modal-basic.html
@@ -1,7 +1,7 @@
-<ng-template #content let-c="close" let-d="dismiss">
+<ng-template #content let-modal>
   <div class="modal-header">
     <h4 class="modal-title" id="modal-basic-title">Profile update</h4>
-    <button type="button" class="close" aria-label="Close" (click)="d('Cross click')">
+    <button type="button" class="close" aria-label="Close" (click)="modal.dismiss('Cross click')">
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
@@ -21,7 +21,7 @@
     </form>
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-outline-dark" (click)="c('Save click')">Save</button>
+    <button type="button" class="btn btn-outline-dark" (click)="modal.close('Save click')">Save</button>
   </div>
 </ng-template>
 

--- a/demo/src/app/components/modal/demos/options/modal-options.html
+++ b/demo/src/app/components/modal/demos/options/modal-options.html
@@ -1,7 +1,7 @@
-<ng-template #content let-c="close" let-d="dismiss">
+<ng-template #content let-modal>
   <div class="modal-header">
     <h4 class="modal-title">Modal title</h4>
-    <button type="button" class="close" aria-label="Close" (click)="d('Cross click')">
+    <button type="button" class="close" aria-label="Close" (click)="modal.dismiss('Cross click')">
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
@@ -9,7 +9,7 @@
     <p>One fine body&hellip;</p>
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-light" (click)="c('Close click')">Close</button>
+    <button type="button" class="btn btn-light" (click)="modal.close('Close click')">Close</button>
   </div>
 </ng-template>
 

--- a/demo/src/app/components/modal/demos/options/modal-options.ts
+++ b/demo/src/app/components/modal/demos/options/modal-options.ts
@@ -1,6 +1,5 @@
-import {Component, ViewEncapsulation} from '@angular/core';
-
-import {NgbModal, ModalDismissReasons} from '@ng-bootstrap/ng-bootstrap';
+import { Component, ViewEncapsulation } from '@angular/core';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
   selector: 'ngbd-modal-options',
@@ -43,5 +42,4 @@ export class NgbdModalOptions {
   openVerticallyCentered(content) {
     this.modalService.open(content, { centered: true });
   }
-
 }

--- a/src/modal/modal-stack.ts
+++ b/src/modal/modal-stack.ts
@@ -1,24 +1,23 @@
 import {DOCUMENT} from '@angular/common';
 import {
   ApplicationRef,
-  Injectable,
-  Injector,
-  Inject,
   ComponentFactoryResolver,
   ComponentRef,
+  Inject,
+  Injectable,
+  Injector,
+  RendererFactory2,
   TemplateRef,
-  RendererFactory2
 } from '@angular/core';
 import {Subject} from 'rxjs';
 
 import {ngbFocusTrap} from '../util/focus-trap';
 import {ContentRef} from '../util/popup';
-import {isDefined, isString} from '../util/util';
 import {ScrollBar} from '../util/scrollbar';
-
+import {isDefined, isString} from '../util/util';
 import {NgbModalBackdrop} from './modal-backdrop';
-import {NgbModalWindow} from './modal-window';
 import {NgbActiveModal, NgbModalRef} from './modal-ref';
+import {NgbModalWindow} from './modal-window';
 
 @Injectable({providedIn: 'root'})
 export class NgbModalStack {
@@ -119,19 +118,24 @@ export class NgbModalStack {
 
   private _getContentRef(
       moduleCFR: ComponentFactoryResolver, contentInjector: Injector, content: any,
-      context: NgbActiveModal): ContentRef {
+      activeModal: NgbActiveModal): ContentRef {
     if (!content) {
       return new ContentRef([]);
     } else if (content instanceof TemplateRef) {
-      return this._createFromTemplateRef(content, context);
+      return this._createFromTemplateRef(content, activeModal);
     } else if (isString(content)) {
       return this._createFromString(content);
     } else {
-      return this._createFromComponent(moduleCFR, contentInjector, content, context);
+      return this._createFromComponent(moduleCFR, contentInjector, content, activeModal);
     }
   }
 
-  private _createFromTemplateRef(content: TemplateRef<any>, context: NgbActiveModal): ContentRef {
+  private _createFromTemplateRef(content: TemplateRef<any>, activeModal: NgbActiveModal): ContentRef {
+    const context = {
+      $implicit: activeModal,
+      close(result) { activeModal.close(result); },
+      dismiss(reason) { activeModal.dismiss(reason); }
+    };
     const viewRef = content.createEmbeddedView(context);
     this._applicationRef.attachView(viewRef);
     return new ContentRef([viewRef.rootNodes], viewRef);

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -1,18 +1,18 @@
+import {CommonModule} from '@angular/common';
 import {
   Component,
-  Injectable,
-  ViewChild,
-  OnDestroy,
-  NgModule,
-  getDebugNode,
   DebugElement,
-  Injector
+  getDebugNode,
+  Injectable,
+  Injector,
+  NgModule,
+  OnDestroy,
+  ViewChild
 } from '@angular/core';
-import {CommonModule} from '@angular/common';
-import {TestBed, ComponentFixture, async} from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 
-import {NgbModalModule, NgbModal, NgbActiveModal, NgbModalRef} from './modal.module';
 import {NgbModalConfig} from './modal-config';
+import {NgbActiveModal, NgbModal, NgbModalModule, NgbModalRef} from './modal.module';
 
 const NOOP = () => {};
 
@@ -188,6 +188,26 @@ describe('ngb-modal', () => {
 
       it('should open and dismiss modal from inside', () => {
         fixture.componentInstance.openTplDismiss().result.catch(NOOP);
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveModal();
+
+        (<HTMLElement>document.querySelector('button#dismiss')).click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveModal();
+      });
+
+      it('should open and close modal from template implicit context', () => {
+        fixture.componentInstance.openTplImplicitContext();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveModal();
+
+        (<HTMLElement>document.querySelector('button#close')).click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveModal();
+      });
+
+      it('should open and dismiss modal from template implicit context', () => {
+        fixture.componentInstance.openTplImplicitContext().result.catch(NOOP);
         fixture.detectChanges();
         expect(fixture.nativeElement).toHaveModal();
 
@@ -816,6 +836,10 @@ export class WithActiveModalCmpt {
     <ng-template #contentWithDismiss let-dismiss="dismiss">
       <button id="dismiss" (click)="dismiss('myReason')">Dismiss me</button>
     </ng-template>
+    <ng-template #contentWithImplicitContext let-modal>
+      <button id="close" (click)="modal.close('myResult')">Close me</button>
+      <button id="dismiss" (click)="modal.dismiss('myReason')">Dismiss me</button>
+    </ng-template>
     <ng-template #contentWithIf>
       <ng-template [ngIf]="show">
         <button id="if" (click)="show = false">Click me</button>
@@ -838,6 +862,7 @@ class TestComponent {
   @ViewChild('destroyableContent') tplDestroyableContent;
   @ViewChild('contentWithClose') tplContentWithClose;
   @ViewChild('contentWithDismiss') tplContentWithDismiss;
+  @ViewChild('contentWithImplicitContext') tplContentWithImplicitContext;
   @ViewChild('contentWithIf') tplContentWithIf;
 
   constructor(private modalService: NgbModal) {}
@@ -857,6 +882,9 @@ class TestComponent {
   openDestroyableTpl(options?: Object) { return this.modalService.open(this.tplDestroyableContent, options); }
   openTplClose(options?: Object) { return this.modalService.open(this.tplContentWithClose, options); }
   openTplDismiss(options?: Object) { return this.modalService.open(this.tplContentWithDismiss, options); }
+  openTplImplicitContext(options?: Object) {
+    return this.modalService.open(this.tplContentWithImplicitContext, options);
+  }
   openTplIf(options?: Object) { return this.modalService.open(this.tplContentWithIf, options); }
 }
 


### PR DESCRIPTION
Any template based modal should now be using implicit context

Before:

```html
<ng-template #content let-c="close" let-d="dismiss">
  <!-- ... -->
  <button (click)="c('closing')">Close</button>
  <button (click)="d('dismiss')">Dismiss</button>
  <!-- ... -->
</ng-template>
```

After:

```html
<ng-template #content let-modal>
  <!-- ... -->
  <button (click)="modal.close('closing')">Close</button>
  <button (click)="modal.dismiss('dismiss')">Dismiss</button>
  <!-- ... -->
</ng-template>
```