### PR TITLE
chore: clarify supported version ranges in readme and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ View all the directives in action at https://ng-bootstrap.github.io
 
 ## Dependencies
 The only two dependencies are [Angular](https://angular.io) and [Bootstrap 4](https://getbootstrap.com) CSS. 
-Here is the list of minimal required versions:
+Here is the list of version ranges we support:
 
-| ng-bootstrap | Angular | Bootstrap CSS |
-| ------------ | ------- | ------------- |
-| 1.x.x        | 5.0.2   | 4.0.0         |
-| 2.x.x        | 6.0.0   | 4.0.0         |
-| 3.x.x        | 6.1.0   | 4.0.0         |
-| 4.x.x        | 7.0.0   | 4.0.0         |
+| ng-bootstrap | Angular             | Bootstrap CSS       |
+| ------------ | ------------------- | ------------------- |
+| 1.x.x        | &ge;5.0.2 &lt;6.0.0 | &ge;4.0.0 &lt;4.1.0 |
+| 2.x.x        | &ge;6.0.0 &lt;6.1.0 | &ge;4.0.0 &lt;4.1.0 |
+| 3.x.x        | &ge;6.1.0 &lt;7.0.0 | &ge;4.0.0 &lt;4.2.0 |
+| 4.x.x        | &ge;7.0.0 &lt;8.0.0 | &ge;4.0.0 &lt;4.2.0 |
 
 ## Installation
 After installing the above dependencies, install `ng-bootstrap` via:

--- a/demo/src/app/getting-started/getting-started.component.html
+++ b/demo/src/app/getting-started/getting-started.component.html
@@ -8,8 +8,8 @@
   </p>
 
   <p>
-    Here is a list of minimal required versions of <a href="https://angular.io" target="_blank">Angular</a>
-    and <a href="https://getbootstrap.com" target="_blank">Bootstrap</a> CSS for ng-bootstrap:
+    Here is the list of <a href="https://angular.io" target="_blank">Angular</a>
+    and <a href="https://getbootstrap.com" target="_blank">Bootstrap</a> CSS version ranges we support:
   </p>
 
   <table class="table" style="width: auto">
@@ -23,23 +23,23 @@
     <tbody>
       <tr>
         <th scope="row">1.x.x</th>
-        <td>5.0.2</td>
-        <td>4.0.0</td>
+        <td>&ge;5.0.2 &lt;6.0.0</td>
+        <td>&ge;4.0.0 &lt;4.1.0</td>
       </tr>
       <tr>
         <th scope="row">2.x.x</th>
-        <td>6.0.0</td>
-        <td>4.0.0</td>
+        <td>&ge;6.0.0 &lt;6.1.0</td>
+        <td>&ge;4.0.0 &lt;4.1.0</td>
       </tr>
       <tr>
         <th scope="row">3.x.x</th>
-        <td>6.1.0</td>
-        <td>4.0.0</td>
+        <td>&ge;6.1.0 &lt;7.0.0</td>
+        <td>&ge;4.0.0 &lt;4.2.0</td>
       </tr>
       <tr>
         <th scope="row">4.x.x</th>
-        <td>7.0.0</td>
-        <td>4.0.0</td>
+        <td>&ge;7.0.0 &lt;8.0.0</td>
+        <td>&ge;4.0.0 &lt;4.2.0</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
Clarifies version ranges support, 
- shows we don't support NG 8 or BS 4.2.0 yet
- shows that we support BS 4.0.0 to 4.1.x