### PR TITLE
fix(typehead): skip writing backup value if value is empty.

### DIFF
--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -224,7 +224,9 @@ export class NgbTypeahead implements ControlValueAccessor,
   dismissPopup() {
     if (this.isPopupOpen()) {
       this._closePopup();
-      this._writeInputValue(this._inputValueBackup);
+      if (this._elementRef.nativeElement.value !== '') {
+        this._writeInputValue(this._inputValueBackup);
+      }
     }
   }
 


### PR DESCRIPTION
Fix #2816

If input value has been emptied by changing model value, writing backup value back to input value should be skipped.