### PR TITLE
test(popover): add e2e tests for autoClose

### DIFF
--- a/e2e-app/e2e/src/popover/popover-autoclose.e2e-spec.ts
+++ b/e2e-app/e2e/src/popover/popover-autoclose.e2e-spec.ts
@@ -1,0 +1,87 @@
+import {browser, Key} from 'protractor';
+import {sendKey} from '../tools';
+import {PopoverAutoClosePage} from './popover-autoclose.po';
+
+describe('Popover Autoclose', () => {
+  let page: PopoverAutoClosePage;
+
+  beforeAll(async () => {
+    page = new PopoverAutoClosePage();
+    await browser.get('#/popover/autoclose');
+  });
+
+  beforeEach(async () => await page.reset());
+
+  it(`should work when autoClose === true`, async () => {
+    await page.selectAutoClose('true');
+
+    // escape
+    await page.openPopover();
+    await sendKey(Key.ESCAPE);
+    expect(await page.getPopover().isPresent()).toBeFalsy(`Popover should be closed on ESC`);
+
+    // outside click
+    await page.openPopover();
+    await page.clickOutside();
+    expect(await page.getPopover().isPresent()).toBeFalsy(`Popover should be closed on outside click`);
+
+    // inside click
+    await page.openPopover();
+    await page.getPopoverContent().click();
+    expect(await page.getPopover().isPresent()).toBeFalsy(`Popover should be closed on date selection`);
+  });
+
+  it(`should work when autoClose === false`, async () => {
+    await page.selectAutoClose('false');
+
+    // escape
+    await page.openPopover();
+    await sendKey(Key.ESCAPE);
+    expect(await page.getPopover().isPresent()).toBeTruthy(`Popover should NOT be closed on ESC`);
+
+    // outside click
+    await page.clickOutside();
+    expect(await page.getPopover().isPresent()).toBeTruthy(`Popover should NOT be closed on outside click`);
+
+    // inside click
+    await page.getPopoverContent().click();
+    expect(await page.getPopover().isPresent()).toBeTruthy(`Popover should NOT be closed on date selection`);
+  });
+
+  it(`should work when autoClose === 'outside'`, async () => {
+    await page.selectAutoClose('outside');
+
+    // escape
+    await page.openPopover();
+    await sendKey(Key.ESCAPE);
+    expect(await page.getPopover().isPresent()).toBeFalsy(`Popover should be closed on ESC`);
+
+    // outside click
+    await page.openPopover();
+    await page.clickOutside();
+    expect(await page.getPopover().isPresent()).toBeFalsy(`Popover should be closed on outside click`);
+
+    // date selection
+    await page.openPopover();
+    await page.getPopoverContent().click();
+    expect(await page.getPopover().isPresent()).toBeTruthy(`Popover should NOT be closed on date selection`);
+  });
+
+  it(`should work when autoClose === 'inside'`, async () => {
+    await page.selectAutoClose('inside');
+
+    // escape
+    await page.openPopover();
+    await sendKey(Key.ESCAPE);
+    expect(await page.getPopover().isPresent()).toBeFalsy(`Popover should be closed on ESC`);
+
+    // outside click
+    await page.openPopover();
+    await page.clickOutside();
+    expect(await page.getPopover().isPresent()).toBeTruthy(`Popover should NOT be closed on outside click`);
+
+    // date selection
+    await page.getPopoverContent().click();
+    expect(await page.getPopover().isPresent()).toBeFalsy(`Popover should be closed on date selection`);
+  });
+});

--- a/e2e-app/e2e/src/popover/popover-autoclose.po.ts
+++ b/e2e-app/e2e/src/popover/popover-autoclose.po.ts
@@ -1,0 +1,40 @@
+import {$} from 'protractor';
+import {expectFocused} from '../tools';
+
+export class PopoverAutoClosePage {
+
+  async close() {
+    await $('#close').click();
+  }
+
+  async clickOutside() {
+    await $('#outside-button').click();
+  }
+
+  getPopover() {
+    return $('ngb-popover-window');
+  }
+
+  getPopoverContent() {
+    return this.getPopover().$('div.popover-body');
+  }
+
+  async openPopover() {
+    await $('button[ngbPopover]').click();
+    expect(await this.getPopover().isPresent()).toBeTruthy(`Popover should be visible`);
+  }
+
+  async selectAutoClose(type: string) {
+    await $('#autoclose-dropdown').click();
+    await $(`#autoclose-${type}`).click();
+  }
+
+  async reset() {
+    await this.close();
+    const body = $('body');
+    await body.click();
+
+    await expectFocused(body, `Nothing should be focused initially`);
+    expect(await this.getPopover().isPresent()).toBeFalsy(`Popover should be hidden initially`);
+  }
+}

--- a/e2e-app/src/app/app.module.ts
+++ b/e2e-app/src/app/app.module.ts
@@ -11,6 +11,7 @@ import {DatepickerAutoCloseComponent} from './datepicker/autoclose/datepicker-au
 import {DatepickerFocusComponent} from './datepicker/focus/datepicker-focus.component';
 import {DropdownAutoCloseComponent} from './dropdown/autoclose/dropdown-autoclose.component';
 import {ModalFocustrapComponent} from './modal/focustrap/modal-focustrap.component';
+import {PopoverAutocloseComponent} from './popover/autoclose/popover-autoclose.component';
 import {TooltipAutocloseComponent} from './tooltip/autoclose/tooltip-autoclose.component';
 import {TypeaheadFocusComponent} from './typeahead/focus/typeahead-focus.component';
 
@@ -21,6 +22,7 @@ import {TypeaheadFocusComponent} from './typeahead/focus/typeahead-focus.compone
     DatepickerFocusComponent,
     DropdownAutoCloseComponent,
     ModalFocustrapComponent,
+    PopoverAutocloseComponent,
     TooltipAutocloseComponent,
     TypeaheadFocusComponent
   ],

--- a/e2e-app/src/app/app.routing.ts
+++ b/e2e-app/src/app/app.routing.ts
@@ -4,6 +4,7 @@ import {DatepickerFocusComponent} from './datepicker/focus/datepicker-focus.comp
 import {DatepickerAutoCloseComponent} from './datepicker/autoclose/datepicker-autoclose.component';
 import {DropdownAutoCloseComponent} from './dropdown/autoclose/dropdown-autoclose.component';
 import {ModalFocustrapComponent} from './modal/focustrap/modal-focustrap.component';
+import {PopoverAutocloseComponent} from './popover/autoclose/popover-autoclose.component';
 import {TooltipAutocloseComponent} from './tooltip/autoclose/tooltip-autoclose.component';
 import {TypeaheadFocusComponent} from './typeahead/focus/typeahead-focus.component';
 
@@ -25,6 +26,12 @@ const routes: Routes = [
     path: 'dropdown',
     children: [
       {path: 'autoclose', component: DropdownAutoCloseComponent}
+    ]
+  },
+  {
+    path: 'popover',
+    children: [
+      {path: 'autoclose', component: PopoverAutocloseComponent}
     ]
   },
   {

--- a/e2e-app/src/app/popover/autoclose/popover-autoclose.component.html
+++ b/e2e-app/src/app/popover/autoclose/popover-autoclose.component.html
@@ -1,11 +1,11 @@
-<h3>Tooltip autoclose tests</h3>
+<h3>Popover autoclose tests</h3>
 
 <form id="default">
   <div class="form-group form-inline">
 
-    <button ngbTooltip="Tooltip here" #t="ngbTooltip" [autoClose]="autoClose" triggers="click"
+    <button ngbPopover="Popover here" #t="ngbPopover" [autoClose]="autoClose" triggers="click"
             type="button" class="btn btn-outline-secondary ml-2">
-      Tooltip
+      Popover
     </button>
 
     <button class="btn btn-outline-secondary ml-5" id="close" (click)="t.close()">Close</button>

--- a/e2e-app/src/app/popover/autoclose/popover-autoclose.component.ts
+++ b/e2e-app/src/app/popover/autoclose/popover-autoclose.component.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+@Component({
+  templateUrl: './popover-autoclose.component.html'
+})
+export class PopoverAutocloseComponent {
+  autoClose: boolean | 'inside' | 'outside' = true;
+}


### PR DESCRIPTION
Part of #2463

Adds autoclose tests for the popover to simplify unit testing with request animation frame