### PR TITLE
fix(NgbCarousel): Prevent browser from loading hidden carousel-items

### DIFF
--- a/src/carousel/carousel.ts
+++ b/src/carousel/carousel.ts
@@ -62,7 +62,7 @@ export class NgbSlide {
     </ol>
     <div class="carousel-inner">
       <div *ngFor="let slide of slides" class="carousel-item" [class.active]="slide.id === activeId">
-        <ng-template [ngTemplateOutlet]="slide.tplRef"></ng-template>
+        <ng-template [ngTemplateOutlet]="slide.tplRef" *ngIf="loadSlide(slide.id)"></ng-template>
       </div>
     </div>
     <a class="carousel-control-prev" role="button" (click)="prev()" *ngIf="showNavigationArrows">
@@ -194,6 +194,11 @@ export class NgbCarousel implements AfterContentChecked,
    * Restarts cycling through the carousel slides from left to right.
    */
   cycle() { this._start$.next(); }
+
+  loadSlide(currentSlideId: string): boolean {
+    return this.activeId === currentSlideId || this.activeId === this._getNextSlide(currentSlideId) ||
+        this.activeId === this._getPrevSlide(currentSlideId);
+  }
 
   private _cycleToSelected(slideIdx: string, direction: NgbSlideEventDirection) {
     let selectedSlide = this._getSlideById(slideIdx);


### PR DESCRIPTION
Closes #2952 by adding lazyload of only previous, active and next carousel-items

Before submitting a pull request, please make sure you have at least performed the following:

 - [/] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [/] built and tested the changes locally.
 - [/] added/updated any applicable tests.
 - [/] added/updated any applicable API documentation.
 - [/] added/updated any applicable demos.
