### PR TITLE
chore(demo): open in github buttons same as stackblitz one

### DIFF
--- a/demo/src/app/components/shared/api-docs/api-docs-class.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs-class.component.html
@@ -12,13 +12,15 @@
       {{apiDocs.className}}<span class="text-muted font-weight-light" *ngIf="apiDocs.typeParameter">&lt;{{apiDocs.typeParameter}}&gt;</span>
     </span>
     <a
-      class="github-link"
+      role="button"
+      target="_blank"
+      class="github btn btn-light"
       (click)="trackSourceClick()"
       href="https://github.com/ng-bootstrap/ng-bootstrap/tree/master/{{apiDocs.fileName}}"
-      target="_blank"
-      title="Link to Github: {{apiDocs.className}}"
+      title="Open '{{apiDocs.className}}' on Github"
     >
-      <img src="img/github.svg" alt="Link to Github {{apiDocs.className}}"/>
+      <img src="img/github.svg" class="github-icon" alt="Open '{{apiDocs.className}}' on Github"/>
+      Github
     </a>
   </h3>
   <ngbd-api-docs-badge [type]="apiDocs.type" [deprecated]="apiDocs.deprecated" [since]="apiDocs.since"></ngbd-api-docs-badge>

--- a/demo/src/app/components/shared/api-docs/api-docs-config.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs-config.component.html
@@ -13,12 +13,15 @@
       {{apiDocs.className}}<span class="text-muted font-weight-light" *ngIf="apiDocs.typeParameter">&lt;{{apiDocs.typeParameter}}&gt;</span>
     </span>
     <a
-      class="github-link"
-      href="https://github.com/ng-bootstrap/ng-bootstrap/tree/master/{{apiDocs.fileName}}"
+      role="button"
       target="_blank"
-      title="Link to Github: {{apiDocs.className}}"
+      class="github btn btn-light"
+      (click)="trackSourceClick()"
+      href="https://github.com/ng-bootstrap/ng-bootstrap/tree/master/{{apiDocs.fileName}}"
+      title="Open '{{apiDocs.className}}' on Github"
     >
-      <img src="img/github.svg" alt="Link to Github {{apiDocs.className}}"/>
+      <img src="img/github.svg" class="github-icon" alt="Open '{{apiDocs.className}}' on Github"/>
+      Github
     </a>
   </h3>
   <ngbd-api-docs-badge type="Configuration" [deprecated]="apiDocs.deprecated" [since]="apiDocs.since"></ngbd-api-docs-badge>

--- a/demo/src/app/components/shared/api-docs/api-docs.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs.component.html
@@ -11,13 +11,15 @@
       {{apiDocs.className}}<span class="text-muted font-weight-light" *ngIf="apiDocs.typeParameter">&lt;{{apiDocs.typeParameter}}&gt;</span>
     </span>
     <a
-      class="github-link"
+      role="button"
+      target="_blank"
+      class="github btn btn-light"
       (click)="trackSourceClick()"
       href="https://github.com/ng-bootstrap/ng-bootstrap/tree/master/{{apiDocs.fileName}}"
-      target="_blank"
-      title="Link to Github: {{apiDocs.className}}"
+      title="Open '{{apiDocs.className}}' on Github"
     >
-      <img src="img/github.svg" alt="Link to Github {{apiDocs.className}}"/>
+      <img src="img/github.svg" class="github-icon" alt="Open '{{apiDocs.className}}' on Github"/>
+      Github
     </a>
   </h3>
   <ngbd-api-docs-badge [type]="apiDocs.type" [deprecated]="apiDocs.deprecated" [since]="apiDocs.since"></ngbd-api-docs-badge>

--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -185,16 +185,24 @@ div.api-doc-component, .overview {
 
   h2,
   h3 {
-    .github-link {
-      transition: opacity 0.5s;
-      opacity: 0.3;
-      margin-left: .5rem;
+    display: flex;
+
+    > span {
+      flex-grow: 1;
+    }
+
+    .github {
+      display: flex;
+      align-items: center;
+      align-self: center;
+
+      .github-icon {
+        height: 1.2rem;
+        margin-right: 0.5rem;
+      }
     }
 
     &:hover {
-      .github-link {
-        opacity: 1;
-      }
       & > .title-fragment {
         opacity: 1;
       }


### PR DESCRIPTION
Simple consistency PR to align Open in Github buttons with latest refactor we did in #2730 for Stackblitz ones.

<img width="624" alt="image" src="https://user-images.githubusercontent.com/1152740/45952705-22263200-c008-11e8-88a6-c541ec2d50cf.png">
