### PR TITLE
feat(popover): add ability to toggle popover based on boolean value

### DIFF
--- a/demo/src/app/components/popover/demos/openif/popover-openif.html
+++ b/demo/src/app/components/popover/demos/openif/popover-openif.html
@@ -1,0 +1,22 @@
+<p>You can set the popover to open or close based on a boolean value.</p>
+
+<form>
+  <div class="form-group">
+    <div class="form-check">
+      <input class="form-check-input" type="radio" name="openIf" id="openTrue" [value]="true" [(ngModel)]="openIf">
+      <label class="form-check-label" for="openTrue">
+        open
+      </label>
+    </div>
+    <div class="form-check">
+      <input class="form-check-input" type="radio" name="openIf" id="openFalse" [value]="false" [(ngModel)]="openIf">
+      <label class="form-check-label" for="openFalse">
+        close
+      </label>
+    </div>
+  </div>
+  <div class="form-group">
+    <input type="text" class="form-control" ngbPopover="What a great tip!" popoverTitle="Pop title" [autoClose]="false"
+      triggers="manual" [openIf]="openIf">
+  </div>
+</form>

--- a/demo/src/app/components/popover/demos/openif/popover-openif.ts
+++ b/demo/src/app/components/popover/demos/openif/popover-openif.ts
@@ -1,0 +1,11 @@
+import {Component} from '@angular/core';
+
+
+
+@Component({
+  selector: 'ngbd-popover-openif',
+  templateUrl: './popover-openif.html'
+})
+export class NgbdPopoverOpenif {
+  openIf = true;
+}

--- a/demo/src/app/components/popover/popover.module.ts
+++ b/demo/src/app/components/popover/popover.module.ts
@@ -6,6 +6,7 @@ import { NgbdComponentsSharedModule, NgbdDemoList } from '../shared';
 import { NgbdApiPage } from '../shared/api-page/api.component';
 import { NgbdExamplesPage } from '../shared/examples-page/examples.component';
 import { NgbdPopoverAutoclose } from './demos/autoclose/popover-autoclose';
+import { NgbdPopoverOpenif } from './demos/openif/popover-openif';
 import { NgbdPopoverBasic } from './demos/basic/popover-basic';
 import { NgbdPopoverConfig } from './demos/config/popover-config';
 import { NgbdPopoverContainer } from './demos/container/popover-container';
@@ -21,6 +22,7 @@ const DEMO_DIRECTIVES = [
   NgbdPopoverTplwithcontext,
   NgbdPopoverTriggers,
   NgbdPopoverAutoclose,
+  NgbdPopoverOpenif,
   NgbdPopoverVisibility,
   NgbdPopoverContainer,
   NgbdPopoverCustomclass,
@@ -51,6 +53,12 @@ const DEMOS = {
     type: NgbdPopoverAutoclose,
     code: require('!!raw-loader!./demos/autoclose/popover-autoclose'),
     markup: require('!!raw-loader!./demos/autoclose/popover-autoclose.html')
+  },
+  openIf: {
+    title: 'Open or close based on boolean value',
+    type: NgbdPopoverOpenif,
+    code: require('!!raw-loader!./demos/openif/popover-openif'),
+    markup: require('!!raw-loader!./demos/openif/popover-openif.html')
   },
   tplwithcontext: {
     title: 'Context and manual triggers',

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kwall2004/ng-bootstrap",
-  "version": "3.3.0",
+  "version": "3.3.0-rc.0",
   "description": "Angular powered Bootstrap",
   "keywords": [
     "angular",

--- a/src/package.json
+++ b/src/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ng-bootstrap/ng-bootstrap",
+  "name": "@kwall2004/ng-bootstrap",
   "version": "3.3.0",
   "description": "Angular powered Bootstrap",
   "keywords": [

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -899,6 +899,26 @@ describe('ngb-popover', () => {
       buttonEl.triggerEventHandler('click', {});
     });
   });
+
+  describe('openIf', () => {
+    beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPopoverModule]}); });
+
+    it('should support openIf is true', () => {
+      const fixture = createTestComponent(`<div ngbPopover="Great tip!"></div>`);
+
+      fixture.componentInstance.popover.openIf = true;
+      fixture.detectChanges();
+      expect(getWindow(fixture.nativeElement)).not.toBeNull();
+    });
+
+    it('should support openIf is false', () => {
+      const fixture = createTestComponent(`<div ngbPopover="Great tip!"></div>`);
+
+      fixture.componentInstance.popover.openIf = false;
+      fixture.detectChanges();
+      expect(getWindow(fixture.nativeElement)).toBeNull();
+    });
+  });
 });
 
 @Component({selector: 'test-cmpt', template: ``})

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -138,7 +138,7 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
    */
   @Input() popoverClass: string;
   /**
-   * Emits an event when the popover is shown
+   * Shows or hides the popover based on a boolean value
    */
   @Input()
   set openIf(value: boolean) {
@@ -148,6 +148,9 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
       this.close();
     }
   }
+  /**
+   * Emits an event when the popover is shown
+   */
   @Output() shown = new EventEmitter();
   /**
    * Emits an event when the popover is hidden

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -140,6 +140,14 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
   /**
    * Emits an event when the popover is shown
    */
+  @Input()
+  set isOpen(value: boolean) {
+    if (value) {
+      this.open();
+    } else {
+      this.close();
+    }
+  }
   @Output() shown = new EventEmitter();
   /**
    * Emits an event when the popover is hidden
@@ -263,7 +271,7 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
   /**
    * Returns whether or not the popover is currently being shown
    */
-  isOpen(): boolean { return this._windowRef != null; }
+  get isOpen(): boolean { return this._windowRef != null; }
 
   ngOnInit() {
     this._unregisterListenersFn = listenToTriggers(

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -141,7 +141,7 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
    * Emits an event when the popover is shown
    */
   @Input()
-  set isOpen(value: boolean) {
+  set openIf(value: boolean) {
     if (value) {
       this.open();
     } else {
@@ -271,7 +271,7 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
   /**
    * Returns whether or not the popover is currently being shown
    */
-  get isOpen(): boolean { return this._windowRef != null; }
+  isOpen(): boolean { return this._windowRef != null; }
 
   ngOnInit() {
     this._unregisterListenersFn = listenToTriggers(


### PR DESCRIPTION
I have a requirement to toggle a popover based on a boolean input value.  Without this change, I have to write this code for each instance:

```
@Component({
  selector: 'ngbd-popover-openif',
  templateUrl: './popover-openif.html'
})
export class NgbdPopoverOpenif {
  @ViewChild('popover') popover: NgbPopover;

  @Input()
  set openIf(value: boolean) {
    if (value) {
      this.popover.open();
    } else {
      this.popover.close();
    }
  }
}
```