### PR TITLE
feat(datepicker): allow to pass user data to the day template context

### DIFF
--- a/src/datepicker/datepicker-config.ts
+++ b/src/datepicker/datepicker-config.ts
@@ -10,6 +10,7 @@ import {NgbDateStruct} from './ngb-date-struct';
 @Injectable({providedIn: 'root'})
 export class NgbDatepickerConfig {
   dayTemplate: TemplateRef<DayTemplateContext>;
+  dayTemplateData: (date: NgbDateStruct, current: {year: number, month: number}) => any;
   displayMonths = 1;
   firstDayOfWeek = 1;
   markDisabled: (date: NgbDateStruct, current: {year: number, month: number}) => boolean;

--- a/src/datepicker/datepicker-day-template-context.ts
+++ b/src/datepicker/datepicker-day-template-context.ts
@@ -9,6 +9,13 @@ export interface DayTemplateContext {
   currentMonth: number;
 
   /**
+   * Any data you pass using `dayTemplateData` input in the datepicker
+   *
+   * @since 3.3.0
+   */
+  data?: any;
+
+  /**
    * Date that corresponds to the template
    */
   date: NgbDate;

--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -656,6 +656,17 @@ describe('NgbInputDatepicker', () => {
       expect(dp.dayTemplate).toBeDefined();
     });
 
+    it('should propagate the "dayTemplateData" option', () => {
+      const fixture = createTestCmpt(`<input ngbDatepicker [dayTemplateData]="noop">`);
+      const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
+
+      dpInput.open();
+      fixture.detectChanges();
+
+      const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+      expect(dp.dayTemplateData).toBeDefined();
+    });
+
     it('should propagate the "displayMonths" option', () => {
       const fixture = createTestCmpt(`<input ngbDatepicker [displayMonths]="3">`);
       const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -88,6 +88,14 @@ export class NgbInputDatepicker implements OnChanges,
   @Input() dayTemplate: TemplateRef<DayTemplateContext>;
 
   /**
+   * Callback to pass any arbitrary data to the custom day template context
+   * 'Current' contains the month that will be displayed in the view
+   *
+   * @since 3.3.0
+   */
+  @Input() dayTemplateData: (date: NgbDate, current: {year: number, month: number}) => any;
+
+  /**
    * Number of months to display
    */
   @Input() displayMonths: number;
@@ -359,8 +367,8 @@ export class NgbInputDatepicker implements OnChanges,
   }
 
   private _applyDatepickerInputs(datepickerInstance: NgbDatepicker): void {
-    ['dayTemplate', 'displayMonths', 'firstDayOfWeek', 'markDisabled', 'minDate', 'maxDate', 'navigation',
-     'outsideDays', 'showNavigation', 'showWeekdays', 'showWeekNumbers']
+    ['dayTemplate', 'dayTemplateData', 'displayMonths', 'firstDayOfWeek', 'markDisabled', 'minDate', 'maxDate',
+     'navigation', 'outsideDays', 'showNavigation', 'showWeekdays', 'showWeekNumbers']
         .forEach((optionName: string) => {
           if (this[optionName] !== undefined) {
             datepickerInstance[optionName] = this[optionName];

--- a/src/datepicker/datepicker-service.spec.ts
+++ b/src/datepicker/datepicker-service.spec.ts
@@ -883,6 +883,35 @@ describe('ngb-datepicker-service', () => {
     });
   });
 
+  describe(`dayTemplateData`, () => {
+
+    it(`should not pass anything to the template by default`, () => {
+      // MAY 2017
+      service.focus(new NgbDate(2017, 5, 1));
+      expect(getDay(0).context.data).toBeUndefined();
+    });
+
+    it(`should pass arbitrary data to the template`, () => {
+      service.dayTemplateData = () => 'data';
+
+      // MAY 2017
+      service.focus(new NgbDate(2017, 5, 1));
+      expect(getDay(0).context.data).toBe('data');
+    });
+
+    it(`should update months when 'dayTemplateData' changes`, () => {
+      // MAY 2017
+      service.dayTemplateData = () => 'one';
+      service.focus(new NgbDate(2017, 5, 1));
+
+      expect(getDay(0).context.data).toBe('one');
+
+      service.dayTemplateData = (_) => 'two';
+
+      expect(getDay(0).context.data).toBe('two');
+    });
+  });
+
   describe(`markDisabled`, () => {
 
     it(`should mark dates as disabled by passing 'markDisabled'`, () => {

--- a/src/datepicker/datepicker-service.ts
+++ b/src/datepicker/datepicker-service.ts
@@ -1,7 +1,7 @@
 import {NgbCalendar, NgbPeriod} from './ngb-calendar';
 import {NgbDate} from './ngb-date';
 import {NgbDateStruct} from './ngb-date-struct';
-import {DatepickerViewModel, NgbMarkDisabled} from './datepicker-view-model';
+import {DatepickerViewModel, NgbDayTemplateData, NgbMarkDisabled} from './datepicker-view-model';
 import {Injectable} from '@angular/core';
 import {isInteger, toInteger} from '../util/util';
 import {Observable, Subject} from 'rxjs';
@@ -43,6 +43,12 @@ export class NgbDatepickerService {
   get model$(): Observable<DatepickerViewModel> { return this._model$.pipe(filter(model => model.months.length > 0)); }
 
   get select$(): Observable<NgbDate> { return this._select$.pipe(filter(date => date !== null)); }
+
+  set dayTemplateData(dayTemplateData: NgbDayTemplateData) {
+    if (this._state.dayTemplateData !== dayTemplateData) {
+      this._nextState({dayTemplateData});
+    }
+  }
 
   set disabled(disabled: boolean) {
     if (this._state.disabled !== disabled) {
@@ -234,8 +240,8 @@ export class NgbDatepickerService {
 
     // rebuilding months
     if (startDate) {
-      const forceRebuild = 'firstDayOfWeek' in patch || 'markDisabled' in patch || 'minDate' in patch ||
-          'maxDate' in patch || 'disabled' in patch || 'outsideDays' in patch;
+      const forceRebuild = 'dayTemplateData' in patch || 'firstDayOfWeek' in patch || 'markDisabled' in patch ||
+          'minDate' in patch || 'maxDate' in patch || 'disabled' in patch || 'outsideDays' in patch;
 
       const months = buildMonths(this._calendar, startDate, state, this._i18n, forceRebuild);
 

--- a/src/datepicker/datepicker-tools.ts
+++ b/src/datepicker/datepicker-tools.ts
@@ -119,7 +119,7 @@ export function buildMonths(
 export function buildMonth(
     calendar: NgbCalendar, date: NgbDate, state: DatepickerViewModel, i18n: NgbDatepickerI18n,
     month: MonthViewModel = {} as MonthViewModel): MonthViewModel {
-  const {minDate, maxDate, firstDayOfWeek, markDisabled, outsideDays} = state;
+  const {dayTemplateData, minDate, maxDate, firstDayOfWeek, markDisabled, outsideDays} = state;
 
   month.firstDate = null;
   month.lastDate = null;
@@ -155,6 +155,10 @@ export function buildMonth(
         disabled = markDisabled(newDate, {month: month.number, year: month.year});
       }
 
+      // adding user-provided data to the context
+      let contextUserData =
+          dayTemplateData ? dayTemplateData(newDate, {month: month.number, year: month.year}) : undefined;
+
       // saving first date of the month
       if (month.firstDate === null && newDate.month === month.number) {
         month.firstDate = newDate;
@@ -170,9 +174,13 @@ export function buildMonth(
         dayObject = days[day] = {} as DayViewModel;
       }
       dayObject.date = newDate;
-      dayObject.context = Object.assign(
-          dayObject.context || {},
-          {date: newDate, currentMonth: month.number, disabled, focused: false, selected: false});
+      dayObject.context = Object.assign(dayObject.context || {}, {
+        date: newDate,
+        data: contextUserData,
+        currentMonth: month.number, disabled,
+        focused: false,
+        selected: false
+      });
       dayObject.tabindex = -1;
       dayObject.ariaLabel = ariaLabel;
       dayObject.hidden = false;

--- a/src/datepicker/datepicker-view-model.ts
+++ b/src/datepicker/datepicker-view-model.ts
@@ -3,6 +3,7 @@ import {NgbDateStruct} from './ngb-date-struct';
 import {DayTemplateContext} from './datepicker-day-template-context';
 
 export type NgbMarkDisabled = (date: NgbDateStruct, current: {year: number, month: number}) => boolean;
+export type NgbDayTemplateData = (date: NgbDateStruct, current: {year: number, month: number}) => any;
 
 export type DayViewModel = {
   date: NgbDate,
@@ -29,6 +30,7 @@ export type MonthViewModel = {
 
 // clang-format off
 export type DatepickerViewModel = {
+  dayTemplateData?: NgbDayTemplateData,
   disabled: boolean,
   displayMonths: number,
   firstDate?: NgbDate,

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -111,6 +111,7 @@ function expectFocusedDate(element: DebugElement, focusableDate: NgbDate, isFocu
 
 function expectSameValues(datepicker: NgbDatepicker, config: NgbDatepickerConfig) {
   expect(datepicker.dayTemplate).toBe(config.dayTemplate);
+  expect(datepicker.dayTemplateData).toBe(config.dayTemplateData);
   expect(datepicker.displayMonths).toBe(config.displayMonths);
   expect(datepicker.firstDayOfWeek).toBe(config.firstDayOfWeek);
   expect(datepicker.markDisabled).toBe(config.markDisabled);
@@ -125,6 +126,7 @@ function expectSameValues(datepicker: NgbDatepicker, config: NgbDatepickerConfig
 
 function customizeConfig(config: NgbDatepickerConfig) {
   config.dayTemplate = {} as TemplateRef<DayTemplateContext>;
+  config.dayTemplateData = (date, current) => 42;
   config.firstDayOfWeek = 2;
   config.markDisabled = (date, current) => false;
   config.minDate = {year: 2000, month: 1, day: 1};
@@ -320,14 +322,6 @@ describe('ngb-datepicker', () => {
     expectMaxDate(10000, 1);
   });
 
-  it('should support disabling dates via callback', () => {
-    const fixture = createTestComponent(
-        `<ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [markDisabled]="markDisabled"></ngb-datepicker>`);
-
-    // 22 AUG 2016
-    expect(getDay(fixture.nativeElement, 21)).toHaveCssClass('text-muted');
-  });
-
   it('should support disabling dates via min/max dates', () => {
     const fixture = createTestComponent(
         `<ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate"></ngb-datepicker>`);
@@ -352,6 +346,16 @@ describe('ngb-datepicker', () => {
 
     // 22 AUG 2016
     expect(getDay(fixture.nativeElement, 21)).toHaveCssClass('text-muted');
+  });
+
+  it('should support passing custom data to the day template', () => {
+    const fixture = createTestComponent(`
+      <ng-template #dt let-date="date" let-data="data"><div>{{ date.day }}{{ data }}</div></ng-template>
+      <ngb-datepicker [startDate]="date" [dayTemplate]="dt" [dayTemplateData]="dayTemplateData"></ngb-datepicker>
+    `);
+
+    // 22 AUG 2016
+    expect(getDay(fixture.nativeElement, 21).innerText).toBe('22!');
   });
 
   it('should display multiple months', () => {
@@ -1137,6 +1141,7 @@ class TestComponent {
   disabledForm = new FormGroup({control: new FormControl({value: null, disabled: true})});
   model;
   showWeekdays = true;
+  dayTemplateData = () => '!';
   markDisabled = (date: NgbDateStruct) => { return NgbDate.from(date).equals(new NgbDate(2016, 8, 22)); };
   onNavigate = () => {};
   onSelect = () => {};

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -158,6 +158,14 @@ export class NgbDatepicker implements OnDestroy,
   @Input() dayTemplate: TemplateRef<DayTemplateContext>;
 
   /**
+   * Callback to pass any arbitrary data to the custom day template context
+   * 'Current' contains the month that will be displayed in the view
+   *
+   * @since 3.3.0
+   */
+  @Input() dayTemplateData: (date: NgbDate, current: {year: number, month: number}) => any;
+
+  /**
    * Number of months to display
    */
   @Input() displayMonths: number;
@@ -233,8 +241,8 @@ export class NgbDatepicker implements OnDestroy,
       private _calendar: NgbCalendar, public i18n: NgbDatepickerI18n, config: NgbDatepickerConfig,
       private _cd: ChangeDetectorRef, private _elementRef: ElementRef<HTMLElement>,
       private _ngbDateAdapter: NgbDateAdapter<any>, private _ngZone: NgZone) {
-    ['dayTemplate', 'displayMonths', 'firstDayOfWeek', 'markDisabled', 'minDate', 'maxDate', 'navigation',
-     'outsideDays', 'showWeekdays', 'showWeekNumbers', 'startDate']
+    ['dayTemplate', 'dayTemplateData', 'displayMonths', 'firstDayOfWeek', 'markDisabled', 'minDate', 'maxDate',
+     'navigation', 'outsideDays', 'showWeekdays', 'showWeekNumbers', 'startDate']
         .forEach(input => this[input] = config[input]);
 
     this._selectSubscription = _service.select$.subscribe(date => { this.select.emit(date); });
@@ -301,14 +309,16 @@ export class NgbDatepicker implements OnDestroy,
 
   ngOnInit() {
     if (this.model === undefined) {
-      ['displayMonths', 'markDisabled', 'firstDayOfWeek', 'navigation', 'minDate', 'maxDate', 'outsideDays'].forEach(
-          input => this._service[input] = this[input]);
+      ['dayTemplateData', 'displayMonths', 'markDisabled', 'firstDayOfWeek', 'navigation', 'minDate', 'maxDate',
+       'outsideDays']
+          .forEach(input => this._service[input] = this[input]);
       this.navigateTo(this.startDate);
     }
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    ['displayMonths', 'markDisabled', 'firstDayOfWeek', 'navigation', 'minDate', 'maxDate', 'outsideDays']
+    ['dayTemplateData', 'displayMonths', 'markDisabled', 'firstDayOfWeek', 'navigation', 'minDate', 'maxDate',
+     'outsideDays']
         .filter(input => input in changes)
         .forEach(input => this._service[input] = this[input]);
 


### PR DESCRIPTION
Many custom-day-display customisation cases can be solved by allowing to pass arbitrary user data to the day template context:

```html
<ng-template #t let-date="date" let-data="data">
   {{ data }}    <!-- will display 'custom data' -->
<ng-template>

<ngb-datepicker [dayTemplate]="t" [dayTemplateData]="dayTemplateData"></ngb-datepicker>
```
```ts
dayTemplateData(date: NgbDate, currentMonth: {month, year}): any {
  return 'custom data';
}
```

The big advantage is that this data is computed once when month view is constructed.