### PR TITLE
feat(pagination): allow customizing pagination links

### DIFF
--- a/demo/src/app/components/pagination/demos/customization/pagination-customization.html
+++ b/demo/src/app/components/pagination/demos/customization/pagination-customization.html
@@ -1,0 +1,9 @@
+<p>A pagination with customized links:</p>
+<ngb-pagination [collectionSize]="70" [(page)]="page" aria-label="Custom pagination">
+  <ng-template ngbPaginationPrevious>Prev</ng-template>
+  <ng-template ngbPaginationNext>Next</ng-template>
+  <ng-template ngbPaginationNumber let-p>{{ getPageSymbol(p) }}</ng-template>
+</ngb-pagination>
+<hr>
+
+<pre>Current page: {{page}}</pre>

--- a/demo/src/app/components/pagination/demos/customization/pagination-customization.ts
+++ b/demo/src/app/components/pagination/demos/customization/pagination-customization.ts
@@ -1,0 +1,13 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'ngbd-pagination-customization',
+  templateUrl: './pagination-customization.html'
+})
+export class NgbdPaginationCustomization {
+  page = 4;
+
+  getPageSymbol(current: number) {
+    return ['A', 'B', 'C', 'D', 'E', 'F', 'G'][current - 1];
+  }
+}

--- a/demo/src/app/components/pagination/overview/pagination-overview.component.html
+++ b/demo/src/app/components/pagination/overview/pagination-overview.component.html
@@ -41,3 +41,46 @@
     be exposed.
   </p>
 </ngbd-overview-section>
+
+<ngbd-overview-section [section]="sections['customization']">
+  <p>
+    It is possible to customize what exactly is displayed in each pagination link and there are several ways of doing it.
+  </p>
+
+  <p>
+    You could use the Angular i18n API as all labels are translated. For instance you could replace the default
+    <code>'&laquo;'</code> (previous arrow) with the <code>'Prev'</code> text by providing a different translation for the
+    <code>ngb.pagination.previous</code> key in your i18n file and <code>ngb.pagination.previous-aria</code> for the
+    corresponding <code>aria-label</code> attribute.
+  </p>
+
+  <p>
+    You could also override the CSS to hide the default <code>span</code> and provide an alternative content.
+    For example for the previous arrow:
+  </p>
+  <ngbd-code lang="css" [code]="CUSTOM_CSS"></ngbd-code>
+
+  <h4>
+    Using templates
+  </h4>
+  <ngbd-api-docs-badge [since]="{version: '4.1.0'}"></ngbd-api-docs-badge>
+
+  <p>
+    Sometimes you would want to display an icon, an image or any arbitrary markup instead of the page number.
+    In this case since you could use the template-based API to override any pagination link:
+  </p>
+  <ngbd-code lang="html" [code]="CUSTOM_TPL"></ngbd-code>
+
+  <p>
+    In this case we customize all pagination links, but you can pick only the ones you need of course.
+    The template <a routerLink="../api" fragment="NgbPaginationLinkContext"><code>NgbPaginationLinkContext</code></a>
+    is available for all templates and for page numbers there is a
+    <a routerLink="../api" fragment="NgbPaginationNumberContext"><code>NgbPaginationNumberContext</code></a>
+    that adds displayed number on top.
+  </p>
+
+  <p>
+    Also see the <a routerLink="../examples" fragment="customization">Customization example</a> for a
+    live version.
+  </p>
+</ngbd-overview-section>

--- a/demo/src/app/components/pagination/overview/pagination-overview.component.ts
+++ b/demo/src/app/components/pagination/overview/pagination-overview.component.ts
@@ -21,6 +21,30 @@ export class NgbdPaginationOverviewComponent {
   [pageSize]="pageSize"
   [collectionSize]="items.length"></ngb-pagination>`;
 
+  CUSTOM_CSS = `
+ngb-pagination li {
+  &:first-child a {
+    span {
+      display: none;
+    }
+    &:before {
+      /* provide your content here */
+    }
+  }
+}
+`;
+
+  CUSTOM_TPL = `
+<ngb-pagination>
+  <ng-template ngbPaginationFirst>First</ng-template>
+  <ng-template ngbPaginationLast>Last</ng-template>
+  <ng-template ngbPaginationPrevious>Prev</ng-template>
+  <ng-template ngbPaginationNext>Next</ng-template>
+  <ng-template ngbPaginationEllipsis>...</ng-template>
+  <ng-template ngbPaginationNumber let-page>{{ page }}</ng-template>
+</ngb-pagination>
+`;
+
   sections: NgbdOverview = {};
 
   constructor(demoList: NgbdDemoList) {

--- a/demo/src/app/components/pagination/pagination.module.ts
+++ b/demo/src/app/components/pagination/pagination.module.ts
@@ -26,6 +26,7 @@ const DEMO_DIRECTIVES = [
 
 const OVERVIEW = {
   'basic-usage': 'Basic Usage',
+  'customization': 'Customization',
 };
 
 const DEMOS = {

--- a/demo/src/app/components/pagination/pagination.module.ts
+++ b/demo/src/app/components/pagination/pagination.module.ts
@@ -12,12 +12,14 @@ import {NgbdPaginationDisabled} from './demos/disabled/pagination-disabled';
 import {NgbdPaginationJustify} from './demos/justify/pagination-justify';
 import {NgbdPaginationSize} from './demos/size/pagination-size';
 import {NgbdPaginationOverviewComponent} from './overview/pagination-overview.component';
+import {NgbdPaginationCustomization} from './demos/customization/pagination-customization';
 
 const DEMO_DIRECTIVES = [
   NgbdPaginationAdvanced,
   NgbdPaginationBasic,
   NgbdPaginationSize,
   NgbdPaginationConfig,
+  NgbdPaginationCustomization,
   NgbdPaginationDisabled,
   NgbdPaginationJustify,
 ];
@@ -38,6 +40,12 @@ const DEMOS = {
     type: NgbdPaginationAdvanced,
     code: require('!!raw-loader!./demos/advanced/pagination-advanced'),
     markup: require('!!raw-loader!./demos/advanced/pagination-advanced.html')
+  },
+  customization: {
+    title: 'Custom links',
+    type: NgbdPaginationCustomization,
+    code: require('!!raw-loader!./demos/customization/pagination-customization'),
+    markup: require('!!raw-loader!./demos/customization/pagination-customization.html')
   },
   size: {
     title: 'Pagination size',

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,17 @@ export {
   NgbModalRef,
   ModalDismissReasons
 } from './modal/modal.module';
-export {NgbPaginationModule, NgbPaginationConfig, NgbPagination} from './pagination/pagination.module';
+export {
+  NgbPaginationModule,
+  NgbPaginationConfig,
+  NgbPagination,
+  NgbPaginationEllipsis,
+  NgbPaginationFirst,
+  NgbPaginationLast,
+  NgbPaginationNext,
+  NgbPaginationNumber,
+  NgbPaginationPrevious
+} from './pagination/pagination.module';
 export {NgbPopoverModule, NgbPopoverConfig, NgbPopover} from './popover/popover.module';
 export {NgbProgressbarModule, NgbProgressbarConfig, NgbProgressbar} from './progressbar/progressbar.module';
 export {NgbRatingModule, NgbRatingConfig, NgbRating} from './rating/rating.module';

--- a/src/pagination/pagination.module.ts
+++ b/src/pagination/pagination.module.ts
@@ -1,12 +1,33 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
-import {NgbPagination} from './pagination';
+import {
+  NgbPagination,
+  NgbPaginationEllipsis,
+  NgbPaginationFirst,
+  NgbPaginationLast,
+  NgbPaginationNext,
+  NgbPaginationNumber,
+  NgbPaginationPrevious
+} from './pagination';
 
-export {NgbPagination} from './pagination';
+export {
+  NgbPagination,
+  NgbPaginationEllipsis,
+  NgbPaginationFirst,
+  NgbPaginationLast,
+  NgbPaginationNext,
+  NgbPaginationNumber,
+  NgbPaginationPrevious
+} from './pagination';
 export {NgbPaginationConfig} from './pagination-config';
 
-@NgModule({declarations: [NgbPagination], exports: [NgbPagination], imports: [CommonModule]})
+const DIRECTIVES = [
+  NgbPagination, NgbPaginationEllipsis, NgbPaginationFirst, NgbPaginationLast, NgbPaginationNext, NgbPaginationNumber,
+  NgbPaginationPrevious
+];
+
+@NgModule({declarations: DIRECTIVES, exports: DIRECTIVES, imports: [CommonModule]})
 export class NgbPaginationModule {
   /**
    * Importing with '.forRoot()' is no longer necessary, you can simply import the module.


### PR DESCRIPTION
Provides the way of customizing the markup of pagination links using child templates (in the cases where CSS is not enough):

```html
<ngb-pagination>
  <ng-template ngbPaginationFirst>First</ng-template>
  <ng-template ngbPaginationLast>Last</ng-template>
  <ng-template ngbPaginationPrevious>Prev</ng-template>
  <ng-template ngbPaginationNext>Next</ng-template>
  <ng-template ngbPaginationEllipsis>...</ng-template>
  <ng-template ngbPaginationNumber let-page>{{ page }}</ng-template>
</ngb-pagination>
```

Obviously one can customize only what's necessary, not everything.

`NgbPaginationNumber` template has the following context:
```ts
interface {
  $implicit: number;   // page displayed by current cell
  currentPage: number; // currently selected page
  disabled: boolean;   // true, if current cell is disabled
}
```

All other templates have the following context:
```ts
interface {
  currentPage: number; // currently selected page
  disabled: boolean;   // true, if current cell is disabled
}
```

P.S. Will open another PR with documentation / demo updates

Fixes #899
