### PR TITLE
fix(accordion): restore forgotten 'btn btn-link' after refactoring

### DIFF
--- a/src/accordion/accordion.ts
+++ b/src/accordion/accordion.ts
@@ -172,7 +172,7 @@ export interface NgbPanelChangeEvent {
   host: {'class': 'accordion', 'role': 'tablist', '[attr.aria-multiselectable]': '!closeOtherPanels'},
   template: `
     <ng-template #t ngbPanelHeader let-panel>
-      <button [ngbPanelToggle]="panel">
+      <button class="btn btn-link" [ngbPanelToggle]="panel">
         {{panel.title}}<ng-template [ngTemplateOutlet]="panel.titleTpl?.templateRef"></ng-template>
       </button>
     </ng-template>


### PR DESCRIPTION
Classes were forgotten for default card header implementation in #2981 

cc @benouat :)