### PR TITLE
fix(popover): unregister event listener functions only if present

### DIFF
--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -308,7 +308,11 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
 
   ngOnDestroy() {
     this.close();
-    this._unregisterListenersFn();
+    // This check is needed as it might happen that ngOnDestroy is called before ngOnInit
+    // under certain conditions, see: https://github.com/ng-bootstrap/ng-bootstrap/issues/2199
+    if (this._unregisterListenersFn) {
+      this._unregisterListenersFn();
+    }
     this._zoneSubscription.unsubscribe();
   }
 


### PR DESCRIPTION
Same case as for the tooltip in #2205 

Fixes #2688