### PR TITLE
datepicker: improve Hebrew demo

### DIFF
--- a/demo/src/app/components/datepicker/demos/hebrew/datepicker-hebrew.html
+++ b/demo/src/app/components/datepicker/demos/hebrew/datepicker-hebrew.html
@@ -3,8 +3,16 @@
   In Israel it is used for religious purposes and frequently as an official calendar for civil purposes.
 </p>
 
-<ngb-datepicker class="rtl" #dp [(ngModel)]="model" [displayMonths]="2" [firstDayOfWeek]="7">
+<ngb-datepicker class="hebrew rtl" #dp [(ngModel)]="model" [displayMonths]="1" [firstDayOfWeek]="7" [dayTemplate]="dt"
+[dayTemplateData]="dayTemplateData">
 </ngb-datepicker>
+
+<ng-template #dt let-date let-data="data" let-selected="selected" let-currentMonth="currentMonth">
+  <div class="hebrew-day" [class.outside]="date.month !== currentMonth" [class.selected]="selected">
+    <div class="gregorian-num">{{ data.gregorian.day + '/' + (data.gregorian.month) }}</div>
+    <div class="hebrew-num">{{ i18n.getDayNumerals(date) }}</div>
+  </div>
+</ng-template>
 
 <hr/>
 

--- a/demo/src/app/components/datepicker/demos/hebrew/datepicker-hebrew.ts
+++ b/demo/src/app/components/datepicker/demos/hebrew/datepicker-hebrew.ts
@@ -1,7 +1,7 @@
 import {Component} from '@angular/core';
 import {
   NgbCalendar,
-  NgbCalendarHebrew,
+  NgbCalendarHebrew, NgbDate,
   NgbDatepickerI18n,
   NgbDatepickerI18nHebrew,
   NgbDateStruct
@@ -10,6 +10,30 @@ import {
 @Component({
   selector: 'ngbd-datepicker-hebrew',
   templateUrl: './datepicker-hebrew.html',
+  styles: [`
+    .hebrew-day {
+      text-align: right;
+      padding: 0.25rem 0.65rem 0.25rem 0.25rem;
+      border-radius: 0.25rem;
+      display: inline-block;
+      height: 2.75rem;
+      width: 2.75rem;
+    }
+    .hebrew-day:hover, .hebrew-day.focused {
+      background-color: #e6e6e6;
+    }
+    .hebrew-day.selected {
+      background-color: #007bff;
+      color: white;
+    }
+    .outside {
+      color: lightgray;
+    }
+    .gregorian-num {
+      font-size: 0.5rem;
+      direction: ltr;
+    }
+  `],
   providers: [
     {provide: NgbCalendar, useClass: NgbCalendarHebrew},
     {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nHebrew}
@@ -19,7 +43,15 @@ export class NgbdDatepickerHebrew {
 
   model: NgbDateStruct;
 
-  constructor(private calendar: NgbCalendar) {}
+  constructor(private calendar: NgbCalendar, public i18n: NgbDatepickerI18n) {
+    this.dayTemplateData = this.dayTemplateData.bind(this);
+  }
+
+  dayTemplateData(date: NgbDate) {
+    return {
+      gregorian: (this.calendar as NgbCalendarHebrew).toGregorian(date)
+    };
+  }
 
   selectToday() {
     this.model = this.calendar.getToday();

--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -334,6 +334,19 @@ ngb-datepicker.rtl .ngb-dp-navigation-chevron {
   margin: 0 0.25rem 0 0;
 }
 
+ngb-datepicker.hebrew {
+
+  .ngb-dp-day {
+    width: 2.75rem;
+    height: 2.75rem;
+    line-height: 1rem;
+  }
+
+  .ngb-dp-weekday {
+    width: 2.75rem;
+  }
+}
+
 ngb-carousel {
   .carousel-item img {
     width: 100%;

--- a/src/datepicker/hebrew/datepicker-i18n-hebrew.spec.ts
+++ b/src/datepicker/hebrew/datepicker-i18n-hebrew.spec.ts
@@ -51,8 +51,8 @@ describe('datepicker-i18n-hebrew', () => {
 
   it('should return weekday name', () => {
     expect(i18n.getWeekdayShortName(0)).toBe(undefined);
-    expect(i18n.getWeekdayShortName(1)).toBe('ב׳');
-    expect(i18n.getWeekdayShortName(7)).toBe('א׳');
+    expect(i18n.getWeekdayShortName(1)).toBe('שני');
+    expect(i18n.getWeekdayShortName(7)).toBe('ראשון');
     expect(i18n.getWeekdayShortName(8)).toBe(undefined);
   });
 

--- a/src/datepicker/hebrew/datepicker-i18n-hebrew.ts
+++ b/src/datepicker/hebrew/datepicker-i18n-hebrew.ts
@@ -4,7 +4,7 @@ import {hebrewNumerals, isHebrewLeapYear} from './hebrew';
 import {Injectable} from '@angular/core';
 
 
-const WEEKDAYS = ['ב׳', 'ג׳', 'ד׳', 'ה׳', 'ו׳', 'ש׳', 'א׳'];
+const WEEKDAYS = ['שני', 'שלישי', 'רביעי', 'חמישי', 'שישי', 'שבת', 'ראשון'];
 const MONTHS = ['תשרי', 'חשון', 'כסלו', 'טבת', 'שבט', 'אדר', 'ניסן', 'אייר', 'סיון', 'תמוז', 'אב', 'אלול'];
 const MONTHS_LEAP =
     ['תשרי', 'חשון', 'כסלו', 'טבת', 'שבט', 'אדר א׳', 'אדר ב׳', 'ניסן', 'אייר', 'סיון', 'תמוז', 'אב', 'אלול'];

--- a/src/datepicker/hebrew/hebrew.spec.ts
+++ b/src/datepicker/hebrew/hebrew.spec.ts
@@ -55,7 +55,9 @@ describe('hebrew', () => {
   describe('hebrewNumerals', () => {
     it('should return Hebrew numerals', () => {
       expect(hebrewNumerals(3)).toEqual('ג׳');
+      expect(hebrewNumerals(11)).toEqual('י״א');
       expect(hebrewNumerals(15)).toEqual('ט״ו');
+      expect(hebrewNumerals(19)).toEqual('י״ט');
       expect(hebrewNumerals(5777)).toEqual('תשע״ז');
     });
   });

--- a/src/datepicker/hebrew/hebrew.ts
+++ b/src/datepicker/hebrew/hebrew.ts
@@ -243,13 +243,21 @@ export function hebrewNumerals(numerals: number): string {
   if (!numerals) {
     return '';
   }
-  const hArray0_9 = ['', 'א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ז', 'ח', 'ט'];
-  const hArray10_19 =
-      ['י', 'יא‬', 'יב‬', 'יג‬', 'יד‬', 'טו', 'טז‬', 'יז‬', 'יח‬', 'יט‬'];
-  const hArray20_90 = ['', '', 'כ', 'ל', 'מ', 'נ', 'ס', 'ע', 'פ', 'צ'];
-  const hArray100_900 = ['', 'ק', 'ר', 'ש', 'ת', 'תק', 'תר', 'תש', 'תת', 'תתק'];
-  const hArray1000_9000 = ['', 'א', 'ב', 'אב', 'בב', 'ה', 'אה', 'בה', 'אבה', 'בבה'];
-  const geresh = '׳', gershaim = '״';
+  const hArray0_9 = ['', '\u05d0', '\u05d1', '\u05d2', '\u05d3', '\u05d4', '\u05d5', '\u05d6', '\u05d7', '\u05d8'];
+  const hArray10_19 = [
+    '\u05d9', '\u05d9\u05d0', '\u05d9\u05d1', '\u05d9\u05d2', '\u05d9\u05d3', '\u05d8\u05d5', '\u05d8\u05d6',
+    '\u05d9\u05d6', '\u05d9\u05d7', '\u05d9\u05d8'
+  ];
+  const hArray20_90 = ['', '', '\u05db', '\u05dc', '\u05de', '\u05e0', '\u05e1', '\u05e2', '\u05e4', '\u05e6'];
+  const hArray100_900 = [
+    '', '\u05e7', '\u05e8', '\u05e9', '\u05ea', '\u05ea\u05e7', '\u05ea\u05e8', '\u05ea\u05e9', '\u05ea\u05ea',
+    '\u05ea\u05ea\u05e7'
+  ];
+  const hArray1000_9000 = [
+    '', '\u05d0', '\u05d1', '\u05d1\u05d0', '\u05d1\u05d1', '\u05d4', '\u05d4\u05d0', '\u05d4\u05d1',
+    '\u05d4\u05d1\u05d0', '\u05d4\u05d1\u05d1'
+  ];
+  const geresh = '\u05f3', gershaim = '\u05f4';
   let mem = 0;
   let result = [];
   let step = 0;

--- a/src/datepicker/hebrew/ngb-calendar-hebrew.ts
+++ b/src/datepicker/hebrew/ngb-calendar-hebrew.ts
@@ -1,5 +1,5 @@
 import {NgbDate} from '../ngb-date';
-import {NgbCalendar, NgbPeriod} from '../ngb-calendar';
+import {fromJSDate, NgbCalendar, NgbPeriod, toJSDate} from '../ngb-calendar';
 import {Injectable} from '@angular/core';
 import {isNumber} from '../../util/util';
 import {
@@ -70,4 +70,14 @@ export class NgbCalendarHebrew extends NgbCalendar {
   }
 
   getToday(): NgbDate { return fromGregorian(new Date()); }
+
+  /**
+   * @since 3.4.0
+   */
+  toGregorian(date: NgbDate): NgbDate { return fromJSDate(toGregorian(date)); }
+
+  /**
+   * @since 3.4.0
+   */
+  fromGregorian(date: NgbDate): NgbDate { return fromGregorian(toJSDate(date)); }
 }

--- a/src/datepicker/ngb-calendar.ts
+++ b/src/datepicker/ngb-calendar.ts
@@ -2,10 +2,10 @@ import {NgbDate} from './ngb-date';
 import {Injectable} from '@angular/core';
 import {isInteger} from '../util/util';
 
-function fromJSDate(jsDate: Date) {
+export function fromJSDate(jsDate: Date) {
   return new NgbDate(jsDate.getFullYear(), jsDate.getMonth() + 1, jsDate.getDate());
 }
-function toJSDate(date: NgbDate) {
+export function toJSDate(date: NgbDate) {
   const jsDate = new Date(date.year, date.month - 1, date.day, 12);
   // this is done avoid 30 -> 1930 conversion
   if (!isNaN(jsDate.getTime())) {


### PR DESCRIPTION
(do not squash, several commits)

- changed weekday names to a longer format
- added Gregorian day/month to display
- fixed Hebrew numerals for 11-19

<img width="326" alt="screen shot 2018-10-17 at 16 16 13" src="https://user-images.githubusercontent.com/8074436/47094341-536ed800-d22b-11e8-883e-873a7af405fa.png">

Fixes #2682
