### PR TITLE
feat(widgets): turn on viewEncapsulation.None

### DIFF
--- a/src/alert/alert.scss
+++ b/src/alert/alert.scss
@@ -1,3 +1,3 @@
-:host {
+ngb-alert {
   display: block;
 }

--- a/src/alert/alert.ts
+++ b/src/alert/alert.ts
@@ -8,7 +8,8 @@ import {
   ElementRef,
   OnChanges,
   OnInit,
-  SimpleChanges
+  SimpleChanges,
+  ViewEncapsulation
 } from '@angular/core';
 
 import {NgbAlertConfig} from './alert-config';
@@ -19,6 +20,7 @@ import {NgbAlertConfig} from './alert-config';
 @Component({
   selector: 'ngb-alert',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
   host: {'role': 'alert', 'class': 'alert', '[class.alert-dismissible]': 'dismissible'},
   template: `
     <button *ngIf="dismissible" type="button" class="close" aria-label="Close" i18n-aria-label="@@ngb.alert.close"

--- a/src/datepicker/datepicker-day-view.scss
+++ b/src/datepicker/datepicker-day-view.scss
@@ -1,4 +1,4 @@
-:host {
+[ngbDatepickerDayView] {
   text-align: center;
   width: 2rem;
   height: 2rem;

--- a/src/datepicker/datepicker-day-view.ts
+++ b/src/datepicker/datepicker-day-view.ts
@@ -1,10 +1,11 @@
-import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input, ViewEncapsulation} from '@angular/core';
 import {NgbDate} from './ngb-date';
 import {NgbDatepickerI18n} from './datepicker-i18n';
 
 @Component({
   selector: '[ngbDatepickerDayView]',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
   styleUrls: ['./datepicker-day-view.scss'],
   host: {
     'class': 'btn-light',

--- a/src/datepicker/datepicker-month-view.scss
+++ b/src/datepicker/datepicker-month-view.scss
@@ -1,35 +1,38 @@
-:host {
+ngb-datepicker-month-view {
   display: block;
 }
-.ngb-dp-weekday,
-.ngb-dp-week-number {
-  line-height: 2rem;
-  text-align: center;
-  font-style: italic;
-}
-.ngb-dp-weekday {
-  color: #5bc0de;
-  color: var(--info);
-}
-.ngb-dp-week {
-  border-radius: 0.25rem;
-  display: flex;
-}
-.ngb-dp-weekdays {
-  border-bottom: 1px solid rgba(0, 0, 0, 0.125);
-  border-radius: 0;
-}
-.ngb-dp-day,
-.ngb-dp-weekday,
-.ngb-dp-week-number {
-  width: 2rem;
-  height: 2rem;
-}
-.ngb-dp-day {
-  cursor: pointer;
 
-  &.disabled,
-  &.hidden {
-    cursor: default;
+.ngb-dp {
+  &-weekday,
+  &-week-number {
+    line-height: 2rem;
+    text-align: center;
+    font-style: italic;
+  }
+  &-weekday {
+    color: #5bc0de;
+    color: var(--info);
+  }
+  &-week {
+    border-radius: 0.25rem;
+    display: flex;
+  }
+  &-weekdays {
+    border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+    border-radius: 0;
+  }
+  &-day,
+  &-weekday,
+  &-week-number {
+    width: 2rem;
+    height: 2rem;
+  }
+  &-day {
+    cursor: pointer;
+
+    &.disabled,
+    &.hidden {
+      cursor: default;
+    }
   }
 }

--- a/src/datepicker/datepicker-month-view.ts
+++ b/src/datepicker/datepicker-month-view.ts
@@ -1,4 +1,4 @@
-import {Component, Input, TemplateRef, Output, EventEmitter} from '@angular/core';
+import {Component, Input, TemplateRef, Output, EventEmitter, ViewEncapsulation} from '@angular/core';
 import {MonthViewModel, DayViewModel} from './datepicker-view-model';
 import {NgbDate} from './ngb-date';
 import {NgbDatepickerI18n} from './datepicker-i18n';
@@ -7,6 +7,7 @@ import {DayTemplateContext} from './datepicker-day-template-context';
 @Component({
   selector: 'ngb-datepicker-month-view',
   host: {'role': 'grid'},
+  encapsulation: ViewEncapsulation.None,
   styleUrls: ['./datepicker-month-view.scss'],
   template: `
     <div *ngIf="showWeekdays" class="ngb-dp-week ngb-dp-weekdays bg-light">

--- a/src/datepicker/datepicker-navigation-select.scss
+++ b/src/datepicker/datepicker-navigation-select.scss
@@ -1,4 +1,4 @@
-:host>select {
+ngb-datepicker-navigation-select > .custom-select {
   flex: 1 1 auto;
   padding: 0 0.5rem;
   font-size: 0.875rem;

--- a/src/datepicker/datepicker-navigation-select.ts
+++ b/src/datepicker/datepicker-navigation-select.ts
@@ -1,4 +1,4 @@
-import {Component, Input, Output, EventEmitter, ChangeDetectionStrategy} from '@angular/core';
+import {Component, Input, Output, EventEmitter, ChangeDetectionStrategy, ViewEncapsulation} from '@angular/core';
 import {NgbDate} from './ngb-date';
 import {toInteger} from '../util/util';
 import {NgbDatepickerI18n} from './datepicker-i18n';
@@ -6,6 +6,7 @@ import {NgbDatepickerI18n} from './datepicker-i18n';
 @Component({
   selector: 'ngb-datepicker-navigation-select',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
   styleUrls: ['./datepicker-navigation-select.scss'],
   template: `
     <select

--- a/src/datepicker/datepicker-navigation.scss
+++ b/src/datepicker/datepicker-navigation.scss
@@ -1,53 +1,56 @@
-:host {
+ngb-datepicker-navigation {
   display: flex;
   align-items: center;
 }
-.ngb-dp-navigation-chevron {
-  border-style: solid;
-  border-width: 0.2em 0.2em 0 0;
-  display: inline-block;
-  width: 0.75em;
-  height: 0.75em;
-  margin-left: 0.25em;
-  margin-right: 0.15em;
-  transform: rotate(-135deg);
-}
-.right .ngb-dp-navigation-chevron {
-  transform: rotate(45deg);
-  margin-left: 0.15em;
-  margin-right: 0.25em;
-}
-.ngb-dp-arrow {
-  display: flex;
-  flex: 1 1 auto;
-  padding-right: 0;
-  padding-left: 0;
-  margin: 0;
-  width: 2rem;
-  height: 2rem;
 
-  &.right {
-    justify-content: flex-end;
+.ngb-dp {
+  &-navigation-chevron {
+    border-style: solid;
+    border-width: 0.2em 0.2em 0 0;
+    display: inline-block;
+    width: 0.75em;
+    height: 0.75em;
+    margin-left: 0.25em;
+    margin-right: 0.15em;
+    transform: rotate(-135deg);
   }
-}
-.ngb-dp-arrow-btn {
-  padding: 0 0.25rem;
-  margin: 0 0.5rem;
-  border: none;
-  background-color: transparent;
-  z-index: 1;
+  .right &-navigation-chevron {
+    transform: rotate(45deg);
+    margin-left: 0.15em;
+    margin-right: 0.25em;
+  }
+  &-arrow {
+    display: flex;
+    flex: 1 1 auto;
+    padding-right: 0;
+    padding-left: 0;
+    margin: 0;
+    width: 2rem;
+    height: 2rem;
 
-  &:focus {
-    outline: auto 1px;
+    &.right {
+      justify-content: flex-end;
+    }
   }
-}
-.ngb-dp-month-name {
-  font-size: larger;
-  height: 2rem;
-  line-height: 2rem;
-  text-align: center;
-}
-.ngb-dp-navigation-select {
-  display: flex;
-  flex: 1 1 9rem;
+  &-arrow-btn {
+    padding: 0 0.25rem;
+    margin: 0 0.5rem;
+    border: none;
+    background-color: transparent;
+    z-index: 1;
+
+    &:focus {
+      outline: auto 1px;
+    }
+  }
+  &-month-name {
+    font-size: larger;
+    height: 2rem;
+    line-height: 2rem;
+    text-align: center;
+  }
+  &-navigation-select {
+    display: flex;
+    flex: 1 1 9rem;
+  }
 }

--- a/src/datepicker/datepicker-navigation.ts
+++ b/src/datepicker/datepicker-navigation.ts
@@ -1,4 +1,4 @@
-import {Component, Input, Output, EventEmitter, ChangeDetectionStrategy} from '@angular/core';
+import {Component, Input, Output, EventEmitter, ChangeDetectionStrategy, ViewEncapsulation} from '@angular/core';
 import {NavigationEvent, MonthViewModel} from './datepicker-view-model';
 import {NgbDate} from './ngb-date';
 import {NgbDatepickerI18n} from './datepicker-i18n';
@@ -6,6 +6,7 @@ import {NgbDatepickerI18n} from './datepicker-i18n';
 @Component({
   selector: 'ngb-datepicker-navigation',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
   styleUrls: ['./datepicker-navigation.scss'],
   template: `
     <div class="ngb-dp-arrow">

--- a/src/datepicker/datepicker.scss
+++ b/src/datepicker/datepicker.scss
@@ -1,8 +1,9 @@
-:host {
+ngb-datepicker {
   border: 1px solid #dfdfdf;
   border-radius: 0.25rem;
   display: inline-block;
 }
+
 .ngb-dp-month {
   pointer-events: none;
 }
@@ -21,7 +22,7 @@ ngb-datepicker-month-view {
   text-align: center;
 }
 
-/deep/ .ngb-dp-month {
+.ngb-dp-month {
   & + .ngb-dp-month > ngb-datepicker-month-view > .ngb-dp-week {
     padding-left: 1rem;
   }

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -14,7 +14,8 @@ import {
   Output,
   OnDestroy,
   ElementRef,
-  NgZone
+  NgZone,
+  ViewEncapsulation
 } from '@angular/core';
 import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
 import {NgbCalendar} from './ngb-calendar';
@@ -57,6 +58,7 @@ export interface NgbDatepickerNavigateEvent {
   exportAs: 'ngbDatepicker',
   selector: 'ngb-datepicker',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
   styleUrls: ['./datepicker.scss'],
   template: `
     <ng-template #dt let-date="date" let-currentMonth="currentMonth" let-selected="selected" let-disabled="disabled" let-focused="focused">

--- a/src/popover/popover.scss
+++ b/src/popover/popover.scss
@@ -1,4 +1,4 @@
-:host {
+ngb-popover-window {
   &.bs-popover-top .arrow,
   &.bs-popover-bottom .arrow {
     left: 50%;

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -17,7 +17,8 @@ import {
   ViewContainerRef,
   ComponentFactoryResolver,
   NgZone,
-  SimpleChanges
+  SimpleChanges,
+  ViewEncapsulation
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {fromEvent, race} from 'rxjs';
@@ -35,6 +36,7 @@ let nextId = 0;
 @Component({
   selector: 'ngb-popover-window',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
   host: {
     '[class]':
         '"popover bs-popover-" + placement.split("-")[0]+" bs-popover-" + placement + (popoverClass ? " " + popoverClass : "")',

--- a/src/tooltip/tooltip.scss
+++ b/src/tooltip/tooltip.scss
@@ -1,4 +1,4 @@
-:host {
+ngb-tooltip-window {
   &.bs-tooltip-top .arrow,
   &.bs-tooltip-bottom .arrow {
     left: calc(50% - 0.4rem);

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -15,7 +15,8 @@ import {
   TemplateRef,
   ViewContainerRef,
   ComponentFactoryResolver,
-  NgZone
+  NgZone,
+  ViewEncapsulation
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 
@@ -34,6 +35,7 @@ let nextId = 0;
 @Component({
   selector: 'ngb-tooltip-window',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
   host: {
     '[class]':
         '"tooltip show bs-tooltip-" + placement.split("-")[0]+" bs-tooltip-" + placement + (tooltipClass ? " " + tooltipClass : "")',

--- a/src/typeahead/highlight.ts
+++ b/src/typeahead/highlight.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnChanges, ChangeDetectionStrategy, SimpleChanges} from '@angular/core';
+import {Component, Input, OnChanges, ChangeDetectionStrategy, SimpleChanges, ViewEncapsulation} from '@angular/core';
 import {regExpEscape, toString} from '../util/util';
 
 /**
@@ -8,6 +8,7 @@ import {regExpEscape, toString} from '../util/util';
 @Component({
   selector: 'ngb-highlight',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
   template: `<ng-template ngFor [ngForOf]="parts" let-part let-isOdd="odd">` +
       `<span *ngIf="isOdd; else even" [class]="highlightClass">{{part}}</span><ng-template #even>{{part}}</ng-template>` +
       `</ng-template>`,  // template needs to be formatted in a certain way so we don't add empty text nodes


### PR DESCRIPTION
The purpose of this PR is to allow a better widgets customization with css.

- Fix #2564 and #1875
- It removes the /deep/ selector used in the datepicker, which is deprecated
