### PR TITLE
chore(positioning): provide scrolling subscribers

### DIFF
--- a/e2e-app/src/app/app.module.ts
+++ b/e2e-app/src/app/app.module.ts
@@ -29,6 +29,7 @@ import {TypeaheadFocusComponent} from './typeahead/focus/typeahead-focus.compone
 import {TimepickerFilterComponent} from './timepicker/filter/timepicker-filter.component';
 import {TimepickerNavigationComponent} from './timepicker/navigation/timepicker-navigation.component';
 import {TypeaheadValidationComponent} from './typeahead/validation/typeahead-validation.component';
+import {ScrollComponent} from './position/scroll/scroll.component';
 
 
 @NgModule({
@@ -48,6 +49,7 @@ import {TypeaheadValidationComponent} from './typeahead/validation/typeahead-val
     ModalStackComponent,
     ModalStackConfirmationComponent,
     PopoverAutocloseComponent,
+    ScrollComponent,
     TooltipAutocloseComponent,
     TooltipFocusComponent,
     TooltipPositionComponent,

--- a/e2e-app/src/app/app.routing.ts
+++ b/e2e-app/src/app/app.routing.ts
@@ -14,6 +14,7 @@ import {ModalNestingComponent} from './modal/nesting/modal-nesting.component';
 import {ModalStackComponent} from './modal/stack/modal-stack.component';
 import {ModalStackConfirmationComponent} from './modal/stack-confirmation/modal-stack-confirmation.component';
 import {PopoverAutocloseComponent} from './popover/autoclose/popover-autoclose.component';
+import {ScrollComponent} from './position/scroll/scroll.component';
 import {TooltipAutocloseComponent} from './tooltip/autoclose/tooltip-autoclose.component';
 import {TooltipFocusComponent} from './tooltip/focus/tooltip-focus.component';
 import {TooltipPositionComponent} from './tooltip/position/tooltip-position.component';
@@ -50,8 +51,7 @@ export const routes: Routes = [
       {path: 'focus', component: DropdownFocusComponent}, {path: 'position', component: DropdownPositionComponent}
     ]
   },
-  {path: 'popover', children: [{path: 'autoclose', component: PopoverAutocloseComponent}]},
-  {
+  {path: 'popover', children: [{path: 'autoclose', component: PopoverAutocloseComponent}]}, {
     path: 'tooltip',
     children: [
       {path: 'autoclose', component: TooltipAutocloseComponent}, {path: 'focus', component: TooltipFocusComponent},
@@ -72,6 +72,7 @@ export const routes: Routes = [
       {path: 'filter', component: TimepickerFilterComponent},
     ]
   },
+  {path: 'position', children: [{path: 'scroll', component: ScrollComponent}]}
 ];
 
 export const routing: ModuleWithProviders = RouterModule.forRoot(routes, {useHash: true});

--- a/e2e-app/src/app/position/scroll/scroll.component.html
+++ b/e2e-app/src/app/position/scroll/scroll.component.html
@@ -1,0 +1,21 @@
+<h3>Position with scroll tests</h3>
+
+<div>
+  <button class="btn btn-outline-secondary ml-1" id="container-null" (click)="container = null">Append to widget</button>
+  <button class="btn btn-outline-secondary ml-1" id="container-body" (click)="container = 'body'">Append to body</button>
+</div>
+<div id="outer-container" class="p-3" style="height: 400px; overflow: scroll">
+  <div id="inner-container" class="position-relative d-inline-block p-3" style="height: 200px; overflow: scroll;">
+    <div class="position-relative d-flex justify-content-center align-items-center" style="height: 250px;">
+      <button id="tooltip-target" ngbTooltip="Tooltip here" [autoClose]="false" triggers="click" type="button"
+        class="btn btn-outline-secondary ml-2" [container]="container">
+        Tooltip
+      </button>
+      <button id="popover-target" ngbPopover="Popover here" [container]="container" [autoClose]="false" triggers="click" type="button"
+        class="btn btn-outline-secondary ml-2" [container]="container">
+        Popover
+      </button>
+    </div>
+  </div>
+  <div style="height: 300px; width: 100%;"></div>
+</div>

--- a/e2e-app/src/app/position/scroll/scroll.component.ts
+++ b/e2e-app/src/app/position/scroll/scroll.component.ts
@@ -1,0 +1,6 @@
+import {Component} from '@angular/core';
+
+@Component({templateUrl: './scroll.component.html'})
+export class ScrollComponent {
+  container: null | 'body';
+}

--- a/e2e-app/src/app/position/scroll/scroll.e2e-spec.ts
+++ b/e2e-app/src/app/position/scroll/scroll.e2e-spec.ts
@@ -1,0 +1,148 @@
+import {openUrl} from '../../tools.po';
+import {ScrollPage} from './scroll.po';
+
+const roundLocation = function(location) {
+  location.x = Math.round(location.x);
+  location.y = Math.round(location.y);
+
+  return location;
+};
+
+const popoverMarginBottom = 8;
+
+describe('Scroll', () => {
+
+  let page: ScrollPage;
+
+  const expectPositionOnTop = async(btn, popupElement, offset = 0) => {
+    const btnLocation = roundLocation(await btn.getLocation());
+    const btnSize = await btn.getSize();
+    const popupLocation = roundLocation(await popupElement.getLocation());
+    const popupSize = await popupElement.getSize();
+
+    const yDiff = (popupLocation.y + popupSize.height) - btnLocation.y + offset;
+    const xDiff = (popupLocation.x + popupSize.width / 2) - (btnLocation.x + (btnSize.width / 2));
+
+    expect(Math.abs(yDiff)).toBeLessThanOrEqual(1, `Popup top positionning`);
+    expect(Math.abs(xDiff)).toBeLessThanOrEqual(1, `Popup left positionning`);
+
+  };
+
+  beforeAll(() => page = new ScrollPage());
+
+  beforeEach(async() => await openUrl('position/scroll'));
+
+  describe('Tooltip', () => {
+
+    it(`move with the target (first parent scrolled, container = null)`, async() => {
+
+      const tooltipButton = page.getButton('tooltip');
+      await tooltipButton.click();
+      const tooltip = page.getPopup('tooltip');
+
+      await expectPositionOnTop(tooltipButton, tooltip);
+      await page.scrollElement('inner-container', 50);
+      await expectPositionOnTop(tooltipButton, tooltip);
+
+    });
+
+    it(`move with the target (first parent scrolled, container = body)`, async() => {
+
+      await page.selectContainer('body');
+
+      const tooltipButton = page.getButton('tooltip');
+      await tooltipButton.click();
+      const tooltip = page.getPopup('tooltip');
+
+      await expectPositionOnTop(tooltipButton, tooltip);
+      await page.scrollElement('inner-container', 50);
+      await expectPositionOnTop(tooltipButton, tooltip);
+
+    });
+
+    it(`move with the target (second parent scrolled, container = null)`, async() => {
+
+      const tooltipButton = page.getButton('tooltip');
+      await tooltipButton.click();
+      const tooltip = page.getPopup('tooltip');
+
+      await expectPositionOnTop(tooltipButton, tooltip);
+      await page.scrollElement('outer-container', 50);
+      await expectPositionOnTop(tooltipButton, tooltip);
+
+    });
+
+    it(`move with the target (second parent scrolled, container = body)`, async() => {
+
+      await page.selectContainer('body');
+
+      const tooltipButton = page.getButton('tooltip');
+      await tooltipButton.click();
+      const tooltip = page.getPopup('tooltip');
+
+      await expectPositionOnTop(tooltipButton, tooltip);
+      await page.scrollElement('outer-container', 50);
+      await expectPositionOnTop(tooltipButton, tooltip);
+
+    });
+
+
+  });
+
+  describe('Popover', () => {
+
+    it(`move with the target (first parent scrolled, container = null)`, async() => {
+
+      const popoverButton = page.getButton('popover');
+      await popoverButton.click();
+      const popover = page.getPopup('popover');
+
+      await expectPositionOnTop(popoverButton, popover, popoverMarginBottom);
+      await page.scrollElement('inner-container', 50);
+      await expectPositionOnTop(popoverButton, popover, popoverMarginBottom);
+
+
+    });
+
+    it(`move with the target (first parent scrolled, container = body)`, async() => {
+      await page.selectContainer('body');
+
+      const popoverButton = page.getButton('popover');
+      await popoverButton.click();
+      const popover = page.getPopup('popover');
+
+      await expectPositionOnTop(popoverButton, popover, popoverMarginBottom);
+      await page.scrollElement('inner-container', 50);
+      await expectPositionOnTop(popoverButton, popover, popoverMarginBottom);
+
+    });
+
+    it(`move with the target (second parent scrolled, container = null)`, async() => {
+
+      const popoverButton = page.getButton('popover');
+      await popoverButton.click();
+      const popover = page.getPopup('popover');
+
+      await expectPositionOnTop(popoverButton, popover, popoverMarginBottom);
+      await page.scrollElement('outer-container', 50);
+      await expectPositionOnTop(popoverButton, popover, popoverMarginBottom);
+
+
+    });
+
+    it(`move with the target (second parent scrolled, container = body)`, async() => {
+      await page.selectContainer('body');
+
+      const popoverButton = page.getButton('popover');
+      await popoverButton.click();
+      const popover = page.getPopup('popover');
+
+      await expectPositionOnTop(popoverButton, popover, popoverMarginBottom);
+      await page.scrollElement('outer-container', 50);
+      await expectPositionOnTop(popoverButton, popover, popoverMarginBottom);
+
+    });
+
+  });
+
+});

--- a/e2e-app/src/app/position/scroll/scroll.po.ts
+++ b/e2e-app/src/app/position/scroll/scroll.po.ts
@@ -1,0 +1,16 @@
+import {$, browser} from 'protractor';
+
+export class ScrollPage {
+  getButton(type: 'tooltip' | 'popover') { return $(`#${type}-target`); }
+
+  getPopup(type: 'tooltip' | 'popover') { return $(`ngb-${type}-window`); }
+
+  async scrollElement(elementId: string, elementScrollY) {
+    await browser.executeScript(function(id, scrollY = 0) {
+      // Scroll to given position
+      document.getElementById(id) !.scrollTo(0, scrollY);
+    }, elementId, elementScrollY);
+  }
+
+  async selectContainer(container: null | 'body') { await $(`#container-${container}`).click(); }
+}

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -26,6 +26,7 @@ import {DOCUMENT} from '@angular/common';
 
 import {listenToTriggers} from '../util/triggers';
 import {ngbAutoClose} from '../util/autoclose';
+import {ngbScroll} from '../util/scroll';
 import {positionElements, PlacementArray} from '../util/positioning';
 import {PopupService} from '../util/popup';
 
@@ -189,13 +190,7 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
     this._popupService = new PopupService<NgbPopoverWindow>(
         NgbPopoverWindow, injector, viewContainerRef, _renderer, componentFactoryResolver, applicationRef);
 
-    this._zoneSubscription = _ngZone.onStable.subscribe(() => {
-      if (this._windowRef) {
-        positionElements(
-            this._elementRef.nativeElement, this._windowRef.location.nativeElement, this.placement,
-            this.container === 'body', 'bs-popover');
-      }
-    });
+    this._zoneSubscription = _ngZone.onStable.subscribe(() => { this._positionElements(); });
   }
 
   /**
@@ -216,6 +211,7 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
 
       if (this.container === 'body') {
         this._document.querySelector(this.container).appendChild(this._windowRef.location.nativeElement);
+        ngbScroll(this._ngZone, this._elementRef.nativeElement, () => this._positionElements(), this.hidden);
       }
 
       // We need to detect changes, because we don't know where .open() might be called from.
@@ -294,5 +290,13 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
       this._unregisterListenersFn();
     }
     this._zoneSubscription.unsubscribe();
+  }
+
+  private _positionElements() {
+    if (this._windowRef) {
+      positionElements(
+          this._elementRef.nativeElement, this._windowRef.location.nativeElement, this.placement,
+          this.container === 'body', 'bs-popover');
+    }
   }
 }

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -26,6 +26,7 @@ import {DOCUMENT} from '@angular/common';
 
 import {listenToTriggers} from '../util/triggers';
 import {ngbAutoClose} from '../util/autoclose';
+import {ngbScroll} from '../util/scroll';
 import {positionElements, PlacementArray} from '../util/positioning';
 import {PopupService} from '../util/popup';
 
@@ -156,13 +157,7 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
     this._popupService = new PopupService<NgbTooltipWindow>(
         NgbTooltipWindow, injector, viewContainerRef, _renderer, componentFactoryResolver, applicationRef);
 
-    this._zoneSubscription = _ngZone.onStable.subscribe(() => {
-      if (this._windowRef) {
-        positionElements(
-            this._elementRef.nativeElement, this._windowRef.location.nativeElement, this.placement,
-            this.container === 'body', 'bs-tooltip');
-      }
-    });
+    this._zoneSubscription = _ngZone.onStable.subscribe(() => { this._positionElements(); });
   }
 
   /**
@@ -196,6 +191,7 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 
       if (this.container === 'body') {
         this._document.querySelector(this.container).appendChild(this._windowRef.location.nativeElement);
+        ngbScroll(this._ngZone, this._elementRef.nativeElement, () => this._positionElements(), this.hidden);
       }
 
       // We need to detect changes, because we don't know where .open() might be called from.
@@ -271,5 +267,13 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
       this._unregisterListenersFn();
     }
     this._zoneSubscription.unsubscribe();
+  }
+
+  private _positionElements() {
+    if (this._windowRef) {
+      positionElements(
+          this._elementRef.nativeElement, this._windowRef.location.nativeElement, this.placement,
+          this.container === 'body', 'bs-tooltip');
+    }
   }
 }

--- a/src/util/scroll.ts
+++ b/src/util/scroll.ts
@@ -1,0 +1,34 @@
+import {NgZone} from '@angular/core';
+import {fromEvent, Observable} from 'rxjs';
+import {takeUntil, throttleTime} from 'rxjs/operators';
+
+
+const getScrolledParent = (element, includeHidden = false) => {
+  let style = getComputedStyle(element);
+  const excludeStaticParent = style.position === 'absolute';
+  const overflowRegex = includeHidden ? /(auto|scroll|hidden)/ : /(auto|scroll)/;
+
+  if (style.position !== 'fixed') {
+    for (let parent = element; parent = parent.parentElement;) {
+      style = getComputedStyle(parent);
+      if (excludeStaticParent && style.position === 'static') {
+        continue;
+      }
+      if (overflowRegex.test(style.overflow + style.overflowY + style.overflowX)) {
+        return parent;
+      }
+    }
+  }
+
+  return null;
+};
+
+export function ngbScroll(zone: NgZone, hostElement: HTMLElement, callback: () => void, closed$: Observable<any>) {
+  zone.runOutsideAngular(() => {
+    let scrolledParent = getScrolledParent(hostElement);
+    while (scrolledParent) {
+      fromEvent(scrolledParent, 'scroll').pipe(takeUntil(closed$), throttleTime(10)).subscribe(() => { callback(); });
+      scrolledParent = getScrolledParent(scrolledParent);
+    }
+  });
+}


### PR DESCRIPTION
This is a PR to discuss about adding a scrolling subscription functions to the positioning utility. 

At the moment, it is not ready to be integrated (test page to complete or remove, as it doesn't test anything for now :) ), but the 2e2 page `#/position/scroll` show the issue met when popup are inside parents with scrollbars : when the scroll is done, the popup position is frozen to its original position (comment `export function subscribeScroll` function code to see the issue on the page).

This can be done the the tooltip and popover, but it's also planned to be used in the PR #2823, where this issue will be more visible (a dropdown in a scrolled parent with container="body" will not move while scrolling).

So the current questions are:

- Is it this relevant to have this in an utilty ?
- Do the tooltip and popover placement fixed with this PR (there is no issue related to this problem at the moment) ?
- When scrolling is done, the popup must be scrolled too, or simply closed ? (two valuable UX decisions I think)