### PR TITLE
fix(docs): change day variable to correct argument reference

### DIFF
--- a/demo/src/app/components/datepicker/overview/datepicker-overview.component.ts
+++ b/demo/src/app/components/datepicker/overview/datepicker-overview.component.ts
@@ -104,7 +104,7 @@ providers: [{provide: NgbDateParserFormatter, useClass: YourOwnParserFormatter}]
 `,
   disablingTS: `
 // disable the 13th of each month
-const isDisabled = (date: NgbDate, current: {month: number}) => day.date === 13;
+const isDisabled = (date: NgbDate, current: {month: number}) => date.day === 13;
 `,
   disablingHTML: `
 <ngb-datepicker [minDate]="{year: 2010, month: 1, day: 1}"


### PR DESCRIPTION
Change the documentation for the DatePicker component in the isDisabled section example. Currently, day is undefined if user follows documentation.