### PR TITLE
chore: add navigation to e2e tests to simplify resetting

### DIFF
--- a/e2e-app/e2e/src/datepicker/datepicker-autoclose.e2e-spec.ts
+++ b/e2e-app/e2e/src/datepicker/datepicker-autoclose.e2e-spec.ts
@@ -1,16 +1,13 @@
-import {browser, Key} from 'protractor';
+import {Key} from 'protractor';
 import {DatepickerAutoClosePage} from './datepicker-autoclose.po';
-import {sendKey} from '../tools';
+import {openUrl, sendKey} from '../tools';
 
 describe('Datepicker Autoclose', () => {
   let page: DatepickerAutoClosePage;
 
-  beforeAll(async() => {
-    page = new DatepickerAutoClosePage();
-    await browser.get('#/datepicker/autoclose');
-  });
+  beforeAll(() => page = new DatepickerAutoClosePage());
 
-  beforeEach(async() => await page.reset());
+  beforeEach(async() => await openUrl('datepicker/autoclose'));
 
   it(`should work when autoClose === true`, async() => {
     await page.selectAutoClose('true');

--- a/e2e-app/e2e/src/datepicker/datepicker-autoclose.po.ts
+++ b/e2e-app/e2e/src/datepicker/datepicker-autoclose.po.ts
@@ -1,10 +1,7 @@
 import {$} from 'protractor';
-import {expectFocused} from '../tools';
 import {DatepickerPage} from './datepicker.po';
 
 export class DatepickerAutoClosePage extends DatepickerPage {
-  async clearDate() { await $('#clearDate').click(); }
-
   async close() { await $('#close').click(); }
 
   async clickOutside() { await $('#outside-button').click(); }
@@ -12,17 +9,5 @@ export class DatepickerAutoClosePage extends DatepickerPage {
   async selectAutoClose(type: string) {
     await $('#autoclose-dropdown').click();
     await $(`#autoclose-${type}`).click();
-  }
-
-  async reset() {
-    await this.close();
-    await this.clearDate();
-    const body = $('body');
-    await body.click();
-
-    await expectFocused(body, `Nothing should be focused initially`);
-    expect(await this.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed initially`);
-    expect(await this.getDatepickerInput().getAttribute('value'))
-        .toBe('', `Datepicker input should be cleared initially`);
   }
 }

--- a/e2e-app/e2e/src/datepicker/datepicker-focus.e2e-spec.ts
+++ b/e2e-app/e2e/src/datepicker/datepicker-focus.e2e-spec.ts
@@ -1,5 +1,5 @@
-import {$, browser, Key} from 'protractor';
-import {expectFocused, sendKey} from '../tools';
+import {$, Key} from 'protractor';
+import {expectFocused, sendKey, openUrl} from '../tools';
 import {DatepickerFocusPage} from './datepicker-focus.po';
 
 const getFirstOfMonth = (date: Date) => {
@@ -18,12 +18,9 @@ const getLastOfMonth = (date: Date) => {
 describe('Datepicker', () => {
   let page: DatepickerFocusPage;
 
-  beforeAll(async() => {
-    page = new DatepickerFocusPage();
-    await browser.get('#/datepicker/focus');
-  });
+  beforeAll(() => page = new DatepickerFocusPage());
 
-  beforeEach(async() => await page.reset());
+  beforeEach(async() => await openUrl('datepicker/focus'));
 
   it(`should not be present on the page initially`,
      async() => { expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed initially`); });

--- a/e2e-app/e2e/src/datepicker/datepicker-focus.po.ts
+++ b/e2e-app/e2e/src/datepicker/datepicker-focus.po.ts
@@ -1,21 +1,6 @@
-import {$, Key} from 'protractor';
-import {expectFocused} from '../tools';
+import {$} from 'protractor';
 import {DatepickerPage} from './datepicker.po';
 
 export class DatepickerFocusPage extends DatepickerPage {
-  async clearDate() { await $('#clearDate').click(); }
-
   async preSelectDate() { await $('#selectDate').click(); }
-
-  async reset() {
-    await this.clearDate();
-    const body = $('body');
-    await body.click();
-    await body.sendKeys(Key.ESCAPE);
-
-    await expectFocused(body, `Nothing should be focused initially`);
-    expect(await this.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed initially`);
-    expect(await this.getDatepickerInput().getAttribute('value'))
-        .toBe('', `Datepicker input should be cleared initially`);
-  }
 }

--- a/e2e-app/e2e/src/dropdown/dropdown-autoclose.e2e-spec.ts
+++ b/e2e-app/e2e/src/dropdown/dropdown-autoclose.e2e-spec.ts
@@ -1,16 +1,13 @@
-import {browser, Key} from 'protractor';
-import {sendKey} from '../tools';
+import {Key} from 'protractor';
+import {sendKey, openUrl} from '../tools';
 import {DropdownAutoClosePage} from './dropdown-autoclose.po';
 
 describe('Dropdown Autoclose', () => {
   let page: DropdownAutoClosePage;
 
-  beforeAll(async() => {
-    page = new DropdownAutoClosePage();
-    await browser.get('#/dropdown/autoclose');
-  });
+  beforeAll(() => page = new DropdownAutoClosePage());
 
-  beforeEach(async() => await page.reset());
+  beforeEach(async() => await openUrl('dropdown/autoclose'));
 
   it(`should work when autoClose === true`, async() => {
     await page.selectAutoClose('true');

--- a/e2e-app/e2e/src/dropdown/dropdown-autoclose.po.ts
+++ b/e2e-app/e2e/src/dropdown/dropdown-autoclose.po.ts
@@ -1,9 +1,6 @@
 import {$, ElementFinder} from 'protractor';
-import {expectFocused} from '../tools';
 
 export class DropdownAutoClosePage {
-  async close() { await $('#close').click(); }
-
   async clickOutside() { await $('#outside-button').click(); }
 
   getDropdown(dropDownSelector = '') { return $(`${dropDownSelector}[ngbDropdown]`); }
@@ -23,16 +20,5 @@ export class DropdownAutoClosePage {
   async isOpened(dropdown: ElementFinder) {
     const classNames = await dropdown.getAttribute('class');
     return classNames.includes('show');
-  }
-
-  async reset() {
-    await this.close();
-    const body = $('body');
-    await body.click();
-
-    await expectFocused(body, `Nothing should be focused initially`);
-
-    const dropdown = this.getDropdown('#dropdown');
-    expect(await this.isOpened(dropdown)).toBeFalsy(`Dropdown should be closed initially`);
   }
 }

--- a/e2e-app/e2e/src/modal/modal-focustrap.e2e-spec.ts
+++ b/e2e-app/e2e/src/modal/modal-focustrap.e2e-spec.ts
@@ -1,16 +1,13 @@
 import {ModalFocustrapPage} from './modal-focustrap.po';
+import {openUrl} from '../tools';
 
 describe('Modal', () => {
   let page: ModalFocustrapPage;
 
   beforeEach(async() => {
     page = new ModalFocustrapPage();
-    await page.navigateTo();
+    await openUrl('modal/focustrap');
   });
 
-  it('should be present on the page', async() => {
-    const modal = await page.getModal();
-    const text = await page.getText(modal);
-    expect(text).toEqual('hello modal');
-  });
+  it('should be present on the page', async() => {});
 });

--- a/e2e-app/e2e/src/modal/modal-focustrap.po.ts
+++ b/e2e-app/e2e/src/modal/modal-focustrap.po.ts
@@ -1,8 +1,6 @@
-import {browser, by, element, ElementFinder} from 'protractor';
+import {by, element, ElementFinder} from 'protractor';
 
 export class ModalFocustrapPage {
-  navigateTo() { return browser.get('#/modal/focustrap'); }
-
   getModal(selector = 'ngb-modal-window') { return element(by.css(selector)); }
 
   getText(modal: ElementFinder) { return modal.element(by.css('div.modal-content')).getText(); }

--- a/e2e-app/e2e/src/popover/popover-autoclose.e2e-spec.ts
+++ b/e2e-app/e2e/src/popover/popover-autoclose.e2e-spec.ts
@@ -1,16 +1,13 @@
-import {browser, Key} from 'protractor';
-import {sendKey} from '../tools';
+import {Key} from 'protractor';
+import {sendKey, openUrl} from '../tools';
 import {PopoverAutoClosePage} from './popover-autoclose.po';
 
 describe('Popover Autoclose', () => {
   let page: PopoverAutoClosePage;
 
-  beforeAll(async() => {
-    page = new PopoverAutoClosePage();
-    await browser.get('#/popover/autoclose');
-  });
+  beforeAll(() => page = new PopoverAutoClosePage());
 
-  beforeEach(async() => await page.reset());
+  beforeEach(async() => await openUrl('popover/autoclose'));
 
   it(`should work when autoClose === true`, async() => {
     await page.selectAutoClose('true');

--- a/e2e-app/e2e/src/popover/popover-autoclose.po.ts
+++ b/e2e-app/e2e/src/popover/popover-autoclose.po.ts
@@ -1,9 +1,6 @@
 import {$} from 'protractor';
-import {expectFocused} from '../tools';
 
 export class PopoverAutoClosePage {
-  async close() { await $('#close').click(); }
-
   async clickOutside() { await $('#outside-button').click(); }
 
   getPopover() { return $('ngb-popover-window'); }
@@ -18,14 +15,5 @@ export class PopoverAutoClosePage {
   async selectAutoClose(type: string) {
     await $('#autoclose-dropdown').click();
     await $(`#autoclose-${type}`).click();
-  }
-
-  async reset() {
-    await this.close();
-    const body = $('body');
-    await body.click();
-
-    await expectFocused(body, `Nothing should be focused initially`);
-    expect(await this.getPopover().isPresent()).toBeFalsy(`Popover should be hidden initially`);
   }
 }

--- a/e2e-app/e2e/src/start.e2e-spec.ts
+++ b/e2e-app/e2e/src/start.e2e-spec.ts
@@ -1,0 +1,3 @@
+import {browser} from 'protractor';
+
+beforeAll(async() => await browser.get('#/'));

--- a/e2e-app/e2e/src/tools.ts
+++ b/e2e-app/e2e/src/tools.ts
@@ -1,4 +1,4 @@
-import {browser, ElementFinder, Key, WebElement} from 'protractor';
+import {browser, ElementFinder, Key, WebElement, $} from 'protractor';
 
 /**
  * Sends keys to a currently focused element
@@ -19,4 +19,13 @@ export const sendKey = async(...keys: string[]) => {
 export const expectFocused = async(el: ElementFinder, message: string) => {
   const focused = await browser.driver.switchTo().activeElement();
   expect(await WebElement.equals(el.getWebElement(), focused)).toBeTruthy(message);
+};
+
+/**
+ * Reopens internal URL by navigating to home url and then to desired one
+ */
+export const openUrl = async(url: string) => {
+  await $(`#navigate-home`).click();
+  await $(`#navigation-dropdown`).click();
+  await $(`#navigate-${url.replace('/', '-')}`).click();
 };

--- a/e2e-app/e2e/src/tooltip/tooltip-autoclose.e2e-spec.ts
+++ b/e2e-app/e2e/src/tooltip/tooltip-autoclose.e2e-spec.ts
@@ -1,16 +1,13 @@
-import {browser, Key} from 'protractor';
-import {sendKey} from '../tools';
+import {Key} from 'protractor';
+import {sendKey, openUrl} from '../tools';
 import {TooltipAutoClosePage} from './tooltip-autoclose.po';
 
 describe('Tooltip Autoclose', () => {
   let page: TooltipAutoClosePage;
 
-  beforeAll(async() => {
-    page = new TooltipAutoClosePage();
-    await browser.get('#/tooltip/autoclose');
-  });
+  beforeAll(() => page = new TooltipAutoClosePage());
 
-  beforeEach(async() => await page.reset());
+  beforeEach(async() => await openUrl('tooltip/autoclose'));
 
   it(`should work when autoClose === true`, async() => {
     await page.selectAutoClose('true');

--- a/e2e-app/e2e/src/tooltip/tooltip-autoclose.po.ts
+++ b/e2e-app/e2e/src/tooltip/tooltip-autoclose.po.ts
@@ -1,9 +1,6 @@
 import {$} from 'protractor';
-import {expectFocused} from '../tools';
 
 export class TooltipAutoClosePage {
-  async close() { await $('#close').click(); }
-
   async clickOutside() { await $('#outside-button').click(); }
 
   getTooltip() { return $('ngb-tooltip-window'); }
@@ -18,14 +15,5 @@ export class TooltipAutoClosePage {
   async selectAutoClose(type: string) {
     await $('#autoclose-dropdown').click();
     await $(`#autoclose-${type}`).click();
-  }
-
-  async reset() {
-    await this.close();
-    const body = $('body');
-    await body.click();
-
-    await expectFocused(body, `Nothing should be focused initially`);
-    expect(await this.getTooltip().isPresent()).toBeFalsy(`Tooltip should be hidden initially`);
   }
 }

--- a/e2e-app/e2e/src/typeahead/typeahead-focus.e2e-spec.ts
+++ b/e2e-app/e2e/src/typeahead/typeahead-focus.e2e-spec.ts
@@ -1,6 +1,6 @@
 import {TypeaheadPage} from './typeahead.po';
-import {$, browser, Key} from 'protractor';
-import {expectFocused, sendKey} from '../tools';
+import {Key} from 'protractor';
+import {expectFocused, openUrl, sendKey} from '../tools';
 
 describe('Typeahead', () => {
   let page: TypeaheadPage;
@@ -20,12 +20,9 @@ describe('Typeahead', () => {
   const expectTypeaheadValue =
       async expectedValue => { expect(await page.getTypeaheadValue()).toBe(expectedValue, 'Wrong input value'); };
 
-  beforeAll(async() => {
-    page = new TypeaheadPage();
-    await browser.get('#/typeahead/focus');
-  });
+  beforeAll(() => page = new TypeaheadPage());
 
-  beforeEach(async() => await page.reset());
+  beforeEach(async() => await openUrl('typeahead/focus'));
 
   it(`should be focused on item click`, async() => {
     await page.getTypeaheadInput().click();

--- a/e2e-app/e2e/src/typeahead/typeahead.po.ts
+++ b/e2e-app/e2e/src/typeahead/typeahead.po.ts
@@ -1,6 +1,4 @@
-import {$, Key, browser} from 'protractor';
-import {sendKey} from '../tools';
-import {expectFocused} from '../tools';
+import {$, Key} from 'protractor';
 
 export class TypeaheadPage {
   getInputBefore() { return $('#first'); }
@@ -11,25 +9,5 @@ export class TypeaheadPage {
 
   getDropdownItems() { return this.getDropdown().$$('button'); }
 
-  async clearText() {
-    const typeahead = this.getTypeaheadInput();
-    await typeahead.click();
-    await typeahead.sendKeys(Key.ESCAPE);
-    await typeahead.clear();
-  }
-
   async getTypeaheadValue() { return this.getTypeaheadInput().getAttribute('value'); }
-
-  async reset() {
-    await this.clearText();
-    const body = $('body');
-    await body.click();
-    await body.sendKeys(Key.ESCAPE);
-
-    await expectFocused(body, `Nothing should be focused initially`);
-    expect(await this.getDropdown().isPresent()).toBeFalsy(`Typeahead should be closed initially`);
-    expect(await this.getInputBefore().getAttribute('value'))
-        .toBe('', `Input before typeahead should be cleared initially`);
-    expect(await this.getTypeaheadValue()).toBe('', `Typeahead input should be cleared initially`);
-  }
 }

--- a/e2e-app/src/app/app.component.ts
+++ b/e2e-app/src/app/app.component.ts
@@ -2,7 +2,13 @@ import {Component} from '@angular/core';
 
 @Component({
   selector: 'app-root',
-  template: `<router-outlet></router-outlet>`,
+  template: `
+    <h1>ng-bootstrap e2e test application</h1>
+    <hr>
+    <app-navigation></app-navigation>
+    <hr>
+    <router-outlet></router-outlet>
+  `
 })
 export class AppComponent {
 }

--- a/e2e-app/src/app/app.module.ts
+++ b/e2e-app/src/app/app.module.ts
@@ -6,6 +6,7 @@ import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 
 import {routing} from './app.routing';
 import {AppComponent} from './app.component';
+import {NavigationComponent} from './navigation.component';
 
 import {DatepickerAutoCloseComponent} from './datepicker/autoclose/datepicker-autoclose.component';
 import {DatepickerFocusComponent} from './datepicker/focus/datepicker-focus.component';
@@ -17,8 +18,9 @@ import {TypeaheadFocusComponent} from './typeahead/focus/typeahead-focus.compone
 
 @NgModule({
   declarations: [
-    AppComponent, DatepickerAutoCloseComponent, DatepickerFocusComponent, DropdownAutoCloseComponent,
-    ModalFocustrapComponent, PopoverAutocloseComponent, TooltipAutocloseComponent, TypeaheadFocusComponent
+    AppComponent, NavigationComponent, DatepickerAutoCloseComponent, DatepickerFocusComponent,
+    DropdownAutoCloseComponent, ModalFocustrapComponent, PopoverAutocloseComponent, TooltipAutocloseComponent,
+    TypeaheadFocusComponent
   ],
   imports: [BrowserModule, FormsModule, routing, NgbModule],
   bootstrap: [AppComponent]

--- a/e2e-app/src/app/app.routing.ts
+++ b/e2e-app/src/app/app.routing.ts
@@ -8,7 +8,7 @@ import {PopoverAutocloseComponent} from './popover/autoclose/popover-autoclose.c
 import {TooltipAutocloseComponent} from './tooltip/autoclose/tooltip-autoclose.component';
 import {TypeaheadFocusComponent} from './typeahead/focus/typeahead-focus.component';
 
-const routes: Routes = [
+export const routes: Routes = [
   {
     path: 'datepicker',
     children: [

--- a/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.component.html
+++ b/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.component.html
@@ -4,11 +4,9 @@
   <div class="form-group form-inline">
 
     <div class="input-group">
-      <input class="form-control" name="dp" placeholder="yyyy-mm-dd" #d="ngbDatepicker"
-             ngbDatepicker [(ngModel)]="model" [autoClose]="autoClose" >
+      <input class="form-control" name="dp" placeholder="yyyy-mm-dd" #d="ngbDatepicker" ngbDatepicker [autoClose]="autoClose" >
       <div class="input-group-append">
         <button class="btn btn-outline-secondary" type="button" id="toggle" (click)="d.toggle()">Toggle</button>
-        <button class="btn btn-outline-secondary" type="button" id="clearDate" (click)="model = null">Clear</button>
         <button class="btn btn-outline-secondary" type="button" id="close" (click)="d.close()">Close</button>
       </div>
     </div>

--- a/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.component.ts
+++ b/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.component.ts
@@ -2,6 +2,5 @@ import {Component} from '@angular/core';
 
 @Component({templateUrl: './datepicker-autoclose.component.html'})
 export class DatepickerAutoCloseComponent {
-  model = null;
   autoClose: boolean | 'inside' | 'outside' = true;
 }

--- a/e2e-app/src/app/datepicker/focus/datepicker-focus.component.html
+++ b/e2e-app/src/app/datepicker/focus/datepicker-focus.component.html
@@ -9,7 +9,6 @@
       <div class="input-group-append">
         <button class="btn btn-outline-secondary" type="button" id="toggle" (click)="d.toggle()">Toggle</button>
         <button class="btn btn-outline-secondary" type="button" id="selectDate" (click)="model = {year: 2018, month: 8, day: 10}">10 AUG 2018</button>
-        <button class="btn btn-outline-secondary" type="button" id="clearDate" (click)="model = null">Clear</button>
       </div>
     </div>
   </div>

--- a/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.component.html
+++ b/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.component.html
@@ -3,14 +3,12 @@
 <form id="default">
   <div class="form-group form-inline">
 
-    <div id="dropdown"ngbDropdown #d="ngbDropdown" class="d-inline-block" [autoClose]="autoClose">
+    <div id="dropdown"ngbDropdown class="d-inline-block" [autoClose]="autoClose">
       <button class="btn btn-outline-secondary" ngbDropdownToggle>Dropdown</button>
       <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
         <button class="dropdown-item">Item</button>
       </div>
     </div>
-
-    <button class="btn btn-outline-secondary ml-5" id="close" (click)="d.close()">Close</button>
 
     <div ngbDropdown class="d-inline-block ml-3">
       <button class="btn btn-outline-secondary" id="autoclose-dropdown" ngbDropdownToggle>Choose Autoclose</button>

--- a/e2e-app/src/app/modal/focustrap/modal-focustrap.component.ts
+++ b/e2e-app/src/app/modal/focustrap/modal-focustrap.component.ts
@@ -1,9 +1,6 @@
 import {Component, OnInit} from '@angular/core';
-import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 
 @Component({templateUrl: './modal-focustrap.component.html'})
 export class ModalFocustrapComponent implements OnInit {
-  constructor(private _modal: NgbModal) { this._modal.open('hello modal'); }
-
   ngOnInit(): void {}
 }

--- a/e2e-app/src/app/navigation.component.ts
+++ b/e2e-app/src/app/navigation.component.ts
@@ -1,0 +1,24 @@
+import {Component} from '@angular/core';
+
+import {routes} from './app.routing';
+
+@Component({
+  selector: 'app-navigation',
+  template: `
+  <div ngbDropdown class="d-inline-block">
+    <button class="btn btn-outline-secondary" id="navigation-dropdown" ngbDropdownToggle>Open test suite</button>
+    <div ngbDropdownMenu>
+      <a *ngFor="let url of urls" href="#/{{ url }} " class="dropdown-item" id="navigate-{{ url.replace('/', '-') }}">{{ url }}</a>
+    </div>
+  </div>
+  <a role="button" class="btn btn-outline-primary ml-3" id="navigate-home" href="#/">Reset</a>
+  `
+})
+
+export class NavigationComponent {
+  urls: string[] = [];
+
+  constructor() {
+    routes.forEach(route => route.children.forEach(childRoute => this.urls.push(`${route.path}/${childRoute.path}`)));
+  }
+}

--- a/e2e-app/src/app/popover/autoclose/popover-autoclose.component.html
+++ b/e2e-app/src/app/popover/autoclose/popover-autoclose.component.html
@@ -3,12 +3,9 @@
 <form id="default">
   <div class="form-group form-inline">
 
-    <button ngbPopover="Popover here" #t="ngbPopover" [autoClose]="autoClose" triggers="click"
-            type="button" class="btn btn-outline-secondary ml-2">
+    <button ngbPopover="Popover here" [autoClose]="autoClose" triggers="click" type="button" class="btn btn-outline-secondary ml-2">
       Popover
     </button>
-
-    <button class="btn btn-outline-secondary ml-5" id="close" (click)="t.close()">Close</button>
 
     <div ngbDropdown class="d-inline-block ml-3">
       <button class="btn btn-outline-secondary" id="autoclose-dropdown" ngbDropdownToggle>Choose Autoclose</button>

--- a/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.component.html
+++ b/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.component.html
@@ -3,12 +3,9 @@
 <form id="default">
   <div class="form-group form-inline">
 
-    <button ngbTooltip="Tooltip here" #t="ngbTooltip" [autoClose]="autoClose" triggers="click"
-            type="button" class="btn btn-outline-secondary ml-2">
+    <button ngbTooltip="Tooltip here" [autoClose]="autoClose" triggers="click" type="button" class="btn btn-outline-secondary ml-2">
       Tooltip
     </button>
-
-    <button class="btn btn-outline-secondary ml-5" id="close" (click)="t.close()">Close</button>
 
     <div ngbDropdown class="d-inline-block ml-3">
       <button class="btn btn-outline-secondary" id="autoclose-dropdown" ngbDropdownToggle>Choose Autoclose</button>

--- a/e2e-app/src/app/typeahead/focus/typeahead-focus.component.ts
+++ b/e2e-app/src/app/typeahead/focus/typeahead-focus.component.ts
@@ -1,7 +1,7 @@
 import {Component, ViewChild} from '@angular/core';
 import {NgbTypeahead} from '@ng-bootstrap/ng-bootstrap';
 import {Observable, Subject, merge} from 'rxjs';
-import {debounceTime, distinctUntilChanged, filter, map} from 'rxjs/operators';
+import {distinctUntilChanged, filter, map} from 'rxjs/operators';
 
 const states = [
   'Alabama',


### PR DESCRIPTION
- reset pages with router navigation instead of custom `.reset()` method
- add navigation to switch easily between test suites

![screen shot 2018-10-16 at 10 42 20](https://user-images.githubusercontent.com/8074436/47003745-402b1200-d130-11e8-9a52-f028f21d0379.png)
