### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NG Bootstrap - [Angular](https://angular.io/) directives specific to [Bootstrap 4](https://getbootstrap.com/)
+# NG Bootstrap - Angular powered Bootstrap widgets
 
 [![npm version](https://badge.fury.io/js/%40ng-bootstrap%2Fng-bootstrap.svg)](https://badge.fury.io/js/%40ng-bootstrap%2Fng-bootstrap)
 [![Build Status](https://travis-ci.org/ng-bootstrap/ng-bootstrap.svg?branch=master)](https://travis-ci.org/ng-bootstrap/ng-bootstrap)
@@ -6,31 +6,30 @@
 [![devDependency Status](https://david-dm.org/ng-bootstrap/ng-bootstrap/dev-status.svg?branch=master)](https://david-dm.org/ng-bootstrap/ng-bootstrap#info=devDependencies)
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/pkozlowski.svg)](https://saucelabs.com/u/pkozlowski)
 
-Welcome to the Angular version of the [Angular UI Bootstrap](https://github.com/angular-ui/bootstrap) library.
-This library is being built from scratch by the [ui-bootstrap team](https://github.com/angular-ui/bootstrap).
-We are using TypeScript and targeting the Bootstrap 4 CSS framework.
+[Angular](https://angular.io/) widgets built from the ground up using only [Bootstrap 4](https://getbootstrap.com/) CSS with APIs designed for the Angular ecosystem.
+No dependencies on 3rd party JavaScript.
 
-As with Bootstrap 4, this library is a work in progress. Please check out our list of
-[issues](https://github.com/ng-bootstrap/ng-bootstrap/issues) to see all the things we are implementing.
-Feel free to make comments there.
+Please check our [demo site](https://ng-bootstrap.github.io) and the list of
+[issues](https://github.com/ng-bootstrap/ng-bootstrap/issues) to see all the things we are working on. Feel free to make comments there.
+ 
 
 ## Table of Contents
 
 - [Demo](#demo)
 - [Dependencies](#dependencies)
 - [Installation](#installation)
-  - [SystemJS](#systemjs)
 - [Supported browsers](#supported-browsers)
-- [Contributing to the project](#contributing-to-the-project)
-- [Getting Help](#getting-help)
+- [Getting help](#getting-help)
 - [You think you've found a bug?](#you-think-youve-found-a-bug)
-- [Code of Conduct](#code-of-conduct)
+- [Contributing to the project](#contributing-to-the-project)
+- [Code of conduct](#code-of-conduct)
 
 ## Demo
 
-View all the directives in action at https://ng-bootstrap.github.io
+Please check all components we have in action at https://ng-bootstrap.github.io
 
 ## Dependencies
+
 The only two dependencies are [Angular](https://angular.io) and [Bootstrap 4](https://getbootstrap.com) CSS. 
 Here is the list of minimal required versions:
 
@@ -41,7 +40,21 @@ Here is the list of minimal required versions:
 | 3.x.x        | 6.1.0   | 4.0.0         |
 | 4.x.x        | 7.0.0   | 4.0.0         |
 
+
 ## Installation
+
+You need to have an Angular project with the supported Angular version. We strongly recommend using [Angular CLI](https://cli.angular.io) for this.
+
+You also need to add Bootstrap 4 CSS to your application by using your preferred way (it really depends on the setup you're using). Ex. for Angular CLI you can [get Bootstrap from npm](https://www.npmjs.com/package/bootstrap) and update your `angular.json` with something like:
+
+```json
+"styles": [
+  "node_modules/bootstrap/dist/css/bootstrap.min.css"
+]
+```
+
+Please note that you need only CSS and **should not** add other JavaScript dependencies like `bootstrap.js`, `jQuery` or `popper.js` as ng-bootstrap's goal is to completely replace them.
+
 After installing the above dependencies, install `ng-bootstrap` via:
 ```shell
 npm install --save @ng-bootstrap/ng-bootstrap
@@ -74,19 +87,10 @@ export class YourAppModule {
 }
 ```
 
-### SystemJS
-If you are using SystemJS, you should also adjust your configuration to point to the UMD bundle.
 
-In your SystemJS config file, `map` needs to tell the System loader where to look for `ng-bootstrap`:
-```js
-map: {
-  '@ng-bootstrap/ng-bootstrap': 'node_modules/@ng-bootstrap/ng-bootstrap/bundles/ng-bootstrap.js',
-}
-```
 ## Supported browsers
 
-We support the same browsers and versions supported by both Bootstrap 4 and Angular, whichever is _more_ restrictive.
-See [this](https://angular.io/guide/browser-support) for up-to-date Angular browser support.
+We support the same browsers and versions supported by both Bootstrap 4 and Angular, whichever is _more_ restrictive. See [Angular browser support](https://angular.io/guide/browser-support) and [Bootstrap browser support](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/#supported-browsers) for more details, but on the high-level it should be something like:  
 
 * Chrome (45+)
 * Firefox (40+)
@@ -94,13 +98,8 @@ See [this](https://angular.io/guide/browser-support) for up-to-date Angular brow
 * Edge (20+)
 * Safari (7+)
 
-Also check [Bootstrap 4's notes](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/#supported-browsers) on browsers support.
 
-## Contributing to the project
-
-Please check the [CONTRIBUTING.md](CONTRIBUTING.md) doc for contribution guidelines.
-
-## Getting Help
+## Getting help
 
 Please, do not open issues for the general support questions as we want to keep GitHub issues for bug reports and feature requests. You've got much better chances of getting your question answered on [StackOverflow](http://stackoverflow.com/questions/tagged/ng-bootstrap) where maintainers are looking at questions tagged with `ng-bootstrap`.
 
@@ -111,21 +110,27 @@ StackOverflow is a much better place to ask questions since:
 
 To save your and our time we will be systematically closing all the issues that are requests for general support and redirecting people to StackOverflow.
 
+
 ## You think you've found a bug?
 
-Oh, we are ashamed and want to fix it ASAP! But before fixing a bug we need to reproduce and confirm it. In order to reproduce bugs we will systematically ask you to provide a _minimal_ reproduction scenario using https://stackblitz.com. Having a live, reproducible scenario gives us wealth of important information without going back & forth to you with additional questions like:
-* version of Angular used
-* version of this library that you are using
-* 3rd-party libraries used, if any
-* and most importantly - a use-case that fails
+We want to fix it ASAP! But before fixing a bug we need to reproduce and confirm it.
 
-A minimal reproduce scenario using https://stackblitz.com allows us to quickly confirm a bug (or point out coding problem) as well as confirm that we are fixing the right problem.
-The best part is that you do not need to create StackBlitzes from scratch - you can fork one from our [demo page](https://ng-bootstrap.github.io/#/components).
+We ask you to respect two things:
+* fill the GitHub issue template by providing the bug description and appropriate versions of Angular, ng-bootstrap and TypeScript
+* provide a use-case that fails with a **minimal reproduction scenario** using [StackBlitz](https://stackblitz) (you can start by forking one from our [demo page](https://ng-bootstrap.github.io/#/components))
 
-We will be insisting on a minimal reproduce scenario in order to save maintainers time and ultimately be able to fix more bugs. Interestingly, from our experience users often find coding problems themselves while preparing a minimal StackBlitz. We understand that sometimes it might be hard to extract essentials bits of code from a larger code-base but we really need to isolate the problem before we can fix it.
+A minimal reproduction scenario allows us to quickly confirm a bug (or point out a coding problem) as well as confirm that we are fixing the right problem.
 
-Unfortunately we are not able to investigate / fix bugs without a minimal reproduce scenario using https://stackblitz.com, so if we don't hear back from you we are going to close an issue that don't have enough info to be reproduced.
+Please not that **we will be insisting on a minimal reproduce scenario** in order to save maintainers time and ultimately be able to fix more bugs. We'll mark the issue as non-actionable without it and close if not heard from the reporter. 
 
-## Code of Conduct
+Interestingly, from our experience users often find coding problems themselves while preparing a minimal StackBlitz. We understand that sometimes it might be hard to extract essentials bits of code from a larger code-base but we really need to isolate the problem before we can fix it.
+
+
+## Contributing to the project
+
+Please check the [DEVELOPER.md](DEVELOPER.md) for documentation on running the project locally and [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
+
+
+## Code of conduct
 
 Please take a moment and read our [Code of Conduct](CODE_OF_CONDUCT.md)


### PR DESCRIPTION
Update main `README.md`:
- reflect the main page on https://ng-bootstrap.github.io
- header says "Angular powered Bootstrap widgets" instead of "Angular directives specific to Bootstrap 4"
- update installation instructions with note on Bootstrap CSS and JS
- remove `SystemJS` installation instructions
- simplify and move higher the "You think you've found found a bug?" section

Resulting version here → https://github.com/maxokorokov/core/tree/docs/refresh-readme#ng-bootstrap---angular-powered-bootstrap-widgets