### PR TITLE
corrects a typo in the documentation for the date selector's minDate/maxDate

### DIFF
--- a/demo/src/app/components/datepicker/overview/datepicker-overview.component.ts
+++ b/demo/src/app/components/datepicker/overview/datepicker-overview.component.ts
@@ -86,8 +86,8 @@ providers: [{provide: NgbDateParserFormatter, useClass: YourOwnParserFormatter}]
 const isDisabled = (date: NgbDateStruct, current: {month: number}) => day.date === 13;
 `,
   disablingHTML: `
-<ngb-datepicker [minDate]="{year: 2010, month: 1, day, 1}"
-                [maxDate]="{year: 2048, month 12, day, 31}"
+<ngb-datepicker [minDate]="{year: 2010, month: 1, day: 1}"
+                [maxDate]="{year: 2048, month: 12, day: 31}"
                 [markDisabled]="isDisabled">
 </ngb-datepicker>
 `,


### PR DESCRIPTION
Just a little change to the documentation: the page here: https://ng-bootstrap.github.io/#/components/datepicker/overview has some invalid json in the minDate and maxDate boxes. This change should fix it