### PR TITLE
Refactor keyboard handling to avoid event hijacking

### DIFF
--- a/src/datepicker/datepicker-keymap-service.ts
+++ b/src/datepicker/datepicker-keymap-service.ts
@@ -1,7 +1,6 @@
 import {Injectable} from '@angular/core';
 import {NgbDatepickerService} from './datepicker-service';
 import {NgbCalendar} from './ngb-calendar';
-import {toString} from '../util/util';
 import {Key} from '../util/key';
 import {NgbDate} from './ngb-date';
 
@@ -23,43 +22,41 @@ export class NgbDatepickerKeyMapService {
 
   processKey(event: KeyboardEvent) {
     // tslint:disable-next-line:deprecation
-    const {which} = event;
-    if (Key[toString(which)]) {
-      switch (which) {
-        case Key.PageUp:
-          this._service.focusMove(event.shiftKey ? 'y' : 'm', -1);
-          break;
-        case Key.PageDown:
-          this._service.focusMove(event.shiftKey ? 'y' : 'm', 1);
-          break;
-        case Key.End:
-          this._service.focus(event.shiftKey ? this._maxDate : this._lastViewDate);
-          break;
-        case Key.Home:
-          this._service.focus(event.shiftKey ? this._minDate : this._firstViewDate);
-          break;
-        case Key.ArrowLeft:
-          this._service.focusMove('d', -1);
-          break;
-        case Key.ArrowUp:
-          this._service.focusMove('d', -this._calendar.getDaysPerWeek());
-          break;
-        case Key.ArrowRight:
-          this._service.focusMove('d', 1);
-          break;
-        case Key.ArrowDown:
-          this._service.focusMove('d', this._calendar.getDaysPerWeek());
-          break;
-        case Key.Enter:
-        case Key.Space:
-          this._service.focusSelect();
-          break;
-        default:
-          return;
-      }
-
-      event.preventDefault();
-      event.stopPropagation();
+    switch (event.which) {
+      case Key.PageUp:
+        this._service.focusMove(event.shiftKey ? 'y' : 'm', -1);
+        break;
+      case Key.PageDown:
+        this._service.focusMove(event.shiftKey ? 'y' : 'm', 1);
+        break;
+      case Key.End:
+        this._service.focus(event.shiftKey ? this._maxDate : this._lastViewDate);
+        break;
+      case Key.Home:
+        this._service.focus(event.shiftKey ? this._minDate : this._firstViewDate);
+        break;
+      case Key.ArrowLeft:
+        this._service.focusMove('d', -1);
+        break;
+      case Key.ArrowUp:
+        this._service.focusMove('d', -this._calendar.getDaysPerWeek());
+        break;
+      case Key.ArrowRight:
+        this._service.focusMove('d', 1);
+        break;
+      case Key.ArrowDown:
+        this._service.focusMove('d', this._calendar.getDaysPerWeek());
+        break;
+      case Key.Enter:
+      case Key.Space:
+        this._service.focusSelect();
+        break;
+      default:
+        return;
     }
+
+    // note 'return' in default case
+    event.preventDefault();
+    event.stopPropagation();
   }
 }

--- a/src/rating/rating.ts
+++ b/src/rating/rating.ts
@@ -13,7 +13,7 @@ import {
   ChangeDetectorRef
 } from '@angular/core';
 import {NgbRatingConfig} from './rating-config';
-import {toString, getValueInRange} from '../util/util';
+import {getValueInRange} from '../util/util';
 import {Key} from '../util/key';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 
@@ -142,27 +142,27 @@ export class NgbRating implements ControlValueAccessor,
 
   handleKeyDown(event: KeyboardEvent) {
     // tslint:disable-next-line:deprecation
-    const {which} = event;
-    if (Key[toString(which)]) {
-      event.preventDefault();
-
-      switch (which) {
-        case Key.ArrowDown:
-        case Key.ArrowLeft:
-          this.update(this.rate - 1);
-          break;
-        case Key.ArrowUp:
-        case Key.ArrowRight:
-          this.update(this.rate + 1);
-          break;
-        case Key.Home:
-          this.update(0);
-          break;
-        case Key.End:
-          this.update(this.max);
-          break;
-      }
+    switch (event.which) {
+      case Key.ArrowDown:
+      case Key.ArrowLeft:
+        this.update(this.rate - 1);
+        break;
+      case Key.ArrowUp:
+      case Key.ArrowRight:
+        this.update(this.rate + 1);
+        break;
+      case Key.Home:
+        this.update(0);
+        break;
+      case Key.End:
+        this.update(this.max);
+        break;
+      default:
+        return;
     }
+
+    // note 'return' in default case
+    event.preventDefault();
   }
 
   ngOnChanges(changes: SimpleChanges) {

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -244,35 +244,32 @@ export class NgbTypeahead implements ControlValueAccessor,
     }
 
     // tslint:disable-next-line:deprecation
-    const {which} = event;
-    if (Key[toString(which)]) {
-      switch (which) {
-        case Key.ArrowDown:
+    switch (event.which) {
+      case Key.ArrowDown:
+        event.preventDefault();
+        this._windowRef.instance.next();
+        this._showHint();
+        break;
+      case Key.ArrowUp:
+        event.preventDefault();
+        this._windowRef.instance.prev();
+        this._showHint();
+        break;
+      case Key.Enter:
+      case Key.Tab:
+        const result = this._windowRef.instance.getActive();
+        if (isDefined(result)) {
           event.preventDefault();
-          this._windowRef.instance.next();
-          this._showHint();
-          break;
-        case Key.ArrowUp:
-          event.preventDefault();
-          this._windowRef.instance.prev();
-          this._showHint();
-          break;
-        case Key.Enter:
-        case Key.Tab:
-          const result = this._windowRef.instance.getActive();
-          if (isDefined(result)) {
-            event.preventDefault();
-            event.stopPropagation();
-            this._selectResult(result);
-          }
-          this._closePopup();
-          break;
-        case Key.Escape:
-          event.preventDefault();
-          this._resubscribeTypeahead.next(null);
-          this.dismissPopup();
-          break;
-      }
+          event.stopPropagation();
+          this._selectResult(result);
+        }
+        this._closePopup();
+        break;
+      case Key.Escape:
+        event.preventDefault();
+        this._resubscribeTypeahead.next(null);
+        this.dismissPopup();
+        break;
     }
   }
 


### PR DESCRIPTION
Before #2473 `Keys` corresponded ONLY to keys processed by the current widget
After the change `Keys` contain the list of ALL known Keys to ALL widgets.

Because of this some `preventDefault()` were called on keys not processed by current widget.

(2 commits)

Fixes #2895

P.S. Not sure what kind of tests to add for this