### PR TITLE
refactor(autoclose): transform service into a function to avoid DI

### DIFF
--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -1,10 +1,12 @@
 import {
+  ChangeDetectorRef,
   ComponentFactoryResolver,
   ComponentRef,
   Directive,
   ElementRef,
   EventEmitter,
   forwardRef,
+  Inject,
   Input,
   NgZone,
   OnChanges,
@@ -13,14 +15,16 @@ import {
   Renderer2,
   SimpleChanges,
   TemplateRef,
-  ViewContainerRef,
-  ChangeDetectorRef,
+  ViewContainerRef
 } from '@angular/core';
+import {DOCUMENT} from '@angular/common';
 import {AbstractControl, ControlValueAccessor, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validator} from '@angular/forms';
 import {Subject} from 'rxjs';
 
+import {ngbAutoClose} from '../util/autoclose';
 import {ngbFocusTrap} from '../util/focus-trap';
 import {PlacementArray, positionElements} from '../util/positioning';
+
 import {NgbDateAdapter} from './adapters/ngb-date-adapter';
 import {NgbDatepicker, NgbDatepickerNavigateEvent} from './datepicker';
 import {DayTemplateContext} from './datepicker-day-template-context';
@@ -29,7 +33,6 @@ import {NgbCalendar} from './ngb-calendar';
 import {NgbDate} from './ngb-date';
 import {NgbDateParserFormatter} from './ngb-date-parser-formatter';
 import {NgbDateStruct} from './ngb-date-struct';
-import {AutoClose} from '../util/autoclose';
 
 const NGB_DATEPICKER_VALUE_ACCESSOR = {
   provide: NG_VALUE_ACCESSOR,
@@ -203,8 +206,8 @@ export class NgbInputDatepicker implements OnChanges,
       private _parserFormatter: NgbDateParserFormatter, private _elRef: ElementRef<HTMLInputElement>,
       private _vcRef: ViewContainerRef, private _renderer: Renderer2, private _cfr: ComponentFactoryResolver,
       private _ngZone: NgZone, private _service: NgbDatepickerService, private _calendar: NgbCalendar,
-      private _dateAdapter: NgbDateAdapter<any>, private _changeDetector: ChangeDetectorRef,
-      private _autoClose: AutoClose) {
+      private _dateAdapter: NgbDateAdapter<any>, @Inject(DOCUMENT) private _document: any,
+      private _changeDetector: ChangeDetectorRef) {
     this._zoneSubscription = _ngZone.onStable.subscribe(() => {
       if (this._cRef) {
         positionElements(
@@ -295,10 +298,10 @@ export class NgbInputDatepicker implements OnChanges,
 
       // focus handling
       ngbFocusTrap(this._cRef.location.nativeElement, this._closed$, true);
-
       this._cRef.instance.focus();
-      this._autoClose.install(
-          this.autoClose, () => this.close(), this._closed$, [],
+
+      ngbAutoClose(
+          this._ngZone, this._document, this.autoClose, () => this.close(), this._closed$, [],
           [this._elRef.nativeElement, this._cRef.location.nativeElement]);
     }
   }

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -15,9 +15,11 @@ import {
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {Subject, Subscription} from 'rxjs';
-import {NgbDropdownConfig} from './dropdown-config';
+
 import {positionElements, PlacementArray, Placement} from '../util/positioning';
-import {AutoClose} from '../util/autoclose';
+import {ngbAutoClose} from '../util/autoclose';
+
+import {NgbDropdownConfig} from './dropdown-config';
 
 /**
  */
@@ -142,7 +144,7 @@ export class NgbDropdown implements OnInit, OnDestroy {
 
   constructor(
       private _changeDetector: ChangeDetectorRef, config: NgbDropdownConfig, @Inject(DOCUMENT) private _document: any,
-      private _ngZone: NgZone, private _autoClose: AutoClose) {
+      private _ngZone: NgZone) {
     this.placement = config.placement;
     this.autoClose = config.autoClose;
     this._zoneSubscription = _ngZone.onStable.subscribe(() => { this._positionMenu(); });
@@ -176,9 +178,9 @@ export class NgbDropdown implements OnInit, OnDestroy {
   }
 
   private _setCloseHandlers() {
-    this._autoClose.install(
-        this.autoClose, () => this.close(), this._closed$, this._menu ? [this._menu.getNativeElement()] : [],
-        this._anchor ? [this._anchor.getNativeElement()] : []);
+    ngbAutoClose(
+        this._ngZone, this._document, this.autoClose, () => this.close(), this._closed$,
+        this._menu ? [this._menu.getNativeElement()] : [], this._anchor ? [this._anchor.getNativeElement()] : []);
   }
 
   /**

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -24,11 +24,11 @@ import {
 import {DOCUMENT} from '@angular/common';
 
 import {listenToTriggers} from '../util/triggers';
-import {positionElements, Placement, PlacementArray} from '../util/positioning';
+import {ngbAutoClose} from '../util/autoclose';
+import {positionElements, PlacementArray} from '../util/positioning';
 import {PopupService} from '../util/popup';
 
 import {NgbPopoverConfig} from './popover-config';
-import {AutoClose} from '../util/autoclose';
 
 let nextId = 0;
 
@@ -135,8 +135,7 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
   constructor(
       private _elementRef: ElementRef<HTMLElement>, private _renderer: Renderer2, injector: Injector,
       componentFactoryResolver: ComponentFactoryResolver, viewContainerRef: ViewContainerRef, config: NgbPopoverConfig,
-      private _ngZone: NgZone, @Inject(DOCUMENT) private _document: any, private _autoClose: AutoClose,
-      private _changeDetector: ChangeDetectorRef) {
+      private _ngZone: NgZone, @Inject(DOCUMENT) private _document: any, private _changeDetector: ChangeDetectorRef) {
     this.autoClose = config.autoClose;
     this.placement = config.placement;
     this.triggers = config.triggers;
@@ -176,8 +175,9 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
       // apply styling to set basic css-classes on target element, before going for positioning
       this._windowRef.changeDetectorRef.markForCheck();
 
-      this._autoClose.install(
-          this.autoClose, () => this.close(), this.hidden, [this._windowRef.location.nativeElement]);
+      ngbAutoClose(
+          this._ngZone, this._document, this.autoClose, () => this.close(), this.hidden,
+          [this._windowRef.location.nativeElement]);
       this.shown.emit();
     }
   }

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -22,11 +22,11 @@ import {
 import {DOCUMENT} from '@angular/common';
 
 import {listenToTriggers} from '../util/triggers';
-import {positionElements, Placement, PlacementArray} from '../util/positioning';
+import {ngbAutoClose} from '../util/autoclose';
+import {positionElements, PlacementArray} from '../util/positioning';
 import {PopupService} from '../util/popup';
 
 import {NgbTooltipConfig} from './tooltip-config';
-import {AutoClose} from '../util/autoclose';
 
 let nextId = 0;
 
@@ -107,8 +107,7 @@ export class NgbTooltip implements OnInit, OnDestroy {
   constructor(
       private _elementRef: ElementRef<HTMLElement>, private _renderer: Renderer2, injector: Injector,
       componentFactoryResolver: ComponentFactoryResolver, viewContainerRef: ViewContainerRef, config: NgbTooltipConfig,
-      private _ngZone: NgZone, @Inject(DOCUMENT) private _document: any, private _autoClose: AutoClose,
-      private _changeDetector: ChangeDetectorRef) {
+      private _ngZone: NgZone, @Inject(DOCUMENT) private _document: any, private _changeDetector: ChangeDetectorRef) {
     this.autoClose = config.autoClose;
     this.placement = config.placement;
     this.triggers = config.triggers;
@@ -159,8 +158,9 @@ export class NgbTooltip implements OnInit, OnDestroy {
       // apply styling to set basic css-classes on target element, before going for positioning
       this._windowRef.changeDetectorRef.markForCheck();
 
-      this._autoClose.install(
-          this.autoClose, () => this.close(), this.hidden, [this._windowRef.location.nativeElement]);
+      ngbAutoClose(
+          this._ngZone, this._document, this.autoClose, () => this.close(), this.hidden,
+          [this._windowRef.location.nativeElement]);
 
       this.shown.emit();
     }


### PR DESCRIPTION
The motivation for this PR is to rollback breaking changes for those who extend autocloseable components (`NgbDatepickerInput`, `NgbTypeahead`, `NgbTooltip`, `NgbDropdown`, `NgbPopover`):

```ts
  @Component()
  class NgbPopover {
    constructor(..., private _autoClose: AutoClose);
  }
```

It was introduced in `4.0.1` and will break in `NgbPopover` children classes, because `AutoClose` is a private service.

---

**However, we don't want people to subclass our components** and https://github.com/ng-bootstrap/ng-bootstrap/issues/2623#issuecomment-413793539 is still true, but adding an injectable`AutoClose` change should have not been a part of a minor release IMO