### PR TITLE
fix(timepicker): chevron width and height must match

### DIFF
--- a/src/timepicker/timepicker.ts
+++ b/src/timepicker/timepicker.ts
@@ -63,7 +63,7 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
       -webkit-transform: rotate(-45deg);
       -ms-transform: rotate(-45deg);
       vertical-align: middle;
-      width: 0.71em;
+      width: 0.69em;
     }
 
     .chevron.bottom:before {


### PR DESCRIPTION
Fixes https://github.com/ng-bootstrap/ng-bootstrap/issues/2663

When width and height of the chevron don't match, the chevron might look chopped off at some root font sizes

**Default root font-size: 16px:** 
![image](https://user-images.githubusercontent.com/25089646/44913675-bb7a6500-ad36-11e8-8f27-036e6ac97351.png)
![image](https://user-images.githubusercontent.com/25089646/44913817-1744ee00-ad37-11e8-96df-3eed173c0046.png)

**Custom root font-size: 12px:** 
![image](https://user-images.githubusercontent.com/25089646/44913895-40657e80-ad37-11e8-8ce3-3b9457da77d3.png)
![image](https://user-images.githubusercontent.com/25089646/44913771-f5e40200-ad36-11e8-8dc7-86edee55234b.png)

When width and height are equal, rendered chevron looks fine with any root font-size:
![image](https://user-images.githubusercontent.com/25089646/44913940-5a9f5c80-ad37-11e8-947e-b707eb0f4ecf.png)
![image](https://user-images.githubusercontent.com/25089646/44913918-52472180-ad37-11e8-8806-f346ccd4e256.png)


