### PR TITLE
The bootstrap sizes to include xl

### DIFF
--- a/src/modal/modal-config.ts
+++ b/src/modal/modal-config.ts
@@ -49,7 +49,7 @@ export interface NgbModalOptions {
   /**
    * Size of a new modal window.
    */
-  size?: 'sm' | 'lg';
+  size?: 'sm' | 'lg' | 'xl';
 
   /**
    * Custom class to append to the modal window


### PR DESCRIPTION
According to the bootstrap documentation there are 3 sizes 

https://getbootstrap.com/docs/4.3/components/modal/#optional-sizes

Before submitting a pull request, please make sure you have at least performed the following:

 - [] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [] built and tested the changes locally.
 - [] added/updated any applicable tests.
 - [] added/updated any applicable API documentation.
 - [] added/updated any applicable demos.
