### PR TITLE
refactor(datepicker): relax NgbDate comparison API to use NgbDateStruct

### DIFF
--- a/demo/src/app/components/datepicker/overview/datepicker-overview.component.html
+++ b/demo/src/app/components/datepicker/overview/datepicker-overview.component.html
@@ -107,18 +107,30 @@
 <!-- DATE MODEL-->
 <ngbd-overview-section [section]="sections['date-model']">
   <p>
-    Datepicker uses <code>NgbDateStruct</code> as a model and not the native
-    <code>Date</code> object. It's a simple data structure with 3 fields.
-    Also note that months start with 1 (as in ISO 8601).
+    Datepicker uses <a routerLink="../api" fragment="NgbDateStruct"><code>NgbDateStruct</code></a>
+    interface as a model and not the native <code>Date</code> object.
+    It's a simple data structure with 3 fields, but note that months start with 1 (as in ISO 8601).
   </p>
 
   <ngbd-code lang="typescript" [code]="snippets.dateStruct"></ngbd-code>
 
   <p>
-    You can tell datepicker to use the native javascript date adapter (bundled with ng-bootstrap) as in the
+    All datepicker APIs will consume <code>NgbDateStruct</code>, but will produce it's implementation
+    class <a routerLink="../api" fragment="NgbDate"><code>NgbDate</code></a> when returning dates to you.
+    It offers additional methods for easy date comparison, and using it together with
+    <a routerLink="../api" fragment="NgbCalendar"><code>NgbCalendar</code></a> will cover most
+    of the date-related calculations.
+  </p>
+
+  <ngbd-code lang="typescript" [code]="snippets.date"></ngbd-code>
+
+  <h4>Adapters</h4>
+
+  <p>
+    You can also tell datepicker to use the native javascript date adapter (bundled with ng-bootstrap) as in the
     <a routerLink="../examples" fragment="adapter">custom date adapter example</a>. For now
     the adapter works only for the form integration, so for instance <code>(ngModelChange)</code>
-    will return a native date object. All other APIs continue to use <code>NgbDateStruct</code>
+    will return a native date object. All other APIs continue to use <code>NgbDateStruct</code>.
   </p>
 
   <ngbd-code lang="typescript" [code]="snippets.nativeAdapter"></ngbd-code>

--- a/demo/src/app/components/datepicker/overview/datepicker-overview.component.ts
+++ b/demo/src/app/components/datepicker/overview/datepicker-overview.component.ts
@@ -41,7 +41,13 @@ export class NgbdDatepickerOverviewComponent {
 <button (click)="d.navigateTo({year: 2048, month: 1})">Goto JAN 2048</button>
 `,
     dateStruct: `
-const date: NgbDateStruct = { day: 14, month: 7, year: 1789 }; // July, 14 1789
+const date: NgbDateStruct = { year: 1789, month: 7, day: 14 }; // July, 14 1789
+`,
+date: `
+const date: NgbDate = new NgbDate(1789, 7, 14);                // July, 14 1789
+
+date.before({ year: 1789, month: 7, day: 14 });                // compare to a structure
+date.equals(NgbDate.from({ year: 1789, month: 7, day: 14 }));  // or to another date object
 `,
     nativeAdapter: `
 // native adapter is bundled with library
@@ -83,7 +89,7 @@ providers: [{provide: NgbDateParserFormatter, useClass: YourOwnParserFormatter}]
 `,
   disablingTS: `
 // disable the 13th of each month
-const isDisabled = (date: NgbDateStruct, current: {month: number}) => day.date === 13;
+const isDisabled = (date: NgbDate, current: {month: number}) => day.date === 13;
 `,
   disablingHTML: `
 <ngb-datepicker [minDate]="{year: 2010, month: 1, day: 1}"

--- a/src/datepicker/ngb-date.spec.ts
+++ b/src/datepicker/ngb-date.spec.ts
@@ -24,6 +24,8 @@ describe('ngb-date', () => {
 
     it('should return true for the same dates', () => { expect(date.equals(new NgbDate(2016, 8, 18))).toBeTruthy(); });
 
+    it('should work with structures', () => { expect(date.equals({day: 18, month: 8, year: 2016})).toBeTruthy(); });
+
     it('should return false different dates', () => {
       expect(date.equals(new NgbDate(0, 8, 18))).toBeFalsy();
       expect(date.equals(new NgbDate(2016, 0, 18))).toBeFalsy();
@@ -43,6 +45,8 @@ describe('ngb-date', () => {
       expect(date.before(null)).toBeFalsy();
       expect(date.before(undefined)).toBeFalsy();
     });
+
+    it('should work with structures', () => { expect(date.before({day: 18, month: 9, year: 2016})).toBeTruthy(); });
 
     it('should return true if current date is before the other one', () => {
       expect(date.before(new NgbDate(2016, 8, 19))).toBeTruthy();
@@ -64,6 +68,8 @@ describe('ngb-date', () => {
       expect(date.after(null)).toBeFalsy();
       expect(date.after(undefined)).toBeFalsy();
     });
+
+    it('should work with structures', () => { expect(date.after({day: 17, month: 8, year: 2016})).toBeTruthy(); });
 
     it('should return true if current date is after the other one', () => {
       expect(date.after(new NgbDate(2016, 8, 17))).toBeTruthy();

--- a/src/datepicker/ngb-date.ts
+++ b/src/datepicker/ngb-date.ts
@@ -42,14 +42,14 @@ export class NgbDate implements NgbDateStruct {
   /**
    * Checks if current date is equal to another date
    */
-  equals(other: NgbDate): boolean {
+  equals(other: NgbDateStruct): boolean {
     return other && this.year === other.year && this.month === other.month && this.day === other.day;
   }
 
   /**
    * Checks if current date is before another date
    */
-  before(other: NgbDate): boolean {
+  before(other: NgbDateStruct): boolean {
     if (!other) {
       return false;
     }
@@ -68,7 +68,7 @@ export class NgbDate implements NgbDateStruct {
   /**
    * Checks if current date is after another date
    */
-  after(other: NgbDate): boolean {
+  after(other: NgbDateStruct): boolean {
     if (!other) {
       return false;
     }


### PR DESCRIPTION
- relaxes implementation of `NgbDate` comparison methods
- updates documentation to clarify `NgbDate` vs `NgbDateStruct` differences

Don't squash, two separate commits