### PR TITLE
test(dropdown): add e2e tests for autoClose

### DIFF
--- a/e2e-app/e2e/src/dropdown/dropdown-autoclose.e2e-spec.ts
+++ b/e2e-app/e2e/src/dropdown/dropdown-autoclose.e2e-spec.ts
@@ -1,0 +1,91 @@
+import {browser, Key} from 'protractor';
+import {sendKey} from '../tools';
+import {DropdownAutoClosePage} from './dropdown-autoclose.po';
+
+describe('Dropdown Autoclose', () => {
+  let page: DropdownAutoClosePage;
+
+  beforeAll(async () => {
+    page = new DropdownAutoClosePage();
+    await browser.get('#/dropdown/autoclose');
+  });
+
+  beforeEach(async () => await page.reset());
+
+  it(`should work when autoClose === true`, async () => {
+    await page.selectAutoClose('true');
+    const dropdown = page.getDropdown('#dropdown');
+
+    // escape
+    await page.open(dropdown);
+    await sendKey(Key.ESCAPE);
+    expect(await page.isOpened(dropdown)).toBeFalsy(`Dropdown should be closed on ESC`);
+
+    // outside click
+    await page.open(dropdown);
+    await page.clickOutside();
+    expect(await page.isOpened(dropdown)).toBeFalsy(`Dropdown should be closed on outside click`);
+
+    // inside click
+    await page.open(dropdown);
+    await page.getFirstItem(dropdown).click();
+    expect(await page.isOpened(dropdown)).toBeFalsy(`Dropdown should be closed on date selection`);
+  });
+
+  it(`should work when autoClose === false`, async () => {
+    await page.selectAutoClose('false');
+    const dropdown = page.getDropdown('#dropdown');
+
+    // escape
+    await page.open(dropdown);
+    await sendKey(Key.ESCAPE);
+    expect(await page.isOpened(dropdown)).toBeTruthy(`Dropdown should NOT be closed on ESC`);
+
+    // outside click
+    await page.clickOutside();
+    expect(await page.isOpened(dropdown)).toBeTruthy(`Dropdown should NOT be closed on outside click`);
+
+    // inside click
+    await page.getFirstItem(dropdown).click();
+    expect(await page.isOpened(dropdown)).toBeTruthy(`Dropdown should NOT be closed on date selection`);
+  });
+
+  it(`should work when autoClose === 'outside'`, async () => {
+    await page.selectAutoClose('outside');
+    const dropdown = page.getDropdown('#dropdown');
+
+    // escape
+    await page.open(dropdown);
+    await sendKey(Key.ESCAPE);
+    expect(await page.isOpened(dropdown)).toBeFalsy(`Dropdown should be closed on ESC`);
+
+    // outside click
+    await page.open(dropdown);
+    await page.clickOutside();
+    expect(await page.isOpened(dropdown)).toBeFalsy(`Dropdown should be closed on outside click`);
+
+    // date selection
+    await page.open(dropdown);
+    await page.getFirstItem(dropdown).click();
+    expect(await page.isOpened(dropdown)).toBeTruthy(`Dropdown should NOT be closed on date selection`);
+  });
+
+  it(`should work when autoClose === 'inside'`, async () => {
+    await page.selectAutoClose('inside');
+    const dropdown = page.getDropdown('#dropdown');
+
+    // escape
+    await page.open(dropdown);
+    await sendKey(Key.ESCAPE);
+    expect(await page.isOpened(dropdown)).toBeFalsy(`Dropdown should be closed on ESC`);
+
+    // outside click
+    await page.open(dropdown);
+    await page.clickOutside();
+    expect(await page.isOpened(dropdown)).toBeTruthy(`Dropdown should NOT be closed on outside click`);
+
+    // date selection
+    await page.getFirstItem(dropdown).click();
+    expect(await page.isOpened(dropdown)).toBeFalsy(`Dropdown should be closed on date selection`);
+  });
+});

--- a/e2e-app/e2e/src/dropdown/dropdown-autoclose.po.ts
+++ b/e2e-app/e2e/src/dropdown/dropdown-autoclose.po.ts
@@ -1,0 +1,47 @@
+import {$, ElementFinder} from 'protractor';
+import {expectFocused} from '../tools';
+
+export class DropdownAutoClosePage {
+
+  async close() {
+    await $('#close').click();
+  }
+
+  async clickOutside() {
+    await $('#outside-button').click();
+  }
+
+  getDropdown(dropDownSelector = '') {
+    return $(`${dropDownSelector}[ngbDropdown]`);
+  }
+
+  getFirstItem(dropdown: ElementFinder) {
+    return dropdown.$$(`.dropdown-item`).first();
+  }
+
+  async open(dropdown: ElementFinder) {
+    await dropdown.$(`button[ngbDropdownToggle]`).click();
+    expect(await this.isOpened(dropdown)).toBeTruthy(`Dropdown should have been opened`);
+  }
+
+  async selectAutoClose(type: string) {
+    await $('#autoclose-dropdown').click();
+    await $(`#autoclose-${type}`).click();
+  }
+
+  async isOpened(dropdown: ElementFinder) {
+    const classNames = await dropdown.getAttribute('class');
+    return classNames.includes('show');
+  }
+
+  async reset() {
+    await this.close();
+    const body = $('body');
+    await body.click();
+
+    await expectFocused(body, `Nothing should be focused initially`);
+
+    const dropdown = this.getDropdown('#dropdown');
+    expect(await this.isOpened(dropdown)).toBeFalsy(`Dropdown should be closed initially`);
+  }
+}

--- a/e2e-app/src/app/app.module.ts
+++ b/e2e-app/src/app/app.module.ts
@@ -10,12 +10,14 @@ import {AppComponent} from './app.component';
 import {DatepickerAutoCloseComponent} from './datepicker/autoclose/datepicker-autoclose.component';
 import {DatepickerFocusComponent} from './datepicker/focus/datepicker-focus.component';
 import {ModalFocustrapComponent} from './modal/focustrap/modal-focustrap.component';
+import {DropdownAutoCloseComponent} from './dropdown/autoclose/dropdown-autoclose.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     DatepickerAutoCloseComponent,
     DatepickerFocusComponent,
+    DropdownAutoCloseComponent,
     ModalFocustrapComponent
   ],
   imports: [

--- a/e2e-app/src/app/app.routing.ts
+++ b/e2e-app/src/app/app.routing.ts
@@ -1,8 +1,9 @@
 import {ModuleWithProviders} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router';
 import {DatepickerFocusComponent} from './datepicker/focus/datepicker-focus.component';
-import {ModalFocustrapComponent} from './modal/focustrap/modal-focustrap.component';
 import {DatepickerAutoCloseComponent} from './datepicker/autoclose/datepicker-autoclose.component';
+import {DropdownAutoCloseComponent} from './dropdown/autoclose/dropdown-autoclose.component';
+import {ModalFocustrapComponent} from './modal/focustrap/modal-focustrap.component';
 
 const routes: Routes = [
   {
@@ -16,6 +17,12 @@ const routes: Routes = [
     path: 'modal',
     children: [
       {path: 'focustrap', component: ModalFocustrapComponent}
+    ]
+  },
+  {
+    path: 'dropdown',
+    children: [
+      {path: 'autoclose', component: DropdownAutoCloseComponent}
     ]
   }
 ];

--- a/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.component.html
+++ b/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.component.html
@@ -1,0 +1,27 @@
+<h3>Dropdown autoclose tests</h3>
+
+<form id="default">
+  <div class="form-group form-inline">
+
+    <div id="dropdown"ngbDropdown #d="ngbDropdown" class="d-inline-block" [autoClose]="autoClose">
+      <button class="btn btn-outline-secondary" ngbDropdownToggle>Dropdown</button>
+      <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
+        <button class="dropdown-item">Item</button>
+      </div>
+    </div>
+
+    <button class="btn btn-outline-secondary ml-5" id="close" (click)="d.close()">Close</button>
+
+    <div ngbDropdown class="d-inline-block ml-3">
+      <button class="btn btn-outline-secondary" id="autoclose-dropdown" ngbDropdownToggle>Choose Autoclose</button>
+      <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
+        <button class="dropdown-item" id="autoclose-true" (click)="autoClose = true">True</button>
+        <button class="dropdown-item" id="autoclose-false" (click)="autoClose = false">False</button>
+        <button class="dropdown-item" id="autoclose-outside" (click)="autoClose = 'outside'">'Outside'</button>
+        <button class="dropdown-item" id="autoclose-inside" (click)="autoClose = 'inside'">'Inside'</button>
+      </div>
+    </div>
+
+    <button class="btn btn-outline-secondary ml-1" id="outside-button">Outside button</button>
+  </div>
+</form>

--- a/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.component.ts
+++ b/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.component.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+@Component({
+  templateUrl: './dropdown-autoclose.component.html'
+})
+export class DropdownAutoCloseComponent {
+  autoClose: boolean | 'inside' | 'outside' = true;
+}


### PR DESCRIPTION
Part of #2463 

Adds autoclose tests for the dropdown to simplify unit testing with request animation frame