### PR TITLE
fix(datepicker): focus handling performance regression

### DIFF
--- a/src/datepicker/datepicker-service.spec.ts
+++ b/src/datepicker/datepicker-service.spec.ts
@@ -449,6 +449,19 @@ describe('ngb-datepicker-service', () => {
       expect(mock.onNext).toHaveBeenCalledTimes(1);
     });
 
+    it(`should not rebuild months when focus visibility changes`, () => {
+      service.focus(new NgbDate(2017, 5, 1));
+      expect(model.focusVisible).toEqual(false);
+      expect(model.months.length).toBe(1);
+      const month = model.months[0];
+      const date = month.weeks[0].days[0].date;
+
+      service.focusVisible = true;
+      expect(model.focusVisible).toEqual(true);
+      expect(model.months[0]).toBe(month);
+      expect(getDay(0).date).toBe(date);
+    });
+
   });
 
   describe(`navigation`, () => {

--- a/src/datepicker/datepicker-service.ts
+++ b/src/datepicker/datepicker-service.ts
@@ -220,6 +220,11 @@ export class NgbDatepickerService {
       startDate = state.selectedDate;
     }
 
+    // terminate early if only focus visibility was changed
+    if ('focusVisible' in patch) {
+      return state;
+    }
+
     // focus date changed
     if ('focusDate' in patch) {
       state.focusDate = checkDateInRange(state.focusDate, state.minDate, state.maxDate);

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -1133,7 +1133,7 @@ describe('ngb-datepicker', () => {
     });
 
     it('should initialize inputs with provided config as provider', () => {
-      const fixture = createGenericTestComponent('', NgbDatepicker);
+      const fixture = TestBed.createComponent(NgbDatepicker);
 
       const datepicker = fixture.componentInstance;
       expectSameValues(datepicker, config);

--- a/src/util/util.spec.ts
+++ b/src/util/util.spec.ts
@@ -1,4 +1,4 @@
-import {toInteger, toString, getValueInRange, isInteger, isString} from './util';
+import {toInteger, toString, getValueInRange, isInteger, isString, hasClassName} from './util';
 
 describe('util', () => {
 
@@ -88,6 +88,25 @@ describe('util', () => {
       expect(isString(undefined)).toBeFalsy();
     });
 
+  });
+
+  describe('hasClassName', () => {
+
+    it('should find classes correctly', () => {
+      const element = {className: 'foo bar  baz'};
+
+      expect(hasClassName(element, 'foo')).toBeTruthy();
+      expect(hasClassName(element, 'bar')).toBeTruthy();
+      expect(hasClassName(element, 'baz')).toBeTruthy();
+      expect(hasClassName(element, 'fo')).toBeFalsy();
+      expect(hasClassName(element, ' ')).toBeFalsy();
+    });
+
+    it('should work with incorrect values', () => {
+      expect(hasClassName(null, 'foo')).toBeFalsy();
+      expect(hasClassName({}, 'foo')).toBeFalsy();
+      expect(hasClassName({className: null}, 'foo')).toBeFalsy();
+    });
   });
 
 });

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -37,3 +37,8 @@ export function padNumber(value: number) {
 export function regExpEscape(text) {
   return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 }
+
+export function hasClassName(element: any, className: string): boolean {
+  return element && element.className && element.className.split &&
+      element.className.split(/\s+/).indexOf(className) >= 0;
+}


### PR DESCRIPTION
Removes unnecessary model updates and change detections when focus moves
inside the datepicker

Before:

![before](https://user-images.githubusercontent.com/8074436/49929678-51d82e00-fec3-11e8-875d-3a67dff403a6.png)

After:

![after](https://user-images.githubusercontent.com/8074436/49929686-57357880-fec3-11e8-82b0-58ce33641849.png)


Two commits, don't squash