### PR TITLE
feat(accordion): allow any content in the accordion card header

### DIFF
--- a/demo/src/app/components/accordion/accordion.module.ts
+++ b/demo/src/app/components/accordion/accordion.module.ts
@@ -10,8 +10,11 @@ import { NgbdAccordionConfig } from './demos/config/accordion-config';
 import { NgbdAccordionPreventchange } from './demos/preventchange/accordion-preventchange';
 import { NgbdAccordionStatic } from './demos/static/accordion-static';
 import { NgbdAccordionToggle } from './demos/toggle/accordion-toggle';
+import { NgbdAccordionHeader } from './demos/header/accordion-header';
 
-const DEMO_DIRECTIVES = [NgbdAccordionBasic, NgbdAccordionPreventchange, NgbdAccordionStatic, NgbdAccordionToggle, NgbdAccordionConfig];
+const DEMO_DIRECTIVES = [
+  NgbdAccordionBasic, NgbdAccordionPreventchange, NgbdAccordionStatic, NgbdAccordionToggle, NgbdAccordionConfig, NgbdAccordionHeader
+];
 
 const DEMOS = {
   basic: {
@@ -31,6 +34,12 @@ const DEMOS = {
     code: require('!!raw-loader!./demos/toggle/accordion-toggle'),
     markup: require('!!raw-loader!./demos/toggle/accordion-toggle.html'),
     type: NgbdAccordionToggle
+  },
+  header: {
+    title: 'Custom header',
+    code: require('!!raw-loader!./demos/header/accordion-header'),
+    markup: require('!!raw-loader!./demos/header/accordion-header.html'),
+    type: NgbdAccordionHeader
   },
   preventchange: {
     title: 'Prevent panel toggle',

--- a/demo/src/app/components/accordion/demos/header/accordion-header.html
+++ b/demo/src/app/components/accordion/demos/header/accordion-header.html
@@ -1,0 +1,56 @@
+<ngb-accordion #a="ngbAccordion" activeIds="custom-panel-1">
+  <ngb-panel id="custom-panel-1">
+    <ng-template ngbPanelHeader let-opened="opened">
+      <div class="d-flex align-items-center justify-content-between">
+        <h5 class="m-0">First panel - {{ opened ? 'opened' : 'collapsed' }}</h5>
+        <button ngbPanelToggle class="btn btn-link p-0">Toggle first</button>
+      </div>
+    </ng-template>
+    <ng-template ngbPanelContent>
+      Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia
+      aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor,
+      sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica,
+      craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan excepteur butcher vice lomo. Leggings
+      occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt you probably haven't heard of them accusamus
+      labore sustainable VHS.
+    </ng-template>
+  </ngb-panel>
+  <ngb-panel>
+    <ng-template ngbPanelHeader>
+      <div class="d-flex align-items-center justify-content-between">
+        <h5 class="m-0">Second panel</h5>
+        <div>
+          <button ngbPanelToggle class="btn btn-sm btn-outline-primary ml-2">Toggle second</button>
+          <button type="button" class="btn btn-sm btn-outline-secondary ml-2" (click)="disabled = !disabled">
+            {{ disabled ? 'En' : 'Dis' }}able third
+          </button>
+          <button type="button" class="btn btn-sm btn-outline-danger ml-2" (click)="a.collapseAll()">Collapse all</button>
+        </div>
+      </div>
+    </ng-template>
+    <ng-template ngbPanelContent>
+      Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia
+      aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor,
+      sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica,
+      craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan excepteur butcher vice lomo. Leggings
+      occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt you probably haven't heard of them accusamus
+      labore sustainable VHS.
+    </ng-template>
+  </ngb-panel>
+  <ngb-panel [disabled]="disabled">
+    <ng-template ngbPanelHeader>
+      <div class="d-flex align-items-center justify-content-between">
+        <button ngbPanelToggle class="btn btn-link container-fluid text-left pl-0">Third panel</button>
+        <p *ngIf="disabled" class="text-muted m-0 small">[I'm&nbsp;disabled]</p>
+      </div>
+    </ng-template>
+    <ng-template ngbPanelContent>
+      Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia
+      aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor,
+      sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica,
+      craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan excepteur butcher vice lomo. Leggings
+      occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt you probably haven't heard of them accusamus
+      labore sustainable VHS.
+    </ng-template>
+  </ngb-panel>
+</ngb-accordion>

--- a/demo/src/app/components/accordion/demos/header/accordion-header.ts
+++ b/demo/src/app/components/accordion/demos/header/accordion-header.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'ngbd-accordion-header',
+  templateUrl: './accordion-header.html'
+})
+export class NgbdAccordionHeader {
+  disabled = false;
+}

--- a/src/accordion/accordion.module.ts
+++ b/src/accordion/accordion.module.ts
@@ -1,12 +1,22 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
-import {NgbAccordion, NgbPanel, NgbPanelTitle, NgbPanelContent} from './accordion';
+import {NgbAccordion, NgbPanel, NgbPanelTitle, NgbPanelContent, NgbPanelHeader, NgbPanelToggle} from './accordion';
 
-export {NgbAccordion, NgbPanel, NgbPanelTitle, NgbPanelContent, NgbPanelChangeEvent} from './accordion';
+export {
+  NgbAccordion,
+  NgbPanel,
+  NgbPanelTitle,
+  NgbPanelContent,
+  NgbPanelChangeEvent,
+  NgbPanelHeader,
+  NgbPanelHeaderContext,
+  NgbPanelToggle
+} from './accordion';
 export {NgbAccordionConfig} from './accordion-config';
 
-const NGB_ACCORDION_DIRECTIVES = [NgbAccordion, NgbPanel, NgbPanelTitle, NgbPanelContent];
+const NGB_ACCORDION_DIRECTIVES =
+    [NgbAccordion, NgbPanel, NgbPanelTitle, NgbPanelContent, NgbPanelHeader, NgbPanelToggle];
 
 @NgModule({declarations: NGB_ACCORDION_DIRECTIVES, exports: NGB_ACCORDION_DIRECTIVES, imports: [CommonModule]})
 export class NgbAccordionModule {

--- a/src/accordion/accordion.spec.ts
+++ b/src/accordion/accordion.spec.ts
@@ -244,6 +244,76 @@ describe('ngb-accordion', () => {
     titles.forEach((title: HTMLElement, idx: number) => { expect(title.textContent.trim()).toBe(`Panel ${idx + 1}`); });
   });
 
+  it('can use header as a template', () => {
+    const testHtml = `
+    <ngb-accordion>
+     <ngb-panel>
+       <ng-template ngbPanelHeader>
+         <button ngbPanelToggle>Title 1</button>
+       </ng-template>
+       <ng-template ngbPanelContent>Content 1</ng-template>
+     </ngb-panel>
+     <ngb-panel>
+       <ng-template ngbPanelHeader>
+         <button ngbPanelToggle>Title 2</button>
+       </ng-template>
+       <ng-template ngbPanelContent>Content 2</ng-template>
+     </ngb-panel>
+    </ngb-accordion>
+    `;
+    const fixture = createTestComponent(testHtml);
+    const titles = getPanelsTitle(fixture.nativeElement);
+    titles.forEach((title: HTMLElement, idx: number) => { expect(title.textContent.trim()).toBe(`Title ${idx + 1}`); });
+  });
+
+  it('can should pass context to a header template', () => {
+    const testHtml = `
+    <ngb-accordion [activeIds]="activeIds">
+     <ngb-panel id="one">
+       <ng-template ngbPanelHeader let-opened="opened">
+         <button ngbPanelToggle>{{ opened ? 'opened' : 'closed' }}</button>
+       </ng-template>
+       <ng-template ngbPanelContent>Content 1</ng-template>
+     </ngb-panel>
+    </ngb-accordion>
+    `;
+    const fixture = createTestComponent(testHtml);
+    const titleButton = getPanelsTitle(fixture.nativeElement)[0];
+
+    expectOpenPanels(fixture.nativeElement, [false]);
+    expect(titleButton.textContent.trim()).toBe(`closed`);
+
+    fixture.componentInstance.activeIds = 'one';
+    fixture.detectChanges();
+
+    expectOpenPanels(fixture.nativeElement, [true]);
+    expect(titleButton.textContent.trim()).toBe(`opened`);
+  });
+
+  it('can should prefer header as a template to other ways of providing a title', () => {
+    const testHtml = `
+    <ngb-accordion>
+     <ngb-panel title="Panel Title 1">
+       <ng-template ngbPanelHeader>
+         <button ngbPanelToggle>Header Title 1</button>
+       </ng-template>
+       <ng-template ngbPanelContent>Content 1</ng-template>
+     </ngb-panel>
+     <ngb-panel>
+       <ng-template ngbPanelTitle>Panel Title 2</ng-template>
+       <ng-template ngbPanelHeader>
+         <button ngbPanelToggle>Header Title 2</button>
+       </ng-template>
+       <ng-template ngbPanelContent>Content 2</ng-template>
+     </ngb-panel>
+    </ngb-accordion>
+    `;
+    const fixture = createTestComponent(testHtml);
+    const titles = getPanelsTitle(fixture.nativeElement);
+    titles.forEach(
+        (title: HTMLElement, idx: number) => { expect(title.textContent.trim()).toBe(`Header Title ${idx + 1}`); });
+  });
+
   it('should not pick up titles from nested accordions', () => {
     const testHtml = `
     <ngb-accordion activeIds="open_me">

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,10 @@ export {
   NgbAccordion,
   NgbPanel,
   NgbPanelTitle,
-  NgbPanelContent
+  NgbPanelContent,
+  NgbPanelHeader,
+  NgbPanelHeaderContext,
+  NgbPanelToggle
 } from './accordion/accordion.module';
 export {NgbAlertModule, NgbAlertConfig, NgbAlert} from './alert/alert.module';
 export {NgbButtonsModule, NgbButtonLabel, NgbCheckBox, NgbRadio, NgbRadioGroup} from './buttons/buttons.module';


### PR DESCRIPTION
A more genetic alternative to #2845 to add any content to accordion header.

The idea is to introduce two directives `ng-template[ngbPanelHeader]` and `button[ngbPanelToggle]` to be used as follows:

```html
<ngb-accordion>
  <ngb-panel>
    <ng-template ngbPanelHeader let-opened="opened">
      <!-- anything here -->
      <button ngbPanelToggle>Panel Title</button>
      <!-- anything here -->
    </ng-template>
     <ng-template ngbPanelContent> ... </ng-template>
  </ngb-panel>
</ngb-accordion>
```

Demo shows an example of adding some controls to headers:

<img width="785" alt="screen shot 2019-02-14 at 16 02 56" src="https://user-images.githubusercontent.com/8074436/52795725-af7b2900-3072-11e9-9a5a-8ad66705da3d.png">


This will compliment and take precedence over two existing ways of providing a title:

```html
<!-- 1. title as an attribute -->
<ngb-accordion>
  <ngb-panel title="Panel Title">
     <ng-template ngbPanelContent> ... </ng-template>
  </ngb-panel>
</ngb-accordion>

<!-- 2. title as template for the button content -->
<ngb-accordion>
  <ngb-panel>
     <ng-template ngbPanelTitle>Panel Title</ng-template>
     <ng-template ngbPanelContent> ... </ng-template>
  </ngb-panel>
</ngb-accordion>
```

I would even deprecate `ngbPanelTitle`

Fixes #717
