### PR TITLE
feat(typeahead): add e2e tests for focus

### DIFF
--- a/e2e-app/e2e/src/typeahead/typeahead-focus.e2e-spec.ts
+++ b/e2e-app/e2e/src/typeahead/typeahead-focus.e2e-spec.ts
@@ -1,0 +1,107 @@
+import { TypeaheadPage } from './typeahead.po';
+import { $, browser, Key } from 'protractor';
+import { expectFocused, sendKey } from '../tools';
+
+describe('Typeahead', () => {
+  let page: TypeaheadPage;
+
+  const expectTypeaheadFocused = async () => {
+    await expectFocused(await page.getTypeaheadInput(), `Typeahead should be focused`);
+  };
+
+  const expectDropdownOpen = async (expectedDropdownItems = 10) => {
+    expect(page.getDropdown().isPresent()).toBeTruthy(
+      `The dropdown should be open`
+    );
+
+    expect(page.getDropdownItems().count()).toBe(
+      expectedDropdownItems,
+      `Wrong number of dropdown items`
+    );
+  };
+
+  const expectDropDownClosed = async () => {
+    expect(await page.getDropdown().isPresent()).toBeFalsy(`The dropdown shouldn't be open`);
+  };
+
+  const expectTypeaheadValue = async expectedValue => {
+    expect(await page.getTypeaheadValue()).toBe(expectedValue, 'Wrong input value');
+  };
+
+  beforeAll(async () => {
+    page = new TypeaheadPage();
+    await browser.get('#/typeahead/focus');
+  });
+
+  beforeEach(async () => await page.reset());
+
+  it(`should be focused on item click`, async () => {
+    await page.getTypeaheadInput().click();
+    expectDropdownOpen();
+
+    await page.getDropdownItems().get(0).click();
+    expectTypeaheadValue('Alabama');
+    // expectTypeaheadFocused();
+  });
+
+  it(`should be open after a second click`, async () => {
+    await page.getTypeaheadInput().click();
+    expectTypeaheadFocused();
+    await page.getTypeaheadInput().click();
+    expectDropdownOpen();
+    expectTypeaheadFocused();
+  });
+
+  it(`should be close on click outside`, async () => {
+    await page.getTypeaheadInput().click();
+    await page.getInputBefore().click();
+    expectDropDownClosed();
+  });
+
+  it(`should preserve value previously selected with mouse when reopening with focus then closing without selection`, async () => {
+    const input = page.getTypeaheadInput();
+    await input.click();
+    await input.sendKeys('col');
+
+    expectDropdownOpen(2);
+    expectTypeaheadFocused();
+
+    await page.getDropdownItems().get(0).click();
+    expectTypeaheadValue('Colorado');
+    // expectTypeaheadFocused();
+
+    await page.getInputBefore().click();
+    await sendKey(Key.TAB);
+
+    expectTypeaheadFocused();
+    expectDropdownOpen(1);
+    expectTypeaheadValue('Colorado');
+
+    await sendKey(Key.ESCAPE);
+    expectTypeaheadFocused();
+    expectDropDownClosed();
+    expectTypeaheadValue('Colorado');
+  });
+
+  describe('Keyboard', () => {
+    it(`should be focused on item selection`, async () => {
+      await page.getInputBefore().click();
+      await sendKey(Key.TAB);
+      expectTypeaheadFocused();
+      expectDropdownOpen();
+
+      await sendKey(Key.ENTER);
+      expectTypeaheadValue('Alabama');
+      expectTypeaheadFocused();
+    });
+
+    it(`should select element on tab`, async () => {
+      await page.getInputBefore().click();
+      await sendKey(Key.TAB);
+      await sendKey(Key.TAB);
+      expectTypeaheadFocused();
+      expectDropDownClosed();
+      expectTypeaheadValue('Alabama');
+    });
+  });
+});

--- a/e2e-app/e2e/src/typeahead/typeahead.po.ts
+++ b/e2e-app/e2e/src/typeahead/typeahead.po.ts
@@ -1,0 +1,45 @@
+import {$, Key, browser} from 'protractor';
+import {sendKey} from '../tools';
+import {expectFocused} from '../tools';
+
+export class TypeaheadPage {
+
+  getInputBefore() {
+    return $('#first');
+  }
+
+  getTypeaheadInput() {
+    return $('#typeahead');
+  }
+
+  getDropdown() {
+    return $('ngb-typeahead-window');
+  }
+
+  getDropdownItems() {
+    return this.getDropdown().$$('button');
+  }
+
+  async clearText() {
+    const typeahead = this.getTypeaheadInput();
+    await typeahead.click();
+    await typeahead.sendKeys(Key.ESCAPE);
+    await typeahead.clear();
+  }
+
+  async getTypeaheadValue() {
+    return this.getTypeaheadInput().getAttribute('value');
+  }
+
+  async reset() {
+    await this.clearText();
+    const body = $('body');
+    await body.click();
+    await body.sendKeys(Key.ESCAPE);
+
+    await expectFocused(body, `Nothing should be focused initially`);
+    expect(await this.getDropdown().isPresent()).toBeFalsy(`Typeahead should be closed initially`);
+    expect(await this.getInputBefore().getAttribute('value')).toBe('', `Input before typeahead should be cleared initially`);
+    expect(await this.getTypeaheadValue()).toBe('', `Typeahead input should be cleared initially`);
+  }
+}

--- a/e2e-app/src/app/app.module.ts
+++ b/e2e-app/src/app/app.module.ts
@@ -11,6 +11,7 @@ import {DatepickerAutoCloseComponent} from './datepicker/autoclose/datepicker-au
 import {DatepickerFocusComponent} from './datepicker/focus/datepicker-focus.component';
 import {ModalFocustrapComponent} from './modal/focustrap/modal-focustrap.component';
 import {DropdownAutoCloseComponent} from './dropdown/autoclose/dropdown-autoclose.component';
+import {TypeaheadFocusComponent} from './typeahead/focus/typeahead-focus.component';
 
 @NgModule({
   declarations: [
@@ -18,7 +19,8 @@ import {DropdownAutoCloseComponent} from './dropdown/autoclose/dropdown-autoclos
     DatepickerAutoCloseComponent,
     DatepickerFocusComponent,
     DropdownAutoCloseComponent,
-    ModalFocustrapComponent
+    ModalFocustrapComponent,
+    TypeaheadFocusComponent
   ],
   imports: [
     BrowserModule,

--- a/e2e-app/src/app/app.routing.ts
+++ b/e2e-app/src/app/app.routing.ts
@@ -4,6 +4,7 @@ import {DatepickerFocusComponent} from './datepicker/focus/datepicker-focus.comp
 import {DatepickerAutoCloseComponent} from './datepicker/autoclose/datepicker-autoclose.component';
 import {DropdownAutoCloseComponent} from './dropdown/autoclose/dropdown-autoclose.component';
 import {ModalFocustrapComponent} from './modal/focustrap/modal-focustrap.component';
+import {TypeaheadFocusComponent} from './typeahead/focus/typeahead-focus.component';
 
 const routes: Routes = [
   {
@@ -11,6 +12,12 @@ const routes: Routes = [
     children: [
       {path: 'focus', component: DatepickerFocusComponent},
       {path: 'autoclose', component: DatepickerAutoCloseComponent}
+    ]
+  },
+  {
+    path: 'typeahead',
+    children: [
+      {path: 'focus', component: TypeaheadFocusComponent}
     ]
   },
   {

--- a/e2e-app/src/app/typeahead/focus/typeahead-focus.component.html
+++ b/e2e-app/src/app/typeahead/focus/typeahead-focus.component.html
@@ -1,0 +1,28 @@
+<h3>Typeahead tests</h3>
+
+<form>
+  <div class="form-group form-inline">
+    <div class="input-group mr-2">
+        <label for="first" class="mr-2">Before</label>
+        <input id="first">
+    </div>
+    <div class="input-group mr-2">
+      <label for="typeahead" class="mr-2">Typeahead</label>
+      <input
+        id="typeahead"
+        name="typeahead"
+        type="text"
+        class="form-control"
+        [(ngModel)]="model"
+        [ngbTypeahead]="search"
+        (focus)="focus$.next($event.target.value)"
+        (click)="click$.next($event.target.value)"
+        #instance="ngbTypeahead"
+      />
+    </div>
+    <div class="input-group mr-2">
+        <label for="last" class="mr-2">After</label>
+        <input id="last">
+    </div>
+  </div>
+</form>

--- a/e2e-app/src/app/typeahead/focus/typeahead-focus.component.ts
+++ b/e2e-app/src/app/typeahead/focus/typeahead-focus.component.ts
@@ -1,0 +1,36 @@
+import { Component, ViewChild } from '@angular/core';
+import {NgbTypeahead} from '@ng-bootstrap/ng-bootstrap';
+import {Observable, Subject, merge} from 'rxjs';
+import {debounceTime, distinctUntilChanged, filter, map} from 'rxjs/operators';
+
+const states = ['Alabama', 'Alaska', 'American Samoa', 'Arizona', 'Arkansas', 'California', 'Colorado',
+  'Connecticut', 'Delaware', 'District Of Columbia', 'Federated States Of Micronesia', 'Florida', 'Georgia',
+  'Guam', 'Hawaii', 'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky', 'Louisiana', 'Maine',
+  'Marshall Islands', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi', 'Missouri', 'Montana',
+  'Nebraska', 'Nevada', 'New Hampshire', 'New Jersey', 'New Mexico', 'New York', 'North Carolina', 'North Dakota',
+  'Northern Mariana Islands', 'Ohio', 'Oklahoma', 'Oregon', 'Palau', 'Pennsylvania', 'Puerto Rico', 'Rhode Island',
+  'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont', 'Virgin Islands', 'Virginia',
+  'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'];
+
+@Component({
+  templateUrl: './typeahead-focus.component.html'
+})
+export class TypeaheadFocusComponent {
+
+  model: any;
+
+  @ViewChild('instance') instance: NgbTypeahead;
+  focus$ = new Subject<string>();
+  click$ = new Subject<string>();
+
+  search = (text$: Observable<string>) => {
+    const debouncedText$ = text$.pipe(distinctUntilChanged());
+    const clicksWithClosedPopup$ = this.click$.pipe(filter(() => !this.instance.isPopupOpen()));
+    const inputFocus$ = this.focus$;
+
+    return merge(debouncedText$, inputFocus$, clicksWithClosedPopup$).pipe(
+      map(term => (term === '' ? states
+        : states.filter(v => v.toLowerCase().indexOf(term.toLowerCase()) > -1)).slice(0, 10))
+    );
+  }
+}


### PR DESCRIPTION
Part of #2463

Tests for typeahead focus. This is the implementation of what has been removed in #2464 (typeahead part).


