### PR TITLE
fix(typehead): write value back to FormControl if updateOn is 'blur'.

### DIFF
--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -13,9 +13,10 @@ import {
   Output,
   Renderer2,
   TemplateRef,
-  ViewContainerRef
+  ViewContainerRef,
+  Type
 } from '@angular/core';
-import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
+import {ControlValueAccessor, NG_VALUE_ACCESSOR, NgControl, FormControl} from '@angular/forms';
 import {Observable, BehaviorSubject, Subscription, fromEvent} from 'rxjs';
 import {positionElements, PlacementArray} from '../util/positioning';
 import {NgbTypeaheadWindow, ResultTemplateContext} from './typeahead-window';
@@ -311,6 +312,16 @@ export class NgbTypeahead implements ControlValueAccessor,
     this._selectResult(result);
     this._closePopup();
     this._elementRef.nativeElement.focus();
+
+    try {
+      const ngModel = this._injector.get<NgControl>(NgControl as Type<NgControl>);
+      const formControl = ngModel.control as FormControl;
+      if (formControl.updateOn === 'blur') {
+        formControl.patchValue(this._elementRef.nativeElement.value);
+      }
+    } catch {
+      // do nothing
+    }
   }
 
   private _showHint() {


### PR DESCRIPTION
Fix #2786

If updateOn is set to 'blur', update input value back to FormControl to coerce the synchronization.
