### PR TITLE
test(datepicker): add e2e tests for autoClose

### DIFF
--- a/e2e-app/e2e/src/datepicker/datepicker-autoclose.e2e-spec.ts
+++ b/e2e-app/e2e/src/datepicker/datepicker-autoclose.e2e-spec.ts
@@ -1,0 +1,87 @@
+import {browser, Key} from 'protractor';
+import {DatepickerAutoClosePage} from './datepicker-autoclose.po';
+import {sendKey} from '../tools';
+
+describe('Datepicker Autoclose', () => {
+  let page: DatepickerAutoClosePage;
+
+  beforeAll(async () => {
+    page = new DatepickerAutoClosePage();
+    await browser.get('#/datepicker/autoclose');
+  });
+
+  beforeEach(async () => await page.reset());
+
+  it(`should work when autoClose === true`, async () => {
+    await page.selectAutoClose('true');
+
+    // escape
+    await page.openDatepicker();
+    await sendKey(Key.ESCAPE);
+    expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on ESC`);
+
+    // outside click
+    await page.openDatepicker();
+    await page.clickOutside();
+    expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on outside click`);
+
+    // date selection
+    await page.openDatepicker();
+    await page.getDayElement(new Date()).click();
+    expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on date selection`);
+  });
+
+  it(`should work when autoClose === false`, async () => {
+    await page.selectAutoClose('false');
+
+    // escape
+    await page.openDatepicker();
+    await sendKey(Key.ESCAPE);
+    expect(await page.getDatepicker().isPresent()).toBeTruthy(`Datepicker should NOT be closed on ESC`);
+
+    // outside click
+    await page.clickOutside();
+    expect(await page.getDatepicker().isPresent()).toBeTruthy(`Datepicker should NOT be closed on outside click`);
+
+    // date selection
+    await page.getDayElement(new Date()).click();
+    expect(await page.getDatepicker().isPresent()).toBeTruthy(`Datepicker should NOT be closed on date selection`);
+  });
+
+  it(`should work when autoClose === 'outside'`, async () => {
+    await page.selectAutoClose('outside');
+
+    // escape
+    await page.openDatepicker();
+    await sendKey(Key.ESCAPE);
+    expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on ESC`);
+
+    // outside click
+    await page.openDatepicker();
+    await page.clickOutside();
+    expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on outside click`);
+
+    // date selection
+    await page.openDatepicker();
+    await page.getDayElement(new Date()).click();
+    expect(await page.getDatepicker().isPresent()).toBeTruthy(`Datepicker should NOT be closed on date selection`);
+  });
+
+  it(`should work when autoClose === 'inside'`, async () => {
+    await page.selectAutoClose('inside');
+
+    // escape
+    await page.openDatepicker();
+    await sendKey(Key.ESCAPE);
+    expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on ESC`);
+
+    // outside click
+    await page.openDatepicker();
+    await page.clickOutside();
+    expect(await page.getDatepicker().isPresent()).toBeTruthy(`Datepicker should NOT be closed on outside click`);
+
+    // date selection
+    await page.getDayElement(new Date()).click();
+    expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on date selection`);
+  });
+});

--- a/e2e-app/e2e/src/datepicker/datepicker-autoclose.po.ts
+++ b/e2e-app/e2e/src/datepicker/datepicker-autoclose.po.ts
@@ -1,0 +1,33 @@
+import {$} from 'protractor';
+import {expectFocused} from '../tools';
+import {DatepickerPage} from './datepicker.po';
+
+export class DatepickerAutoClosePage extends DatepickerPage {
+  async clearDate() {
+    await $('#clearDate').click();
+  }
+
+  async close() {
+    await $('#close').click();
+  }
+
+  async clickOutside() {
+    await $('#outside-button').click();
+  }
+
+  async selectAutoClose(type: string) {
+    await $('#autoclose-dropdown').click();
+    await $(`#autoclose-${type}`).click();
+  }
+
+  async reset() {
+    await this.close();
+    await this.clearDate();
+    const body = $('body');
+    await body.click();
+
+    await expectFocused(body, `Nothing should be focused initially`);
+    expect(await this.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed initially`);
+    expect(await this.getDatepickerInput().getAttribute('value')).toBe('', `Datepicker input should be cleared initially`);
+  }
+}

--- a/e2e-app/e2e/src/datepicker/datepicker-focus.e2e-spec.ts
+++ b/e2e-app/e2e/src/datepicker/datepicker-focus.e2e-spec.ts
@@ -1,6 +1,6 @@
-import {DatepickerPage} from './datepicker.po';
 import {$, browser, Key} from 'protractor';
 import {expectFocused, sendKey} from '../tools';
+import {DatepickerFocusPage} from './datepicker-focus.po';
 
 const getFirstOfMonth = (date: Date) => {
   const first = new Date(date);
@@ -16,10 +16,10 @@ const getLastOfMonth = (date: Date) => {
 };
 
 describe('Datepicker', () => {
-  let page: DatepickerPage;
+  let page: DatepickerFocusPage;
 
   beforeAll(async () => {
-    page = new DatepickerPage();
+    page = new DatepickerFocusPage();
     await browser.get('#/datepicker/focus');
   });
 

--- a/e2e-app/e2e/src/datepicker/datepicker-focus.po.ts
+++ b/e2e-app/e2e/src/datepicker/datepicker-focus.po.ts
@@ -1,0 +1,24 @@
+import {$, Key} from 'protractor';
+import {expectFocused} from '../tools';
+import {DatepickerPage} from './datepicker.po';
+
+export class DatepickerFocusPage extends DatepickerPage {
+  async clearDate() {
+    await $('#clearDate').click();
+  }
+
+  async preSelectDate() {
+    await $('#selectDate').click();
+  }
+
+  async reset() {
+    await this.clearDate();
+    const body = $('body');
+    await body.click();
+    await body.sendKeys(Key.ESCAPE);
+
+    await expectFocused(body, `Nothing should be focused initially`);
+    expect(await this.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed initially`);
+    expect(await this.getDatepickerInput().getAttribute('value')).toBe('', `Datepicker input should be cleared initially`);
+  }
+}

--- a/e2e-app/e2e/src/datepicker/datepicker.po.ts
+++ b/e2e-app/e2e/src/datepicker/datepicker.po.ts
@@ -1,8 +1,6 @@
-import {$, Key} from 'protractor';
-import {expectFocused} from '../tools';
+import {$} from 'protractor';
 
-export class DatepickerPage {
-
+export abstract class DatepickerPage {
   getDatepicker(selector = 'ngb-datepicker') {
     return $(selector);
   }
@@ -15,16 +13,8 @@ export class DatepickerPage {
     return $('#toggle');
   }
 
-  getClearDateButton() {
-    return $('#clearDate');
-  }
-
-  getSelectDateButton() {
-    return $('#selectDate');
-  }
-
   getDayElement(date: Date) {
-    const ariaLabel = date.toLocaleString('en', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' });
+    const ariaLabel = date.toLocaleString('en', {weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'});
     return this.getDatepicker().$(`div.ngb-dp-day[aria-label="${ariaLabel}"]`);
   }
 
@@ -48,27 +38,8 @@ export class DatepickerPage {
     return this.getDatepicker().$(`button[aria-label="Next month"]`);
   }
 
-  async clearDate() {
-    await this.getClearDateButton().click();
-  }
-
-  async preSelectDate() {
-    await this.getSelectDateButton().click();
-  }
-
   async openDatepicker() {
     await this.getToggle().click();
     expect(await this.getDatepicker().isPresent()).toBeTruthy(`Datepicker should be present on the page`);
-  }
-
-  async reset() {
-    await this.clearDate();
-    const body = $('body');
-    await body.click();
-    await body.sendKeys(Key.ESCAPE);
-
-    await expectFocused(body, `Nothing should be focused initially`);
-    expect(await this.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed initially`);
-    expect(await this.getDatepickerInput().getAttribute('value')).toBe('', `Datepicker input should be cleared initially`);
   }
 }

--- a/e2e-app/src/app/app.module.ts
+++ b/e2e-app/src/app/app.module.ts
@@ -7,12 +7,14 @@ import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 import {routing} from './app.routing';
 import {AppComponent} from './app.component';
 
+import {DatepickerAutoCloseComponent} from './datepicker/autoclose/datepicker-autoclose.component';
 import {DatepickerFocusComponent} from './datepicker/focus/datepicker-focus.component';
 import {ModalFocustrapComponent} from './modal/focustrap/modal-focustrap.component';
 
 @NgModule({
   declarations: [
     AppComponent,
+    DatepickerAutoCloseComponent,
     DatepickerFocusComponent,
     ModalFocustrapComponent
   ],

--- a/e2e-app/src/app/app.routing.ts
+++ b/e2e-app/src/app/app.routing.ts
@@ -2,12 +2,14 @@ import {ModuleWithProviders} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router';
 import {DatepickerFocusComponent} from './datepicker/focus/datepicker-focus.component';
 import {ModalFocustrapComponent} from './modal/focustrap/modal-focustrap.component';
+import {DatepickerAutoCloseComponent} from './datepicker/autoclose/datepicker-autoclose.component';
 
 const routes: Routes = [
   {
     path: 'datepicker',
     children: [
-      {path: 'focus', component: DatepickerFocusComponent}
+      {path: 'focus', component: DatepickerFocusComponent},
+      {path: 'autoclose', component: DatepickerAutoCloseComponent}
     ]
   },
   {

--- a/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.component.html
+++ b/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.component.html
@@ -1,0 +1,28 @@
+<h3>Datepicker autoclose tests</h3>
+
+<form id="default">
+  <div class="form-group form-inline">
+
+    <div class="input-group">
+      <input class="form-control" name="dp" placeholder="yyyy-mm-dd" #d="ngbDatepicker"
+             ngbDatepicker [(ngModel)]="model" [autoClose]="autoClose" >
+      <div class="input-group-append">
+        <button class="btn btn-outline-secondary" type="button" id="toggle" (click)="d.toggle()">Toggle</button>
+        <button class="btn btn-outline-secondary" type="button" id="clearDate" (click)="model = null">Clear</button>
+        <button class="btn btn-outline-secondary" type="button" id="close" (click)="d.close()">Close</button>
+      </div>
+    </div>
+
+    <div ngbDropdown class="d-inline-block ml-3">
+      <button class="btn btn-outline-secondary" id="autoclose-dropdown" ngbDropdownToggle>Choose Autoclose</button>
+      <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
+        <button class="dropdown-item" id="autoclose-true" (click)="autoClose = true">True</button>
+        <button class="dropdown-item" id="autoclose-false" (click)="autoClose = false">False</button>
+        <button class="dropdown-item" id="autoclose-outside" (click)="autoClose = 'outside'">'Outside'</button>
+        <button class="dropdown-item" id="autoclose-inside" (click)="autoClose = 'inside'">'Inside'</button>
+      </div>
+    </div>
+
+    <button class="btn btn-outline-secondary ml-1" id="outside-button">Outside button</button>
+  </div>
+</form>

--- a/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.component.ts
+++ b/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.component.ts
@@ -1,0 +1,9 @@
+import {Component} from '@angular/core';
+
+@Component({
+  templateUrl: './datepicker-autoclose.component.html'
+})
+export class DatepickerAutoCloseComponent {
+  model = null;
+  autoClose: boolean | 'inside' | 'outside' = true;
+}


### PR DESCRIPTION
Part of #2463 

Adds autoclose tests for the datepicker to simplify unit testing with request animation frame
