### PR TITLE
fix(modal): support lazy loaded modules in an app-wide modal service

### DIFF
--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -26,8 +26,11 @@ export class NgbModal {
    * Also see the [`NgbModalOptions`](#/components/modal/api#NgbModalOptions) for the list of supported options.
    */
   open(content: any, options: NgbModalOptions = {}): NgbModalRef {
+    const injector = options.injector || this._injector;
+    const cfr = injector.get<ComponentFactoryResolver>(ComponentFactoryResolver as any, this._moduleCFR);
     const combinedOptions = Object.assign({}, this._config, options);
-    return this._modalStack.open(this._moduleCFR, this._injector, content, combinedOptions);
+
+    return this._modalStack.open(cfr, this._injector, content, combinedOptions);
   }
 
   /**


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.

Fixes #2920

With these little changes you are free to:
- still provide a ```ModalService``` for each lazy loaded module (like recommended in several previous support requests)
- provide a single ```ModalService``` in your app module and pass the child ```Injector``` of your lazy loaded module as an argument to the ```open``` method.

I use this little extension already since three months in an enterprise app and I just can say that it works perfectly. Now I found the time to contribute. It is not 100% testable in a unit test because I found no way to setup the two modules with different injectors using TestBed. If anyone has an idea how to test that, please leave a comment or feeling free to update the tests.

### Link to minimally-working StackBlitz that reproduces the issue:
https://stackblitz.com/edit/angular-us1evx