### PR TITLE
demo(typeahead): mention tap instead of do operator

### DIFF
--- a/demo/src/app/components/typeahead/demos/http/typeahead-http.html
+++ b/demo/src/app/components/typeahead/demos/http/typeahead-http.html
@@ -2,7 +2,7 @@ A typeahead example that gets values from the <code>WikipediaService</code>
 <ul>
   <li>remote data retrieval</li>
   <li><code>debounceTime</code> operator</li>
-  <li><code>do</code> operator</li>
+  <li><code>tap</code> operator</li>
   <li><code>distinctUntilChanged</code> operator</li>
   <li><code>switchMap</code> operator</li>
   <li><code>catch</code> operator to display an error message in case of connectivity issue</li>


### PR DESCRIPTION
The wikipedia demo mentions the `do` operator but uses the `tap` operator.

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [] added/updated any applicable tests.
 - [] added/updated any applicable API documentation.
 - [] added/updated any applicable demos.
