### PR TITLE
fix(modal): add missing 'aria-modal' and 'aria-hidden' attributes

### DIFF
--- a/src/modal/modal-window.ts
+++ b/src/modal/modal-window.ts
@@ -22,6 +22,7 @@ import {ModalDismissReasons} from './modal-dismiss-reasons';
     'tabindex': '-1',
     '(keyup.esc)': 'escKey($event)',
     '(click)': 'backdropClick($event)',
+    '[attr.aria-modal]': 'true',
     '[attr.aria-labelledby]': 'ariaLabelledBy',
   },
   template: `


### PR DESCRIPTION
- add missing `aria-modal` on the modal window.
- add `aria-hidden` on all sibling DOM branches from the modal window up to the document body

Fixes #2575
