### PR TITLE
feat(modal): set strong typing in componentInstance getter property

### DIFF
--- a/src/modal/modal-ref.ts
+++ b/src/modal/modal-ref.ts
@@ -30,7 +30,7 @@ export class NgbActiveModal {
 /**
  * A reference to the newly opened modal returned by the `NgbModal.open()` method.
  */
-export class NgbModalRef {
+export class NgbModalRef<T = any> {
   private _resolve: (result?: any) => void;
   private _reject: (reason?: any) => void;
 
@@ -39,7 +39,7 @@ export class NgbModalRef {
    *
    * When a `TemplateRef` is used as the content or when the modal is closed, will return `undefined`.
    */
-  get componentInstance(): any {
+  get componentInstance(): T extends new (...args: any[]) => any? InstanceType<T>: undefined {
     if (this._contentRef && this._contentRef.componentRef) {
       return this._contentRef.componentRef.instance;
     }

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -1087,7 +1087,7 @@ export class WithSkipTabindexFirstFocusableModalCmpt {
 })
 class TestComponent {
   name = 'World';
-  openedModal: NgbModalRef;
+  openedModal: NgbModalRef<string>;
   show = true;
   @ViewChild('content', {static: true}) tplContent;
   @ViewChild('destroyableContent', {static: true}) tplDestroyableContent;

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -25,7 +25,7 @@ export class NgbModal {
    *
    * Also see the [`NgbModalOptions`](#/components/modal/api#NgbModalOptions) for the list of supported options.
    */
-  open(content: any, options: NgbModalOptions = {}): NgbModalRef {
+  open<T>(content: T, options: NgbModalOptions = {}): NgbModalRef<T> {
     const combinedOptions = Object.assign({}, this._config, options);
     return this._modalStack.open(this._moduleCFR, this._injector, content, combinedOptions);
   }


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.


This should be mostly compatible with current branch. As latest version of this use Angular 6.1 and Angular itself uses TS2.9, I take the liberty to update those dependencies to latest of each branch to be able to use conditional types. 

Using conditional types I manage to strong type the `componentInstance` property only when you open a Component. However by using default types, developers should have the same experience that they currently have, meaning, the `componentInstance` property is default to any. Regardless that, this could have some breaking scenarios, but please notice that those scenarios should not be working on the first place as this change only typing, and not behavior.

Fix: #2479 