### PR TITLE
fix(demo) add Object.values polyfill

### DIFF
--- a/demo/src/polyfills.ts
+++ b/demo/src/polyfills.ts
@@ -34,6 +34,8 @@ import 'core-js/es6/map';
 import 'core-js/es6/weak-map';
 import 'core-js/es6/set';
 
+import 'core-js/fn/object/values';
+
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 


### PR DESCRIPTION
Demo uses `Object.values`, which is part of ES7, so it's not part of the `core-js/es6/object` polyfill. Because of that the demo doesn't work in the following browsers:
- Chrome < 54
- Edge < 14
- Firefox < 47
- Safari < 10.1
- IE

Source: [Object.values Browser compatibility on MDN ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Object/values#Browser_compatibility)
Screenshot: https://i.imgur.com/wqgUF7s.png