### PR TITLE
Fix CSS prefixes

### DIFF
--- a/src/datepicker/datepicker-navigation-select.ts
+++ b/src/datepicker/datepicker-navigation-select.ts
@@ -8,10 +8,8 @@ import {NgbDatepickerI18n} from './datepicker-i18n';
   changeDetection: ChangeDetectionStrategy.OnPush,
   styles: [`
     :host>select {
-      display: flex;
-      display: -ms-flexbox;
       -ms-flex: 1 1 auto;
-      width: 100%;
+      flex: 1 1 auto;
       padding: 0 0.5rem;
       font-size: 0.875rem;
       height: 1.85rem;

--- a/src/datepicker/datepicker-navigation.ts
+++ b/src/datepicker/datepicker-navigation.ts
@@ -11,6 +11,7 @@ import {NgbDatepickerI18n} from './datepicker-i18n';
     :host {
       display: -ms-flexbox;
       display: flex;
+      -ms-flex-align: center;
       align-items: center;
     }
     .ngb-dp-navigation-chevron {
@@ -21,11 +22,11 @@ import {NgbDatepickerI18n} from './datepicker-i18n';
       height: 0.75em;
       margin-left: 0.25em;
       margin-right: 0.15em;
+      -webkit-transform: rotate(-135deg);
       transform: rotate(-135deg);
-      -ms-transform: rotate(-135deg);
     }
     .right .ngb-dp-navigation-chevron {
-      -ms-transform: rotate(45deg);
+      -webkit-transform: rotate(45deg);
       transform: rotate(45deg);
       margin-left: 0.15em;
       margin-right: 0.25em;
@@ -34,7 +35,7 @@ import {NgbDatepickerI18n} from './datepicker-i18n';
       display: -ms-flexbox;
       display: flex;
       -ms-flex: 1 1 auto;
-      flex-grow: 1;
+      flex: 1 1 auto;
       padding-right: 0;
       padding-left: 0;
       margin: 0;
@@ -65,8 +66,7 @@ import {NgbDatepickerI18n} from './datepicker-i18n';
       display: -ms-flexbox;
       display: flex;
       -ms-flex: 1 1 9rem;
-      flex-grow: 1;
-      flex-basis: 9rem;
+      flex: 1 1 9rem;
     }
   `],
   template: `

--- a/src/datepicker/datepicker-navigation.ts
+++ b/src/datepicker/datepicker-navigation.ts
@@ -22,11 +22,9 @@ import {NgbDatepickerI18n} from './datepicker-i18n';
       height: 0.75em;
       margin-left: 0.25em;
       margin-right: 0.15em;
-      -webkit-transform: rotate(-135deg);
       transform: rotate(-135deg);
     }
     .right .ngb-dp-navigation-chevron {
-      -webkit-transform: rotate(45deg);
       transform: rotate(45deg);
       margin-left: 0.15em;
       margin-right: 0.25em;

--- a/src/timepicker/timepicker.ts
+++ b/src/timepicker/timepicker.ts
@@ -59,9 +59,8 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
       left: 0.05em;
       position: relative;
       top: 0.15em;
-      transform: rotate(-45deg);
       -webkit-transform: rotate(-45deg);
-      -ms-transform: rotate(-45deg);
+      transform: rotate(-45deg);
       vertical-align: middle;
       width: 0.71em;
     }
@@ -69,7 +68,6 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
     .chevron.bottom:before {
       top: -.3em;
       -webkit-transform: rotate(135deg);
-      -ms-transform: rotate(135deg);
       transform: rotate(135deg);
     }
 

--- a/src/timepicker/timepicker.ts
+++ b/src/timepicker/timepicker.ts
@@ -59,7 +59,6 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
       left: 0.05em;
       position: relative;
       top: 0.15em;
-      -webkit-transform: rotate(-45deg);
       transform: rotate(-45deg);
       vertical-align: middle;
       width: 0.71em;
@@ -67,7 +66,6 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
 
     .chevron.bottom:before {
       top: -.3em;
-      -webkit-transform: rotate(135deg);
       transform: rotate(135deg);
     }
 


### PR DESCRIPTION
Fixes:
1. Native properties must go after prefixed ones
2. Remove `-ms-transform` (required only for IE9 ([caniuse](https://caniuse.com/#feat=transforms2d)))
3. Remove `-webkit-transform` (required only for Android 4.4+, Bootstrap supports Android 5.0+)
4. Add missing `-ms` flexbox prefixes (required for IE10)
5. Refactor flex properties:
```
-ms-flex: 1 1 9rem;
flex-grow: 1;
flex-basis: 9rem;
```
↓
```
-ms-flex: 1 1 9rem;
flex: 1 1 9rem;
```

P.S. I tested my changes in IE10, changed elements look good.