### PR TITLE
fix(modal): 'dimiss' ambiguity in docs

### DIFF
--- a/src/modal/modal-ref.ts
+++ b/src/modal/modal-ref.ts
@@ -16,7 +16,7 @@ export class NgbActiveModal {
   close(result?: any): void {}
 
   /**
-   * Can be used to dismiss a modal, passing an optional reason.
+   * Can be used to dismiss a modal, passing an optional reason (result is discarded).
    */
   dismiss(reason?: any): void {}
 }

--- a/src/modal/modal-ref.ts
+++ b/src/modal/modal-ref.ts
@@ -11,12 +11,12 @@ import {ContentRef} from '../util/popup';
  */
 export class NgbActiveModal {
   /**
-   * Closes the modal with an optional 'result' object. The 'NgbMobalRef.result' promise will be resolved with the 'result' object.
+   * Closes the modal with an optional 'result' value. The 'NgbMobalRef.result' promise will be resolved with provided value.
    */
   close(result?: any): void {}
 
   /**
-   * Dismisses the modal with an optional 'reason' object. The 'NgbModalRef.result' promise will be rejected with the 'reason' object.
+   * Dismisses the modal with an optional 'reason' value. The 'NgbModalRef.result' promise will be rejected with provided value.
    */
   dismiss(reason?: any): void {}
 }
@@ -56,7 +56,7 @@ export class NgbModalRef {
   }
 
   /**
-   * Closes the modal with an optional 'result' object. The 'NgbMobalRef.result' promise will be resolved with the 'result' object.
+   * Closes the modal with an optional 'result' value. The 'NgbMobalRef.result' promise will be resolved with provided value.
    */
   close(result?: any): void {
     if (this._windowCmptRef) {
@@ -71,7 +71,7 @@ export class NgbModalRef {
   }
 
   /**
-   * Dismisses the modal with an optional 'reason' object. The 'NgbModalRef.result' promise will be rejected with the 'reason' object.
+   * Dismisses the modal with an optional 'reason' value. The 'NgbModalRef.result' promise will be rejected with provided value.
    */
   dismiss(reason?: any): void {
     if (this._windowCmptRef) {

--- a/src/modal/modal-ref.ts
+++ b/src/modal/modal-ref.ts
@@ -11,12 +11,14 @@ import {ContentRef} from '../util/popup';
  */
 export class NgbActiveModal {
   /**
-   * Closes the modal with an optional 'result' value. The 'NgbMobalRef.result' promise will be resolved with provided value.
+   * Closes the modal with an optional 'result' value.
+   * The 'NgbMobalRef.result' promise will be resolved with provided value.
    */
   close(result?: any): void {}
 
   /**
-   * Dismisses the modal with an optional 'reason' value. The 'NgbModalRef.result' promise will be rejected with provided value.
+   * Dismisses the modal with an optional 'reason' value.
+   * The 'NgbModalRef.result' promise will be rejected with provided value.
    */
   dismiss(reason?: any): void {}
 }
@@ -56,7 +58,8 @@ export class NgbModalRef {
   }
 
   /**
-   * Closes the modal with an optional 'result' value. The 'NgbMobalRef.result' promise will be resolved with provided value.
+   * Closes the modal with an optional 'result' value.
+   * The 'NgbMobalRef.result' promise will be resolved with provided value.
    */
   close(result?: any): void {
     if (this._windowCmptRef) {
@@ -71,7 +74,8 @@ export class NgbModalRef {
   }
 
   /**
-   * Dismisses the modal with an optional 'reason' value. The 'NgbModalRef.result' promise will be rejected with provided value.
+   * Dismisses the modal with an optional 'reason' value.
+   * The 'NgbModalRef.result' promise will be rejected with provided value.
    */
   dismiss(reason?: any): void {
     if (this._windowCmptRef) {

--- a/src/modal/modal-ref.ts
+++ b/src/modal/modal-ref.ts
@@ -11,18 +11,18 @@ import {ContentRef} from '../util/popup';
  */
 export class NgbActiveModal {
   /**
-   * Can be used to close a modal, passing an optional result.
+   * Closes the modal with an optional 'result' object. The 'NgbMobalRef.result' promise will be resolved with the 'result' object.
    */
   close(result?: any): void {}
 
   /**
-   * Can be used to dismiss a modal, passing an optional reason (result is discarded).
+   * Dismisses the modal with an optional 'reason' object. The 'NgbModalRef.result' promise will be rejected with the 'reason' object.
    */
   dismiss(reason?: any): void {}
 }
 
 /**
- * A reference to a newly opened modal.
+ * A reference to a newly opened modal returned by the 'NgbModal.open()' method.
  */
 export class NgbModalRef {
   private _resolve: (result?: any) => void;
@@ -39,7 +39,7 @@ export class NgbModalRef {
   }
 
   /**
-   * A promise that is resolved when a modal is closed and rejected when a modal is dismissed.
+   * A promise that is resolved when the modal is closed and rejected when the modal is dismissed.
    */
   result: Promise<any>;
 
@@ -56,7 +56,7 @@ export class NgbModalRef {
   }
 
   /**
-   * Can be used to close a modal, passing an optional result.
+   * Closes the modal with an optional 'result' object. The 'NgbMobalRef.result' promise will be resolved with the 'result' object.
    */
   close(result?: any): void {
     if (this._windowCmptRef) {
@@ -71,7 +71,7 @@ export class NgbModalRef {
   }
 
   /**
-   * Can be used to dismiss a modal, passing an optional reason.
+   * Dismisses the modal with an optional 'reason' object. The 'NgbModalRef.result' promise will be rejected with the 'reason' object.
    */
   dismiss(reason?: any): void {
     if (this._windowCmptRef) {


### PR DESCRIPTION
At first glance it was hard to differentiate `close` and `dismiss`.