### PR TITLE
docs(table): add demo section about the table component

### DIFF
--- a/demo/src/app/app.module.ts
+++ b/demo/src/app/app.module.ts
@@ -16,6 +16,7 @@ import { NgbdPaginationModule } from './components/pagination/pagination.module'
 import { NgbdPopoverModule } from './components/popover/popover.module';
 import { NgbdProgressbarModule } from './components/progressbar/progressbar.module';
 import { NgbdRatingModule } from './components/rating/rating.module';
+import { NgbdTableModule } from './components/table/table.module';
 import { NgbdTabsetModule } from './components/tabset/tabset.module';
 import { NgbdTimepickerModule } from './components/timepicker/timepicker.module';
 import { NgbdTooltipModule } from './components/tooltip/tooltip.module';
@@ -37,6 +38,7 @@ const DEMOS = [
   NgbdPopoverModule,
   NgbdProgressbarModule,
   NgbdRatingModule,
+  NgbdTableModule,
   NgbdTabsetModule,
   NgbdTimepickerModule,
   NgbdTooltipModule,

--- a/demo/src/app/app.routing.ts
+++ b/demo/src/app/app.routing.ts
@@ -13,6 +13,7 @@ import { ROUTES as PAGINATION_ROUTES } from './components/pagination/pagination.
 import { ROUTES as POPOVER_ROUTES } from './components/popover/popover.module';
 import { ROUTES as PROGRESSBAR_ROUTES } from './components/progressbar/progressbar.module';
 import { ROUTES as RATING_ROUTES } from './components/rating/rating.module';
+import { ROUTES as TABLE_ROUTES } from './components/table/table.module';
 import { ROUTES as TABSET_ROUTES } from './components/tabset/tabset.module';
 import { ROUTES as TIMEPICKER_ROUTES } from './components/timepicker/timepicker.module';
 import { ROUTES as TOOLTIP_ROUTES } from './components/tooltip/tooltip.module';
@@ -73,6 +74,10 @@ const routes: Routes = [
   {
     path: 'components/rating',
     children: RATING_ROUTES
+  },
+  {
+    path: 'components/table',
+    children: TABLE_ROUTES
   },
   {
     path: 'components/tabset',

--- a/demo/src/app/components/table/demos/basic/table-basic.html
+++ b/demo/src/app/components/table/demos/basic/table-basic.html
@@ -1,0 +1,23 @@
+<p>Table is just a mapping of objects to table rows with <code>ngFor</code></p>
+
+<table class="table table-striped">
+  <thead>
+  <tr>
+    <th scope="col">#</th>
+    <th scope="col">Country</th>
+    <th scope="col">Area</th>
+    <th scope="col">Population</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr *ngFor="let country of countries; index as i">
+    <th scope="row">{{ i + 1 }}</th>
+    <td>
+      <img [src]="'https://upload.wikimedia.org/wikipedia/commons/' + country.flag" class="mr-2" style="width: 20px">
+      {{ country.name }}
+    </td>
+    <td>{{ country.area | number }}</td>
+    <td>{{ country.population | number }}</td>
+  </tr>
+  </tbody>
+</table>

--- a/demo/src/app/components/table/demos/basic/table-basic.ts
+++ b/demo/src/app/components/table/demos/basic/table-basic.ts
@@ -1,0 +1,44 @@
+import { Component } from '@angular/core';
+
+interface Country {
+  name: string;
+  flag: string;
+  area: number;
+  population: number;
+}
+
+const COUNTRIES: Country[] = [
+  {
+    name: 'Russia',
+    flag: 'f/f3/Flag_of_Russia.svg',
+    area: 17075200,
+    population: 146989754
+  },
+  {
+    name: 'Canada',
+    flag: 'c/cf/Flag_of_Canada.svg',
+    area: 9976140,
+    population: 36624199
+  },
+  {
+    name: 'United States',
+    flag: 'a/a4/Flag_of_the_United_States.svg',
+    area: 9629091,
+    population: 324459463
+  },
+  {
+    name: 'China',
+    flag: 'f/fa/Flag_of_the_People%27s_Republic_of_China.svg',
+    area: 9596960,
+    population: 1409517397
+  }
+];
+
+@Component({
+  selector: 'ngbd-table-basic',
+  templateUrl: './table-basic.html'
+})
+export class NgbdTableBasic {
+
+  countries = COUNTRIES;
+}

--- a/demo/src/app/components/table/demos/complete/countries.ts
+++ b/demo/src/app/components/table/demos/complete/countries.ts
@@ -1,0 +1,95 @@
+import {Country} from './country';
+
+export const COUNTRIES: Country[] = [
+  {
+    id: 1,
+    name: 'Russia',
+    flag: 'f/f3/Flag_of_Russia.svg',
+    area: 17075200,
+    population: 146989754
+  },
+  {
+    id: 2,
+    name: 'France',
+    flag: 'c/c3/Flag_of_France.svg',
+    area: 640679,
+    population: 64979548
+  },
+  {
+    id: 3,
+    name: 'Germany',
+    flag: 'b/ba/Flag_of_Germany.svg',
+    area: 357114,
+    population: 82114224
+  },
+  {
+    id: 4,
+    name: 'Portugal',
+    flag: '5/5c/Flag_of_Portugal.svg',
+    area: 92090,
+    population: 10329506
+  },
+  {
+    id: 5,
+    name: 'Canada',
+    flag: 'c/cf/Flag_of_Canada.svg',
+    area: 9976140,
+    population: 36624199
+  },
+  {
+    id: 6,
+    name: 'Vietnam',
+    flag: '2/21/Flag_of_Vietnam.svg',
+    area: 331212,
+    population: 95540800
+  },
+  {
+    id: 7,
+    name: 'Brazil',
+    flag: '0/05/Flag_of_Brazil.svg',
+    area: 8515767,
+    population: 209288278
+  },
+  {
+    id: 8,
+    name: 'Mexico',
+    flag: 'f/fc/Flag_of_Mexico.svg',
+    area: 1964375,
+    population: 129163276
+  },
+  {
+    id: 9,
+    name: 'United States',
+    flag: 'a/a4/Flag_of_the_United_States.svg',
+    area: 9629091,
+    population: 324459463
+  },
+  {
+    id: 10,
+    name: 'India',
+    flag: '4/41/Flag_of_India.svg',
+    area: 3287263,
+    population: 1324171354
+  },
+  {
+    id: 11,
+    name: 'Indonesia',
+    flag: '9/9f/Flag_of_Indonesia.svg',
+    area: 1910931,
+    population: 263991379
+  },
+  {
+    id: 12,
+    name: 'Tuvalu',
+    flag: '3/38/Flag_of_Tuvalu.svg',
+    area: 26,
+    population: 11097
+  },
+  {
+    id: 13,
+    name: 'China',
+    flag: 'f/fa/Flag_of_the_People%27s_Republic_of_China.svg',
+    area: 9596960,
+    population: 1409517397
+  }
+];

--- a/demo/src/app/components/table/demos/complete/country.service.ts
+++ b/demo/src/app/components/table/demos/complete/country.service.ts
@@ -1,0 +1,107 @@
+import {Injectable, PipeTransform} from '@angular/core';
+
+import {BehaviorSubject, Observable, of, Subject} from 'rxjs';
+
+import {Country} from './country';
+import {COUNTRIES} from './countries';
+import {DecimalPipe} from '@angular/common';
+import {debounceTime, delay, switchMap, tap} from 'rxjs/operators';
+import {SortDirection} from './sortable.directive';
+
+interface SearchResult {
+  countries: Country[];
+  total: number;
+}
+
+interface State {
+  page: number;
+  pageSize: number;
+  searchTerm: string;
+  sortColumn: string;
+  sortDirection: SortDirection;
+}
+
+function compare(v1, v2) {
+  return v1 < v2 ? -1 : v1 > v2 ? 1 : 0;
+}
+
+function sort(countries: Country[], column: string, direction: string): Country[] {
+  if (direction === '') {
+    return countries;
+  } else {
+    return [...countries].sort((a, b) => {
+      const res = compare(a[column], b[column]);
+      return direction === 'asc' ? res : -res;
+    });
+  }
+}
+
+function matches(country: Country, term: string, pipe: PipeTransform) {
+  return country.name.toLowerCase().includes(term)
+    || pipe.transform(country.area).includes(term)
+    || pipe.transform(country.population).includes(term);
+}
+
+@Injectable({providedIn: 'root'})
+export class CountryService {
+  private _loading$ = new BehaviorSubject<boolean>(true);
+  private _search$ = new Subject<void>();
+  private _countries$ = new BehaviorSubject<Country[]>([]);
+  private _total$ = new BehaviorSubject<number>(0);
+
+  private _state: State = {
+    page: 1,
+    pageSize: 4,
+    searchTerm: '',
+    sortColumn: '',
+    sortDirection: ''
+  };
+
+  constructor(private pipe: DecimalPipe) {
+    this._search$.pipe(
+      tap(() => this._loading$.next(true)),
+      debounceTime(200),
+      switchMap(() => this._search()),
+      delay(200),
+      tap(() => this._loading$.next(false))
+    ).subscribe(result => {
+      this._countries$.next(result.countries);
+      this._total$.next(result.total);
+    });
+
+    this._search$.next();
+  }
+
+  get countries$() { return this._countries$.asObservable(); }
+  get total$() { return this._total$.asObservable(); }
+  get loading$() { return this._loading$.asObservable(); }
+  get page() { return this._state.page; }
+  get pageSize() { return this._state.pageSize; }
+  get searchTerm() { return this._state.searchTerm; }
+
+  set page(page: number) { this._set({page}); }
+  set pageSize(pageSize: number) { this._set({pageSize}); }
+  set searchTerm(searchTerm: string) { this._set({searchTerm}); }
+  set sortColumn(sortColumn: string) { this._set({sortColumn}); }
+  set sortDirection(sortDirection: SortDirection) { this._set({sortDirection}); }
+
+  private _set(patch: Partial<State>) {
+    Object.assign(this._state, patch);
+    this._search$.next();
+  }
+
+  private _search(): Observable<SearchResult> {
+    const {sortColumn, sortDirection, pageSize, page, searchTerm} = this._state;
+
+    // 1. sort
+    let countries = sort(COUNTRIES, sortColumn, sortDirection);
+
+    // 2. filter
+    countries = countries.filter(country => matches(country, searchTerm, this.pipe));
+    const total = countries.length;
+
+    // 3. paginate
+    countries = countries.slice((page - 1) * pageSize, (page - 1) * pageSize + pageSize);
+    return of({countries, total});
+  }
+}

--- a/demo/src/app/components/table/demos/complete/country.ts
+++ b/demo/src/app/components/table/demos/complete/country.ts
@@ -1,0 +1,7 @@
+export interface Country {
+  id: number;
+  name: string;
+  flag: string;
+  area: number;
+  population: number;
+}

--- a/demo/src/app/components/table/demos/complete/sortable.directive.ts
+++ b/demo/src/app/components/table/demos/complete/sortable.directive.ts
@@ -1,0 +1,29 @@
+import {Directive, EventEmitter, Input, Output} from '@angular/core';
+
+export type SortDirection = 'asc' | 'desc' | '';
+const rotate: {[key: string]: SortDirection} = { 'asc': 'desc', 'desc': '', '': 'asc' };
+
+export interface SortEvent {
+  column: string;
+  direction: SortDirection;
+}
+
+@Directive({
+  selector: 'th[sortable]',
+  host: {
+    '[class.asc]': 'direction === "asc"',
+    '[class.desc]': 'direction === "desc"',
+    '(click)': 'rotate()'
+  }
+})
+export class NgbdSortableHeader {
+
+  @Input() sortable: string;
+  @Input() direction: SortDirection = '';
+  @Output() sort = new EventEmitter<SortEvent>();
+
+  rotate() {
+    this.direction = rotate[this.direction];
+    this.sort.emit({column: this.sortable, direction: this.direction});
+  }
+}

--- a/demo/src/app/components/table/demos/complete/table-complete.html
+++ b/demo/src/app/components/table/demos/complete/table-complete.html
@@ -1,0 +1,50 @@
+<p>This is a more complete example with a service that simulates server calling:</p>
+
+<ul>
+  <li>an observable async service to fetch a list of countries</li>
+  <li>sorting, filtering and pagination</li>
+  <li>simulated delay and loading indicator</li>
+  <li>debouncing of search requests</li>
+</ul>
+
+<form>
+  <div class="form-group form-inline">
+      Full text search: <input class="form-control ml-2" type="text" name="searchTerm" [(ngModel)]="service.searchTerm"/>
+      <span class="ml-3" *ngIf="service.loading$ | async">Loading...</span>
+  </div>
+
+  <table class="table table-striped">
+    <thead>
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col" sortable="name" (sort)="onSort($event)">Country</th>
+      <th scope="col" sortable="area" (sort)="onSort($event)">Area</th>
+      <th scope="col" sortable="population" (sort)="onSort($event)">Population</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr *ngFor="let country of countries$ | async">
+      <th scope="row">{{ country.id }}</th>
+      <td>
+        <img [src]="'https://upload.wikimedia.org/wikipedia/commons/' + country.flag" class="mr-2" style="width: 20px">
+        <ngb-highlight [result]="country.name" [term]="service.searchTerm"></ngb-highlight>
+      </td>
+      <td><ngb-highlight [result]="country.area | number" [term]="service.searchTerm"></ngb-highlight></td>
+      <td><ngb-highlight [result]="country.population | number" [term]="service.searchTerm"></ngb-highlight></td>
+    </tr>
+    </tbody>
+  </table>
+
+  <div class="d-flex justify-content-between p-2">
+    <ngb-pagination
+      [collectionSize]="total$ | async" [(page)]="service.page" [pageSize]="service.pageSize">
+    </ngb-pagination>
+
+    <select class="custom-select" style="width: auto" name="pageSize" [(ngModel)]="service.pageSize">
+      <option [ngValue]="2">2 items per page</option>
+      <option [ngValue]="4">4 items per page</option>
+      <option [ngValue]="6">6 items per page</option>
+    </select>
+  </div>
+
+</form>

--- a/demo/src/app/components/table/demos/complete/table-complete.ts
+++ b/demo/src/app/components/table/demos/complete/table-complete.ts
@@ -1,0 +1,37 @@
+import {Component, QueryList, ViewChildren} from '@angular/core';
+import {DecimalPipe} from '@angular/common';
+
+import {Observable} from 'rxjs';
+import {CountryService} from './country.service';
+import {Country} from './country';
+import {NgbdSortableHeader, SortEvent} from './sortable.directive';
+
+@Component({
+  selector: 'ngbd-table-complete',
+  templateUrl: './table-complete.html',
+  providers: [CountryService, DecimalPipe]
+})
+export class NgbdTableComplete {
+  countries$: Observable<Country[]>;
+  total$: Observable<number>;
+
+  @ViewChildren(NgbdSortableHeader) headers: QueryList<NgbdSortableHeader>;
+
+  constructor(public service: CountryService) {
+    this.countries$ = service.countries$;
+    this.total$ = service.total$;
+  }
+
+  onSort({column, direction}: SortEvent) {
+
+    // resetting other headers
+    this.headers.forEach(header => {
+      if (header.sortable !== column) {
+        header.direction = '';
+      }
+    });
+
+    this.service.sortColumn = column;
+    this.service.sortDirection = direction;
+  }
+}

--- a/demo/src/app/components/table/demos/filtering/table-filtering.html
+++ b/demo/src/app/components/table/demos/filtering/table-filtering.html
@@ -1,0 +1,29 @@
+<p>You can do filter table data, in this case with observables and our <code>NgbHighlight</code> component used in Typeahead</p>
+
+<form>
+  <div class="form-group form-inline">
+      Full text search: <input class="form-control ml-2" type="text" [formControl]="filter"/>
+  </div>
+</form>
+
+<table class="table table-striped">
+  <thead>
+  <tr>
+    <th scope="col">#</th>
+    <th scope="col">Country</th>
+    <th scope="col">Area</th>
+    <th scope="col">Population</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr *ngFor="let country of countries$ | async; index as i">
+    <th scope="row">{{ i + 1 }}</th>
+    <td>
+      <img [src]="'https://upload.wikimedia.org/wikipedia/commons/' + country.flag" class="mr-2" style="width: 20px">
+      <ngb-highlight [result]="country.name" [term]="filter.value"></ngb-highlight>
+    </td>
+    <td><ngb-highlight [result]="country.area | number" [term]="filter.value"></ngb-highlight></td>
+    <td><ngb-highlight [result]="country.population | number" [term]="filter.value"></ngb-highlight></td>
+  </tr>
+  </tbody>
+</table>

--- a/demo/src/app/components/table/demos/filtering/table-filtering.ts
+++ b/demo/src/app/components/table/demos/filtering/table-filtering.ts
@@ -1,0 +1,67 @@
+import { Component, PipeTransform } from '@angular/core';
+import { DecimalPipe } from '@angular/common';
+import { FormControl } from '@angular/forms';
+
+import { Observable } from 'rxjs';
+import { map, startWith } from 'rxjs/operators';
+
+interface Country {
+  name: string;
+  flag: string;
+  area: number;
+  population: number;
+}
+
+const COUNTRIES: Country[] = [
+  {
+    name: 'Russia',
+    flag: 'f/f3/Flag_of_Russia.svg',
+    area: 17075200,
+    population: 146989754
+  },
+  {
+    name: 'Canada',
+    flag: 'c/cf/Flag_of_Canada.svg',
+    area: 9976140,
+    population: 36624199
+  },
+  {
+    name: 'United States',
+    flag: 'a/a4/Flag_of_the_United_States.svg',
+    area: 9629091,
+    population: 324459463
+  },
+  {
+    name: 'China',
+    flag: 'f/fa/Flag_of_the_People%27s_Republic_of_China.svg',
+    area: 9596960,
+    population: 1409517397
+  }
+];
+
+function search(text: string, pipe: PipeTransform): Country[] {
+  return COUNTRIES.filter(country => {
+    const term = text.toLowerCase();
+    return country.name.toLowerCase().includes(term)
+        || pipe.transform(country.area).includes(term)
+        || pipe.transform(country.population).includes(term);
+  });
+}
+
+@Component({
+  selector: 'ngbd-table-filtering',
+  templateUrl: './table-filtering.html',
+  providers: [DecimalPipe]
+})
+export class NgbdTableFiltering {
+
+  countries$: Observable<Country[]>;
+  filter = new FormControl('');
+
+  constructor(pipe: DecimalPipe) {
+    this.countries$ = this.filter.valueChanges.pipe(
+      startWith(''),
+      map(text => search(text, pipe))
+    );
+  }
+}

--- a/demo/src/app/components/table/demos/pagination/table-pagination.html
+++ b/demo/src/app/components/table/demos/pagination/table-pagination.html
@@ -1,0 +1,34 @@
+<p>You can bind our <code>NgbPagination</code> component with slicing the data list</p>
+
+<table class="table table-striped">
+  <thead>
+  <tr>
+    <th scope="col">#</th>
+    <th scope="col">Country</th>
+    <th scope="col">Area</th>
+    <th scope="col">Population</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr *ngFor="let country of countries">
+    <th scope="row">{{ country.id }}</th>
+    <td>
+      <img [src]="'https://upload.wikimedia.org/wikipedia/commons/' + country.flag" class="mr-2" style="width: 20px">
+      {{ country.name }}
+    </td>
+    <td>{{ country.area | number}}</td>
+    <td>{{ country.population | number }}</td>
+  </tr>
+  </tbody>
+</table>
+
+<div class="d-flex justify-content-between p-2">
+  <ngb-pagination [collectionSize]="collectionSize" [(page)]="page" [pageSize]="pageSize">
+  </ngb-pagination>
+
+  <select class="custom-select" style="width: auto" [(ngModel)]="pageSize">
+    <option [ngValue]="2">2 items per page</option>
+    <option [ngValue]="4">4 items per page</option>
+    <option [ngValue]="6">6 items per page</option>
+  </select>
+</div>

--- a/demo/src/app/components/table/demos/pagination/table-pagination.ts
+++ b/demo/src/app/components/table/demos/pagination/table-pagination.ts
@@ -1,0 +1,107 @@
+import { Component } from '@angular/core';
+
+interface Country {
+  id?: number;
+  name: string;
+  flag: string;
+  area: number;
+  population: number;
+}
+
+const COUNTRIES: Country[] = [
+  {
+    name: 'Russia',
+    flag: 'f/f3/Flag_of_Russia.svg',
+    area: 17075200,
+    population: 146989754
+  },
+  {
+    name: 'France',
+    flag: 'c/c3/Flag_of_France.svg',
+    area: 640679,
+    population: 64979548
+  },
+  {
+    name: 'Germany',
+    flag: 'b/ba/Flag_of_Germany.svg',
+    area: 357114,
+    population: 82114224
+  },
+  {
+    name: 'Portugal',
+    flag: '5/5c/Flag_of_Portugal.svg',
+    area: 92090,
+    population: 10329506
+  },
+  {
+    name: 'Canada',
+    flag: 'c/cf/Flag_of_Canada.svg',
+    area: 9976140,
+    population: 36624199
+  },
+  {
+    name: 'Vietnam',
+    flag: '2/21/Flag_of_Vietnam.svg',
+    area: 331212,
+    population: 95540800
+  },
+  {
+    name: 'Brazil',
+    flag: '0/05/Flag_of_Brazil.svg',
+    area: 8515767,
+    population: 209288278
+  },
+  {
+    name: 'Mexico',
+    flag: 'f/fc/Flag_of_Mexico.svg',
+    area: 1964375,
+    population: 129163276
+  },
+  {
+    name: 'United States',
+    flag: 'a/a4/Flag_of_the_United_States.svg',
+    area: 9629091,
+    population: 324459463
+  },
+  {
+    name: 'India',
+    flag: '4/41/Flag_of_India.svg',
+    area: 3287263,
+    population: 1324171354
+  },
+  {
+    name: 'Indonesia',
+    flag: '9/9f/Flag_of_Indonesia.svg',
+    area: 1910931,
+    population: 263991379
+  },
+  {
+    name: 'Tuvalu',
+    flag: '3/38/Flag_of_Tuvalu.svg',
+    area: 26,
+    population: 11097
+  },
+  {
+    name: 'China',
+    flag: 'f/fa/Flag_of_the_People%27s_Republic_of_China.svg',
+    area: 9596960,
+    population: 1409517397
+  }
+];
+
+@Component({
+  selector: 'ngbd-table-pagination',
+  templateUrl: './table-pagination.html'
+})
+export class NgbdTablePagination {
+
+  page = 1;
+  pageSize = 4;
+  collectionSize = COUNTRIES.length;
+
+  get countries(): Country[] {
+    return COUNTRIES
+      .map((country, i) => ({id: i + 1, ...country}))
+      .slice((this.page - 1) * this.pageSize, (this.page - 1) * this.pageSize + this.pageSize);
+  }
+}

--- a/demo/src/app/components/table/demos/sortable/table-sortable.html
+++ b/demo/src/app/components/table/demos/sortable/table-sortable.html
@@ -1,0 +1,23 @@
+<p>You can introduce custom directives for table headers to sort columns</p>
+
+<table class="table table-striped">
+  <thead>
+  <tr>
+    <th scope="col">#</th>
+    <th scope="col" sortable="name" (sort)="onSort($event)">Country</th>
+    <th scope="col" sortable="area" (sort)="onSort($event)">Area</th>
+    <th scope="col" sortable="population" (sort)="onSort($event)">Population</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr *ngFor="let country of countries">
+    <th scope="row">{{ country.id }}</th>
+    <td>
+      <img [src]="'https://upload.wikimedia.org/wikipedia/commons/' + country.flag" class="mr-2" style="width: 20px">
+      {{ country.name }}
+    </td>
+    <td>{{ country.area | number }}</td>
+    <td>{{ country.population | number }}</td>
+  </tr>
+  </tbody>
+</table>

--- a/demo/src/app/components/table/demos/sortable/table-sortable.ts
+++ b/demo/src/app/components/table/demos/sortable/table-sortable.ts
@@ -1,0 +1,101 @@
+import { Component, Directive, EventEmitter, Input, Output, QueryList, ViewChildren } from '@angular/core';
+
+interface Country {
+  id: number;
+  name: string;
+  flag: string;
+  area: number;
+  population: number;
+}
+
+const COUNTRIES: Country[] = [
+  {
+    id: 1,
+    name: 'Russia',
+    flag: 'f/f3/Flag_of_Russia.svg',
+    area: 17075200,
+    population: 146989754
+  },
+  {
+    id: 2,
+    name: 'Canada',
+    flag: 'c/cf/Flag_of_Canada.svg',
+    area: 9976140,
+    population: 36624199
+  },
+  {
+    id: 3,
+    name: 'United States',
+    flag: 'a/a4/Flag_of_the_United_States.svg',
+    area: 9629091,
+    population: 324459463
+  },
+  {
+    id: 4,
+    name: 'China',
+    flag: 'f/fa/Flag_of_the_People%27s_Republic_of_China.svg',
+    area: 9596960,
+    population: 1409517397
+  }
+];
+
+export type SortDirection = 'asc' | 'desc' | '';
+const rotate: {[key: string]: SortDirection} = { 'asc': 'desc', 'desc': '', '': 'asc' };
+export const compare = (v1, v2) => v1 < v2 ? -1 : v1 > v2 ? 1 : 0;
+
+export interface SortEvent {
+  column: string;
+  direction: SortDirection;
+}
+
+@Directive({
+  selector: 'th[sortable]',
+  host: {
+    '[class.asc]': 'direction === "asc"',
+    '[class.desc]': 'direction === "desc"',
+    '(click)': 'rotate()'
+  }
+})
+export class NgbdSortableHeader {
+
+  @Input() sortable: string;
+  @Input() direction: SortDirection = '';
+  @Output() sort = new EventEmitter<SortEvent>();
+
+  rotate() {
+    this.direction = rotate[this.direction];
+    this.sort.emit({column: this.sortable, direction: this.direction});
+  }
+}
+
+@Component({
+  selector: 'ngbd-table-sortable',
+  templateUrl: './table-sortable.html'
+})
+export class NgbdTableSortable {
+
+  countries = COUNTRIES;
+
+  @ViewChildren(NgbdSortableHeader) headers: QueryList<NgbdSortableHeader>;
+
+  onSort({column, direction}: SortEvent) {
+
+    // resetting other headers
+    this.headers.forEach(header => {
+      if (header.sortable !== column) {
+        header.direction = '';
+      }
+    });
+
+    // sorting countries
+    if (direction === '') {
+      this.countries = COUNTRIES;
+    } else {
+      this.countries = [...COUNTRIES].sort((a, b) => {
+        const res = compare(a[column], b[column]);
+        return direction === 'asc' ? res : -res;
+      });
+    }
+  }
+
+}

--- a/demo/src/app/components/table/overview/demo/table-overview-demo.component.ts
+++ b/demo/src/app/components/table/overview/demo/table-overview-demo.component.ts
@@ -1,0 +1,58 @@
+import { Component } from '@angular/core';
+
+interface Country {
+  name: string;
+  flag: string;
+  area: number;
+  population: number;
+}
+
+@Component({
+  selector: 'ngbd-table-overview-demo',
+  template: `
+    <table class="table table-striped">
+      <thead>
+      <tr>
+        <th scope="col">#</th>
+        <th scope="col">Country</th>
+        <th scope="col">Area</th>
+        <th scope="col">Population</th>
+      </tr>
+      </thead>
+      <tbody>
+      <tr *ngFor="let country of countries; index as i">
+        <th scope="row">{{ i + 1 }}</th>
+        <td>
+          <img [src]="'https://upload.wikimedia.org/wikipedia/commons/' + country.flag" class="mr-2" style="width: 20px">
+          {{ country.name }}
+        </td>
+        <td>{{ country.area | number }}</td>
+        <td>{{ country.population | number }}</td>
+      </tr>
+      </tbody>
+    </table>
+  `
+})
+export class NgbdTableOverviewDemo {
+
+  countries: Country[] = [
+    {
+      name: 'Russia',
+      flag: 'f/f3/Flag_of_Russia.svg',
+      area: 17075200,
+      population: 146989754
+    },
+    {
+      name: 'Canada',
+      flag: 'c/cf/Flag_of_Canada.svg',
+      area: 9976140,
+      population: 36624199
+    },
+    {
+      name: 'United States',
+      flag: 'a/a4/Flag_of_the_United_States.svg',
+      area: 9629091,
+      population: 324459463
+    }
+  ];
+}

--- a/demo/src/app/components/table/overview/table-overview.component.html
+++ b/demo/src/app/components/table/overview/table-overview.component.html
@@ -1,0 +1,67 @@
+<p>
+  Bootstrap provides the some basic <a href="https://getbootstrap.com/docs/{{ bootstrapVersion }}/content/tables/">styling for the tables</a>
+  including CSS classes for responsiveness, striping odd/even rows, changing borders and captions, hovering rows, etc.
+  These styles are opt-in and can be used with pure Angular to produce something like this:
+</p>
+
+<ngbd-table-overview-demo></ngbd-table-overview-demo>
+
+<br>
+
+<ngb-alert [dismissible]="false">
+  At the moment we do not have plans to provide a dedicated component like <code>NgbTable</code> or <code>NgbGrid</code>
+  as a part of ng-bootstrap project. As usual we're open to the <i>productive</i> discussion on GitHub.
+</ngb-alert>
+
+<ngbd-overview-section [section]="sections['why-not']">
+  <p>
+    Most importantly, there are way too many different use cases and options for such a complex component.
+    Instead of building a <b>monster-of-a-widget</b> with hundreds of options and customizations, we would
+    encourage you to use composition and pure Angular. Most tables don't need all the features
+    and if you want a spreadsheet-like functionality there are dedicated libraries available.
+  </p>
+
+  <p>
+    Think about implementing the features you need and wrapping them into a component for your application.
+    It might be simpler than it seems.
+  </p>
+
+  <p>
+    If you decide to choose a library for tables, make sure that it plays nicely with Angular:
+  </p>
+
+  <ul>
+    <li>doesn't trigger change detection excessively</li>
+    <li>doesn't generate thousands of DOM nodes</li>
+    <li>doesn't bloat your resulting bundle size by bringing 3rd party dependencies</li>
+    <li>doesn't pretend to be an Angular library by wrapping something else</li>
+  </ul>
+</ngbd-overview-section>
+
+<ngbd-overview-section [section]="sections['examples']">
+  <p>
+    Having said that, we decided to give you some simple examples of common table features.
+    Take a look at them for the inspiration and maybe even use them as a starting point.
+  </p>
+
+  <ul>
+    <li>
+      <a routerLink="../examples" fragment="sortable">Sorting</a> -
+      shows a sample <code>NgbdSortableHeader</code> directive that you can stick on a <code>&lt;th&gt;</code>
+      element to handle sorting
+    </li>
+    <li>
+      <a routerLink="../examples" fragment="pagination">Pagination</a> -
+      shows how to use a <a routerLink="../../pagination"><code>NgbPagination</code></a> component together with the table
+    </li>
+    <li>
+      <a routerLink="../examples" fragment="filtering">Search / filtering</a> -
+      full text search example over the table data
+    </li>
+    <li>
+      <a routerLink="../examples" fragment="complete">Service example</a> -
+      a service that will handle sorting, pagination and filtering in an asynchronous manner.
+      It is based on observables and simulates debouncing and a custom delay for the data fetch.
+    </li>
+  </ul>
+</ngbd-overview-section>

--- a/demo/src/app/components/table/overview/table-overview.component.ts
+++ b/demo/src/app/components/table/overview/table-overview.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import { environment } from '../../../../environments/environment';
+
+import { NgbdDemoList } from '../../shared';
+import { NgbdOverview } from '../../shared/overview';
+
+@Component({
+  selector: 'ngbd-table-overview',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './table-overview.component.html',
+  host: {
+    '[class.overview]': 'true'
+  }
+})
+export class NgbdTableOverviewComponent {
+
+  bootstrapVersion = environment.bootstrap;
+
+  sections: NgbdOverview = {};
+
+  constructor(demoList: NgbdDemoList) {
+    this.sections = demoList.getOverviewSections('table');
+  }
+}

--- a/demo/src/app/components/table/table.module.ts
+++ b/demo/src/app/components/table/table.module.ts
@@ -1,0 +1,89 @@
+import { NgModule } from '@angular/core';
+
+import { NgbdSharedModule } from '../../shared';
+import { ComponentWrapper } from '../../shared/component-wrapper/component-wrapper.component';
+import { NgbdComponentsSharedModule, NgbdDemoList } from '../shared';
+import { NgbdExamplesPage } from '../shared/examples-page/examples.component';
+import { NgbdTableBasic } from './demos/basic/table-basic';
+import { NgbdSortableHeader as NgbdSortableHeader1, NgbdTableSortable } from './demos/sortable/table-sortable';
+import { NgbdTableFiltering } from './demos/filtering/table-filtering';
+import { NgbdTablePagination } from './demos/pagination/table-pagination';
+import { NgbdTableComplete } from './demos/complete/table-complete';
+import { NgbdSortableHeader as NgbdSortableHeader2 } from './demos/complete/sortable.directive';
+import { NgbdTableOverviewComponent } from './overview/table-overview.component';
+import { NgbdTableOverviewDemo } from './overview/demo/table-overview-demo.component';
+
+const DEMO_DIRECTIVES = [
+  NgbdTableBasic, NgbdTableSortable, NgbdTableFiltering, NgbdTablePagination, NgbdTableComplete
+];
+
+const OVERVIEW = {
+  'why-not': 'Why not?',
+  'examples': 'Code examples'
+};
+
+const DEMOS = {
+  basic: {
+    title: 'Basic table',
+    type: NgbdTableBasic,
+    code: require('!!raw-loader!./demos/basic/table-basic'),
+    markup: require('!!raw-loader!./demos/basic/table-basic.html')
+  },
+  sortable: {
+    title: 'Sortable table',
+    type: NgbdTableSortable,
+    code: require('!!raw-loader!./demos/sortable/table-sortable'),
+    markup: require('!!raw-loader!./demos/sortable/table-sortable.html')
+  },
+  filtering: {
+    title: 'Search and filtering',
+    type: NgbdTableFiltering,
+    code: require('!!raw-loader!./demos/filtering/table-filtering'),
+    markup: require('!!raw-loader!./demos/filtering/table-filtering.html')
+  },
+  pagination: {
+    title: 'Pagination',
+    type: NgbdTablePagination,
+    code: require('!!raw-loader!./demos/pagination/table-pagination'),
+    markup: require('!!raw-loader!./demos/pagination/table-pagination.html')
+  },
+  complete: {
+    title: 'Complete example',
+    type: NgbdTableComplete,
+    code: require('!!raw-loader!./demos/complete/table-complete'),
+    markup: require('!!raw-loader!./demos/complete/table-complete.html')
+  }
+};
+
+export const ROUTES = [
+  { path: '', pathMatch: 'full', redirectTo: 'overview' },
+  {
+    path: '',
+    component: ComponentWrapper,
+    data: { OVERVIEW },
+    children: [
+      { path: 'overview', component: NgbdTableOverviewComponent },
+      { path: 'examples', component: NgbdExamplesPage }
+    ]
+  }
+];
+
+@NgModule({
+  imports: [
+    NgbdSharedModule,
+    NgbdComponentsSharedModule
+  ],
+  declarations: [
+    DEMO_DIRECTIVES,
+    NgbdSortableHeader1,
+    NgbdSortableHeader2,
+    NgbdTableOverviewComponent,
+    NgbdTableOverviewDemo
+  ],
+  entryComponents: DEMO_DIRECTIVES
+})
+export class NgbdTableModule {
+  constructor(demoList: NgbdDemoList) {
+    demoList.register('table', DEMOS, OVERVIEW);
+  }
+}

--- a/demo/src/app/shared/side-nav/side-nav.component.ts
+++ b/demo/src/app/shared/side-nav/side-nav.component.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 
 export const componentsList = [
   'Accordion', 'Alert', 'Buttons', 'Carousel', 'Collapse', 'Datepicker', 'Dropdown', 'Modal', 'Pagination', 'Popover',
-  'Progressbar', 'Rating', 'Tabset', 'Timepicker', 'Tooltip', 'Typeahead'
+  'Progressbar', 'Rating', 'Table', 'Tabset', 'Timepicker', 'Tooltip', 'Typeahead'
 ];
 
 @Component({

--- a/demo/src/environments/environment.prod.ts
+++ b/demo/src/environments/environment.prod.ts
@@ -1,4 +1,7 @@
+import { versions } from './versions';
+
 export const environment = {
   production: true,
-  version: require('../../../src/package.json').version
+  version: versions.ngBootstrap,
+  bootstrap: versions.bootstrap
 };

--- a/demo/src/environments/environment.ts
+++ b/demo/src/environments/environment.ts
@@ -3,9 +3,12 @@
 // `ng build --env=prod` then `environment.prod.ts` will be used instead.
 // The list of which env maps to which file can be found in `.angular-cli.json`.
 
+import { versions } from './versions';
+
 export const environment = {
   production: false,
-  version: require('../../../src/package.json').version
+  version: versions.ngBootstrap,
+  bootstrap: versions.bootstrap
 };
 
 /*

--- a/demo/src/environments/versions.ts
+++ b/demo/src/environments/versions.ts
@@ -1,0 +1,8 @@
+// extracts only the minor version from package.json
+// ex. "bootstrap": "4.0.1" -> "4.0"
+let bootstrap: string = require('../../../package.json').devDependencies['bootstrap'];
+bootstrap = bootstrap.substr(0, bootstrap.lastIndexOf('.'));
+
+const ngBootstrap = require('../../../src/package.json').version;
+
+export const versions: {[key: string]: string} = { bootstrap, ngBootstrap };

--- a/demo/src/style/demos.css
+++ b/demo/src/style/demos.css
@@ -1,7 +1,43 @@
+/* Datepicker popup icon */
+
 button.calendar, button.calendar:active {
   width: 2.75rem;
   background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACIAAAAcCAYAAAAEN20fAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAEUSURBVEiJ7ZQxToVAEIY/YCHGxN6XGOIpnpaEsBSeQC9ArZbm9TZ6ADyBNzAhQGGl8Riv4BLAWAgmkpBYkH1b8FWT2WK/zJ8ZJ4qiI6XUI3ANnGKWBnht2/ZBDRK3hgVGNsCd7/ui+JkEIrKtqurLpEWaphd933+IyI3LEIdpCYCiKD6HcuOa/nwOa0ScJEnk0BJg0UTUWJRl6RxCYEzEmomsIlPU3IPW+grIAbquy+q6fluy/28RIBeRMwDXdXMgXLj/B2uimRXpui4D9sBeRLKl+1N+L+t6RwbWrZliTTTr1oxYtzVWiTQAcRxvTX+eJMnlUDaO1vpZRO5NS0x48sIwfPc87xg4B04MCzQi8hIEwe4bl1DnFMCN2zsAAAAASUVORK5CYII=') !important;
   background-repeat: no-repeat;
   background-size: 23px;
   background-position: center;
+}
+
+/* Sortable table demo */
+
+th[sortable] {
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+th[sortable].desc:before, th[sortable].asc:before {
+  content: '';
+  display: block;
+  background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAAXNSR0IArs4c6QAAAmxJREFUeAHtmksrRVEUx72fH8CIGQNJkpGUUmakDEiZSJRIZsRQmCkTJRmZmJgQE0kpX0D5DJKJgff7v+ru2u3O3vvc67TOvsdatdrnnP1Y///v7HvvubdbUiIhBISAEBACQkAICAEhIAQ4CXSh2DnyDfmCPEG2Iv9F9MPlM/LHyAecdyMzHYNwR3fdNK/OH9HXl1UCozD24TCvILxizEDWIEzA0FcM8woCgRrJCoS5PIwrANQSMAJX1LEI9bqpQo4JYNFFKRSvIgsxHDVnqZgIkPnNBM0rIGtYk9YOOsqgbgepRCfdbmFtqhFkVEDVPjJp0+Z6e6hRHhqBKgg6ZDCvYBygVmUoEGoh5JTRvIJwhJo1aUOoh4CLPMyvxxi7EWOMgnCGsXXI1GIXlZUYX7ucU+kbR8NW8lh3O7cue0Pk32MKndfUxQFAwxdirk3fHappAnc0oqDPzDfGTBrCfHP04dM4oTV8cxr0SVzH9FF07xD3ib6xCDE+M+aUcVygtWzzbtGX2rPBrEUYfecfQkaFzYi6HjVnGBdtL7epqAlc1+jRdAap74RrnPc4BCijttY2tRcdN0g17w7HqZrXhdJTYAuS3hd8z+vKgK3V1zWPae0mZDMykadBn1hTQBLnZNwVrJpSe/NwEeDsEwCctEOsJTsgxLvCqUl2ACftEGvJDgjxrnBqkh3ASTvEWrIDQrwrnJpkB3DSDrGW7IAQ7wqnJtkBnLRztejXXVu4+mxz/nQ9jR1w5VB86ejLTFcnnDwhzV+F6T+CHZlx6THSjn76eyyBIOPHyDakhBAQAkJACAgBISAEhIAQYCLwC8JxpAmsEGt6AAAAAElFTkSuQmCC') no-repeat;
+  background-size: 22px;
+  width: 22px;
+  height: 22px;
+  float: left;
+  margin-left: -22px;
+}
+
+th[sortable].desc:before {
+  transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+}
+
+/* Filtering table demo */
+ngbd-table-filtering span.ngb-highlight {
+  background-color: yellow;
+}
+
+/* Complete table demo */
+ngbd-table-complete span.ngb-highlight {
+  background-color: yellow;
 }

--- a/src/package.json
+++ b/src/package.json
@@ -18,6 +18,7 @@
     "popover",
     "progressbar",
     "rating",
+    "table",
     "tabset",
     "timepicker",
     "tooltip",


### PR DESCRIPTION
Adds the `Table` section to the demo site with an overview and several examples:

- basic table
- sorting
- pagination
- filtering
- async data service

cc @ExFlo, @pkozlowski-opensource, @benouat, @fbasso 