### PR TITLE
fix: add missing exports

### DIFF
--- a/src/dropdown/dropdown.module.ts
+++ b/src/dropdown/dropdown.module.ts
@@ -1,7 +1,7 @@
 import {NgModule, ModuleWithProviders} from '@angular/core';
 import {NgbDropdown, NgbDropdownAnchor, NgbDropdownToggle, NgbDropdownMenu} from './dropdown';
 
-export {NgbDropdown, NgbDropdownToggle, NgbDropdownMenu} from './dropdown';
+export {NgbDropdown, NgbDropdownAnchor, NgbDropdownToggle, NgbDropdownMenu} from './dropdown';
 export {NgbDropdownConfig} from './dropdown-config';
 
 const NGB_DROPDOWN_DIRECTIVES = [NgbDropdown, NgbDropdownAnchor, NgbDropdownToggle, NgbDropdownMenu];

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export {
   NgbPanelContent
 } from './accordion/accordion.module';
 export {NgbAlertModule, NgbAlertConfig, NgbAlert} from './alert/alert.module';
-export {NgbButtonsModule, NgbCheckBox, NgbRadioGroup} from './buttons/buttons.module';
+export {NgbButtonsModule, NgbButtonLabel, NgbCheckBox, NgbRadio, NgbRadioGroup} from './buttons/buttons.module';
 export {NgbCarouselModule, NgbCarouselConfig, NgbCarousel, NgbSlide} from './carousel/carousel.module';
 export {NgbCollapseModule, NgbCollapse} from './collapse/collapse.module';
 export {
@@ -57,7 +57,14 @@ export {
   NgbDatepicker,
   NgbInputDatepicker
 } from './datepicker/datepicker.module';
-export {NgbDropdownModule, NgbDropdownConfig, NgbDropdown} from './dropdown/dropdown.module';
+export {
+  NgbDropdownModule,
+  NgbDropdownAnchor,
+  NgbDropdownConfig,
+  NgbDropdownMenu,
+  NgbDropdownToggle,
+  NgbDropdown
+} from './dropdown/dropdown.module';
 export {
   NgbModalModule,
   NgbModal,


### PR DESCRIPTION
When building ng-bootstrap with Ivy, I'm getting the following error:
```
BUILD ERROR
src/buttons/label.ts(8,14): error TS-993001: Unsupported private class NgbButtonLabel. This class is visible to consumers via NgbButtonsModule -> NgbButtonLabel, but is not exported from the top-level library entrypoint.
src/buttons/radio.ts(80,14): error TS-993001: Unsupported private class NgbRadio. This class is visible to consumers via NgbButtonsModule -> NgbRadio, but is not exported from the top-level library entrypoint.
src/dropdown/dropdown.ts(71,14): error TS-993001: Unsupported private class NgbDropdownAnchor. This class is visible to consumers via NgbDropdownModule -> NgbDropdownAnchor, but is not exported from the top-level library entrypoint.
src/dropdown/dropdown.ts(95,14): error TS-993001: Unsupported private class NgbDropdownToggle. This class is visible to consumers via NgbDropdownModule -> NgbDropdownToggle, but is not exported from the top-level library entrypoint.
src/dropdown/dropdown.ts(28,14): error TS-993001: Unsupported private class NgbDropdownMenu. This class is visible to consumers via NgbDropdownModule -> NgbDropdownMenu, but is not exported from the top-level library entrypoint.
```

I don't know why it happens ... Adding the missing exports solves the issue.