### PR TITLE
fix(datepicker): convert years 0-99 correctly with native adapters

### DIFF
--- a/src/datepicker/adapters/ngb-date-native-adapter.spec.ts
+++ b/src/datepicker/adapters/ngb-date-native-adapter.spec.ts
@@ -15,6 +15,7 @@ describe('ngb-date-native model adapter', () => {
       expect(adapter.fromModel(<any>2)).toBeNull();
       expect(adapter.fromModel(<any>{})).toBeNull();
       expect(adapter.fromModel(<any>{year: 2017, month: 10})).toBeNull();
+      expect(adapter.fromModel(new Date('boom'))).toBeNull();
     });
 
     it('should convert valid date',
@@ -35,6 +36,22 @@ describe('ngb-date-native model adapter', () => {
 
     it('should convert a valid date',
        () => { expect(adapter.toModel({year: 2016, month: 10, day: 15})).toEqual(new Date(2016, 9, 15, 12)); });
+
+    it('should convert years between 0 and 99 correctly', () => {
+
+      function jsDate(jsYear: number, jsMonth: number, jsDay: number): Date {
+        const date = new Date(jsYear, jsMonth, jsDay, 12);
+        if (jsYear >= 0 && jsYear <= 99) {
+          date.setFullYear(jsYear);
+        }
+        return date;
+      }
+
+      expect(adapter.toModel({year: 0, month: 1, day: 1})).toEqual(jsDate(0, 0, 1));
+      expect(adapter.toModel({year: 1, month: 1, day: 1})).toEqual(jsDate(1, 0, 1));
+      expect(adapter.toModel({year: 99, month: 1, day: 1})).toEqual(jsDate(99, 0, 1));
+      expect(adapter.toModel({year: 1900, month: 1, day: 1})).toEqual(jsDate(1900, 0, 1));
+    });
   });
 
 });

--- a/src/datepicker/adapters/ngb-date-native-adapter.ts
+++ b/src/datepicker/adapters/ngb-date-native-adapter.ts
@@ -1,14 +1,26 @@
 import {Injectable} from '@angular/core';
 import {NgbDateAdapter} from './ngb-date-adapter';
 import {NgbDateStruct} from '../ngb-date-struct';
+import {isNumber} from 'util';
 
 @Injectable()
 export class NgbDateNativeAdapter extends NgbDateAdapter<Date> {
   fromModel(date: Date): NgbDateStruct {
-    return (date instanceof Date) ? {year: date.getFullYear(), month: date.getMonth() + 1, day: date.getDate()} : null;
+    return (date instanceof Date && !isNaN(date.getTime())) ? this._fromNativeDate(date) : null;
   }
 
   toModel(date: NgbDateStruct): Date {
-    return date && date.year && date.month ? new Date(date.year, date.month - 1, date.day, 12) : null;
+    return date && isNumber(date.year) && isNumber(date.month) && isNumber(date.day) ? this._toNativeDate(date) : null;
+  }
+
+  protected _fromNativeDate(date: Date): NgbDateStruct {
+    return {year: date.getFullYear(), month: date.getMonth() + 1, day: date.getDate()};
+  }
+
+  protected _toNativeDate(date: NgbDateStruct): Date {
+    const jsDate = new Date(date.year, date.month - 1, date.day, 12);
+    // avoid 30 -> 1930 conversion
+    jsDate.setFullYear(date.year);
+    return jsDate;
   }
 }

--- a/src/datepicker/adapters/ngb-date-native-utc-adapter.spec.ts
+++ b/src/datepicker/adapters/ngb-date-native-utc-adapter.spec.ts
@@ -15,6 +15,7 @@ describe('ngb-date-native-utc model adapter', () => {
       expect(adapter.fromModel(<any>2)).toBeNull();
       expect(adapter.fromModel(<any>{})).toBeNull();
       expect(adapter.fromModel(<any>{year: 2017, month: 10})).toBeNull();
+      expect(adapter.fromModel(new Date('boom'))).toBeNull();
     });
 
     it('should convert valid date',
@@ -35,6 +36,22 @@ describe('ngb-date-native-utc model adapter', () => {
 
     it('should convert a valid date',
        () => { expect(adapter.toModel({year: 2016, month: 10, day: 15})).toEqual(new Date(Date.UTC(2016, 9, 15))); });
+
+    it('should convert years between 0 and 99 correctly', () => {
+
+      function jsDate(jsYear: number, jsMonth: number, jsDay: number): Date {
+        const date = new Date(Date.UTC(jsYear, jsMonth, jsDay));
+        if (jsYear >= 0 && jsYear <= 99) {
+          date.setUTCFullYear(jsYear);
+        }
+        return date;
+      }
+
+      expect(adapter.toModel({year: 0, month: 1, day: 1})).toEqual(jsDate(0, 0, 1));
+      expect(adapter.toModel({year: 1, month: 1, day: 1})).toEqual(jsDate(1, 0, 1));
+      expect(adapter.toModel({year: 99, month: 1, day: 1})).toEqual(jsDate(99, 0, 1));
+      expect(adapter.toModel({year: 1900, month: 1, day: 1})).toEqual(jsDate(1900, 0, 1));
+    });
   });
 
 });

--- a/src/datepicker/adapters/ngb-date-native-utc-adapter.ts
+++ b/src/datepicker/adapters/ngb-date-native-utc-adapter.ts
@@ -1,19 +1,20 @@
 import {Injectable} from '@angular/core';
-import {NgbDateAdapter} from './ngb-date-adapter';
 import {NgbDateStruct} from '../ngb-date-struct';
+import {NgbDateNativeAdapter} from './ngb-date-native-adapter';
 
 /**
  * @since 3.2.0
  */
 @Injectable()
-export class NgbDateNativeUTCAdapter extends NgbDateAdapter<Date> {
-  fromModel(date: Date): NgbDateStruct {
-    return (date instanceof Date) ?
-        {year: date.getUTCFullYear(), month: date.getUTCMonth() + 1, day: date.getUTCDate()} :
-        null;
+export class NgbDateNativeUTCAdapter extends NgbDateNativeAdapter {
+  protected _fromNativeDate(date: Date): NgbDateStruct {
+    return {year: date.getUTCFullYear(), month: date.getUTCMonth() + 1, day: date.getUTCDate()};
   }
 
-  toModel(date: NgbDateStruct): Date {
-    return date && date.year && date.month ? new Date(Date.UTC(date.year, date.month - 1, date.day)) : null;
+  protected _toNativeDate(date: NgbDateStruct): Date {
+    const jsDate = new Date(Date.UTC(date.year, date.month - 1, date.day));
+    // avoid 30 -> 1930 conversion
+    jsDate.setUTCFullYear(date.year);
+    return jsDate;
   }
 }


### PR DESCRIPTION
Fixes #2731
