### PR TITLE
 fix(datepicker): fix 'outsideDays' clicks for multiple months

### DIFF
--- a/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.component.html
+++ b/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.component.html
@@ -4,10 +4,13 @@
   <div class="form-group form-inline">
 
     <div class="input-group">
-      <input class="form-control" name="dp" placeholder="yyyy-mm-dd" #d="ngbDatepicker" ngbDatepicker [autoClose]="autoClose" >
+      <input class="form-control" name="dp" placeholder="yyyy-mm-dd" #d="ngbDatepicker" ngbDatepicker
+             [autoClose]="autoClose" [(ngModel)]="model" [displayMonths]="displayMonths">
       <div class="input-group-append">
         <button class="btn btn-outline-secondary" type="button" id="toggle" (click)="d.toggle()">Toggle</button>
         <button class="btn btn-outline-secondary" type="button" id="close" (click)="d.close()">Close</button>
+        <button class="btn btn-outline-secondary" type="button" id="selectDate" (click)="model = {year: 2018, month: 8, day: 10}">10
+          AUG 2018</button>
       </div>
     </div>
 
@@ -18,6 +21,14 @@
         <button class="dropdown-item" id="autoclose-false" (click)="autoClose = false">False</button>
         <button class="dropdown-item" id="autoclose-outside" (click)="autoClose = 'outside'">'Outside'</button>
         <button class="dropdown-item" id="autoclose-inside" (click)="autoClose = 'inside'">'Inside'</button>
+      </div>
+    </div>
+
+    <div ngbDropdown class="d-inline-block ml-1">
+      <button class="btn btn-outline-secondary" id="displayMonths-dropdown" ngbDropdownToggle>Choose Months</button>
+      <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
+        <button class="dropdown-item" id="displayMonths-1" (click)="displayMonths = 1">One</button>
+        <button class="dropdown-item" id="displayMonths-2" (click)="displayMonths = 2">Two</button>
       </div>
     </div>
 

--- a/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.component.ts
+++ b/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.component.ts
@@ -3,4 +3,6 @@ import {Component} from '@angular/core';
 @Component({templateUrl: './datepicker-autoclose.component.html'})
 export class DatepickerAutoCloseComponent {
   autoClose: boolean | 'inside' | 'outside' = true;
+  model = null;
+  displayMonths = 1;
 }

--- a/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.e2e-spec.ts
+++ b/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.e2e-spec.ts
@@ -7,78 +7,134 @@ describe('Datepicker Autoclose', () => {
 
   beforeAll(() => page = new DatepickerAutoClosePage());
 
-  beforeEach(async() => await openUrl('datepicker/autoclose'));
+  for (let displayMonths of[1, 2]) {
+    describe(`displayMonths = ${displayMonths}`, () => {
 
-  it(`should work when autoClose === true`, async() => {
-    await page.selectAutoClose('true');
+      const DATE_SELECT = new Date(2018, 7, 1);
+      const DATE_OUTSIDE_BEFORE = new Date(2018, 6, 31);
+      const DATE_OUTSIDE_AFTER = displayMonths === 1 ? new Date(2018, 6, 31) : new Date(2018, 9, 1);
 
-    // escape
-    await page.openDatepicker();
-    await sendKey(Key.ESCAPE);
-    expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on ESC`);
+      beforeEach(async() => {
+        await openUrl('datepicker/autoclose');
+        await page.selectDisplayMonths(displayMonths);
+      });
 
-    // outside click
-    await page.openDatepicker();
-    await page.clickOutside();
-    expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on outside click`);
+      it(`should work when autoClose === true`, async() => {
+        await page.selectAutoClose('true');
 
-    // date selection
-    await page.openDatepicker();
-    await page.getDayElement(new Date()).click();
-    expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on date selection`);
-  });
+        // escape
+        await page.openDatepicker();
+        await sendKey(Key.ESCAPE);
+        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on ESC`);
 
-  it(`should work when autoClose === false`, async() => {
-    await page.selectAutoClose('false');
+        // outside click
+        await page.openDatepicker();
+        await page.clickOutside();
+        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on outside click`);
 
-    // escape
-    await page.openDatepicker();
-    await sendKey(Key.ESCAPE);
-    expect(await page.getDatepicker().isPresent()).toBeTruthy(`Datepicker should NOT be closed on ESC`);
+        // date selection
+        await page.openDatepicker();
+        await page.getDayElement(DATE_SELECT).click();
+        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on date selection`);
 
-    // outside click
-    await page.clickOutside();
-    expect(await page.getDatepicker().isPresent()).toBeTruthy(`Datepicker should NOT be closed on outside click`);
+        // outside days click -> month before
+        await page.openDatepicker();
+        await page.getDayElement(DATE_OUTSIDE_BEFORE).click();
+        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on outside day click`);
 
-    // date selection
-    await page.getDayElement(new Date()).click();
-    expect(await page.getDatepicker().isPresent()).toBeTruthy(`Datepicker should NOT be closed on date selection`);
-  });
+        // outside days click -> month after
+        await page.openDatepicker();
+        await page.getDayElement(DATE_OUTSIDE_AFTER).click();
+        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on outside day click`);
+      });
 
-  it(`should work when autoClose === 'outside'`, async() => {
-    await page.selectAutoClose('outside');
+      it(`should work when autoClose === false`, async() => {
+        await page.selectAutoClose('false');
 
-    // escape
-    await page.openDatepicker();
-    await sendKey(Key.ESCAPE);
-    expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on ESC`);
+        // escape
+        await page.openDatepicker();
+        await sendKey(Key.ESCAPE);
+        expect(await page.getDatepicker().isPresent()).toBeTruthy(`Datepicker should NOT be closed on ESC`);
 
-    // outside click
-    await page.openDatepicker();
-    await page.clickOutside();
-    expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on outside click`);
+        // outside click
+        await page.clickOutside();
+        expect(await page.getDatepicker().isPresent()).toBeTruthy(`Datepicker should NOT be closed on outside click`);
 
-    // date selection
-    await page.openDatepicker();
-    await page.getDayElement(new Date()).click();
-    expect(await page.getDatepicker().isPresent()).toBeTruthy(`Datepicker should NOT be closed on date selection`);
-  });
+        // date selection
+        await page.getDayElement(DATE_SELECT).click();
+        expect(await page.getDatepicker().isPresent()).toBeTruthy(`Datepicker should NOT be closed on date selection`);
 
-  it(`should work when autoClose === 'inside'`, async() => {
-    await page.selectAutoClose('inside');
+        // outside days click -> month before
+        await page.getDayElement(DATE_OUTSIDE_BEFORE).click();
+        expect(await page.getDatepicker().isPresent())
+            .toBeTruthy(`Datepicker should NOT be closed on outside day click`);
 
-    // escape
-    await page.openDatepicker();
-    await sendKey(Key.ESCAPE);
-    expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on ESC`);
+        // outside days click -> month after
+        await page.closeDatepicker();
+        await page.openDatepicker();  // to reset visible month
+        await page.getDayElement(DATE_OUTSIDE_AFTER).click();
+        expect(await page.getDatepicker().isPresent())
+            .toBeTruthy(`Datepicker should NOT be closed on outside day click`);
+      });
 
-    // outside click
-    await page.openDatepicker();
-    await page.clickOutside();
-    expect(await page.getDatepicker().isPresent()).toBeTruthy(`Datepicker should NOT be closed on outside click`);
+      it(`should work when autoClose === 'outside'`, async() => {
+        await page.selectAutoClose('outside');
 
-    // date selection
-    await page.getDayElement(new Date()).click();
-    expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on date selection`);
-  });
+        // escape
+        await page.openDatepicker();
+        await sendKey(Key.ESCAPE);
+        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on ESC`);
+
+        // outside click
+        await page.openDatepicker();
+        await page.clickOutside();
+        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on outside click`);
+
+        // date selection
+        await page.openDatepicker();
+        await page.getDayElement(DATE_SELECT).click();
+        expect(await page.getDatepicker().isPresent()).toBeTruthy(`Datepicker should NOT be closed on date selection`);
+
+        // outside days click -> month before
+        await page.getDayElement(DATE_OUTSIDE_BEFORE).click();
+        expect(await page.getDatepicker().isPresent())
+            .toBeTruthy(`Datepicker should NOT be closed on outside day click`);
+
+        // outside days click -> month after
+        await page.closeDatepicker();
+        await page.openDatepicker();  // to reset visible month
+        await page.getDayElement(DATE_OUTSIDE_AFTER).click();
+        expect(await page.getDatepicker().isPresent())
+            .toBeTruthy(`Datepicker should NOT be closed on outside day click`);
+      });
+
+      it(`should work when autoClose === 'inside'`, async() => {
+        await page.selectAutoClose('inside');
+
+        // escape
+        await page.openDatepicker();
+        await sendKey(Key.ESCAPE);
+        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on ESC`);
+
+        // outside click
+        await page.openDatepicker();
+        await page.clickOutside();
+        expect(await page.getDatepicker().isPresent()).toBeTruthy(`Datepicker should NOT be closed on outside click`);
+
+        // date selection
+        await page.getDayElement(DATE_SELECT).click();
+        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on date selection`);
+
+        // outside days click -> month before
+        await page.openDatepicker();
+        await page.getDayElement(DATE_OUTSIDE_BEFORE).click();
+        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on outside day click`);
+
+        // outside days click -> month after
+        await page.openDatepicker();
+        await page.getDayElement(DATE_OUTSIDE_AFTER).click();
+        expect(await page.getDatepicker().isPresent()).toBeFalsy(`Datepicker should be closed on outside day click`);
+      });
+    });
+  }
 });

--- a/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.po.ts
+++ b/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.po.ts
@@ -1,13 +1,23 @@
 import {$} from 'protractor';
-import {DatepickerPage} from './../datepicker.po';
+import {DatepickerPage} from '../datepicker.po';
 
 export class DatepickerAutoClosePage extends DatepickerPage {
-  async close() { await $('#close').click(); }
+  async closeDatepicker() { await $('#close').click(); }
 
   async clickOutside() { await $('#outside-button').click(); }
 
   async selectAutoClose(type: string) {
     await $('#autoclose-dropdown').click();
     await $(`#autoclose-${type}`).click();
+  }
+
+  async selectDisplayMonths(displayMonths: number) {
+    await $('#displayMonths-dropdown').click();
+    await $(`#displayMonths-${displayMonths}`).click();
+  }
+
+  async openDatepicker() {
+    await $('#selectDate').click();
+    await super.openDatepicker();
   }
 }


### PR DESCRIPTION
- adds e2e tests for `autoClose` with `displayMonths` and clicks on outside days
- fixes an issue when datepicker popup was closed when using [autoClose]='outside' and clicking on outside days with multiple months opened

Fixes #2879