### PR TITLE
feat(datepicker): add $implicit property for day template context

### DIFF
--- a/demo/src/app/components/datepicker/demos/customday/datepicker-customday.html
+++ b/demo/src/app/components/datepicker/demos/customday/datepicker-customday.html
@@ -12,7 +12,7 @@
   </div>
 </form>
 
-<ng-template #customDay let-date="date" let-currentMonth="currentMonth" let-selected="selected" let-disabled="disabled" let-focused="focused">
+<ng-template #customDay let-date let-currentMonth="currentMonth" let-selected="selected" let-disabled="disabled" let-focused="focused">
   <span class="custom-day" [class.weekend]="isWeekend(date)" [class.focused]="focused"
         [class.bg-primary]="selected" [class.hidden]="date.month !== currentMonth" [class.text-muted]="disabled">
     {{ date.day }}

--- a/demo/src/app/components/datepicker/demos/range/datepicker-range.html
+++ b/demo/src/app/components/datepicker/demos/range/datepicker-range.html
@@ -1,9 +1,9 @@
 <p>Example of the range selection</p>
 
-<ngb-datepicker #dp (select)="onDateSelection($event)" [displayMonths]="2" [dayTemplate]="t">
+<ngb-datepicker #dp (select)="onDateSelection($event)" [displayMonths]="2" [dayTemplate]="t" outsideDays="hidden">
 </ngb-datepicker>
 
-<ng-template #t let-date="date" let-focused="focused">
+<ng-template #t let-date let-focused="focused">
   <span class="custom-day"
         [class.focused]="focused"
         [class.range]="isRange(date)"

--- a/demo/src/app/components/datepicker/overview/datepicker-overview.component.html
+++ b/demo/src/app/components/datepicker/overview/datepicker-overview.component.html
@@ -209,6 +209,13 @@
   </p>
 
   <ngbd-code lang="html" [code]="snippets.dayTemplate"></ngbd-code>
+
+  <ngb-alert class="mt-3" [dismissible]="false">
+    Note that before v3.3.0 there is no <code>$implicit</code> template property and you have to specify
+    <code>let-date="date"</code> in the template.
+    See <a href="https://angular.io/api/common/NgTemplateOutlet#example">$implicit example</a> in Angular documentation.
+  </ngb-alert>
+
 </ngbd-overview-section>
 
 

--- a/demo/src/app/components/datepicker/overview/datepicker-overview.component.ts
+++ b/demo/src/app/components/datepicker/overview/datepicker-overview.component.ts
@@ -68,7 +68,7 @@ export abstract class NgbDateParserFormatter {
 providers: [{provide: NgbDateParserFormatter, useClass: YourOwnParserFormatter}]
 `,
     dayTemplate: `
-<ng-template #t let-date="date">
+<ng-template #t let-date>
 	{{ date.day }}
 </ng-template>
 

--- a/demo/src/app/components/datepicker/overview/demo/datepicker-overview-demo.component.ts
+++ b/demo/src/app/components/datepicker/overview/demo/datepicker-overview-demo.component.ts
@@ -15,9 +15,7 @@ import {NgbCalendar, NgbDate, NgbDateNativeAdapter} from '@ng-bootstrap/ng-boots
       </p>
     </div>
 
-    <ng-template #dayTemplate let-date="date" let-focused="focused"
-                 let-currentMonth="currentMonth" let-disabled="disabled">
-
+    <ng-template #dayTemplate let-date>
       <span class="custom-day" [ngbTooltip]="getTooltip(date)" container="body"
             [class.holiday]="!!isHoliday(date)"
             [class.weekend]="isWeekend(date)"

--- a/src/datepicker/datepicker-day-template-context.ts
+++ b/src/datepicker/datepicker-day-template-context.ts
@@ -4,6 +4,14 @@ import {NgbDate} from './ngb-date';
  */
 export interface DayTemplateContext {
   /**
+   * Date that corresponds to the template. Same as 'date' property.
+   * Can be used for convenience as a default template key, ex. 'let-d')
+   *
+   * @since 3.3.0
+   */
+  $implicit: NgbDate;
+
+  /**
    * Month currently displayed by the datepicker
    */
   currentMonth: number;

--- a/src/datepicker/datepicker-month-view.spec.ts
+++ b/src/datepicker/datepicker-month-view.spec.ts
@@ -76,6 +76,14 @@ describe('ngb-datepicker-month-view', () => {
     expectDates(fixture.nativeElement, ['', '1', '2', '3', '4', '']);
   });
 
+  it('should use "date" as an implicit value for the template', () => {
+    const fixture = createTestComponent(`
+        <ng-template #tpl let-d>{{ d.day }}</ng-template>
+        <ngb-datepicker-month-view [month]="month" [dayTemplate]="tpl"></ngb-datepicker-month-view>
+      `);
+    expectDates(fixture.nativeElement, ['', '1', '2', '3', '4', '']);
+  });
+
   it('should send date selection events', () => {
     const fixture = createTestComponent(`
         <ng-template #tpl let-date="date">{{ date.day }}</ng-template>
@@ -174,14 +182,28 @@ class TestComponent {
         days: [
           {
             date: new NgbDate(2016, 7, 4),
-            context: {currentMonth: 8, date: new NgbDate(2016, 7, 4), disabled: false, focused: false, selected: false},
+            context: {
+              currentMonth: 8,
+              $implicit: new NgbDate(2016, 7, 4),
+              date: new NgbDate(2016, 7, 4),
+              disabled: false,
+              focused: false,
+              selected: false
+            },
             tabindex: -1,
             ariaLabel: 'Monday',
             hidden: true
           },
           {
             date: new NgbDate(2016, 8, 1),
-            context: {currentMonth: 8, date: new NgbDate(2016, 8, 1), disabled: false, focused: false, selected: false},
+            context: {
+              currentMonth: 8,
+              $implicit: new NgbDate(2016, 8, 1),
+              date: new NgbDate(2016, 8, 1),
+              disabled: false,
+              focused: false,
+              selected: false
+            },
             tabindex: -1,
             ariaLabel: 'Monday',
             hidden: false
@@ -195,14 +217,28 @@ class TestComponent {
         days: [
           {
             date: new NgbDate(2016, 8, 2),
-            context: {currentMonth: 8, date: new NgbDate(2016, 8, 2), disabled: true, focused: false, selected: false},
+            context: {
+              currentMonth: 8,
+              $implicit: new NgbDate(2016, 8, 2),
+              date: new NgbDate(2016, 8, 2),
+              disabled: true,
+              focused: false,
+              selected: false
+            },
             tabindex: -1,
             ariaLabel: 'Friday',
             hidden: false
           },
           {
             date: new NgbDate(2016, 8, 3),
-            context: {currentMonth: 8, date: new NgbDate(2016, 8, 3), disabled: false, focused: false, selected: false},
+            context: {
+              currentMonth: 8,
+              $implicit: new NgbDate(2016, 8, 3),
+              date: new NgbDate(2016, 8, 3),
+              disabled: false,
+              focused: false,
+              selected: false
+            },
             tabindex: -1,
             ariaLabel: 'Saturday',
             hidden: false
@@ -216,14 +252,28 @@ class TestComponent {
         days: [
           {
             date: new NgbDate(2016, 8, 4),
-            context: {currentMonth: 8, date: new NgbDate(2016, 8, 4), disabled: false, focused: false, selected: false},
+            context: {
+              currentMonth: 8,
+              $implicit: new NgbDate(2016, 8, 4),
+              date: new NgbDate(2016, 8, 4),
+              disabled: false,
+              focused: false,
+              selected: false
+            },
             tabindex: -1,
             ariaLabel: 'Sunday',
             hidden: false
           },
           {
             date: new NgbDate(2016, 9, 1),
-            context: {currentMonth: 8, date: new NgbDate(2016, 9, 1), disabled: false, focused: false, selected: false},
+            context: {
+              currentMonth: 8,
+              $implicit: new NgbDate(2016, 9, 1),
+              date: new NgbDate(2016, 9, 1),
+              disabled: false,
+              focused: false,
+              selected: false
+            },
             tabindex: -1,
             ariaLabel: 'Saturday',
             hidden: true
@@ -237,14 +287,28 @@ class TestComponent {
         days: [
           {
             date: new NgbDate(2016, 9, 2),
-            context: {currentMonth: 8, date: new NgbDate(2016, 9, 2), disabled: false, focused: false, selected: false},
+            context: {
+              currentMonth: 8,
+              $implicit: new NgbDate(2016, 9, 2),
+              date: new NgbDate(2016, 9, 2),
+              disabled: false,
+              focused: false,
+              selected: false
+            },
             tabindex: -1,
             ariaLabel: 'Sunday',
             hidden: true
           },
           {
             date: new NgbDate(2016, 9, 3),
-            context: {currentMonth: 8, date: new NgbDate(2016, 9, 3), disabled: false, focused: false, selected: false},
+            context: {
+              currentMonth: 8,
+              $implicit: new NgbDate(2016, 9, 3),
+              date: new NgbDate(2016, 9, 3),
+              disabled: false,
+              focused: false,
+              selected: false
+            },
             tabindex: -1,
             ariaLabel: 'Monday',
             hidden: true

--- a/src/datepicker/datepicker-service.spec.ts
+++ b/src/datepicker/datepicker-service.spec.ts
@@ -1282,6 +1282,11 @@ describe('ngb-datepicker-service', () => {
       expect(getDayCtx(1).date).toEqual(new NgbDate(2017, 9, 26));
     });
 
+    it(`should generate date as $implicit value for day template`, () => {
+      service.focus(new NgbDate(2017, 5, 1));
+      expect(getDayCtx(0).$implicit).toEqual(new NgbDate(2017, 5, 1));
+    });
+
     it(`should generate 'currentMonth' for day template`, () => {
       service.focus(new NgbDate(2017, 5, 1));
       expect(getDayCtx(0).currentMonth).toBe(5);

--- a/src/datepicker/datepicker-tools.ts
+++ b/src/datepicker/datepicker-tools.ts
@@ -175,6 +175,7 @@ export function buildMonth(
       }
       dayObject.date = newDate;
       dayObject.context = Object.assign(dayObject.context || {}, {
+        $implicit: newDate,
         date: newDate,
         data: contextUserData,
         currentMonth: month.number, disabled,


### PR DESCRIPTION
Allows using $implicit shortcut for the day template context (previous `let-d='date'` also works):

```html
<ng-template #t let-d> {{ d.day }}</ng-template>
<ngb-datepicker [dayTemplate]="t"></ngb-datepicker>
```

cc @benouat 