### PR TITLE
test(tooltip): add e2e tests for autoClose

### DIFF
--- a/e2e-app/e2e/src/tooltip/tooltip-autoclose.e2e-spec.ts
+++ b/e2e-app/e2e/src/tooltip/tooltip-autoclose.e2e-spec.ts
@@ -1,0 +1,87 @@
+import {browser, Key} from 'protractor';
+import {sendKey} from '../tools';
+import {TooltipAutoClosePage} from './tooltip-autoclose.po';
+
+describe('Tooltip Autoclose', () => {
+  let page: TooltipAutoClosePage;
+
+  beforeAll(async () => {
+    page = new TooltipAutoClosePage();
+    await browser.get('#/tooltip/autoclose');
+  });
+
+  beforeEach(async () => await page.reset());
+
+  it(`should work when autoClose === true`, async () => {
+    await page.selectAutoClose('true');
+
+    // escape
+    await page.openTooltip();
+    await sendKey(Key.ESCAPE);
+    expect(await page.getTooltip().isPresent()).toBeFalsy(`Tooltip should be closed on ESC`);
+
+    // outside click
+    await page.openTooltip();
+    await page.clickOutside();
+    expect(await page.getTooltip().isPresent()).toBeFalsy(`Tooltip should be closed on outside click`);
+
+    // inside click
+    await page.openTooltip();
+    await page.getTooltipContent().click();
+    expect(await page.getTooltip().isPresent()).toBeFalsy(`Tooltip should be closed on date selection`);
+  });
+
+  it(`should work when autoClose === false`, async () => {
+    await page.selectAutoClose('false');
+
+    // escape
+    await page.openTooltip();
+    await sendKey(Key.ESCAPE);
+    expect(await page.getTooltip().isPresent()).toBeTruthy(`Tooltip should NOT be closed on ESC`);
+
+    // outside click
+    await page.clickOutside();
+    expect(await page.getTooltip().isPresent()).toBeTruthy(`Tooltip should NOT be closed on outside click`);
+
+    // inside click
+    await page.getTooltipContent().click();
+    expect(await page.getTooltip().isPresent()).toBeTruthy(`Tooltip should NOT be closed on date selection`);
+  });
+
+  it(`should work when autoClose === 'outside'`, async () => {
+    await page.selectAutoClose('outside');
+
+    // escape
+    await page.openTooltip();
+    await sendKey(Key.ESCAPE);
+    expect(await page.getTooltip().isPresent()).toBeFalsy(`Tooltip should be closed on ESC`);
+
+    // outside click
+    await page.openTooltip();
+    await page.clickOutside();
+    expect(await page.getTooltip().isPresent()).toBeFalsy(`Tooltip should be closed on outside click`);
+
+    // date selection
+    await page.openTooltip();
+    await page.getTooltipContent().click();
+    expect(await page.getTooltip().isPresent()).toBeTruthy(`Tooltip should NOT be closed on date selection`);
+  });
+
+  it(`should work when autoClose === 'inside'`, async () => {
+    await page.selectAutoClose('inside');
+
+    // escape
+    await page.openTooltip();
+    await sendKey(Key.ESCAPE);
+    expect(await page.getTooltip().isPresent()).toBeFalsy(`Tooltip should be closed on ESC`);
+
+    // outside click
+    await page.openTooltip();
+    await page.clickOutside();
+    expect(await page.getTooltip().isPresent()).toBeTruthy(`Tooltip should NOT be closed on outside click`);
+
+    // date selection
+    await page.getTooltipContent().click();
+    expect(await page.getTooltip().isPresent()).toBeFalsy(`Tooltip should be closed on date selection`);
+  });
+});

--- a/e2e-app/e2e/src/tooltip/tooltip-autoclose.po.ts
+++ b/e2e-app/e2e/src/tooltip/tooltip-autoclose.po.ts
@@ -1,0 +1,40 @@
+import {$} from 'protractor';
+import {expectFocused} from '../tools';
+
+export class TooltipAutoClosePage {
+
+  async close() {
+    await $('#close').click();
+  }
+
+  async clickOutside() {
+    await $('#outside-button').click();
+  }
+
+  getTooltip() {
+    return $('ngb-tooltip-window');
+  }
+
+  getTooltipContent() {
+    return this.getTooltip().$('div.tooltip-inner');
+  }
+
+  async openTooltip() {
+    await $('button[ngbTooltip]').click();
+    expect(await this.getTooltip().isPresent()).toBeTruthy(`Tooltip should be visible`);
+  }
+
+  async selectAutoClose(type: string) {
+    await $('#autoclose-dropdown').click();
+    await $(`#autoclose-${type}`).click();
+  }
+
+  async reset() {
+    await this.close();
+    const body = $('body');
+    await body.click();
+
+    await expectFocused(body, `Nothing should be focused initially`);
+    expect(await this.getTooltip().isPresent()).toBeFalsy(`Tooltip should be hidden initially`);
+  }
+}

--- a/e2e-app/src/app/app.module.ts
+++ b/e2e-app/src/app/app.module.ts
@@ -9,8 +9,9 @@ import {AppComponent} from './app.component';
 
 import {DatepickerAutoCloseComponent} from './datepicker/autoclose/datepicker-autoclose.component';
 import {DatepickerFocusComponent} from './datepicker/focus/datepicker-focus.component';
-import {ModalFocustrapComponent} from './modal/focustrap/modal-focustrap.component';
 import {DropdownAutoCloseComponent} from './dropdown/autoclose/dropdown-autoclose.component';
+import {ModalFocustrapComponent} from './modal/focustrap/modal-focustrap.component';
+import {TooltipAutocloseComponent} from './tooltip/autoclose/tooltip-autoclose.component';
 import {TypeaheadFocusComponent} from './typeahead/focus/typeahead-focus.component';
 
 @NgModule({
@@ -20,6 +21,7 @@ import {TypeaheadFocusComponent} from './typeahead/focus/typeahead-focus.compone
     DatepickerFocusComponent,
     DropdownAutoCloseComponent,
     ModalFocustrapComponent,
+    TooltipAutocloseComponent,
     TypeaheadFocusComponent
   ],
   imports: [

--- a/e2e-app/src/app/app.routing.ts
+++ b/e2e-app/src/app/app.routing.ts
@@ -4,6 +4,7 @@ import {DatepickerFocusComponent} from './datepicker/focus/datepicker-focus.comp
 import {DatepickerAutoCloseComponent} from './datepicker/autoclose/datepicker-autoclose.component';
 import {DropdownAutoCloseComponent} from './dropdown/autoclose/dropdown-autoclose.component';
 import {ModalFocustrapComponent} from './modal/focustrap/modal-focustrap.component';
+import {TooltipAutocloseComponent} from './tooltip/autoclose/tooltip-autoclose.component';
 import {TypeaheadFocusComponent} from './typeahead/focus/typeahead-focus.component';
 
 const routes: Routes = [
@@ -12,12 +13,6 @@ const routes: Routes = [
     children: [
       {path: 'focus', component: DatepickerFocusComponent},
       {path: 'autoclose', component: DatepickerAutoCloseComponent}
-    ]
-  },
-  {
-    path: 'typeahead',
-    children: [
-      {path: 'focus', component: TypeaheadFocusComponent}
     ]
   },
   {
@@ -30,6 +25,18 @@ const routes: Routes = [
     path: 'dropdown',
     children: [
       {path: 'autoclose', component: DropdownAutoCloseComponent}
+    ]
+  },
+  {
+    path: 'tooltip',
+    children: [
+      {path: 'autoclose', component: TooltipAutocloseComponent}
+    ]
+  },
+  {
+    path: 'typeahead',
+    children: [
+      {path: 'focus', component: TypeaheadFocusComponent}
     ]
   }
 ];

--- a/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.component.html
+++ b/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.component.html
@@ -1,0 +1,25 @@
+<h3>Dropdown autoclose tests</h3>
+
+<form id="default">
+  <div class="form-group form-inline">
+
+    <button ngbTooltip="Tooltip here" #t="ngbTooltip" [autoClose]="autoClose" triggers="click"
+            type="button" class="btn btn-outline-secondary ml-2">
+      Tooltip
+    </button>
+
+    <button class="btn btn-outline-secondary ml-5" id="close" (click)="t.close()">Close</button>
+
+    <div ngbDropdown class="d-inline-block ml-3">
+      <button class="btn btn-outline-secondary" id="autoclose-dropdown" ngbDropdownToggle>Choose Autoclose</button>
+      <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
+        <button class="dropdown-item" id="autoclose-true" (click)="autoClose = true">True</button>
+        <button class="dropdown-item" id="autoclose-false" (click)="autoClose = false">False</button>
+        <button class="dropdown-item" id="autoclose-outside" (click)="autoClose = 'outside'">'Outside'</button>
+        <button class="dropdown-item" id="autoclose-inside" (click)="autoClose = 'inside'">'Inside'</button>
+      </div>
+    </div>
+
+    <button class="btn btn-outline-secondary ml-1" id="outside-button">Outside button</button>
+  </div>
+</form>

--- a/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.component.ts
+++ b/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.component.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+@Component({
+  templateUrl: './tooltip-autoclose.component.html'
+})
+export class TooltipAutocloseComponent {
+  autoClose: boolean | 'inside' | 'outside' = true;
+}


### PR DESCRIPTION
Part of #2463

Adds autoclose tests for the tooltip to simplify unit testing with request animation frame