### PR TITLE
feat(datepicker): outside days not clickable anymore

### DIFF
--- a/src/datepicker/datepicker-day-view.scss
+++ b/src/datepicker/datepicker-day-view.scss
@@ -8,5 +8,7 @@
 
   &.outside {
     opacity: 0.5;
+    cursor: default;
+    background-color: inherit;
   }
 }

--- a/src/datepicker/datepicker-month-view.ts
+++ b/src/datepicker/datepicker-month-view.ts
@@ -43,7 +43,8 @@ export class NgbDatepickerMonthView {
   constructor(public i18n: NgbDatepickerI18n) {}
 
   doSelect(day: DayViewModel) {
-    if (!day.context.disabled && !day.hidden) {
+    const context = day.context;
+    if (day.date.month === context.currentMonth && !context.disabled && !day.hidden) {
       this.select.emit(day.date);
     }
   }

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -689,7 +689,7 @@ describe('ngb-datepicker', () => {
              });
        }));
 
-    it('should switch month when clicked on the date outside of current month', async(() => {
+    it('should\'t switch month when clicked on the date outside of current month', async(() => {
          const fixture = createTestComponent(
              `<ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="model"></ngb-datepicker>`);
          fixture.detectChanges();
@@ -698,12 +698,12 @@ describe('ngb-datepicker', () => {
            let dates = getDates(fixture.nativeElement);
 
            dates[31].click();  // 1 SEP 2016
-           expect(fixture.componentInstance.model).toEqual({year: 2016, month: 9, day: 1});
+           expect(fixture.componentInstance.model).toBeUndefined();
 
            // month changes to SEP
            fixture.detectChanges();
-           expect(getDay(fixture.nativeElement, 0).innerText).toBe('29');          // 29 AUG 2016
-           expect(getDay(fixture.nativeElement, 3)).toHaveCssClass('bg-primary');  // 1 SEP still selected
+           expect(getDay(fixture.nativeElement, 0).innerText).toBe('1');               // 1 AUG 2016
+           expect(getDay(fixture.nativeElement, 3)).not.toHaveCssClass('bg-primary');  // 1 SEP not selected
          });
        }));
 


### PR DESCRIPTION
Render the outside days seems to be more natural, as it prevents actions which are not available with the keyboard (outside days not navigable).

By the way, it fixes #2879