### PR TITLE
chore: update demo parsing for stackblitzes

### DIFF
--- a/misc/parse-demo-test-cases/multiple/one/test.component.ts
+++ b/misc/parse-demo-test-cases/multiple/one/test.component.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'test-component1',
+  template: ''
+})
+export class TestComponent1 {
+}

--- a/misc/parse-demo-test-cases/multiple/one/test.module.ts
+++ b/misc/parse-demo-test-cases/multiple/one/test.module.ts
@@ -1,0 +1,10 @@
+import {NgModule} from '@angular/core';
+
+import {TestComponent1} from './test.component';
+
+@NgModule({
+  declarations: [TestComponent1],
+  bootstrap: [TestComponent1]
+})
+export class TestModule1 {
+}

--- a/misc/parse-demo-test-cases/multiple/two/test.component.ts
+++ b/misc/parse-demo-test-cases/multiple/two/test.component.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'test-component2',
+  template: ''
+})
+export class TestComponent2 {
+}

--- a/misc/parse-demo-test-cases/multiple/two/test.module.ts
+++ b/misc/parse-demo-test-cases/multiple/two/test.module.ts
@@ -1,0 +1,10 @@
+import {NgModule} from '@angular/core';
+
+import {TestComponent2} from './test.component';
+
+@NgModule({
+  declarations: [TestComponent2],
+  bootstrap: [TestComponent2]
+})
+export class TestModule2 {
+}

--- a/misc/parse-demo.spec.ts
+++ b/misc/parse-demo.spec.ts
@@ -2,32 +2,48 @@ import {parseDemo} from './parse-demo';
 
 describe(`Parse demo for StackBlitz`, () => {
 
-  it('should extract module name an component selector', () => {
-    expect(parseDemo('./misc/parse-demo-test-cases/simple'))
-        .toEqual({bootstrapComponentSelector: 'test-component', moduleClassName: 'TestModule'});
+  it('should extract a module name and a component selector', () => {
+    expect(parseDemo('./misc/parse-demo-test-cases/simple/**/*.ts')).toEqual(new Map([[
+      'misc/parse-demo-test-cases/simple/test.module.ts',
+      {bootstrapComponentSelector: 'test-component', moduleClassName: 'TestModule'}
+    ]]));
   });
 
-  it('should extract module name an component selector (strange formatting)', () => {
-    expect(parseDemo('./misc/parse-demo-test-cases/syntax'))
-        .toEqual({bootstrapComponentSelector: 'test-component', moduleClassName: 'TestModule'});
+  it('should extract multiple module names and component selectors', () => {
+    expect(parseDemo('./misc/parse-demo-test-cases/multiple/**/*.ts')).toEqual(new Map([
+      [
+        'misc/parse-demo-test-cases/multiple/one/test.module.ts',
+        {bootstrapComponentSelector: 'test-component1', moduleClassName: 'TestModule1'}
+      ],
+      [
+        'misc/parse-demo-test-cases/multiple/two/test.module.ts',
+        {bootstrapComponentSelector: 'test-component2', moduleClassName: 'TestModule2'}
+      ]
+    ]));
+  });
+
+  it('should extract module name and component selector (strange formatting)', () => {
+    expect(parseDemo('./misc/parse-demo-test-cases/syntax/**/*.ts')).toEqual(new Map([[
+      'misc/parse-demo-test-cases/syntax/test.module.ts',
+      {bootstrapComponentSelector: 'test-component', moduleClassName: 'TestModule'}
+    ]]));
   });
 
   it('should fail if there is no module', () => {
     expect(() => {
-      parseDemo('./misc/parse-demo-test-cases/no-module');
-    }).toThrowError(`Couldn't find any NgModules in ./misc/parse-demo-test-cases/no-module`);
+      parseDemo('./misc/parse-demo-test-cases/no-module/**/*.ts');
+    }).toThrowError(`Couldn't find any NgModules in ./misc/parse-demo-test-cases/no-module/**/*.ts`);
   });
 
   it('should fail if there is no bootstrap component', () => {
-    expect(() => { parseDemo('./misc/parse-demo-test-cases/no-bootstrap-component'); })
+    expect(() => { parseDemo('./misc/parse-demo-test-cases/no-bootstrap-component/**/*.ts'); })
         .toThrowError(
-            `Couldn't find any bootstrap components in TestModule in ./misc/parse-demo-test-cases/no-bootstrap-component`);
+            `Couldn't find any bootstrap components in TestModule in misc/parse-demo-test-cases/no-bootstrap-component/test.module.ts`);
   });
 
   it('should fail if there is no bootstrap component selector', () => {
-    expect(() => { parseDemo('./misc/parse-demo-test-cases/no-component-selector'); })
-        .toThrowError(
-            `Couldn't get bootstrap component selector for component ` +
-            `TestComponent in TestModule in ./misc/parse-demo-test-cases/no-component-selector`);
+    expect(() => {
+      parseDemo('./misc/parse-demo-test-cases/no-component-selector/**/*.ts');
+    }).toThrowError(`Couldn't get bootstrap component selector for component TestComponent`);
   });
 });


### PR DESCRIPTION
Now parses all existing demos in one take and returns a Map → much faster compilation time compared to parsing demos one-by-one