### PR TITLE
refactor(autoclose): share autoclose code between components

### DIFF
--- a/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.component.html
+++ b/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.component.html
@@ -1,8 +1,10 @@
-<h3>Datepicker autoclose tests</h3>
+<h3>
+  Datepicker autoclose tests
+  <span class="ml-1 badge {{d.isOpen() ? 'badge-success' : 'badge-danger'}}" id="open-status">{{d.isOpen() ? 'open' : 'closed'}}</span>
+</h3>
 
 <form id="default">
   <div class="form-group form-inline">
-
     <div class="input-group">
       <input class="form-control" name="dp" placeholder="yyyy-mm-dd" #d="ngbDatepicker" ngbDatepicker
              [autoClose]="autoClose" [(ngModel)]="model" [displayMonths]="displayMonths">

--- a/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.component.html
+++ b/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.component.html
@@ -3,7 +3,7 @@
   <span class="ml-1 badge {{d.isOpen() ? 'badge-success' : 'badge-danger'}}" id="open-status">{{d.isOpen() ? 'open' : 'closed'}}</span>
 </h3>
 
-<form id="default">
+<form id="default" (contextmenu)="$event.preventDefault()">
   <div class="form-group form-inline">
     <div class="input-group">
       <input class="form-control" name="dp" placeholder="yyyy-mm-dd" #d="ngbDatepicker" ngbDatepicker

--- a/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.component.ts
+++ b/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.component.ts
@@ -1,6 +1,6 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 
-@Component({templateUrl: './datepicker-autoclose.component.html'})
+@Component({templateUrl: './datepicker-autoclose.component.html', changeDetection: ChangeDetectionStrategy.OnPush})
 export class DatepickerAutoCloseComponent {
   autoClose: boolean | 'inside' | 'outside' = true;
   model = null;

--- a/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.e2e-spec.ts
+++ b/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.e2e-spec.ts
@@ -1,6 +1,6 @@
 import {Key} from 'protractor';
 import {DatepickerAutoClosePage} from './datepicker-autoclose.po';
-import {openUrl, sendKey} from '../../tools.po';
+import {openUrl, sendKey, rightClick} from '../../tools.po';
 
 describe('Datepicker Autoclose', () => {
   let page: DatepickerAutoClosePage;
@@ -37,6 +37,18 @@ describe('Datepicker Autoclose', () => {
       beforeEach(async() => {
         await openUrl('datepicker/autoclose');
         await page.selectDisplayMonths(displayMonths);
+      });
+
+      it(`should not close when right clicking`, async() => {
+        await page.selectAutoClose('true');
+
+        await openDatepicker(`Opening datepicker for right clicks`);
+
+        await rightClick(page.getDayElement(DATE_SELECT));
+        await expectDatepickerToBeOpen(`Datepicker should NOT be closed on right click inside`);
+
+        await page.rightClickOutside();
+        await expectDatepickerToBeOpen(`Datepicker should NOT be closed on right click outside`);
       });
 
       it(`should work when autoClose === true`, async() => {

--- a/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.e2e-spec.ts
+++ b/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.e2e-spec.ts
@@ -7,6 +7,26 @@ describe('Datepicker Autoclose', () => {
 
   beforeAll(() => page = new DatepickerAutoClosePage());
 
+  const expectDatepickerToBeOpen = async(message: string) => {
+    expect(await page.getDatepicker().isPresent()).toBeTruthy(message);
+    expect(await page.getOpenStatus().getText()).toBe('open', message);
+  };
+
+  const expectDatepickerToBeClosed = async(message: string) => {
+    expect(await page.getDatepicker().isPresent()).toBeFalsy(message);
+    expect(await page.getOpenStatus().getText()).toBe('closed', message);
+  };
+
+  const openDatepicker = async(message: string) => {
+    await page.openDatepicker();
+    await expectDatepickerToBeOpen(message);
+  };
+
+  const closeDatepicker = async(message: string) => {
+    await page.closeDatepicker();
+    await expectDatepickerToBeClosed(message);
+  };
+
   for (let displayMonths of[1, 2]) {
     describe(`displayMonths = ${displayMonths}`, () => {
 
@@ -23,117 +43,113 @@ describe('Datepicker Autoclose', () => {
         await page.selectAutoClose('true');
 
         // escape
-        await page.openDatepicker();
+        await openDatepicker(`Opening datepicker for escape`);
         await sendKey(Key.ESCAPE);
-        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on ESC`);
+        await expectDatepickerToBeClosed(`Datepicker should be closed on ESC`);
 
         // outside click
-        await page.openDatepicker();
+        await openDatepicker(`Opening datepicker for outside click`);
         await page.clickOutside();
-        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on outside click`);
+        await expectDatepickerToBeClosed(`Datepicker should be closed on outside click`);
 
         // date selection
-        await page.openDatepicker();
+        await openDatepicker(`Opening datepicker for date selection`);
         await page.getDayElement(DATE_SELECT).click();
-        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on date selection`);
+        await expectDatepickerToBeClosed(`Datepicker should be closed on date selection`);
 
         // outside days click -> month before
-        await page.openDatepicker();
+        await openDatepicker(`Opening datepicker for outside days click -> month before`);
         await page.getDayElement(DATE_OUTSIDE_BEFORE).click();
-        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on outside day click`);
+        await expectDatepickerToBeClosed(`Datepicker should be closed on outside day click`);
 
         // outside days click -> month after
-        await page.openDatepicker();
+        await openDatepicker(`Opening datepicker for outside days click -> month after`);
         await page.getDayElement(DATE_OUTSIDE_AFTER).click();
-        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on outside day click`);
+        await expectDatepickerToBeClosed(`Datepicker should be closed on outside day click`);
       });
 
       it(`should work when autoClose === false`, async() => {
         await page.selectAutoClose('false');
 
         // escape
-        await page.openDatepicker();
+        await openDatepicker(`Opening datepicker`);
         await sendKey(Key.ESCAPE);
-        expect(await page.getDatepicker().isPresent()).toBeTruthy(`Datepicker should NOT be closed on ESC`);
+        await expectDatepickerToBeOpen(`Datepicker should NOT be closed on ESC`);
 
         // outside click
         await page.clickOutside();
-        expect(await page.getDatepicker().isPresent()).toBeTruthy(`Datepicker should NOT be closed on outside click`);
+        await expectDatepickerToBeOpen(`Datepicker should NOT be closed on outside click`);
 
         // date selection
         await page.getDayElement(DATE_SELECT).click();
-        expect(await page.getDatepicker().isPresent()).toBeTruthy(`Datepicker should NOT be closed on date selection`);
+        await expectDatepickerToBeOpen(`Datepicker should NOT be closed on date selection`);
 
         // outside days click -> month before
         await page.getDayElement(DATE_OUTSIDE_BEFORE).click();
-        expect(await page.getDatepicker().isPresent())
-            .toBeTruthy(`Datepicker should NOT be closed on outside day click`);
+        await expectDatepickerToBeOpen(`Datepicker should NOT be closed on outside day click`);
 
         // outside days click -> month after
-        await page.closeDatepicker();
-        await page.openDatepicker();  // to reset visible month
+        await closeDatepicker(`Closing datepicker`);
+        await openDatepicker(`Reopening datepicker`);  // to reset visible month
         await page.getDayElement(DATE_OUTSIDE_AFTER).click();
-        expect(await page.getDatepicker().isPresent())
-            .toBeTruthy(`Datepicker should NOT be closed on outside day click`);
+        await expectDatepickerToBeOpen(`Datepicker should NOT be closed on outside day click`);
       });
 
       it(`should work when autoClose === 'outside'`, async() => {
         await page.selectAutoClose('outside');
 
         // escape
-        await page.openDatepicker();
+        await openDatepicker(`Opening datepicker for escape`);
         await sendKey(Key.ESCAPE);
-        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on ESC`);
+        await expectDatepickerToBeClosed(`Datepicker should be closed on ESC`);
 
         // outside click
-        await page.openDatepicker();
+        await openDatepicker(`Opening datepicker for outside click`);
         await page.clickOutside();
-        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on outside click`);
+        await expectDatepickerToBeClosed(`Datepicker should be closed on outside click`);
 
         // date selection
-        await page.openDatepicker();
+        await openDatepicker(`Opening datepicker for date selection`);
         await page.getDayElement(DATE_SELECT).click();
-        expect(await page.getDatepicker().isPresent()).toBeTruthy(`Datepicker should NOT be closed on date selection`);
+        await expectDatepickerToBeOpen(`Datepicker should NOT be closed on date selection`);
 
         // outside days click -> month before
         await page.getDayElement(DATE_OUTSIDE_BEFORE).click();
-        expect(await page.getDatepicker().isPresent())
-            .toBeTruthy(`Datepicker should NOT be closed on outside day click`);
+        await expectDatepickerToBeOpen(`Datepicker should NOT be closed on outside day click`);
 
         // outside days click -> month after
-        await page.closeDatepicker();
-        await page.openDatepicker();  // to reset visible month
+        await closeDatepicker(`Closing datepicker`);
+        await openDatepicker(`Reopening datepicker`);  // to reset visible month
         await page.getDayElement(DATE_OUTSIDE_AFTER).click();
-        expect(await page.getDatepicker().isPresent())
-            .toBeTruthy(`Datepicker should NOT be closed on outside day click`);
+        await expectDatepickerToBeOpen(`Datepicker should NOT be closed on outside day click`);
       });
 
       it(`should work when autoClose === 'inside'`, async() => {
         await page.selectAutoClose('inside');
 
         // escape
-        await page.openDatepicker();
+        await openDatepicker(`Opening datepicker for escape`);
         await sendKey(Key.ESCAPE);
-        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on ESC`);
+        await expectDatepickerToBeClosed(`Datepicker should be closed on ESC`);
 
         // outside click
-        await page.openDatepicker();
+        await openDatepicker(`Opening datepicker for outside click`);
         await page.clickOutside();
-        expect(await page.getDatepicker().isPresent()).toBeTruthy(`Datepicker should NOT be closed on outside click`);
+        await expectDatepickerToBeOpen(`Datepicker should NOT be closed on outside click`);
 
         // date selection
         await page.getDayElement(DATE_SELECT).click();
-        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on date selection`);
+        await expectDatepickerToBeClosed(`Datepicker should be closed on date selection`);
 
         // outside days click -> month before
-        await page.openDatepicker();
+        await openDatepicker(`Opening datepicker for outside days click -> month before`);
         await page.getDayElement(DATE_OUTSIDE_BEFORE).click();
-        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on outside day click`);
+        await expectDatepickerToBeClosed(`Datepicker should be closed on outside day click`);
 
         // outside days click -> month after
-        await page.openDatepicker();
+        await openDatepicker(`Opening datepicker for outside days click -> month after`);
         await page.getDayElement(DATE_OUTSIDE_AFTER).click();
-        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on outside day click`);
+        await expectDatepickerToBeClosed(`Datepicker should be closed on outside day click`);
       });
     });
   }

--- a/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.po.ts
+++ b/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.po.ts
@@ -2,6 +2,8 @@ import {$} from 'protractor';
 import {DatepickerPage} from '../datepicker.po';
 
 export class DatepickerAutoClosePage extends DatepickerPage {
+  getOpenStatus() { return $('#open-status'); }
+
   async closeDatepicker() { await $('#close').click(); }
 
   async clickOutside() { await $('#outside-button').click(); }

--- a/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.po.ts
+++ b/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.po.ts
@@ -1,5 +1,6 @@
 import {$} from 'protractor';
 import {DatepickerPage} from '../datepicker.po';
+import {rightClick} from '../../tools.po';
 
 export class DatepickerAutoClosePage extends DatepickerPage {
   getOpenStatus() { return $('#open-status'); }
@@ -7,6 +8,8 @@ export class DatepickerAutoClosePage extends DatepickerPage {
   async closeDatepicker() { await $('#close').click(); }
 
   async clickOutside() { await $('#outside-button').click(); }
+
+  async rightClickOutside() { await rightClick($('#outside-button')); }
 
   async selectAutoClose(type: string) {
     await $('#autoclose-dropdown').click();

--- a/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.component.html
+++ b/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.component.html
@@ -1,9 +1,12 @@
-<h3>Dropdown autoclose tests</h3>
+<h3>
+  Dropdown autoclose tests
+  <span class="ml-1 badge {{d.isOpen() ? 'badge-success' : 'badge-danger'}}" id="open-status">{{d.isOpen() ? 'open' : 'closed'}}</span>
+</h3>
 
 <form id="default">
   <div class="form-group form-inline">
 
-    <div id="dropdown"ngbDropdown class="d-inline-block" [autoClose]="autoClose">
+    <div id="dropdown" #d="ngbDropdown" ngbDropdown class="d-inline-block" [autoClose]="autoClose">
       <button class="btn btn-outline-secondary" ngbDropdownToggle>Dropdown</button>
       <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
         <button class="dropdown-item">Item</button>

--- a/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.component.html
+++ b/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.component.html
@@ -3,7 +3,7 @@
   <span class="ml-1 badge {{d.isOpen() ? 'badge-success' : 'badge-danger'}}" id="open-status">{{d.isOpen() ? 'open' : 'closed'}}</span>
 </h3>
 
-<form id="default">
+<form id="default" (contextmenu)="$event.preventDefault()">
   <div class="form-group form-inline">
 
     <div id="dropdown" #d="ngbDropdown" ngbDropdown class="d-inline-block" [autoClose]="autoClose">

--- a/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.component.ts
+++ b/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.component.ts
@@ -1,6 +1,6 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 
-@Component({templateUrl: './dropdown-autoclose.component.html'})
+@Component({templateUrl: './dropdown-autoclose.component.html', changeDetection: ChangeDetectionStrategy.OnPush})
 export class DropdownAutoCloseComponent {
   autoClose: boolean | 'inside' | 'outside' = true;
 }

--- a/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.e2e-spec.ts
+++ b/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.e2e-spec.ts
@@ -1,5 +1,5 @@
 import {Key, ElementFinder} from 'protractor';
-import {sendKey, openUrl} from '../../tools.po';
+import {sendKey, openUrl, rightClick} from '../../tools.po';
 import {DropdownAutoClosePage} from './dropdown-autoclose.po';
 
 describe('Dropdown Autoclose', () => {
@@ -23,6 +23,18 @@ describe('Dropdown Autoclose', () => {
   beforeAll(() => page = new DropdownAutoClosePage());
 
   beforeEach(async() => await openUrl('dropdown/autoclose'));
+
+  it(`should not close when right clicking`, async() => {
+    await page.selectAutoClose('true');
+    const dropdown = page.getDropdown('#dropdown');
+
+    await openDropdown(dropdown, `Opening dropdown for right clicks`);
+    await rightClick(page.getFirstItem(dropdown));
+    await expectDropdownToBeVisible(dropdown, `Dropdown should NOT be closed on right click inside`);
+
+    await page.rightClickOutside();
+    await expectDropdownToBeVisible(dropdown, `Dropdown should NOT be closed on right click outside`);
+  });
 
   it(`should work when autoClose === true`, async() => {
     await page.selectAutoClose('true');

--- a/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.e2e-spec.ts
+++ b/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.e2e-spec.ts
@@ -1,9 +1,24 @@
-import {Key} from 'protractor';
+import {Key, ElementFinder} from 'protractor';
 import {sendKey, openUrl} from '../../tools.po';
 import {DropdownAutoClosePage} from './dropdown-autoclose.po';
 
 describe('Dropdown Autoclose', () => {
   let page: DropdownAutoClosePage;
+
+  const expectDropdownToBeVisible = async(dropdown: ElementFinder, message: string) => {
+    expect(await page.isOpened(dropdown)).toBeTruthy(message);
+    expect(await page.getOpenStatus().getText()).toBe('open', message);
+  };
+
+  const expectDropdownToBeHidden = async(dropdown: ElementFinder, message: string) => {
+    expect(await page.isOpened(dropdown)).toBeFalsy(message);
+    expect(await page.getOpenStatus().getText()).toBe('closed', message);
+  };
+
+  const openDropdown = async(dropdown: ElementFinder, message: string) => {
+    await page.open(dropdown);
+    await expectDropdownToBeVisible(dropdown, message);
+  };
 
   beforeAll(() => page = new DropdownAutoClosePage());
 
@@ -14,19 +29,19 @@ describe('Dropdown Autoclose', () => {
     const dropdown = page.getDropdown('#dropdown');
 
     // escape
-    await page.open(dropdown);
+    await openDropdown(dropdown, `Opening dropdown for escape`);
     await sendKey(Key.ESCAPE);
-    expect(await page.isOpened(dropdown)).toBeFalsy(`Dropdown should be closed on ESC`);
+    await expectDropdownToBeHidden(dropdown, `Dropdown should be closed on ESC`);
 
     // outside click
-    await page.open(dropdown);
+    await openDropdown(dropdown, `Opening dropdown for outside click`);
     await page.clickOutside();
-    expect(await page.isOpened(dropdown)).toBeFalsy(`Dropdown should be closed on outside click`);
+    await expectDropdownToBeHidden(dropdown, `Dropdown should be closed on outside click`);
 
     // inside click
-    await page.open(dropdown);
+    await openDropdown(dropdown, `Opening dropdown for inside click`);
     await page.getFirstItem(dropdown).click();
-    expect(await page.isOpened(dropdown)).toBeFalsy(`Dropdown should be closed on date selection`);
+    await expectDropdownToBeHidden(dropdown, `Dropdown should be closed on inside click`);
   });
 
   it(`should work when autoClose === false`, async() => {
@@ -34,17 +49,17 @@ describe('Dropdown Autoclose', () => {
     const dropdown = page.getDropdown('#dropdown');
 
     // escape
-    await page.open(dropdown);
+    await openDropdown(dropdown, `Opening dropdown for escape`);
     await sendKey(Key.ESCAPE);
-    expect(await page.isOpened(dropdown)).toBeTruthy(`Dropdown should NOT be closed on ESC`);
+    await expectDropdownToBeVisible(dropdown, `Dropdown should NOT be closed on ESC`);
 
     // outside click
     await page.clickOutside();
-    expect(await page.isOpened(dropdown)).toBeTruthy(`Dropdown should NOT be closed on outside click`);
+    await expectDropdownToBeVisible(dropdown, `Dropdown should NOT be closed on outside click`);
 
     // inside click
     await page.getFirstItem(dropdown).click();
-    expect(await page.isOpened(dropdown)).toBeTruthy(`Dropdown should NOT be closed on date selection`);
+    await expectDropdownToBeVisible(dropdown, `Dropdown should NOT be closed on inside click`);
   });
 
   it(`should work when autoClose === 'outside'`, async() => {
@@ -52,19 +67,19 @@ describe('Dropdown Autoclose', () => {
     const dropdown = page.getDropdown('#dropdown');
 
     // escape
-    await page.open(dropdown);
+    await openDropdown(dropdown, `Opening dropdown for escape`);
     await sendKey(Key.ESCAPE);
-    expect(await page.isOpened(dropdown)).toBeFalsy(`Dropdown should be closed on ESC`);
+    await expectDropdownToBeHidden(dropdown, `Dropdown should be closed on ESC`);
 
     // outside click
-    await page.open(dropdown);
+    await openDropdown(dropdown, `Opening dropdown for outside click`);
     await page.clickOutside();
-    expect(await page.isOpened(dropdown)).toBeFalsy(`Dropdown should be closed on outside click`);
+    await expectDropdownToBeHidden(dropdown, `Dropdown should be closed on outside click`);
 
-    // date selection
-    await page.open(dropdown);
+    // inside click
+    await openDropdown(dropdown, `Opening dropdown for inside click`);
     await page.getFirstItem(dropdown).click();
-    expect(await page.isOpened(dropdown)).toBeTruthy(`Dropdown should NOT be closed on date selection`);
+    await expectDropdownToBeVisible(dropdown, `Dropdown should NOT be closed on inside click`);
   });
 
   it(`should work when autoClose === 'inside'`, async() => {
@@ -72,17 +87,17 @@ describe('Dropdown Autoclose', () => {
     const dropdown = page.getDropdown('#dropdown');
 
     // escape
-    await page.open(dropdown);
+    await openDropdown(dropdown, `Opening dropdown for escape`);
     await sendKey(Key.ESCAPE);
-    expect(await page.isOpened(dropdown)).toBeFalsy(`Dropdown should be closed on ESC`);
+    await expectDropdownToBeHidden(dropdown, `Dropdown should be closed on ESC`);
 
     // outside click
-    await page.open(dropdown);
+    await openDropdown(dropdown, `Opening dropdown for outside click`);
     await page.clickOutside();
-    expect(await page.isOpened(dropdown)).toBeTruthy(`Dropdown should NOT be closed on outside click`);
+    await expectDropdownToBeVisible(dropdown, `Dropdown should NOT be closed on outside click`);
 
-    // date selection
+    // inside click
     await page.getFirstItem(dropdown).click();
-    expect(await page.isOpened(dropdown)).toBeFalsy(`Dropdown should be closed on date selection`);
+    await expectDropdownToBeHidden(dropdown, `Dropdown should be closed on inside click`);
   });
 });

--- a/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.po.ts
+++ b/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.po.ts
@@ -1,4 +1,5 @@
 import {$, ElementFinder} from 'protractor';
+import {rightClick} from '../../tools.po';
 
 export class DropdownAutoClosePage {
   async clickOutside() { await $('#outside-button').click(); }
@@ -8,6 +9,8 @@ export class DropdownAutoClosePage {
   getFirstItem(dropdown: ElementFinder) { return dropdown.$$(`.dropdown-item`).first(); }
 
   getOpenStatus() { return $('#open-status'); }
+
+  async rightClickOutside() { await rightClick($('#outside-button')); }
 
   async open(dropdown: ElementFinder) {
     await dropdown.$(`button[ngbDropdownToggle]`).click();

--- a/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.po.ts
+++ b/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.po.ts
@@ -7,6 +7,8 @@ export class DropdownAutoClosePage {
 
   getFirstItem(dropdown: ElementFinder) { return dropdown.$$(`.dropdown-item`).first(); }
 
+  getOpenStatus() { return $('#open-status'); }
+
   async open(dropdown: ElementFinder) {
     await dropdown.$(`button[ngbDropdownToggle]`).click();
     expect(await this.isOpened(dropdown)).toBeTruthy(`Dropdown should have been opened`);

--- a/e2e-app/src/app/popover/autoclose/popover-autoclose.component.html
+++ b/e2e-app/src/app/popover/autoclose/popover-autoclose.component.html
@@ -1,9 +1,12 @@
-<h3>Popover autoclose tests</h3>
+<h3>
+  Popover autoclose tests
+  <span class="ml-1 badge {{d.isOpen() ? 'badge-success' : 'badge-danger'}}" id="open-status">{{d.isOpen() ? 'open' : 'closed'}}</span>
+</h3>
 
 <form id="default">
   <div class="form-group form-inline">
 
-    <button ngbPopover="Popover here" [autoClose]="autoClose" triggers="click" type="button" class="btn btn-outline-secondary ml-2">
+    <button #d="ngbPopover" ngbPopover="Popover here" [autoClose]="autoClose" triggers="click" type="button" class="btn btn-outline-secondary ml-2">
       Popover
     </button>
 

--- a/e2e-app/src/app/popover/autoclose/popover-autoclose.component.html
+++ b/e2e-app/src/app/popover/autoclose/popover-autoclose.component.html
@@ -3,7 +3,7 @@
   <span class="ml-1 badge {{d.isOpen() ? 'badge-success' : 'badge-danger'}}" id="open-status">{{d.isOpen() ? 'open' : 'closed'}}</span>
 </h3>
 
-<form id="default">
+<form id="default" (contextmenu)="$event.preventDefault()">
   <div class="form-group form-inline">
 
     <button #d="ngbPopover" ngbPopover="Popover here" [autoClose]="autoClose" triggers="click" type="button" class="btn btn-outline-secondary ml-2">

--- a/e2e-app/src/app/popover/autoclose/popover-autoclose.component.ts
+++ b/e2e-app/src/app/popover/autoclose/popover-autoclose.component.ts
@@ -1,6 +1,6 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 
-@Component({templateUrl: './popover-autoclose.component.html'})
+@Component({templateUrl: './popover-autoclose.component.html', changeDetection: ChangeDetectionStrategy.OnPush})
 export class PopoverAutocloseComponent {
   autoClose: boolean | 'inside' | 'outside' = true;
 }

--- a/e2e-app/src/app/popover/autoclose/popover-autoclose.e2e-spec.ts
+++ b/e2e-app/src/app/popover/autoclose/popover-autoclose.e2e-spec.ts
@@ -1,5 +1,5 @@
 import {Key} from 'protractor';
-import {sendKey, openUrl} from '../../tools.po';
+import {sendKey, openUrl, rightClick} from '../../tools.po';
 import {PopoverAutoClosePage} from './popover-autoclose.po';
 
 describe('Popover Autoclose', () => {
@@ -23,6 +23,16 @@ describe('Popover Autoclose', () => {
   beforeAll(() => page = new PopoverAutoClosePage());
 
   beforeEach(async() => await openUrl('popover/autoclose'));
+
+  it(`should not close popover on right clicks`, async() => {
+    await openPopover(`Opening popover for right clicks`);
+
+    await rightClick(page.getPopoverContent());
+    await expectPopoverToBeOpen(`Popover should stay visible when right-clicking inside`);
+
+    await page.rightClickOutside();
+    await expectPopoverToBeOpen(`Popover should stay visible when right-clicking outside`);
+  });
 
   it(`should work when autoClose === true`, async() => {
     await page.selectAutoClose('true');

--- a/e2e-app/src/app/popover/autoclose/popover-autoclose.e2e-spec.ts
+++ b/e2e-app/src/app/popover/autoclose/popover-autoclose.e2e-spec.ts
@@ -5,6 +5,21 @@ import {PopoverAutoClosePage} from './popover-autoclose.po';
 describe('Popover Autoclose', () => {
   let page: PopoverAutoClosePage;
 
+  const expectPopoverToBeOpen = async(message: string) => {
+    expect(await page.getPopover().isPresent()).toBeTruthy(message);
+    expect(await page.getOpenStatus().getText()).toBe('open', message);
+  };
+
+  const expectPopoverToBeClosed = async(message: string) => {
+    expect(await page.getPopover().isPresent()).toBeFalsy(message);
+    expect(await page.getOpenStatus().getText()).toBe('closed', message);
+  };
+
+  const openPopover = async(message: string) => {
+    await page.openPopover();
+    await expectPopoverToBeOpen(message);
+  };
+
   beforeAll(() => page = new PopoverAutoClosePage());
 
   beforeEach(async() => await openUrl('popover/autoclose'));
@@ -13,72 +28,72 @@ describe('Popover Autoclose', () => {
     await page.selectAutoClose('true');
 
     // escape
-    await page.openPopover();
+    await openPopover(`Opening popover for escape`);
     await sendKey(Key.ESCAPE);
-    expect(await page.getPopover().isPresent()).toBeFalsy(`Popover should be closed on ESC`);
+    await expectPopoverToBeClosed(`Popover should be closed on ESC`);
 
     // outside click
-    await page.openPopover();
+    await openPopover(`Opening popover for outside click`);
     await page.clickOutside();
-    expect(await page.getPopover().isPresent()).toBeFalsy(`Popover should be closed on outside click`);
+    await expectPopoverToBeClosed(`Popover should be closed on outside click`);
 
     // inside click
-    await page.openPopover();
+    await openPopover(`Opening popover for inside click`);
     await page.getPopoverContent().click();
-    expect(await page.getPopover().isPresent()).toBeFalsy(`Popover should be closed on date selection`);
+    await expectPopoverToBeClosed(`Popover should be closed on inside click`);
   });
 
   it(`should work when autoClose === false`, async() => {
     await page.selectAutoClose('false');
 
     // escape
-    await page.openPopover();
+    await openPopover(`Opening popover for escape`);
     await sendKey(Key.ESCAPE);
-    expect(await page.getPopover().isPresent()).toBeTruthy(`Popover should NOT be closed on ESC`);
+    await expectPopoverToBeOpen(`Popover should NOT be closed on ESC`);
 
     // outside click
     await page.clickOutside();
-    expect(await page.getPopover().isPresent()).toBeTruthy(`Popover should NOT be closed on outside click`);
+    await expectPopoverToBeOpen(`Popover should NOT be closed on outside click`);
 
     // inside click
     await page.getPopoverContent().click();
-    expect(await page.getPopover().isPresent()).toBeTruthy(`Popover should NOT be closed on date selection`);
+    await expectPopoverToBeOpen(`Popover should NOT be closed on inside click`);
   });
 
   it(`should work when autoClose === 'outside'`, async() => {
     await page.selectAutoClose('outside');
 
     // escape
-    await page.openPopover();
+    await openPopover(`Opening popover for escape`);
     await sendKey(Key.ESCAPE);
-    expect(await page.getPopover().isPresent()).toBeFalsy(`Popover should be closed on ESC`);
+    await expectPopoverToBeClosed(`Popover should be closed on ESC`);
 
     // outside click
-    await page.openPopover();
+    await openPopover(`Opening popover for outside click`);
     await page.clickOutside();
-    expect(await page.getPopover().isPresent()).toBeFalsy(`Popover should be closed on outside click`);
+    await expectPopoverToBeClosed(`Popover should be closed on outside click`);
 
-    // date selection
-    await page.openPopover();
+    // inside click
+    await openPopover(`Opening popover for inside click`);
     await page.getPopoverContent().click();
-    expect(await page.getPopover().isPresent()).toBeTruthy(`Popover should NOT be closed on date selection`);
+    await expectPopoverToBeOpen(`Popover should NOT be closed on inside click`);
   });
 
   it(`should work when autoClose === 'inside'`, async() => {
     await page.selectAutoClose('inside');
 
     // escape
-    await page.openPopover();
+    await openPopover(`Opening popover for escape`);
     await sendKey(Key.ESCAPE);
-    expect(await page.getPopover().isPresent()).toBeFalsy(`Popover should be closed on ESC`);
+    await expectPopoverToBeClosed(`Popover should be closed on ESC`);
 
     // outside click
-    await page.openPopover();
+    await openPopover(`Opening popover for outside click`);
     await page.clickOutside();
-    expect(await page.getPopover().isPresent()).toBeTruthy(`Popover should NOT be closed on outside click`);
+    await expectPopoverToBeOpen(`Popover should NOT be closed on outside click`);
 
-    // date selection
+    // inside click
     await page.getPopoverContent().click();
-    expect(await page.getPopover().isPresent()).toBeFalsy(`Popover should be closed on date selection`);
+    await expectPopoverToBeClosed(`Popover should be closed on inside click`);
   });
 });

--- a/e2e-app/src/app/popover/autoclose/popover-autoclose.po.ts
+++ b/e2e-app/src/app/popover/autoclose/popover-autoclose.po.ts
@@ -3,6 +3,8 @@ import {$} from 'protractor';
 export class PopoverAutoClosePage {
   async clickOutside() { await $('#outside-button').click(); }
 
+  getOpenStatus() { return $('#open-status'); }
+
   getPopover() { return $('ngb-popover-window'); }
 
   getPopoverContent() { return this.getPopover().$('div.popover-body'); }

--- a/e2e-app/src/app/popover/autoclose/popover-autoclose.po.ts
+++ b/e2e-app/src/app/popover/autoclose/popover-autoclose.po.ts
@@ -1,4 +1,5 @@
 import {$} from 'protractor';
+import {rightClick} from '../../tools.po';
 
 export class PopoverAutoClosePage {
   async clickOutside() { await $('#outside-button').click(); }
@@ -13,6 +14,8 @@ export class PopoverAutoClosePage {
     await $('button[ngbPopover]').click();
     expect(await this.getPopover().isPresent()).toBeTruthy(`Popover should be visible`);
   }
+
+  async rightClickOutside() { await rightClick($('#outside-button')); }
 
   async selectAutoClose(type: string) {
     await $('#autoclose-dropdown').click();

--- a/e2e-app/src/app/tools.po.ts
+++ b/e2e-app/src/app/tools.po.ts
@@ -1,4 +1,4 @@
-import {browser, ElementFinder, Key, WebElement, $, $$} from 'protractor';
+import {browser, ElementFinder, Key, WebElement, $, $$, Button} from 'protractor';
 
 /**
  * Sends keys to a currently focused element
@@ -8,6 +8,14 @@ import {browser, ElementFinder, Key, WebElement, $, $$} from 'protractor';
 export const sendKey = async(...keys: string[]) => {
   const focused = await browser.driver.switchTo().activeElement();
   await focused.sendKeys(Key.chord(...keys));
+};
+
+/**
+ * Clicks on the given element with the right button of the mouse.
+ * @param el element to right click on
+ */
+export const rightClick = async(el: ElementFinder) => {
+  await browser.actions().click(el, Button.RIGHT).perform();
 };
 
 /**

--- a/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.component.html
+++ b/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.component.html
@@ -3,7 +3,7 @@
   <span class="ml-1 badge {{d.isOpen() ? 'badge-success' : 'badge-danger'}}" id="open-status">{{d.isOpen() ? 'open' : 'closed'}}</span>
 </h3>
 
-<form id="default">
+<form id="default" (contextmenu)="$event.preventDefault()">
   <div class="form-group form-inline">
 
     <button #d="ngbTooltip" ngbTooltip="Tooltip here" [autoClose]="autoClose" triggers="click" type="button" class="btn btn-outline-secondary ml-2">

--- a/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.component.html
+++ b/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.component.html
@@ -1,9 +1,12 @@
-<h3>Tooltip autoclose tests</h3>
+<h3>
+  Tooltip autoclose tests
+  <span class="ml-1 badge {{d.isOpen() ? 'badge-success' : 'badge-danger'}}" id="open-status">{{d.isOpen() ? 'open' : 'closed'}}</span>
+</h3>
 
 <form id="default">
   <div class="form-group form-inline">
 
-    <button ngbTooltip="Tooltip here" [autoClose]="autoClose" triggers="click" type="button" class="btn btn-outline-secondary ml-2">
+    <button #d="ngbTooltip" ngbTooltip="Tooltip here" [autoClose]="autoClose" triggers="click" type="button" class="btn btn-outline-secondary ml-2">
       Tooltip
     </button>
 

--- a/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.component.ts
+++ b/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.component.ts
@@ -1,6 +1,6 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 
-@Component({templateUrl: './tooltip-autoclose.component.html'})
+@Component({templateUrl: './tooltip-autoclose.component.html', changeDetection: ChangeDetectionStrategy.OnPush})
 export class TooltipAutocloseComponent {
   autoClose: boolean | 'inside' | 'outside' = true;
 }

--- a/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.e2e-spec.ts
+++ b/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.e2e-spec.ts
@@ -1,5 +1,5 @@
 import {Key} from 'protractor';
-import {sendKey, openUrl} from '../../tools.po';
+import {sendKey, openUrl, rightClick} from '../../tools.po';
 import {TooltipAutoClosePage} from './tooltip-autoclose.po';
 
 describe('Tooltip Autoclose', () => {
@@ -23,6 +23,16 @@ describe('Tooltip Autoclose', () => {
   beforeAll(() => page = new TooltipAutoClosePage());
 
   beforeEach(async() => await openUrl('tooltip/autoclose'));
+
+  it(`should not close tooltip on right clicks`, async() => {
+    await openTooltip(`Opening tooltip for right clicks`);
+
+    await rightClick(page.getTooltipContent());
+    await expectTooltipToBeOpen(`Tooltip should stay visible when right-clicking inside`);
+
+    await page.rightClickOutside();
+    await expectTooltipToBeOpen(`Tooltip should stay visible when right-clicking outside`);
+  });
 
   it(`should work when autoClose === true`, async() => {
     await page.selectAutoClose('true');

--- a/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.e2e-spec.ts
+++ b/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.e2e-spec.ts
@@ -5,6 +5,21 @@ import {TooltipAutoClosePage} from './tooltip-autoclose.po';
 describe('Tooltip Autoclose', () => {
   let page: TooltipAutoClosePage;
 
+  const expectTooltipToBeOpen = async(message: string) => {
+    expect(await page.getTooltip().isPresent()).toBeTruthy(message);
+    expect(await page.getOpenStatus().getText()).toBe('open', message);
+  };
+
+  const expectTooltipToBeClosed = async(message: string) => {
+    expect(await page.getTooltip().isPresent()).toBeFalsy(message);
+    expect(await page.getOpenStatus().getText()).toBe('closed', message);
+  };
+
+  const openTooltip = async(message: string) => {
+    await page.openTooltip();
+    await expectTooltipToBeOpen(message);
+  };
+
   beforeAll(() => page = new TooltipAutoClosePage());
 
   beforeEach(async() => await openUrl('tooltip/autoclose'));
@@ -13,72 +28,72 @@ describe('Tooltip Autoclose', () => {
     await page.selectAutoClose('true');
 
     // escape
-    await page.openTooltip();
+    await openTooltip(`Opening tooltip for escape`);
     await sendKey(Key.ESCAPE);
-    expect(await page.getTooltip().isPresent()).toBeFalsy(`Tooltip should be closed on ESC`);
+    await expectTooltipToBeClosed(`Tooltip should be closed on ESC`);
 
     // outside click
-    await page.openTooltip();
+    await openTooltip(`Opening tooltip for outside click`);
     await page.clickOutside();
-    expect(await page.getTooltip().isPresent()).toBeFalsy(`Tooltip should be closed on outside click`);
+    await expectTooltipToBeClosed(`Tooltip should be closed on outside click`);
 
     // inside click
-    await page.openTooltip();
+    await openTooltip(`Opening tooltip for inside click`);
     await page.getTooltipContent().click();
-    expect(await page.getTooltip().isPresent()).toBeFalsy(`Tooltip should be closed on date selection`);
+    await expectTooltipToBeClosed(`Tooltip should be closed on date selection`);
   });
 
   it(`should work when autoClose === false`, async() => {
     await page.selectAutoClose('false');
 
     // escape
-    await page.openTooltip();
+    await openTooltip(`Opening tooltip for escape`);
     await sendKey(Key.ESCAPE);
-    expect(await page.getTooltip().isPresent()).toBeTruthy(`Tooltip should NOT be closed on ESC`);
+    await expectTooltipToBeOpen(`Tooltip should NOT be closed on ESC`);
 
     // outside click
     await page.clickOutside();
-    expect(await page.getTooltip().isPresent()).toBeTruthy(`Tooltip should NOT be closed on outside click`);
+    await expectTooltipToBeOpen(`Tooltip should NOT be closed on outside click`);
 
     // inside click
     await page.getTooltipContent().click();
-    expect(await page.getTooltip().isPresent()).toBeTruthy(`Tooltip should NOT be closed on date selection`);
+    await expectTooltipToBeOpen(`Tooltip should NOT be closed on date selection`);
   });
 
   it(`should work when autoClose === 'outside'`, async() => {
     await page.selectAutoClose('outside');
 
     // escape
-    await page.openTooltip();
+    await openTooltip(`Opening tooltip for escape`);
     await sendKey(Key.ESCAPE);
-    expect(await page.getTooltip().isPresent()).toBeFalsy(`Tooltip should be closed on ESC`);
+    await expectTooltipToBeClosed(`Tooltip should be closed on ESC`);
 
     // outside click
-    await page.openTooltip();
+    await openTooltip(`Opening tooltip for outside click`);
     await page.clickOutside();
-    expect(await page.getTooltip().isPresent()).toBeFalsy(`Tooltip should be closed on outside click`);
+    await expectTooltipToBeClosed(`Tooltip should be closed on outside click`);
 
     // date selection
-    await page.openTooltip();
+    await openTooltip(`Opening tooltip for date selection`);
     await page.getTooltipContent().click();
-    expect(await page.getTooltip().isPresent()).toBeTruthy(`Tooltip should NOT be closed on date selection`);
+    await expectTooltipToBeOpen(`Tooltip should NOT be closed on date selection`);
   });
 
   it(`should work when autoClose === 'inside'`, async() => {
     await page.selectAutoClose('inside');
 
     // escape
-    await page.openTooltip();
+    await openTooltip(`Opening tooltip for escape`);
     await sendKey(Key.ESCAPE);
-    expect(await page.getTooltip().isPresent()).toBeFalsy(`Tooltip should be closed on ESC`);
+    await expectTooltipToBeClosed(`Tooltip should be closed on ESC`);
 
     // outside click
-    await page.openTooltip();
+    await openTooltip(`Opening tooltip for outside click`);
     await page.clickOutside();
-    expect(await page.getTooltip().isPresent()).toBeTruthy(`Tooltip should NOT be closed on outside click`);
+    await expectTooltipToBeOpen(`Tooltip should NOT be closed on outside click`);
 
     // date selection
     await page.getTooltipContent().click();
-    expect(await page.getTooltip().isPresent()).toBeFalsy(`Tooltip should be closed on date selection`);
+    await expectTooltipToBeClosed(`Tooltip should be closed on date selection`);
   });
 });

--- a/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.po.ts
+++ b/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.po.ts
@@ -1,4 +1,5 @@
 import {$} from 'protractor';
+import {rightClick} from '../../tools.po';
 
 export class TooltipAutoClosePage {
   async clickOutside() { await $('#outside-button').click(); }
@@ -13,6 +14,8 @@ export class TooltipAutoClosePage {
     await $('button[ngbTooltip]').click();
     expect(await this.getTooltip().isPresent()).toBeTruthy(`Tooltip should be visible`);
   }
+
+  async rightClickOutside() { await rightClick($('#outside-button')); }
 
   async selectAutoClose(type: string) {
     await $('#autoclose-dropdown').click();

--- a/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.po.ts
+++ b/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.po.ts
@@ -3,6 +3,8 @@ import {$} from 'protractor';
 export class TooltipAutoClosePage {
   async clickOutside() { await $('#outside-button').click(); }
 
+  getOpenStatus() { return $('#open-status'); }
+
   getTooltip() { return $('ngb-tooltip-window'); }
 
   getTooltipContent() { return this.getTooltip().$('div.tooltip-inner'); }

--- a/e2e-app/src/app/typeahead/autoclose/typeahead-autoclose.component.html
+++ b/e2e-app/src/app/typeahead/autoclose/typeahead-autoclose.component.html
@@ -3,7 +3,7 @@
   <span class="ml-1 badge {{d.isPopupOpen() ? 'badge-success' : 'badge-danger'}}" id="open-status">{{d.isPopupOpen() ? 'open' : 'closed'}}</span>
 </h3>
 
-<form>
+<form (contextmenu)="$event.preventDefault()">
   <div class="form-group form-inline">
 
     <div class="input-group mr-2">

--- a/e2e-app/src/app/typeahead/autoclose/typeahead-autoclose.component.html
+++ b/e2e-app/src/app/typeahead/autoclose/typeahead-autoclose.component.html
@@ -1,11 +1,14 @@
-<h3>Typeahead autoclose tests</h3>
+<h3>
+  Typeahead autoclose tests
+  <span class="ml-1 badge {{d.isPopupOpen() ? 'badge-success' : 'badge-danger'}}" id="open-status">{{d.isPopupOpen() ? 'open' : 'closed'}}</span>
+</h3>
 
 <form>
   <div class="form-group form-inline">
 
     <div class="input-group mr-2">
       <label for="typeahead" class="mr-2">Typeahead</label>
-      <input id="typeahead" type="text" class="form-control" [ngbTypeahead]="search" [showHint]="showHint" />
+      <input #d="ngbTypeahead" id="typeahead" type="text" class="form-control" [ngbTypeahead]="search" [showHint]="showHint" />
     </div>
 
     <div ngbDropdown class="

--- a/e2e-app/src/app/typeahead/autoclose/typeahead-autoclose.component.ts
+++ b/e2e-app/src/app/typeahead/autoclose/typeahead-autoclose.component.ts
@@ -1,10 +1,10 @@
-import {Component} from '@angular/core';
+import {Component, ChangeDetectionStrategy} from '@angular/core';
 import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 
 const items = ['one', 'two', 'three'];
 
-@Component({templateUrl: './typeahead-autoclose.component.html'})
+@Component({templateUrl: './typeahead-autoclose.component.html', changeDetection: ChangeDetectionStrategy.OnPush})
 export class TypeaheadAutoCloseComponent {
   showHint = false;
 

--- a/e2e-app/src/app/typeahead/autoclose/typeahead-autoclose.e2e-spec.ts
+++ b/e2e-app/src/app/typeahead/autoclose/typeahead-autoclose.e2e-spec.ts
@@ -1,4 +1,4 @@
-import {openUrl, expectFocused, sendKey} from '../../tools.po';
+import {openUrl, expectFocused, sendKey, rightClick} from '../../tools.po';
 import {TypeaheadAutoClosePage} from './typeahead-autoclose.po';
 import {Key} from 'protractor';
 
@@ -25,6 +25,19 @@ describe('Typeahead Autoclose', () => {
 
   beforeEach(async() => await openUrl('typeahead/autoclose'));
 
+  it(`should not close typeahead on right clicks`, async() => {
+    await openTypeahead();
+
+    await rightClick(page.getTypeaheadInput());
+    await expectTypeaheadToBeOpen(`Dropdown should stay visible when right-clicking on the input`);
+
+    await rightClick(page.getDropdownItems().get(0));
+    await expectTypeaheadToBeOpen(`Dropdown should stay visible when right-clicking inside`);
+
+    await page.rightClickOutside();
+    await expectTypeaheadToBeOpen(`Dropdown should stay visible when right-clicking outside`);
+  });
+
   it(`should close typeahead on outside click and lose focus`, async() => {
     await openTypeahead();
 
@@ -36,12 +49,12 @@ describe('Typeahead Autoclose', () => {
   it(`should close typeahead on outside click and lose focus (with hint)`, async() => {
     await page.showHint(true);
     await openTypeahead();
-    expect(page.getTypeaheadValue()).toBe('one', `Hint should be shown`);
+    expect(await page.getTypeaheadValue()).toBe('one', `Hint should be shown`);
 
     await page.getOutsideButton().click();
     await expectTypeaheadToBeClosed(`Dropdown should become hidden`);
     await expectFocused(page.getOutsideButton(), `Clicked button should be focused`);
-    expect(page.getTypeaheadValue()).toBe('o', `Hint should have been removed`);
+    expect(await page.getTypeaheadValue()).toBe('o', `Hint should have been removed`);
   });
 
   it(`should not close typeahead on input click and stay focused`, async() => {
@@ -63,7 +76,7 @@ describe('Typeahead Autoclose', () => {
   it(`should close typeahead on Escape and stay focused`, async() => {
     await openTypeahead();
 
-    sendKey(Key.ESCAPE);
+    await sendKey(Key.ESCAPE);
     await expectTypeaheadToBeClosed(`Dropdown should become hidden`);
     await expectFocused(page.getTypeaheadInput(), `Typeahead input should stay focused`);
   });
@@ -71,11 +84,11 @@ describe('Typeahead Autoclose', () => {
   it(`should close typeahead on Escape and stay focused (with hint)`, async() => {
     await page.showHint(true);
     await openTypeahead();
-    expect(page.getTypeaheadValue()).toBe('one', `Hint should be shown`);
+    expect(await page.getTypeaheadValue()).toBe('one', `Hint should be shown`);
 
-    sendKey(Key.ESCAPE);
+    await sendKey(Key.ESCAPE);
     await expectTypeaheadToBeClosed(`Dropdown should become hidden`);
     await expectFocused(page.getTypeaheadInput(), `Typeahead input should stay focused`);
-    expect(page.getTypeaheadValue()).toBe('o', `Hint should have been removed`);
+    expect(await page.getTypeaheadValue()).toBe('o', `Hint should have been removed`);
   });
 });

--- a/e2e-app/src/app/typeahead/autoclose/typeahead-autoclose.e2e-spec.ts
+++ b/e2e-app/src/app/typeahead/autoclose/typeahead-autoclose.e2e-spec.ts
@@ -5,67 +5,77 @@ import {Key} from 'protractor';
 describe('Typeahead Autoclose', () => {
   let page: TypeaheadAutoClosePage;
 
+  const expectTypeaheadToBeOpen = async(message: string) => {
+    expect(await page.getDropdown().isPresent()).toBeTruthy(message);
+    expect(await page.getOpenStatus().getText()).toBe('open', message);
+  };
+
+  const expectTypeaheadToBeClosed = async(message: string) => {
+    expect(await page.getDropdown().isPresent()).toBeFalsy(message);
+    expect(await page.getOpenStatus().getText()).toBe('closed', message);
+  };
+
+  const openTypeahead = async() => {
+    await page.setTypeaheadValue('o');
+    await expectTypeaheadToBeOpen(`Opening typeahead`);
+    expect(await page.getDropdownItems().count()).toBe(2);
+  };
+
   beforeAll(() => page = new TypeaheadAutoClosePage());
 
   beforeEach(async() => await openUrl('typeahead/autoclose'));
 
   it(`should close typeahead on outside click and lose focus`, async() => {
-    await page.setTypeaheadValue('o');
-    expect(page.getDropdownItems().count()).toBe(2);
+    await openTypeahead();
 
     await page.getOutsideButton().click();
-    expect(await page.getDropdown().isPresent()).toBeFalsy(`Dropdown should become hidden`);
-    expectFocused(page.getOutsideButton(), `Clicked button should be focused`);
+    await expectTypeaheadToBeClosed(`Dropdown should become hidden`);
+    await expectFocused(page.getOutsideButton(), `Clicked button should be focused`);
   });
 
   it(`should close typeahead on outside click and lose focus (with hint)`, async() => {
     await page.showHint(true);
-    await page.setTypeaheadValue('o');
-    expect(page.getDropdownItems().count()).toBe(2);
+    await openTypeahead();
     expect(page.getTypeaheadValue()).toBe('one', `Hint should be shown`);
 
     await page.getOutsideButton().click();
-    expect(await page.getDropdown().isPresent()).toBeFalsy(`Dropdown should become hidden`);
-    expectFocused(page.getOutsideButton(), `Clicked button should be focused`);
+    await expectTypeaheadToBeClosed(`Dropdown should become hidden`);
+    await expectFocused(page.getOutsideButton(), `Clicked button should be focused`);
     expect(page.getTypeaheadValue()).toBe('o', `Hint should have been removed`);
   });
 
   it(`should not close typeahead on input click and stay focused`, async() => {
-    await page.setTypeaheadValue('o');
-    expect(page.getDropdownItems().count()).toBe(2);
+    await openTypeahead();
 
     await page.getTypeaheadInput().click();
-    expect(await page.getDropdown().isPresent()).toBeTruthy(`Dropdown should stay visible`);
-    expectFocused(page.getTypeaheadInput(), `Typeahead input should stay focused`);
+    await expectTypeaheadToBeOpen(`Dropdown should stay visible`);
+    await expectFocused(page.getTypeaheadInput(), `Typeahead input should stay focused`);
   });
 
   it(`should close typeahead on item click and stay focused`, async() => {
-    await page.setTypeaheadValue('o');
-    expect(page.getDropdownItems().count()).toBe(2);
+    await openTypeahead();
 
     await page.getDropdownItems().get(0).click();
-    expect(await page.getDropdown().isPresent()).toBeFalsy(`Dropdown should become hidden`);
-    expectFocused(page.getTypeaheadInput(), `Typeahead input should stay focused`);
+    await expectTypeaheadToBeClosed(`Dropdown should become hidden`);
+    await expectFocused(page.getTypeaheadInput(), `Typeahead input should stay focused`);
   });
 
   it(`should close typeahead on Escape and stay focused`, async() => {
-    await page.setTypeaheadValue('o');
-    expect(page.getDropdownItems().count()).toBe(2);
+    await openTypeahead();
 
     sendKey(Key.ESCAPE);
-    expect(await page.getDropdown().isPresent()).toBeFalsy(`Dropdown should become hidden`);
-    expectFocused(page.getTypeaheadInput(), `Typeahead input should stay focused`);
+    await expectTypeaheadToBeClosed(`Dropdown should become hidden`);
+    await expectFocused(page.getTypeaheadInput(), `Typeahead input should stay focused`);
   });
 
   it(`should close typeahead on Escape and stay focused (with hint)`, async() => {
     await page.showHint(true);
-    await page.setTypeaheadValue('o');
-    expect(page.getDropdownItems().count()).toBe(2);
+    await openTypeahead();
     expect(page.getTypeaheadValue()).toBe('one', `Hint should be shown`);
 
     sendKey(Key.ESCAPE);
-    expect(await page.getDropdown().isPresent()).toBeFalsy(`Dropdown should become hidden`);
-    expectFocused(page.getTypeaheadInput(), `Typeahead input should stay focused`);
+    await expectTypeaheadToBeClosed(`Dropdown should become hidden`);
+    await expectFocused(page.getTypeaheadInput(), `Typeahead input should stay focused`);
     expect(page.getTypeaheadValue()).toBe('o', `Hint should have been removed`);
   });
 });

--- a/e2e-app/src/app/typeahead/autoclose/typeahead-autoclose.po.ts
+++ b/e2e-app/src/app/typeahead/autoclose/typeahead-autoclose.po.ts
@@ -2,6 +2,8 @@ import {$} from 'protractor';
 import {TypeaheadPage} from '../typeahead.po';
 
 export class TypeaheadAutoClosePage extends TypeaheadPage {
+  getOpenStatus() { return $('#open-status'); }
+
   getOutsideButton() { return $('#outside-button'); }
 
   async showHint(hint: boolean) {

--- a/e2e-app/src/app/typeahead/autoclose/typeahead-autoclose.po.ts
+++ b/e2e-app/src/app/typeahead/autoclose/typeahead-autoclose.po.ts
@@ -1,10 +1,13 @@
 import {$} from 'protractor';
 import {TypeaheadPage} from '../typeahead.po';
+import {rightClick} from '../../tools.po';
 
 export class TypeaheadAutoClosePage extends TypeaheadPage {
   getOpenStatus() { return $('#open-status'); }
 
   getOutsideButton() { return $('#outside-button'); }
+
+  async rightClickOutside() { await rightClick($('#outside-button')); }
 
   async showHint(hint: boolean) {
     await $('#hint-dropdown').click();

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -14,6 +14,7 @@ import {
   SimpleChanges,
   TemplateRef,
   ViewContainerRef,
+  ChangeDetectorRef,
 } from '@angular/core';
 import {AbstractControl, ControlValueAccessor, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validator} from '@angular/forms';
 import {Subject} from 'rxjs';
@@ -202,7 +203,8 @@ export class NgbInputDatepicker implements OnChanges,
       private _parserFormatter: NgbDateParserFormatter, private _elRef: ElementRef<HTMLInputElement>,
       private _vcRef: ViewContainerRef, private _renderer: Renderer2, private _cfr: ComponentFactoryResolver,
       private _ngZone: NgZone, private _service: NgbDatepickerService, private _calendar: NgbCalendar,
-      private _dateAdapter: NgbDateAdapter<any>, private _autoClose: AutoClose) {
+      private _dateAdapter: NgbDateAdapter<any>, private _changeDetector: ChangeDetectorRef,
+      private _autoClose: AutoClose) {
     this._zoneSubscription = _ngZone.onStable.subscribe(() => {
       if (this._cRef) {
         positionElements(
@@ -308,6 +310,7 @@ export class NgbInputDatepicker implements OnChanges,
       this._vcRef.remove(this._vcRef.indexOf(this._cRef.hostView));
       this._cRef = null;
       this._closed$.next();
+      this._changeDetector.markForCheck();
     }
   }
 

--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -248,7 +248,7 @@ describe('ngb-dropdown', () => {
 describe('ngb-dropdown-toggle', () => {
   beforeEach(() => {
     jasmine.addMatchers(jasmineMatchers);
-    TestBed.configureTestingModule({declarations: [TestComponent, TestClickCloseOnPush], imports: [NgbDropdownModule]});
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbDropdownModule]});
   });
 
   it('should toggle dropdown on click', () => {
@@ -300,115 +300,6 @@ describe('ngb-dropdown-toggle', () => {
     toggleEl.click();
     fixture.detectChanges();
     expect(compiled).not.toBeShown();
-  });
-
-  it('should close on outside click', () => {
-    const html = `
-      <button>Outside</button>
-      <div ngbDropdown [open]="true">
-        <button ngbDropdownAnchor></button>
-        <div ngbDropdownMenu></div>
-      </div>`;
-
-    const fixture = createTestComponent(html);
-    const compiled = fixture.nativeElement;
-    const buttonEl = compiled.querySelector('button');
-
-    expect(compiled).toBeShown();
-
-    buttonEl.click();
-    fixture.detectChanges();
-    expect(compiled).not.toBeShown();
-  });
-
-  it('should close on inside click, outside click and escape when inside the OnPush component', () => {
-    const fixture = createTestComponent(`<test-click-close-on-push></test-click-close-on-push>`);
-    const compiled = fixture.nativeElement;
-    const toggleEl = compiled.querySelector('button');
-    const outsideEl = compiled.querySelector('.outside');
-    const insideEl = compiled.querySelector('.inside');
-
-    const reopen = () => {
-      toggleEl.click();
-      fixture.detectChanges();
-      expect(compiled).toBeShown();
-    };
-
-    // inside click
-    insideEl.click();
-    fixture.detectChanges();
-    expect(compiled).not.toBeShown();
-
-
-    // outside click
-    reopen();
-    outsideEl.click();
-    fixture.detectChanges();
-    expect(compiled).not.toBeShown();
-
-
-    // escape
-    reopen();
-    document.dispatchEvent(createFakeEscapeKeyUpEvent());
-    fixture.detectChanges();
-    expect(compiled).not.toBeShown();
-  });
-
-  it('should not close on outside click if right button click', () => {
-    const html = `
-      <button>Outside</button>
-      <div ngbDropdown [open]="true">
-        <button ngbDropdownAnchor></button>
-        <div ngbDropdownMenu></div>
-      </div>`;
-
-    const fixture = createTestComponent(html);
-    const compiled = fixture.nativeElement;
-    const buttonEl = compiled.querySelector('button');
-
-    expect(compiled).toBeShown();
-
-    const evt = document.createEvent('MouseEvent');
-    evt.initMouseEvent('click', true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 2, null);
-    buttonEl.dispatchEvent(evt);
-    fixture.detectChanges();
-    expect(compiled).toBeShown();
-  });
-
-  it('should close on other dropdown click', () => {
-    const html = `
-      <div ngbDropdown>
-          <button ngbDropdownToggle>Toggle dropdown 1</button>
-          <div ngbDropdownMenu>
-            <a class="dropdown-item">Action 1</a>
-          </div>
-      </div>
-      <div ngbDropdown>
-          <button ngbDropdownToggle>Toggle dropdown 2</button>
-          <div ngbDropdownMenu>
-            <a class="dropdown-item">Action 2</a>
-          </div>
-      </div>`;
-
-    const fixture = createTestComponent(html);
-    const compiled = fixture.nativeElement;
-
-    const buttonEls = compiled.querySelectorAll('button');
-    const dropdownEls = compiled.querySelectorAll('div[ngbDropdown]');
-
-    fixture.detectChanges();
-    expect(dropdownEls[0]).not.toHaveCssClass('show');
-    expect(dropdownEls[1]).not.toHaveCssClass('show');
-
-    buttonEls[0].click();
-    fixture.detectChanges();
-    expect(dropdownEls[0]).toHaveCssClass('show');
-    expect(dropdownEls[1]).not.toHaveCssClass('show');
-
-    buttonEls[1].click();
-    fixture.detectChanges();
-    expect(dropdownEls[0]).not.toHaveCssClass('show');
-    expect(dropdownEls[1]).toHaveCssClass('show');
   });
 
   describe('Custom config', () => {
@@ -479,20 +370,4 @@ class TestComponent {
     this.stateChanges.push($event);
     this.isOpen = $event;
   }
-}
-
-@Component({
-  selector: 'test-click-close-on-push',
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  template: `
-    <div ngbDropdown [open]="true">
-      <button ngbDropdownToggle>Toggle dropdown</button>
-      <div ngbDropdownMenu>
-        <a class="dropdown-item inside">Action</a>
-      </div>
-    </div>
-    <button class="outside">Outside</button>
-  `
-})
-class TestClickCloseOnPush {
 }

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -177,12 +177,7 @@ export class NgbDropdown implements OnInit, OnDestroy {
 
   private _setCloseHandlers() {
     this._autoClose.install(
-        this.autoClose,
-        () => {
-          this.close();
-          this._changeDetector.markForCheck();
-        },
-        this._closed$, this._menu ? [this._menu.getNativeElement()] : [],
+        this.autoClose, () => this.close(), this._closed$, this._menu ? [this._menu.getNativeElement()] : [],
         this._anchor ? [this._anchor.getNativeElement()] : []);
   }
 
@@ -194,6 +189,7 @@ export class NgbDropdown implements OnInit, OnDestroy {
       this._open = false;
       this._closed$.next();
       this.openChange.emit(false);
+      this._changeDetector.markForCheck();
     }
   }
 

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -18,7 +18,8 @@ import {
   ComponentFactoryResolver,
   NgZone,
   SimpleChanges,
-  ViewEncapsulation
+  ViewEncapsulation,
+  ChangeDetectorRef
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 
@@ -155,7 +156,8 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
   constructor(
       private _elementRef: ElementRef<HTMLElement>, private _renderer: Renderer2, injector: Injector,
       componentFactoryResolver: ComponentFactoryResolver, viewContainerRef: ViewContainerRef, config: NgbPopoverConfig,
-      private _ngZone: NgZone, @Inject(DOCUMENT) private _document: any, private _autoClose: AutoClose) {
+      private _ngZone: NgZone, @Inject(DOCUMENT) private _document: any, private _autoClose: AutoClose,
+      private _changeDetector: ChangeDetectorRef) {
     this.autoClose = config.autoClose;
     this.placement = config.placement;
     this.triggers = config.triggers;
@@ -218,6 +220,7 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
       this._popupService.close();
       this._windowRef = null;
       this.hidden.emit();
+      this._changeDetector.markForCheck();
     }
   }
 

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -21,15 +21,13 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
-import {fromEvent, race} from 'rxjs';
-import {filter, takeUntil} from 'rxjs/operators';
 
 import {listenToTriggers} from '../util/triggers';
 import {positionElements, Placement, PlacementArray} from '../util/positioning';
 import {PopupService} from '../util/popup';
-import {Key} from '../util/key';
 
 import {NgbPopoverConfig} from './popover-config';
+import {AutoClose} from '../util/autoclose';
 
 let nextId = 0;
 
@@ -75,15 +73,6 @@ export class NgbPopoverWindow {
     this._renderer.addClass(this._element.nativeElement, 'bs-popover-' + this.placement.toString().split('-')[0]);
     this._renderer.addClass(this._element.nativeElement, 'bs-popover-' + this.placement.toString());
   }
-
-  /**
-   * Tells whether the event has been triggered from this component's subtree or not.
-   *
-   * @param event the event to check
-   *
-   * @return whether the event has been triggered from this component's subtree or not.
-   */
-  isEventFrom(event: Event): boolean { return this._element.nativeElement.contains(event.target as HTMLElement); }
 }
 
 /**
@@ -166,7 +155,7 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
   constructor(
       private _elementRef: ElementRef<HTMLElement>, private _renderer: Renderer2, injector: Injector,
       componentFactoryResolver: ComponentFactoryResolver, viewContainerRef: ViewContainerRef, config: NgbPopoverConfig,
-      private _ngZone: NgZone, @Inject(DOCUMENT) private _document: any) {
+      private _ngZone: NgZone, @Inject(DOCUMENT) private _document: any, private _autoClose: AutoClose) {
     this.autoClose = config.autoClose;
     this.placement = config.placement;
     this.triggers = config.triggers;
@@ -214,30 +203,8 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
               this._elementRef.nativeElement, this._windowRef.location.nativeElement, this.placement,
               this.container === 'body'));
 
-      if (this.autoClose) {
-        this._ngZone.runOutsideAngular(() => {
-          // prevents automatic closing right after an opening by putting a guard for the time of one event handling
-          // pass
-          // use case: click event would reach an element opening the popover first, then reach the autoClose handler
-          // which would close it
-          let justOpened = true;
-          requestAnimationFrame(() => justOpened = false);
-
-          const escapes$ = fromEvent<KeyboardEvent>(this._document, 'keyup')
-                               .pipe(
-                                   takeUntil(this.hidden),
-                                   // tslint:disable-next-line:deprecation
-                                   filter(event => event.which === Key.Escape));
-
-          const clicks$ = fromEvent<MouseEvent>(this._document, 'click')
-                              .pipe(
-                                  takeUntil(this.hidden), filter(() => !justOpened),
-                                  filter(event => this._shouldCloseFromClick(event)));
-
-          race<Event>([escapes$, clicks$]).subscribe(() => this._ngZone.run(() => this.close()));
-        });
-      }
-
+      this._autoClose.install(
+          this.autoClose, () => this.close(), this.hidden, [this._windowRef.location.nativeElement]);
       this.shown.emit();
     }
   }
@@ -291,23 +258,5 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
       this._unregisterListenersFn();
     }
     this._zoneSubscription.unsubscribe();
-  }
-
-  private _shouldCloseFromClick(event: MouseEvent) {
-    if (event.button !== 2) {
-      if (this.autoClose === true) {
-        return true;
-      } else if (this.autoClose === 'inside' && this._isEventFromPopover(event)) {
-        return true;
-      } else if (this.autoClose === 'outside' && !this._isEventFromPopover(event)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private _isEventFromPopover(event: MouseEvent) {
-    const popup = this._windowRef.instance;
-    return popup ? popup.isEventFrom(event) : false;
   }
 }

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -16,7 +16,8 @@ import {
   ViewContainerRef,
   ComponentFactoryResolver,
   NgZone,
-  ViewEncapsulation
+  ViewEncapsulation,
+  ChangeDetectorRef
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 
@@ -127,7 +128,8 @@ export class NgbTooltip implements OnInit, OnDestroy {
   constructor(
       private _elementRef: ElementRef<HTMLElement>, private _renderer: Renderer2, injector: Injector,
       componentFactoryResolver: ComponentFactoryResolver, viewContainerRef: ViewContainerRef, config: NgbTooltipConfig,
-      private _ngZone: NgZone, @Inject(DOCUMENT) private _document: any, private _autoClose: AutoClose) {
+      private _ngZone: NgZone, @Inject(DOCUMENT) private _document: any, private _autoClose: AutoClose,
+      private _changeDetector: ChangeDetectorRef) {
     this.autoClose = config.autoClose;
     this.placement = config.placement;
     this.triggers = config.triggers;
@@ -204,6 +206,7 @@ export class NgbTooltip implements OnInit, OnDestroy {
       this._popupService.close();
       this._windowRef = null;
       this.hidden.emit();
+      this._changeDetector.markForCheck();
     }
   }
 

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -203,45 +203,6 @@ describe('ngb-typeahead', () => {
          });
        }));
 
-    it('should be closed on document click', () => {
-      const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="find"/>`);
-      const compiled = fixture.nativeElement;
-
-      changeInput(compiled, 'one');
-      fixture.detectChanges();
-      expect(getWindow(compiled)).not.toBeNull();
-
-      fixture.nativeElement.click();
-      expect(getWindow(compiled)).toBeNull();
-    });
-
-    it('should not be closed on input click', () => {
-      const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="find"/>`);
-      const compiled = fixture.nativeElement;
-
-      changeInput(compiled, 'one');
-      fixture.detectChanges();
-      expect(getWindow(compiled)).not.toBeNull();
-
-      getNativeInput(compiled).click();
-      expect(getWindow(compiled)).not.toBeNull();
-    });
-
-    it('should be closed when ESC is pressed', () => {
-      const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="find"/>`);
-      const compiled = fixture.nativeElement;
-
-      changeInput(compiled, 'one');
-      fixture.detectChanges();
-      expect(getWindow(compiled)).not.toBeNull();
-
-      const event = createKeyDownEvent(Key.Escape);
-      getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-      fixture.detectChanges();
-      expect(getWindow(compiled)).toBeNull();
-      expect(event.preventDefault).toHaveBeenCalled();
-    });
-
     it('should select the result on click, close window and fill the input', async(() => {
          const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
          const compiled = fixture.nativeElement;
@@ -482,39 +443,6 @@ describe('ngb-typeahead', () => {
 
          // Make sure that it is resubscribed again
          changeInput(compiled, 'two');
-         fixture.detectChanges();
-         tick(250);
-         expect(getWindow(compiled)).not.toBeNull();
-       }));
-
-    it('should not display results when "Escape" is pressed', fakeAsync(() => {
-         const fixture = createAsyncTestComponent(`<input type="text" [ngbTypeahead]="find"/>`);
-         const compiled = fixture.nativeElement;
-
-         // Change input first time
-         changeInput(compiled, 'one');
-         fixture.detectChanges();
-
-         // Results for first input are loaded
-         tick(250);
-         expect(getWindow(compiled)).not.toBeNull();
-
-         // Change input second time
-         changeInput(compiled, 'two');
-         fixture.detectChanges();
-         tick(50);
-
-         // Press Escape while second is still in progress
-         const event = createKeyDownEvent(Key.Escape);
-         getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-         fixture.detectChanges();
-
-         // Results for second input are loaded (window shouldn't be opened in this case)
-         tick(250);
-         expect(getWindow(compiled)).toBeNull();
-
-         // Make sure that it is resubscribed again
-         changeInput(compiled, 'three');
          fixture.detectChanges();
          tick(250);
          expect(getWindow(compiled)).not.toBeNull();
@@ -911,30 +839,6 @@ describe('ngb-typeahead', () => {
            });
          }));
 
-      it('should restore hint when results window is dismissed with Esc', async(() => {
-           const fixture = createTestComponent(
-               `<input type="text" [(ngModel)]="model" [ngbTypeahead]="findAnywhere" [showHint]="true"/>`);
-           fixture.detectChanges();
-           const compiled = fixture.nativeElement;
-           const inputEl = getNativeInput(compiled);
-
-           fixture.whenStable().then(() => {
-             changeInput(compiled, 'on');
-             fixture.detectChanges();
-             expectWindowResults(compiled, ['+one', 'one more']);
-             expect(inputEl.value).toBe('one');
-             expect(inputEl.selectionStart).toBe(2);
-             expect(inputEl.selectionEnd).toBe(3);
-
-             const event = createKeyDownEvent(Key.Escape);
-             getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-             fixture.detectChanges();
-             expect(inputEl.value).toBe('on');
-             expect(inputEl.selectionStart).toBe(2);
-             expect(inputEl.selectionEnd).toBe(2);
-           });
-         }));
-
       it('should not show hint when there is no result selected', async(() => {
            const fixture = createTestComponent(
                `<input type="text" [(ngModel)]="model" [ngbTypeahead]="find" [showHint]="true" [focusFirst]="false"/>`);
@@ -948,27 +852,6 @@ describe('ngb-typeahead', () => {
              expectWindowResults(compiled, ['one', 'one more']);
              expect(inputEl.value).toBe('on');
            });
-         }));
-
-      it('should restore hint when results window is dismissed with click outside', async(async() => {
-           const fixture = createTestComponent(
-               `<input type="text" [(ngModel)]="model" [ngbTypeahead]="findAnywhere" [showHint]="true"/>`);
-           fixture.detectChanges();
-           const compiled = fixture.nativeElement;
-           const inputEl = getNativeInput(compiled);
-
-           await fixture.whenStable();
-           changeInput(compiled, 'on');
-           fixture.detectChanges();
-
-           expect(getWindow(compiled)).not.toBeNull();
-           expectInputValue(compiled, 'one');
-           expect(inputEl.selectionStart).toBe(2);
-           expect(inputEl.selectionEnd).toBe(3);
-
-           document.body.click();
-           fixture.detectChanges();
-           expectInputValue(compiled, 'on');
          }));
 
       describe('should clear input properly when model get reset to empty string', () => {

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -16,7 +16,7 @@ import {
   ViewContainerRef,
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
-import {BehaviorSubject, fromEvent, Observable, Subscription} from 'rxjs';
+import {BehaviorSubject, fromEvent, Observable, Subscription, Subject} from 'rxjs';
 import {map, switchMap, tap} from 'rxjs/operators';
 
 import {Live} from '../util/accessibility/live';
@@ -26,6 +26,7 @@ import {PlacementArray, positionElements} from '../util/positioning';
 import {isDefined, toString} from '../util/util';
 import {NgbTypeaheadConfig} from './typeahead-config';
 import {NgbTypeaheadWindow, ResultTemplateContext} from './typeahead-window';
+import {AutoClose} from '../util/autoclose';
 
 
 
@@ -61,7 +62,6 @@ let nextWindowId = 0;
   host: {
     '(blur)': 'handleBlur()',
     '[class.open]': 'isPopupOpen()',
-    '(document:click)': 'onDocumentClick($event)',
     '(keydown)': 'handleKeyDown($event)',
     '[autocomplete]': 'autocomplete',
     'autocapitalize': 'off',
@@ -79,6 +79,7 @@ export class NgbTypeahead implements ControlValueAccessor,
     OnInit, OnDestroy {
   private _popupService: PopupService<NgbTypeaheadWindow>;
   private _subscription: Subscription;
+  private _closed$ = new Subject();
   private _inputValueBackup: string;
   private _valueChanges: Observable<string>;
   private _resubscribeTypeahead: BehaviorSubject<any>;
@@ -158,7 +159,7 @@ export class NgbTypeahead implements ControlValueAccessor,
   constructor(
       private _elementRef: ElementRef<HTMLInputElement>, private _viewContainerRef: ViewContainerRef,
       private _renderer: Renderer2, private _injector: Injector, componentFactoryResolver: ComponentFactoryResolver,
-      config: NgbTypeaheadConfig, ngZone: NgZone, private _live: Live) {
+      config: NgbTypeaheadConfig, ngZone: NgZone, private _live: Live, private _autoClose: AutoClose) {
     this.container = config.container;
     this.editable = config.editable;
     this.focusFirst = config.focusFirst;
@@ -220,17 +221,12 @@ export class NgbTypeahead implements ControlValueAccessor,
     this._renderer.setProperty(this._elementRef.nativeElement, 'disabled', isDisabled);
   }
 
-  onDocumentClick(event) {
-    if (event.target !== this._elementRef.nativeElement) {
-      this.dismissPopup();
-    }
-  }
-
   /**
    * Dismisses typeahead popup window
    */
   dismissPopup() {
     if (this.isPopupOpen()) {
+      this._resubscribeTypeahead.next(null);
       this._closePopup();
       if (this.showHint && this._inputValueBackup !== null) {
         this._writeInputValue(this._inputValueBackup);
@@ -275,11 +271,6 @@ export class NgbTypeahead implements ControlValueAccessor,
         }
         this._closePopup();
         break;
-      case Key.Escape:
-        event.preventDefault();
-        this._resubscribeTypeahead.next(null);
-        this.dismissPopup();
-        break;
     }
   }
 
@@ -294,10 +285,14 @@ export class NgbTypeahead implements ControlValueAccessor,
       if (this.container === 'body') {
         window.document.querySelector(this.container).appendChild(this._windowRef.location.nativeElement);
       }
+      this._autoClose.install(
+          'outside', () => this.dismissPopup(), this._closed$,
+          [this._elementRef.nativeElement, this._windowRef.location.nativeElement]);
     }
   }
 
   private _closePopup() {
+    this._closed$.next();
     this._popupService.close();
     this._windowRef = null;
     this.activeDescendant = undefined;

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -14,6 +14,7 @@ import {
   Renderer2,
   TemplateRef,
   ViewContainerRef,
+  ChangeDetectorRef,
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {BehaviorSubject, fromEvent, Observable, Subscription, Subject} from 'rxjs';
@@ -159,7 +160,8 @@ export class NgbTypeahead implements ControlValueAccessor,
   constructor(
       private _elementRef: ElementRef<HTMLInputElement>, private _viewContainerRef: ViewContainerRef,
       private _renderer: Renderer2, private _injector: Injector, componentFactoryResolver: ComponentFactoryResolver,
-      config: NgbTypeaheadConfig, ngZone: NgZone, private _live: Live, private _autoClose: AutoClose) {
+      config: NgbTypeaheadConfig, ngZone: NgZone, private _live: Live, private _autoClose: AutoClose,
+      private _changeDetector: ChangeDetectorRef) {
     this.container = config.container;
     this.editable = config.editable;
     this.focusFirst = config.focusFirst;
@@ -231,6 +233,7 @@ export class NgbTypeahead implements ControlValueAccessor,
       if (this.showHint && this._inputValueBackup !== null) {
         this._writeInputValue(this._inputValueBackup);
       }
+      this._changeDetector.markForCheck();
     }
   }
 
@@ -288,6 +291,7 @@ export class NgbTypeahead implements ControlValueAccessor,
       this._autoClose.install(
           'outside', () => this.dismissPopup(), this._closed$,
           [this._elementRef.nativeElement, this._windowRef.location.nativeElement]);
+      this._changeDetector.markForCheck();
     }
   }
 

--- a/src/util/autoclose.ts
+++ b/src/util/autoclose.ts
@@ -1,0 +1,56 @@
+import {Injectable, NgZone, Inject} from '@angular/core';
+import {fromEvent, Observable, race} from 'rxjs';
+import {DOCUMENT} from '@angular/common';
+import {takeUntil, filter, withLatestFrom, map} from 'rxjs/operators';
+import {Key} from './key';
+
+const isHTMLElementContainedIn = (element: HTMLElement, array?: HTMLElement[]) =>
+    array ? array.some(item => item.contains(element)) : false;
+
+@Injectable({providedIn: 'root'})
+export class AutoClose {
+  constructor(private _ngZone: NgZone, @Inject(DOCUMENT) private _document: any) {}
+
+  install(
+      autoClose: boolean | 'inside' | 'outside', close: () => void, closed$: Observable<any>,
+      insideElements: HTMLElement[], ignoreElements?: HTMLElement[]) {
+    // closing on ESC and outside clicks
+    if (autoClose) {
+      this._ngZone.runOutsideAngular(() => {
+
+        const shouldCloseOnClick = (event: MouseEvent) => {
+          const element = event.target as HTMLElement;
+          if (event.button === 2 || isHTMLElementContainedIn(element, ignoreElements)) {
+            return false;
+          }
+          if (autoClose === 'inside') {
+            return isHTMLElementContainedIn(element, insideElements);
+          } else if (autoClose === 'outside') {
+            return !isHTMLElementContainedIn(element, insideElements);
+          } else /* if (autoClose === true) */ {
+            return true;
+          }
+        };
+
+        const escapes$ = fromEvent<KeyboardEvent>(this._document, 'keydown')
+                             .pipe(
+                                 takeUntil(closed$),
+                                 // tslint:disable-next-line:deprecation
+                                 filter(e => e.which === Key.Escape));
+
+
+        // we have to pre-calculate 'shouldCloseOnClick' on 'mousedown',
+        // because on 'click' DOM nodes might be detached
+        const mouseDowns$ =
+            fromEvent<MouseEvent>(this._document, 'mousedown').pipe(map(shouldCloseOnClick), takeUntil(closed$));
+
+        const outsideClicks$ =
+            fromEvent<MouseEvent>(this._document, 'click')
+                .pipe(withLatestFrom(mouseDowns$), filter(([_, shouldClose]) => shouldClose), takeUntil(closed$));
+
+
+        race<Event>([escapes$, outsideClicks$]).subscribe(() => this._ngZone.run(close));
+      });
+    }
+  }
+}


### PR DESCRIPTION
The datepicker, dropdown, popover, tooltip and typeahead components share
the autoclose code.

The typeahead no longer registers a listener on the `document:click` event until the dropdown is open.

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
