### PR TITLE
fix(modal): fix type error when closing modal

### DIFF
--- a/src/modal/modal-ref.ts
+++ b/src/modal/modal-ref.ts
@@ -101,7 +101,9 @@ export class NgbModalRef {
 
     if (this._backdropCmptRef) {
       const backdropNativeEl = this._backdropCmptRef.location.nativeElement;
-      backdropNativeEl.parentNode.removeChild(backdropNativeEl);
+      if (backdropNativeEl.parentNode) {
+        backdropNativeEl.parentNode.removeChild(backdropNativeEl);
+      }
       this._backdropCmptRef.destroy();
     }
 


### PR DESCRIPTION
This commit fixes the following error:

```
Uncaught (in promise): TypeError: Cannot read property 'removeChild' of null
TypeError: Cannot read property 'removeChild' of null
    at t._removeModalElements
```

It checks that `backdropNativeEl.parentNode` is defined before calling the `removeChild` method.