### PR TITLE
test(datepicker): re-focus current date after inside click

### DIFF
--- a/e2e-app/e2e/src/datepicker/datepicker-focus.e2e-spec.ts
+++ b/e2e-app/e2e/src/datepicker/datepicker-focus.e2e-spec.ts
@@ -155,6 +155,14 @@ describe('Datepicker', () => {
         .toBeFalsy(`Last date of current month should NOT be displayed`);
   });
 
+  it(`should re-focus current element after inside click`, async() => {
+    await page.openDatepicker();
+
+    // click on weekday header
+    await page.getWeekdayElements().first().click();
+    await expectFocused(page.getToday(), `Today's date should stay focused`);
+  });
+
   it(`should allow focusing datepicker input`, async() => {
     await page.openDatepicker();
     const datepickerInput = page.getDatepickerInput();

--- a/e2e-app/e2e/src/datepicker/datepicker.po.ts
+++ b/e2e-app/e2e/src/datepicker/datepicker.po.ts
@@ -12,6 +12,8 @@ export abstract class DatepickerPage {
     return this.getDatepicker().$(`div.ngb-dp-day[aria-label="${ariaLabel}"]`);
   }
 
+  getWeekdayElements() { return this.getDatepicker().$$('div.ngb-dp-weekday'); }
+
   getToday() { return this.getDayElement(new Date()); }
 
   getPrevMonthArrow() { return this.getDatepicker().$(`button[aria-label="Previous month"]`); }


### PR DESCRIPTION
Missing focustrap test for the datepicker