### PR TITLE
fix(typehead): do not exec _onTouched if related target is from ddl.

### DIFF
--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -701,6 +701,25 @@ describe('ngb-typeahead', () => {
            expect(fixture.componentInstance.model).toBeUndefined();
          });
        }));
+
+    it('should validate value after selecting an item from drop down list', async(() => {
+         const html = `
+          <form>
+            <input type="text" [(ngModel)]="model" name="control" required [ngbTypeahead]="find" />
+          </form>`;
+         const fixture = createTestComponent(html);
+         fixture.whenStable().then(() => {
+           fixture.detectChanges();
+           const compiled = fixture.nativeElement;
+
+           changeInput(compiled, 'o');
+           fixture.detectChanges();
+           getWindowLinks(fixture.debugElement)[0].triggerEventHandler('mousedown', {button: 0});
+           fixture.detectChanges();
+           expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
+           expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
+         });
+       }));
   });
 
   describe('select event', () => {

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -56,7 +56,7 @@ let nextWindowId = 0;
   selector: 'input[ngbTypeahead]',
   exportAs: 'ngbTypeahead',
   host: {
-    '(blur)': 'handleBlur()',
+    '(blur)': 'handleBlur($event)',
     '[class.open]': 'isPopupOpen()',
     '(document:click)': 'onDocumentClick($event)',
     '(keydown)': 'handleKeyDown($event)',
@@ -233,8 +233,18 @@ export class NgbTypeahead implements ControlValueAccessor,
    */
   isPopupOpen() { return this._windowRef != null; }
 
-  handleBlur() {
+  handleBlur(event: FocusEvent) {
     this._resubscribeTypeahead.next(null);
+    if (event) {
+      const relatedTarget = event.relatedTarget as HTMLElement;
+      if (relatedTarget) {
+        const isButton = relatedTarget.tagName.toLowerCase() === 'button';
+        const hasDropdownItemClass = relatedTarget.classList.contains('dropdown-item');
+        if (isButton && hasDropdownItemClass) {
+          return;
+        }
+      }
+    }
     this._onTouched();
   }
 


### PR DESCRIPTION
Fix #2719

If related target of blur() is from drop down list selected item, do not proceed to execute _onTouched().