### PR TITLE
fix(accordion): don't submit HTML form when toggling panels

### DIFF
--- a/src/accordion/accordion.spec.ts
+++ b/src/accordion/accordion.spec.ts
@@ -22,7 +22,7 @@ function getPanelsTitle(element: HTMLElement): HTMLButtonElement[] {
 }
 
 function getButton(element: HTMLElement, index: number): HTMLButtonElement {
-  return <HTMLButtonElement>element.querySelectorAll('button')[index];
+  return <HTMLButtonElement>element.querySelectorAll('button[type="button"]')[index];
 }
 
 function expectOpenPanels(nativeEl: HTMLElement, openPanelsDef: boolean[]) {

--- a/src/accordion/accordion.ts
+++ b/src/accordion/accordion.ts
@@ -116,7 +116,8 @@ export interface NgbPanelChangeEvent {
       <div class="card">
         <div role="tab" id="{{panel.id}}-header" [class]="'card-header ' + (panel.type ? 'bg-'+panel.type: type ? 'bg-'+type : '')">
           <h5 class="mb-0">
-            <button class="btn btn-link" (click)="!!toggle(panel.id)" [disabled]="panel.disabled" [class.collapsed]="!panel.isOpen"
+            <button type="button" class="btn btn-link"
+              (click)="toggle(panel.id)" [disabled]="panel.disabled" [class.collapsed]="!panel.isOpen"
               [attr.aria-expanded]="panel.isOpen" [attr.aria-controls]="panel.id">
               {{panel.title}}<ng-template [ngTemplateOutlet]="panel.titleTpl?.templateRef"></ng-template>
             </button>


### PR DESCRIPTION
Fixes #2760

I've also checked all other widgets and all seems fine - only accordion was missing `type="button"`