### PR TITLE
fix(focustrap): modal won't refocus last focused element on click

### DIFF
--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -1,39 +1,37 @@
+import {DOCUMENT} from '@angular/common';
 import {
-  Directive,
-  Input,
-  ComponentRef,
-  ElementRef,
-  ViewContainerRef,
-  Renderer2,
   ComponentFactoryResolver,
-  NgZone,
-  TemplateRef,
-  forwardRef,
+  ComponentRef,
+  Directive,
+  ElementRef,
   EventEmitter,
-  Output,
+  forwardRef,
+  Inject,
+  Input,
+  NgZone,
   OnChanges,
   OnDestroy,
+  Output,
+  Renderer2,
   SimpleChanges,
-  Inject
+  TemplateRef,
+  ViewContainerRef,
 } from '@angular/core';
-import {AbstractControl, ControlValueAccessor, Validator, NG_VALUE_ACCESSOR, NG_VALIDATORS} from '@angular/forms';
-import {DOCUMENT} from '@angular/common';
+import {AbstractControl, ControlValueAccessor, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validator} from '@angular/forms';
+import {fromEvent, NEVER, race, Subject} from 'rxjs';
+import {filter, takeUntil} from 'rxjs/operators';
 
-import {NgbDate} from './ngb-date';
-import {NgbDatepicker, NgbDatepickerNavigateEvent} from './datepicker';
-import {DayTemplateContext} from './datepicker-day-template-context';
-import {NgbDateParserFormatter} from './ngb-date-parser-formatter';
-
-import {positionElements, PlacementArray} from '../util/positioning';
 import {ngbFocusTrap} from '../util/focus-trap';
 import {Key} from '../util/key';
-import {NgbDateStruct} from './ngb-date-struct';
+import {PlacementArray, positionElements} from '../util/positioning';
 import {NgbDateAdapter} from './adapters/ngb-date-adapter';
-import {NgbCalendar} from './ngb-calendar';
+import {NgbDatepicker, NgbDatepickerNavigateEvent} from './datepicker';
+import {DayTemplateContext} from './datepicker-day-template-context';
 import {NgbDatepickerService} from './datepicker-service';
-
-import {Subject, fromEvent, race, NEVER} from 'rxjs';
-import {filter, takeUntil} from 'rxjs/operators';
+import {NgbCalendar} from './ngb-calendar';
+import {NgbDate} from './ngb-date';
+import {NgbDateParserFormatter} from './ngb-date-parser-formatter';
+import {NgbDateStruct} from './ngb-date-struct';
 
 const NGB_DATEPICKER_VALUE_ACCESSOR = {
   provide: NG_VALUE_ACCESSOR,
@@ -296,7 +294,7 @@ export class NgbInputDatepicker implements OnChanges,
       }
 
       // focus handling
-      ngbFocusTrap(this._cRef.location.nativeElement, this._closed$);
+      ngbFocusTrap(this._cRef.location.nativeElement, this._closed$, true);
 
       this._cRef.instance.focus();
 

--- a/src/util/focus-trap.ts
+++ b/src/util/focus-trap.ts
@@ -24,8 +24,10 @@ export function getFocusableBoundaryElements(element: HTMLElement): HTMLElement[
  * @param element The element around which focus will be trapped inside
  * @param stopFocusTrap$ The observable stream. When completed the focus trap will clean up listeners
  * and free internal resources
+ * @param refocusOnClick Put the focus back to the last focused element whenever a click occurs on element (default to
+ * false)
  */
-export const ngbFocusTrap = (element: HTMLElement, stopFocusTrap$: Observable<any>) => {
+export const ngbFocusTrap = (element: HTMLElement, stopFocusTrap$: Observable<any>, refocusOnClick = false) => {
   // last focused element
   const lastFocusedElement$ =
       fromEvent<FocusEvent>(element, 'focusin').pipe(takeUntil(stopFocusTrap$), map(e => e.target));
@@ -48,7 +50,9 @@ export const ngbFocusTrap = (element: HTMLElement, stopFocusTrap$: Observable<an
       });
 
   // inside click
-  fromEvent(element, 'click')
-      .pipe(takeUntil(stopFocusTrap$), withLatestFrom(lastFocusedElement$), map(arr => arr[1] as HTMLElement))
-      .subscribe(lastFocusedElement => lastFocusedElement.focus());
+  if (refocusOnClick) {
+    fromEvent(element, 'click')
+        .pipe(takeUntil(stopFocusTrap$), withLatestFrom(lastFocusedElement$), map(arr => arr[1] as HTMLElement))
+        .subscribe(lastFocusedElement => lastFocusedElement.focus());
+  }
 };


### PR DESCRIPTION
Working on finding a solution for #2779, I realised that `ngbFocustrap()` implementation was refocusing any last focused element whenever clicking inside the element being trapped.

This behaviour might be great/needed for component such as `<input ngbDatePicker />` (ie clicking on any header week day will refocus the selected date), but on modal where plenty of elements _could be_ defined as focusable with `tabindex="-1"` it does not make sense as it will most transparently refocus itself...

The idea behind this PR is to deactivate this part of this code:
https://github.com/ng-bootstrap/ng-bootstrap/blob/a76d7fe4981b93667a9936d40a0a40a804a7ab72/src/util/focus-trap.ts#L50-L53

And only activate it in the datepicker for now.

---

With that fix, using TinyMCE editor (as suggested in #2779) would work with any hack/patch/implementation needed.