### PR TITLE
chore: make total unit test count refect reality

### DIFF
--- a/src/datepicker/hijri/ngb-calendar-islamic-civil.spec.ts
+++ b/src/datepicker/hijri/ngb-calendar-islamic-civil.spec.ts
@@ -297,20 +297,25 @@ describe('ngb-calendar-islamic-civil', () => {
 
   const calendar = new NgbCalendarIslamicCivil();
   describe('toGregorian', () => {
-    DATE_TABLE.forEach(element => {
-      let iDate = new NgbDate(element[0], element[1], element[2]);
-      let gDate = new Date(element[3], element[4], element[5]);
-      it('should convert correctly from Hijri to Gregorian',
-         () => { expect(calendar.toGregorian(iDate).getTime()).toEqual(gDate.getTime()); });
+    it('should convert correctly from Hijri to Gregorian', () => {
+      DATE_TABLE.forEach(element => {
+        let iDate = new NgbDate(element[0], element[1], element[2]);
+        let gDate = new Date(element[3], element[4], element[5]);
+        expect(calendar.toGregorian(iDate).getTime())
+            .toEqual(gDate.getTime(), `Hijri ${iDate.year}-${iDate.month}-${iDate.day} should be Gregorian ${gDate}`);
+      });
     });
   });
 
   describe('fromGregorian', () => {
-    DATE_TABLE.forEach(element => {
-      let iDate = new NgbDate(element[0], element[1], element[2]);
-      const gDate = new Date(element[3], element[4], element[5]);
-      let iDate2 = calendar.fromGregorian(gDate);
-      it('should convert correctly from Gregorian to Hijri', () => { expect(iDate2.equals(iDate)).toBeTruthy(); });
+    it('should convert correctly from Gregorian to Hijri', () => {
+      DATE_TABLE.forEach(element => {
+        let iDate = new NgbDate(element[0], element[1], element[2]);
+        const gDate = new Date(element[3], element[4], element[5]);
+        let iDate2 = calendar.fromGregorian(gDate);
+        expect(iDate2.equals(iDate))
+            .toBeTruthy(`Gregorian ${gDate} should be Hijri ${iDate.year}-${iDate.month}-${iDate.day}`);
+      });
     });
   });
 

--- a/src/datepicker/hijri/ngb-calendar-islamic-umalqura.spec.ts
+++ b/src/datepicker/hijri/ngb-calendar-islamic-umalqura.spec.ts
@@ -848,20 +848,25 @@ describe('ngb-calendar-islamic-umalqura', () => {
   ];
   const calendar = new NgbCalendarIslamicUmalqura();
   describe('toGregorian', () => {
-    DATE_TABLE.forEach(element => {
-      const iDate = new NgbDate(element[3], element[4], element[5]);
-      const gDate = new Date(element[0], element[1], element[2]);
-      it('should convert correctly from Hijri to Gregorian',
-         () => { expect(calendar.toGregorian(iDate).getTime()).toEqual(gDate.getTime()); });
+    it('should convert correctly from Hijri to Gregorian', () => {
+      DATE_TABLE.forEach(element => {
+        const iDate = new NgbDate(element[3], element[4], element[5]);
+        const gDate = new Date(element[0], element[1], element[2]);
+        expect(calendar.toGregorian(iDate).getTime())
+            .toEqual(gDate.getTime(), `Hijri ${iDate.year}-${iDate.month}-${iDate.day} should be Gregorian ${gDate}`);
+      });
     });
   });
 
   describe('fromGregorian', () => {
-    DATE_TABLE.forEach(element => {
-      const iDate = new NgbDate(element[3], element[4], element[5]);
-      const gDate = new Date(element[0], element[1], element[2]);
-      const iDate2 = calendar.fromGregorian(gDate);
-      it('should convert correctly from Gregorian to Hijri', () => { expect(iDate2.equals(iDate)).toBeTruthy(); });
+    it('should convert correctly from Gregorian to Hijri', () => {
+      DATE_TABLE.forEach(element => {
+        const iDate = new NgbDate(element[3], element[4], element[5]);
+        const gDate = new Date(element[0], element[1], element[2]);
+        const iDate2 = calendar.fromGregorian(gDate);
+        expect(iDate2.equals(iDate))
+            .toBeTruthy(`Gregorian ${gDate} should be Hijri ${iDate.year}-${iDate.month}-${iDate.day}`);
+      });
     });
   });
 
@@ -874,9 +879,11 @@ describe('ngb-calendar-islamic-umalqura', () => {
   });
 
   describe('getDaysInIslamicMonth', () => {
-    MONTH_LENGTH.forEach(element => {
-      it('should return the correct number of days in islamic month',
-         () => { expect(calendar.getDaysPerMonth(element[1], element[0])).toEqual(element[2]); });
+    it('should return the correct number of days in islamic month', () => {
+      MONTH_LENGTH.forEach(element => {
+        expect(calendar.getDaysPerMonth(element[1], element[0]))
+            .toEqual(element[2], `Hijri month ${element[1]}-${element[0]} should contain ${element[2]} days`);
+      });
     });
   });
 


### PR DESCRIPTION
Cycle though `expect()` instead of `it()` for calendar conversion tests

Before: 
```sh
Chrome 71.0.3578 (Mac OS X 10.12.6): Executed 8504 of 8504 SUCCESS (25.16 secs / 24.512 secs)
```

After: 
```sh
Chrome 71.0.3578 (Mac OS X 10.12.6): Executed 1217 of 1217 SUCCESS (21.951 secs / 21.531 secs)
```