### PR TITLE
feat(datepicker): add 'closed' event and fire after closing dp window

### DIFF
--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -827,6 +827,8 @@ class TestComponent {
 
   onModelChange() {}
 
+  onClose() {}
+
   open(d: NgbInputDatepicker) { d.open(); }
 
   close(d: NgbInputDatepicker) { d.close(); }

--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -674,6 +674,21 @@ describe('NgbInputDatepicker', () => {
       });
     });
 
+    it('should relay the "closed" event', () => {
+      const fixture = createTestCmpt(`<input ngbDatepicker (closed)="onClose()">`);
+      const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
+
+      spyOn(fixture.componentInstance, 'onClose');
+
+      // open
+      dpInput.open();
+      fixture.detectChanges();
+
+      // close
+      dpInput.close();
+      expect(fixture.componentInstance.onClose).toHaveBeenCalledTimes(1);
+    });
+
     it('should emit both "dateSelect" and "onModelChange" events', () => {
       const fixture = createTestCmpt(`
           <input ngbDatepicker ngModel [startDate]="{year: 2018, month: 3}"

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -186,9 +186,7 @@ export class NgbInputDatepicker implements OnChanges,
   @Output() navigate = new EventEmitter<NgbDatepickerNavigateEvent>();
 
   /**
-   * An event fired after datepicker closing the datepicker.
-   *
-   * @memberof NgbInputDatepicker
+   * An event fired after closing datepicker window.
    */
   @Output() closed = new EventEmitter();
 

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -185,6 +185,13 @@ export class NgbInputDatepicker implements OnChanges,
    */
   @Output() navigate = new EventEmitter<NgbDatepickerNavigateEvent>();
 
+  /**
+   * An event fired after datepicker closing the datepicker.
+   *
+   * @memberof NgbInputDatepicker
+   */
+  @Output() closed = new EventEmitter();
+
   @Input()
   get disabled() {
     return this._disabled;
@@ -314,6 +321,7 @@ export class NgbInputDatepicker implements OnChanges,
       this._vcRef.remove(this._vcRef.indexOf(this._cRef.hostView));
       this._cRef = null;
       this._closed$.next();
+      this.closed.emit();
       this._changeDetector.markForCheck();
     }
   }

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -63,7 +63,6 @@ const NGB_DATEPICKER_VALIDATOR = {
 })
 export class NgbInputDatepicker implements OnChanges,
     OnDestroy, ControlValueAccessor, Validator {
-  private _closed$ = new Subject();
   private _cRef: ComponentRef<NgbDatepicker> = null;
   private _disabled = false;
   private _model: NgbDate;
@@ -188,7 +187,7 @@ export class NgbInputDatepicker implements OnChanges,
   /**
    * An event fired after closing datepicker window.
    */
-  @Output() closed = new EventEmitter();
+  @Output() closed = new EventEmitter<void>();
 
   @Input()
   get disabled() {
@@ -302,11 +301,11 @@ export class NgbInputDatepicker implements OnChanges,
       }
 
       // focus handling
-      ngbFocusTrap(this._cRef.location.nativeElement, this._closed$, true);
+      ngbFocusTrap(this._cRef.location.nativeElement, this.closed, true);
       this._cRef.instance.focus();
 
       ngbAutoClose(
-          this._ngZone, this._document, this.autoClose, () => this.close(), this._closed$, [],
+          this._ngZone, this._document, this.autoClose, () => this.close(), this.closed, [],
           [this._elRef.nativeElement, this._cRef.location.nativeElement]);
     }
   }
@@ -318,7 +317,6 @@ export class NgbInputDatepicker implements OnChanges,
     if (this.isOpen()) {
       this._vcRef.remove(this._vcRef.indexOf(this._cRef.hostView));
       this._cRef = null;
-      this._closed$.next();
       this.closed.emit();
       this._changeDetector.markForCheck();
     }


### PR DESCRIPTION
This pull request adds "closed" event to NgbInputDatepicker, which is fired after closing datepicker window.
Example:
`<input ngbDatepicker (closed)="onClose()">`
Very useful for handling whenever user closing date-picker by clicking outside of dp box.