### PR TITLE
docs(home): add direct link to project code coverage

### DIFF
--- a/demo/src/app/default/default.component.html
+++ b/demo/src/app/default/default.component.html
@@ -57,7 +57,7 @@
       <img src="/img/test.svg" class="float-right float-md-none ml-4 ml-md-0 mb-4" alt="Quality icon">
       <h3>Quality</h3>
       <p>
-        All code is tested with almost 100% coverage, all changes are meticulously reviewed. We are not cutting corners.
+        <a href="https://codecov.io/gh/ng-bootstrap/ng-bootstrap" rel="noopener" target="_blank">All code is tested with almost 100% coverage</a>, all changes are meticulously reviewed. We are not cutting corners.
       </p>
     </div>
 


### PR DESCRIPTION
This wraps the statement about code coverage into the link,
to allow users see that coverage. Should enforce user trust.

Thanks!

![image](https://user-images.githubusercontent.com/14539/49835314-19d7ca80-fd9f-11e8-86fe-ce92dff52814.png)
