### PR TITLE
fix(typeahead): prevent validation during an item click

### DIFF
--- a/e2e-app/src/app/app.module.ts
+++ b/e2e-app/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import {BrowserModule} from '@angular/platform-browser';
 import {NgModule} from '@angular/core';
-import {FormsModule} from '@angular/forms';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 
 import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 
@@ -15,14 +15,15 @@ import {ModalFocusComponent} from './modal/focus/modal-focus.component';
 import {PopoverAutocloseComponent} from './popover/autoclose/popover-autoclose.component';
 import {TooltipAutocloseComponent} from './tooltip/autoclose/tooltip-autoclose.component';
 import {TypeaheadFocusComponent} from './typeahead/focus/typeahead-focus.component';
+import {TypeaheadValidationComponent} from './typeahead/validation/typeahead-validation.component';
 
 @NgModule({
   declarations: [
     AppComponent, NavigationComponent, DatepickerAutoCloseComponent, DatepickerFocusComponent,
     DropdownAutoCloseComponent, ModalFocusComponent, PopoverAutocloseComponent, TooltipAutocloseComponent,
-    TypeaheadFocusComponent
+    TypeaheadFocusComponent, TypeaheadValidationComponent
   ],
-  imports: [BrowserModule, FormsModule, routing, NgbModule],
+  imports: [BrowserModule, FormsModule, ReactiveFormsModule, routing, NgbModule],
   bootstrap: [AppComponent]
 })
 export class AppModule {

--- a/e2e-app/src/app/app.routing.ts
+++ b/e2e-app/src/app/app.routing.ts
@@ -7,6 +7,7 @@ import {ModalFocusComponent} from './modal/focus/modal-focus.component';
 import {PopoverAutocloseComponent} from './popover/autoclose/popover-autoclose.component';
 import {TooltipAutocloseComponent} from './tooltip/autoclose/tooltip-autoclose.component';
 import {TypeaheadFocusComponent} from './typeahead/focus/typeahead-focus.component';
+import {TypeaheadValidationComponent} from './typeahead/validation/typeahead-validation.component';
 
 export const routes: Routes = [
   {
@@ -19,8 +20,13 @@ export const routes: Routes = [
   {path: 'modal', children: [{path: 'focus', component: ModalFocusComponent}]},
   {path: 'dropdown', children: [{path: 'autoclose', component: DropdownAutoCloseComponent}]},
   {path: 'popover', children: [{path: 'autoclose', component: PopoverAutocloseComponent}]},
-  {path: 'tooltip', children: [{path: 'autoclose', component: TooltipAutocloseComponent}]},
-  {path: 'typeahead', children: [{path: 'focus', component: TypeaheadFocusComponent}]}
+  {path: 'tooltip', children: [{path: 'autoclose', component: TooltipAutocloseComponent}]}, {
+    path: 'typeahead',
+    children: [
+      {path: 'focus', component: TypeaheadFocusComponent},
+      {path: 'validation', component: TypeaheadValidationComponent}
+    ]
+  }
 ];
 
 export const routing: ModuleWithProviders = RouterModule.forRoot(routes, {useHash: true});

--- a/e2e-app/src/app/typeahead/validation/typeahead-validation.component.html
+++ b/e2e-app/src/app/typeahead/validation/typeahead-validation.component.html
@@ -1,0 +1,28 @@
+<h3>Typeahead tests</h3>
+
+<form>
+  <div class="form-group form-inline">
+    <div class="input-group mr-2">
+        <label for="first" class="mr-2">Before</label>
+        <input id="first">
+    </div>
+    <div class="input-group mr-2">
+      <label for="typeahead" class="mr-2">Typeahead</label>
+      <input
+        id="typeahead"
+        name="typeahead"
+        type="text"
+        class="form-control"
+        [formControl]="field"
+        [ngbTypeahead]="search"
+        (focus)="focus$.next($event.target.value)"
+        (click)="click$.next($event.target.value)"
+        #instance="ngbTypeahead"
+      />
+    </div>
+    <div class="input-group mr-2">
+        <label for="last" class="mr-2">After</label>
+        <input id="last">
+    </div>
+  </div>
+</form>

--- a/e2e-app/src/app/typeahead/validation/typeahead-validation.component.ts
+++ b/e2e-app/src/app/typeahead/validation/typeahead-validation.component.ts
@@ -1,0 +1,88 @@
+import {Component, ViewChild} from '@angular/core';
+import {NgbTypeahead} from '@ng-bootstrap/ng-bootstrap';
+import {Observable, Subject, merge} from 'rxjs';
+import {distinctUntilChanged, filter, map} from 'rxjs/operators';
+import {FormControl} from '@angular/forms';
+
+const states = [
+  'Alabama',
+  'Alaska',
+  'American Samoa',
+  'Arizona',
+  'Arkansas',
+  'California',
+  'Colorado',
+  'Connecticut',
+  'Delaware',
+  'District Of Columbia',
+  'Federated States Of Micronesia',
+  'Florida',
+  'Georgia',
+  'Guam',
+  'Hawaii',
+  'Idaho',
+  'Illinois',
+  'Indiana',
+  'Iowa',
+  'Kansas',
+  'Kentucky',
+  'Louisiana',
+  'Maine',
+  'Marshall Islands',
+  'Maryland',
+  'Massachusetts',
+  'Michigan',
+  'Minnesota',
+  'Mississippi',
+  'Missouri',
+  'Montana',
+  'Nebraska',
+  'Nevada',
+  'New Hampshire',
+  'New Jersey',
+  'New Mexico',
+  'New York',
+  'North Carolina',
+  'North Dakota',
+  'Northern Mariana Islands',
+  'Ohio',
+  'Oklahoma',
+  'Oregon',
+  'Palau',
+  'Pennsylvania',
+  'Puerto Rico',
+  'Rhode Island',
+  'South Carolina',
+  'South Dakota',
+  'Tennessee',
+  'Texas',
+  'Utah',
+  'Vermont',
+  'Virgin Islands',
+  'Virginia',
+  'Washington',
+  'West Virginia',
+  'Wisconsin',
+  'Wyoming'
+];
+
+@Component({templateUrl: './typeahead-validation.component.html'})
+export class TypeaheadValidationComponent {
+  model: any;
+  public field = new FormControl();
+
+  @ViewChild('instance') instance: NgbTypeahead;
+  focus$ = new Subject<string>();
+  click$ = new Subject<string>();
+
+  search = (text$: Observable<string>) => {
+    const debouncedText$ = text$.pipe(distinctUntilChanged());
+    const clicksWithClosedPopup$ = this.click$.pipe(filter(() => !this.instance.isPopupOpen()));
+    const inputFocus$ = this.focus$;
+
+    return merge(debouncedText$, inputFocus$, clicksWithClosedPopup$)
+        .pipe(
+            map(term => (term === '' ? states : states.filter(v => v.toLowerCase().indexOf(term.toLowerCase()) > -1))
+                            .slice(0, 10)));
+  }
+}

--- a/e2e-app/src/app/typeahead/validation/typeahead-validation.e2e-spec.ts
+++ b/e2e-app/src/app/typeahead/validation/typeahead-validation.e2e-spec.ts
@@ -1,0 +1,25 @@
+import {TypeaheadPage} from '../typeahead.po';
+import {openUrl} from '../../tools.po';
+
+describe('Typeahead', () => {
+  let page: TypeaheadPage;
+
+  const expectUntouched = async() => {
+    const typeaheadInput = page.getTypeaheadInput();
+    expect(typeaheadInput.getAttribute('class')).toContain('ng-untouched', `The input shouldn't be touched`);
+  };
+
+  beforeAll(() => page = new TypeaheadPage());
+
+  beforeEach(async() => await openUrl('typeahead/validation'));
+
+  it(`should stay valid on item click`, async() => {
+    await page.getTypeaheadInput().click();
+    expectUntouched();
+
+    const itemElement = page.getDropdownItems().get(0);
+    await itemElement.click();
+    expectUntouched();
+
+  });
+});


### PR DESCRIPTION
fix #2719 

Landed here the solution proposed in #2843 (thanks @wannadream !), with some changes:

- The fix for this particular issue is separated from the others,
- The 'if' inside the handleBlur has been simplified,
- Protractor tests have been added to cover this case
