### PR TITLE
 chore(timepicker): refactoring, common code for hour/minute/second

### DIFF
--- a/e2e-app/src/app/app.module.ts
+++ b/e2e-app/src/app/app.module.ts
@@ -20,15 +20,28 @@ import {TooltipFocusComponent} from './tooltip/focus/tooltip-focus.component';
 import {TooltipPositionComponent} from './tooltip/position/tooltip-position.component';
 import {TypeaheadAutoCloseComponent} from './typeahead/autoclose/typeahead-autoclose.component';
 import {TypeaheadFocusComponent} from './typeahead/focus/typeahead-focus.component';
+import {TimepickerNavigationComponent} from './timepicker/navigation/timepicker-navigation.component';
 import {TypeaheadValidationComponent} from './typeahead/validation/typeahead-validation.component';
 
 
 @NgModule({
   declarations: [
-    AppComponent, NavigationComponent, DatepickerAutoCloseComponent, DatepickerFocusComponent,
-    DropdownAutoCloseComponent, DropdownFocusComponent, DropdownPositionComponent, ModalFocusComponent,
-    PopoverAutocloseComponent, TooltipAutocloseComponent, TooltipFocusComponent, TooltipPositionComponent,
-    TypeaheadFocusComponent, TypeaheadValidationComponent, TypeaheadAutoCloseComponent
+    AppComponent,
+    NavigationComponent,
+    DatepickerAutoCloseComponent,
+    DatepickerFocusComponent,
+    DropdownAutoCloseComponent,
+    DropdownFocusComponent,
+    DropdownPositionComponent,
+    ModalFocusComponent,
+    PopoverAutocloseComponent,
+    TooltipAutocloseComponent,
+    TooltipFocusComponent,
+    TooltipPositionComponent,
+    TypeaheadFocusComponent,
+    TypeaheadValidationComponent,
+    TypeaheadAutoCloseComponent,
+    TimepickerNavigationComponent,
   ],
   imports: [BrowserModule, FormsModule, ReactiveFormsModule, routing, NgbModule],
   bootstrap: [AppComponent]

--- a/e2e-app/src/app/app.routing.ts
+++ b/e2e-app/src/app/app.routing.ts
@@ -12,6 +12,7 @@ import {TooltipFocusComponent} from './tooltip/focus/tooltip-focus.component';
 import {TooltipPositionComponent} from './tooltip/position/tooltip-position.component';
 import {TypeaheadAutoCloseComponent} from './typeahead/autoclose/typeahead-autoclose.component';
 import {TypeaheadFocusComponent} from './typeahead/focus/typeahead-focus.component';
+import {TimepickerNavigationComponent} from './timepicker/navigation/timepicker-navigation.component';
 import {TypeaheadValidationComponent} from './typeahead/validation/typeahead-validation.component';
 import {DropdownPositionComponent} from './dropdown/position/dropdown-position.component';
 
@@ -24,14 +25,16 @@ export const routes: Routes = [
       {path: 'autoclose', component: DatepickerAutoCloseComponent}
     ]
   },
-  {path: 'modal', children: [{path: 'focus', component: ModalFocusComponent}]}, {
+  {path: 'modal', children: [{path: 'focus', component: ModalFocusComponent}]},
+  {
     path: 'dropdown',
     children: [
       {path: 'autoclose', component: DropdownAutoCloseComponent}, {path: 'focus', component: DropdownFocusComponent},
       {path: 'position', component: DropdownPositionComponent}
     ]
   },
-  {path: 'popover', children: [{path: 'autoclose', component: PopoverAutocloseComponent}]}, {
+  {path: 'popover', children: [{path: 'autoclose', component: PopoverAutocloseComponent}]},
+  {
     path: 'tooltip',
     children: [
       {path: 'autoclose', component: TooltipAutocloseComponent}, {path: 'focus', component: TooltipFocusComponent},
@@ -44,7 +47,13 @@ export const routes: Routes = [
       {path: 'focus', component: TypeaheadFocusComponent}, {path: 'autoclose', component: TypeaheadAutoCloseComponent},
       {path: 'validation', component: TypeaheadValidationComponent}
     ]
-  }
+  },
+  {
+    path: 'timepicker',
+    children: [
+      {path: 'navigation', component: TimepickerNavigationComponent},
+    ]
+  },
 ];
 
 export const routing: ModuleWithProviders = RouterModule.forRoot(routes, {useHash: true});

--- a/e2e-app/src/app/timepicker/navigation/timepicker-navigation.component.html
+++ b/e2e-app/src/app/timepicker/navigation/timepicker-navigation.component.html
@@ -1,0 +1,8 @@
+<input id="before" />
+
+<ngb-timepicker
+    [seconds]="true"
+    [(ngModel)]="time"
+></ngb-timepicker>
+
+<input id="after" />

--- a/e2e-app/src/app/timepicker/navigation/timepicker-navigation.component.ts
+++ b/e2e-app/src/app/timepicker/navigation/timepicker-navigation.component.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+@Component({
+  templateUrl: './timepicker-navigation.component.html',
+})
+export class TimepickerNavigationComponent {
+  time = {hour: 13, minute: 30, second: 30};
+}

--- a/e2e-app/src/app/timepicker/navigation/timepicker-navigation.e2e-spec.ts
+++ b/e2e-app/src/app/timepicker/navigation/timepicker-navigation.e2e-spec.ts
@@ -1,0 +1,87 @@
+import {Key, ElementFinder} from 'protractor';
+
+import {openUrl, expectFocused, sendKey, getCaretPosition} from '../../tools.po';
+
+import {Page} from './timepicker-navigation.po';
+
+describe('Timepicker', () => {
+  let page: Page;
+
+  beforeAll(() => page = new Page());
+  beforeEach(async() => await openUrl('timepicker/navigation'));
+
+  function focusInputBefore() { return page.getInputBefore().click(); }
+
+  function goNext() { return sendKey(Key.TAB); }
+  function goPrevious() { return sendKey(Key.SHIFT, Key.TAB); }
+
+  function pressUp() { return sendKey(Key.ARROW_UP); }
+  function pressDown() { return sendKey(Key.ARROW_DOWN); }
+  function goToBeginningOfField() { return sendKey(Key.HOME); }
+  function goToEndOfField() { return sendKey(Key.END); }
+
+  async function expectCaretPosition(field: ElementFinder, position: number) {
+    const {start, end} = await getCaretPosition(field);
+    expect(end).toBe(end, 'Caret should be at single position (no range selected)');
+    expect(start).toBe(position, `Caret is not at proper position for given field`);
+  }
+
+  describe('navigation', () => {
+    it(`should jump between inputs`, async() => {
+      await focusInputBefore();
+
+      const[hourField, minuteField, secondField] = page.getFields();
+
+      await goNext();
+      await expectFocused(hourField, 'Hour field should be focused');
+      await goNext();
+      await expectFocused(minuteField, 'Minute field should be focused');
+      await goNext();
+      await expectFocused(secondField, 'Second field should be focused');
+      await goNext();
+      expectFocused(page.getInputAfter(), '...');
+
+      await goPrevious();
+      await expectFocused(secondField, 'Second field should be focused');
+      await goPrevious();
+      await expectFocused(minuteField, 'Minute field should be focused');
+      await goPrevious();
+      await expectFocused(hourField, 'Hour field should be focused');
+      await goPrevious();
+      expectFocused(page.getInputBefore(), '...');
+    });
+  });
+
+  describe('arrow keys', () => {
+    it(`should keep caret at the end of the input`, async() => {
+      const testField = async(fieldElement: ElementFinder) => {
+        await fieldElement.click();
+
+        const endPosition = 2;
+        const expectCaretAtEnd = () => expectCaretPosition(fieldElement, endPosition);
+
+        await goToEndOfField();
+        await expectCaretAtEnd();
+
+        await pressUp();
+        await expectCaretAtEnd();
+
+        await pressDown();
+        await expectCaretAtEnd();
+
+        await goToBeginningOfField();
+        await expectCaretPosition(fieldElement, 0);
+
+        await pressUp();
+        await expectCaretAtEnd();
+
+        await pressDown();
+        await expectCaretAtEnd();
+      };
+
+      for (const fieldElement of page.getFields()) {
+        await testField(fieldElement);
+      }
+    });
+  });
+});

--- a/e2e-app/src/app/timepicker/navigation/timepicker-navigation.po.ts
+++ b/e2e-app/src/app/timepicker/navigation/timepicker-navigation.po.ts
@@ -1,0 +1,11 @@
+import {$} from 'protractor';
+
+export type Field = 'hour' | 'minute' | 'second';
+
+export class Page {
+  getInputBefore() { return $('#before'); }
+  getInputAfter() { return $('#after'); }
+  getField(field: Field) { return $(`.ngb-tp-${field} > input`); }
+
+  getFields() { return ['hour', 'minute', 'second'].map((field: Field) => this.getField(field)); }
+}

--- a/e2e-app/src/app/tools.po.ts
+++ b/e2e-app/src/app/tools.po.ts
@@ -43,3 +43,17 @@ export const openUrl = async(url: string) => {
   await $(`#navigate-home`).click();
   await $(`#navigate-${url.replace('/', '-')}`).click();
 };
+
+/**
+ * Returns the caret position ({start, end}) of the given element (must be an input).
+ */
+export async function getCaretPosition(element: ElementFinder) {
+  const[start, end] = await browser.executeScript<[number, number]>(
+      `
+    var element = arguments[0];
+    return [element.selectionStart, element.selectionEnd];
+  `,
+      element.getWebElement());
+
+  return {start, end};
+}

--- a/src/timepicker/ngb-time.spec.ts
+++ b/src/timepicker/ngb-time.spec.ts
@@ -11,20 +11,20 @@ describe('NgbTime', () => {
     const t = new NgbTime(10, 30);
     expect(t.toString()).toBe('10:30:0');
 
-    t.changeHour(1);
+    t.shiftHour(1);
     expect(t.toString()).toBe('11:30:0');
 
-    t.changeHour(5);
+    t.shiftHour(5);
     expect(t.toString()).toBe('16:30:0');
 
-    t.changeHour(-2);
+    t.shiftHour(-2);
     expect(t.toString()).toBe('14:30:0');
   });
 
   it('should properly change undefined hours', () => {
     const t = new NgbTime(undefined, 30);
 
-    t.changeHour(1);
+    t.shiftHour(1);
     expect(t.toString()).toBe('1:30:0');
   });
 
@@ -32,16 +32,16 @@ describe('NgbTime', () => {
     const t = new NgbTime(23, 30);
     expect(t.toString()).toBe('23:30:0');
 
-    t.changeHour(1);
+    t.shiftHour(1);
     expect(t.toString()).toBe('0:30:0');
 
-    t.changeHour(-5);
+    t.shiftHour(-5);
     expect(t.toString()).toBe('19:30:0');
 
-    t.changeHour(6);
+    t.shiftHour(6);
     expect(t.toString()).toBe('1:30:0');
 
-    t.changeHour(26);
+    t.shiftHour(26);
     expect(t.toString()).toBe('3:30:0');
   });
 
@@ -49,7 +49,7 @@ describe('NgbTime', () => {
     const t = new NgbTime(0, 30);
     expect(t.toString()).toBe('0:30:0');
 
-    t.changeHour(-48);
+    t.shiftHour(-48);
     expect(t.toString()).toBe('0:30:0');
   });
 
@@ -57,20 +57,20 @@ describe('NgbTime', () => {
     const t = new NgbTime(10, 30);
     expect(t.toString()).toBe('10:30:0');
 
-    t.changeMinute(1);
+    t.shiftMinute(1);
     expect(t.toString()).toBe('10:31:0');
 
-    t.changeMinute(5);
+    t.shiftMinute(5);
     expect(t.toString()).toBe('10:36:0');
 
-    t.changeMinute(-2);
+    t.shiftMinute(-2);
     expect(t.toString()).toBe('10:34:0');
   });
 
   it('should properly change undefined minutes', () => {
     const t = new NgbTime(1, undefined);
 
-    t.changeMinute(0);
+    t.shiftMinute(0);
     expect(t.toString()).toBe('1:0:0');
   });
 
@@ -78,13 +78,13 @@ describe('NgbTime', () => {
     const t = new NgbTime(10, 30);
     expect(t.toString()).toBe('10:30:0');
 
-    t.changeMinute(41);
+    t.shiftMinute(41);
     expect(t.toString()).toBe('11:11:0');
 
-    t.changeMinute(121);
+    t.shiftMinute(121);
     expect(t.toString()).toBe('13:12:0');
 
-    t.changeMinute(-122);
+    t.shiftMinute(-122);
     expect(t.toString()).toBe('11:10:0');
   });
 
@@ -92,16 +92,16 @@ describe('NgbTime', () => {
     const t = new NgbTime(0, 30);
     expect(t.toString()).toBe('0:30:0');
 
-    t.changeMinute(-40);
+    t.shiftMinute(-40);
     expect(t.toString()).toBe('23:50:0');
 
-    t.changeMinute(50);
+    t.shiftMinute(50);
     expect(t.toString()).toBe('0:40:0');
 
-    t.changeMinute(24 * 60);
+    t.shiftMinute(24 * 60);
     expect(t.toString()).toBe('0:40:0');
 
-    t.changeMinute(-48 * 60);
+    t.shiftMinute(-48 * 60);
     expect(t.toString()).toBe('0:40:0');
   });
 
@@ -109,20 +109,20 @@ describe('NgbTime', () => {
     const t = new NgbTime(10, 30, 30);
     expect(t.toString()).toBe('10:30:30');
 
-    t.changeSecond(1);
+    t.shiftSecond(1);
     expect(t.toString()).toBe('10:30:31');
 
-    t.changeSecond(5);
+    t.shiftSecond(5);
     expect(t.toString()).toBe('10:30:36');
 
-    t.changeSecond(-6);
+    t.shiftSecond(-6);
     expect(t.toString()).toBe('10:30:30');
   });
 
   it('should properly change undefined minutes', () => {
     const t = new NgbTime(1, 20, undefined);
 
-    t.changeSecond(30);
+    t.shiftSecond(30);
     expect(t.toString()).toBe('1:20:30');
   });
 
@@ -130,13 +130,13 @@ describe('NgbTime', () => {
     const t = new NgbTime(10, 30, 30);
     expect(t.toString()).toBe('10:30:30');
 
-    t.changeSecond(60);
+    t.shiftSecond(60);
     expect(t.toString()).toBe('10:31:30');
 
-    t.changeSecond(60 * 60);
+    t.shiftSecond(60 * 60);
     expect(t.toString()).toBe('11:31:30');
 
-    t.changeSecond(-60 * 60);
+    t.shiftSecond(-60 * 60);
     expect(t.toString()).toBe('10:31:30');
   });
 
@@ -144,16 +144,16 @@ describe('NgbTime', () => {
     const t = new NgbTime(0, 0, 30);
     expect(t.toString()).toBe('0:0:30');
 
-    t.changeSecond(-40);
+    t.shiftSecond(-40);
     expect(t.toString()).toBe('23:59:50');
 
-    t.changeSecond(110);
+    t.shiftSecond(110);
     expect(t.toString()).toBe('0:1:40');
 
-    t.changeMinute(24 * 3600);
+    t.shiftMinute(24 * 3600);
     expect(t.toString()).toBe('0:1:40');
 
-    t.changeMinute(-24 * 3600);
+    t.shiftMinute(-24 * 3600);
     expect(t.toString()).toBe('0:1:40');
   });
 
@@ -161,7 +161,7 @@ describe('NgbTime', () => {
     const t = new NgbTime(0, 0, 30);
     expect(t.toString()).toBe('0:0:30');
 
-    t.updateHour(11);
+    t.setHour(11);
     expect(t.toString()).toBe('11:0:30');
   });
 
@@ -169,7 +169,7 @@ describe('NgbTime', () => {
     const t = new NgbTime(0, 0, 30);
     expect(t.toString()).toBe('0:0:30');
 
-    t.updateHour(25);
+    t.setHour(25);
     expect(t.toString()).toBe('1:0:30');
   });
 
@@ -177,7 +177,7 @@ describe('NgbTime', () => {
     const t = new NgbTime(11, 0, 30);
     expect(t.toString()).toBe('11:0:30');
 
-    t.updateMinute(40);
+    t.setMinute(40);
     expect(t.toString()).toBe('11:40:30');
   });
 
@@ -185,10 +185,10 @@ describe('NgbTime', () => {
     const t = new NgbTime(11, 30, 30);
     expect(t.toString()).toBe('11:30:30');
 
-    t.updateMinute(90);
+    t.setMinute(90);
     expect(t.toString()).toBe('12:30:30');
 
-    t.updateMinute(-120);
+    t.setMinute(-120);
     expect(t.toString()).toBe('10:0:30');
   });
 
@@ -196,7 +196,7 @@ describe('NgbTime', () => {
     const t = new NgbTime(11, 0, 30);
     expect(t.toString()).toBe('11:0:30');
 
-    t.updateSecond(40);
+    t.setSecond(40);
     expect(t.toString()).toBe('11:0:40');
   });
 
@@ -204,7 +204,7 @@ describe('NgbTime', () => {
     const t = new NgbTime(11, 0, 30);
     expect(t.toString()).toBe('11:0:30');
 
-    t.updateSecond(70);
+    t.setSecond(70);
     expect(t.toString()).toBe('11:1:10');
   });
 

--- a/src/timepicker/ngb-time.ts
+++ b/src/timepicker/ngb-time.ts
@@ -1,51 +1,87 @@
 import {isNumber, toInteger} from '../util/util';
+import {isDefined} from '@angular/compiler/src/util';
+
+
+
+interface PartSpec {
+  initialValue?: number;
+  transform: (value: number) => number;
+  propagate?: (value: number, transformed: number) => void;
+}
+
+export class Part {
+  value: number;
+
+  constructor(private spec: PartSpec) {
+    const {initialValue} = spec;
+    if (isDefined(initialValue)) {
+      this.value = toInteger(initialValue);
+    }
+  }
+
+  shift(step = 1) {
+    const {value} = this;
+    this.set((isNaN(value) ? 0 : value) + step);
+  }
+
+  set(value: number, doPropagate = true) {
+    if (!isNumber(value)) {
+      this.value = NaN;
+      return;
+    }
+
+    const {transform, propagate} = this.spec;
+    const finalValue = transform(value);
+    this.value = finalValue;
+    if (doPropagate && isDefined(propagate)) {
+      propagate(value, finalValue);
+    }
+  }
+}
+
+
 
 export class NgbTime {
-  hour: number;
-  minute: number;
-  second: number;
+  hourPart: Part;
+  minutePart: Part;
+  secondPart: Part;
+
+  get hour(): number { return this.hourPart.value; }
+  get minute(): number { return this.minutePart.value; }
+  get second(): number { return this.secondPart.value; }
 
   constructor(hour?: number, minute?: number, second?: number) {
-    this.hour = toInteger(hour);
-    this.minute = toInteger(minute);
-    this.second = toInteger(second);
+    this.hourPart = new Part({
+      initialValue: hour,
+      transform: value => (value < 0 ? 24 + value : value) % 24,
+    });
+
+    this.minutePart = new Part({
+      initialValue: minute,
+      transform: value => value % 60 < 0 ? 60 + value % 60 : value % 60,
+      propagate: value => this.shiftHour(Math.floor(value / 60)),
+    });
+
+    this.secondPart = new Part({
+      initialValue: second,
+      transform: value => value < 0 ? 60 + value % 60 : value % 60,
+      propagate: value => this.shiftMinute(Math.floor(value / 60)),
+    });
   }
 
-  changeHour(step = 1) { this.updateHour((isNaN(this.hour) ? 0 : this.hour) + step); }
+  shiftHour(step: number) { this.hourPart.shift(step); }
+  shiftMinute(step: number) { this.minutePart.shift(step); }
+  shiftSecond(step: number) { this.secondPart.shift(step); }
 
-  updateHour(hour: number) {
-    if (isNumber(hour)) {
-      this.hour = (hour < 0 ? 24 + hour : hour) % 24;
-    } else {
-      this.hour = NaN;
-    }
-  }
-
-  changeMinute(step = 1) { this.updateMinute((isNaN(this.minute) ? 0 : this.minute) + step); }
-
-  updateMinute(minute: number) {
-    if (isNumber(minute)) {
-      this.minute = minute % 60 < 0 ? 60 + minute % 60 : minute % 60;
-      this.changeHour(Math.floor(minute / 60));
-    } else {
-      this.minute = NaN;
-    }
-  }
-
-  changeSecond(step = 1) { this.updateSecond((isNaN(this.second) ? 0 : this.second) + step); }
-
-  updateSecond(second: number) {
-    if (isNumber(second)) {
-      this.second = second < 0 ? 60 + second % 60 : second % 60;
-      this.changeMinute(Math.floor(second / 60));
-    } else {
-      this.second = NaN;
-    }
-  }
+  setHour(value: number, propagate?: boolean) { this.hourPart.set(value, propagate); }
+  setMinute(value: number, propagate?: boolean) { this.minutePart.set(value, propagate); }
+  setSecond(value: number, propagate?: boolean) { this.secondPart.set(value, propagate); }
 
   isValid(checkSecs = true) {
     return isNumber(this.hour) && isNumber(this.minute) && (checkSecs ? isNumber(this.second) : true);
   }
 
-  toString() { return `${this.hour || 0}:${this.minute || 0}:${this.second || 0}`; }
+  toString() {
+    return [this.hour, this.minute, this.second].map(value => isNaN(value) || !isDefined(value) ? 0 : value).join(':');
+  }
 }

--- a/src/timepicker/timepicker-part.ts
+++ b/src/timepicker/timepicker-part.ts
@@ -1,0 +1,99 @@
+import {
+  Component,
+  Input,
+} from '@angular/core';
+
+import {PartUI} from './timepicker';
+
+
+
+@Component({
+  selector: 'ngb-timepicker-part',
+  template: `
+    <div
+      [ngClass]="classes"
+    >
+      <button
+        *ngIf="spinners"
+
+        type="button"
+        tabindex="-1"
+        [disabled]="disabled"
+
+        class="btn btn-link"
+        [class.btn-sm]="isSmall"
+        [class.btn-lg]="isLarge"
+        [class.disabled]="disabled"
+
+        (click)="increment()"
+      >
+        <span class="chevron ngb-tp-chevron"></span>
+        <span class="sr-only">{{label_increment}}</span>
+      </button>
+
+      <input
+        type="text"
+        maxlength="2"
+        [readonly]="readonly"
+        [disabled]="disabled"
+
+        class="ngb-tp-input form-control"
+        [class.form-control-sm]="isSmall"
+        [class.form-control-lg]="isLarge"
+
+        [placeholder]="placeholder"
+        [attr.aria-label]="aria_label"
+
+        [value]="value"
+
+        (change)="change($event.target.value)"
+        (keydown.ArrowUp)="increment(); $event.preventDefault();"
+        (keydown.ArrowDown)="decrement(); $event.preventDefault();"
+      >
+
+      <button
+        *ngIf="spinners"
+
+        type="button"
+        tabindex="-1"
+        [disabled]="disabled"
+
+        class="btn btn-link"
+        [class.btn-sm]="isSmall"
+        [class.btn-lg]="isLarge"
+        [class.disabled]="disabled"
+
+        (click)="decrement()"
+      >
+        <span class="chevron ngb-tp-chevron bottom"></span>
+        <span class="sr-only">{{label_decrement}}</span>
+      </button>
+    </div>
+  `,
+})
+export class NgbTimepickerPart {
+  @Input() wrapper: PartUI;
+
+  @Input('class-part') class_part: string;
+
+  @Input() spinners = true;
+  @Input() disabled = false;
+  @Input() readonly = false;
+  @Input() size: 'small' | 'medium' | 'large' = 'medium';
+
+  @Input() placeholder: string;
+  @Input('aria-label') aria_label: string;
+  @Input('label-increment') label_increment: string;
+  @Input('label-decrement') label_decrement: string;
+
+  get value(): string { return this.wrapper.formattedValue; }
+
+  get isSmall(): boolean { return this.size === 'small'; }
+  get isLarge(): boolean { return this.size === 'large'; }
+
+  get classes(): string[] { return ['ngb-tp-input-container', `ngb-tp-${this.class_part}`]; }
+
+  increment() { this.wrapper.increment(); }
+  decrement() { this.wrapper.decrement(); }
+  change(value: string) { this.wrapper.setFromField(value); }
+}

--- a/src/timepicker/timepicker.module.ts
+++ b/src/timepicker/timepicker.module.ts
@@ -2,13 +2,14 @@ import {NgModule, ModuleWithProviders} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NgbTimepicker} from './timepicker';
+import {NgbTimepickerPart} from './timepicker-part';
 
 export {NgbTimepicker} from './timepicker';
 export {NgbTimepickerConfig} from './timepicker-config';
 export {NgbTimeStruct} from './ngb-time-struct';
 export {NgbTimeAdapter} from './ngb-time-adapter';
 
-@NgModule({declarations: [NgbTimepicker], exports: [NgbTimepicker], imports: [CommonModule]})
+@NgModule({declarations: [NgbTimepicker, NgbTimepickerPart], exports: [NgbTimepicker], imports: [CommonModule]})
 export class NgbTimepickerModule {
   /**
    * Importing with '.forRoot()' is no longer necessary, you can simply import the module.

--- a/src/timepicker/timepicker.spec.ts
+++ b/src/timepicker/timepicker.spec.ts
@@ -412,12 +412,12 @@ describe('ngb-timepicker', () => {
 
                const hourInput = getDebugInputs(fixture)[0];
 
-               hourInput.triggerEventHandler('keydown.ArrowUp', {});  // H+
+               hourInput.triggerEventHandler('keydown.ArrowUp', {preventDefault: () => {}});  // H+
                fixture.detectChanges();
                expectToDisplayTime(fixture.nativeElement, '11:30');
                expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
 
-               hourInput.triggerEventHandler('keydown.ArrowDown', {});  // H+
+               hourInput.triggerEventHandler('keydown.ArrowDown', {preventDefault: () => {}});  // H-
                fixture.detectChanges();
                expectToDisplayTime(fixture.nativeElement, '10:30');
                expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
@@ -441,12 +441,12 @@ describe('ngb-timepicker', () => {
 
                const minuteInput = getDebugInputs(fixture)[1];
 
-               minuteInput.triggerEventHandler('keydown.ArrowUp', {});  // M+
+               minuteInput.triggerEventHandler('keydown.ArrowUp', {preventDefault: () => {}});  // M+
                fixture.detectChanges();
                expectToDisplayTime(fixture.nativeElement, '10:31');
                expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 0});
 
-               minuteInput.triggerEventHandler('keydown.ArrowDown', {});  // M-
+               minuteInput.triggerEventHandler('keydown.ArrowDown', {preventDefault: () => {}});  // M-
                fixture.detectChanges();
                expectToDisplayTime(fixture.nativeElement, '10:30');
                expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
@@ -470,12 +470,12 @@ describe('ngb-timepicker', () => {
 
                const secondInput = getDebugInputs(fixture)[2];
 
-               secondInput.triggerEventHandler('keydown.ArrowUp', {});  // S+
+               secondInput.triggerEventHandler('keydown.ArrowUp', {preventDefault: () => {}});  // S+
                fixture.detectChanges();
                expectToDisplayTime(fixture.nativeElement, '10:30:01');
                expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 1});
 
-               secondInput.triggerEventHandler('keydown.ArrowDown', {});  // S-
+               secondInput.triggerEventHandler('keydown.ArrowDown', {preventDefault: () => {}});  // S-
                fixture.detectChanges();
                expectToDisplayTime(fixture.nativeElement, '10:30:00');
                expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});

--- a/src/timepicker/timepicker.ts
+++ b/src/timepicker/timepicker.ts
@@ -31,7 +31,7 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
     <fieldset [disabled]="disabled" [class.disabled]="disabled">
       <div class="ngb-tp">
         <div class="ngb-tp-input-container ngb-tp-hour">
-          <button *ngIf="spinners" type="button" (click)="changeHour(hourStep)"
+          <button *ngIf="spinners" tabindex="-1" type="button" (click)="changeHour(hourStep)"
             class="btn btn-link" [class.btn-sm]="isSmallSize" [class.btn-lg]="isLargeSize" [class.disabled]="disabled"
             [disabled]="disabled">
             <span class="chevron ngb-tp-chevron"></span>
@@ -41,8 +41,9 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
             maxlength="2" placeholder="HH" i18n-placeholder="@@ngb.timepicker.HH"
             [value]="formatHour(model?.hour)" (change)="updateHour($event.target.value)"
             [readonly]="readonlyInputs" [disabled]="disabled" aria-label="Hours" i18n-aria-label="@@ngb.timepicker.hours"
-            (keydown.ArrowUp)="changeHour(hourStep)" (keydown.ArrowDown)="changeHour(-hourStep)">
-          <button *ngIf="spinners" type="button" (click)="changeHour(-hourStep)"
+            (keydown.ArrowUp)="changeHour(hourStep); $event.preventDefault()"
+            (keydown.ArrowDown)="changeHour(-hourStep); $event.preventDefault()">
+          <button *ngIf="spinners" tabindex="-1" type="button" (click)="changeHour(-hourStep)"
             class="btn btn-link" [class.btn-sm]="isSmallSize" [class.btn-lg]="isLargeSize" [class.disabled]="disabled"
             [disabled]="disabled">
             <span class="chevron ngb-tp-chevron bottom"></span>
@@ -51,7 +52,7 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
         </div>
         <div class="ngb-tp-spacer">:</div>
         <div class="ngb-tp-input-container ngb-tp-minute">
-          <button *ngIf="spinners" type="button" (click)="changeMinute(minuteStep)"
+          <button *ngIf="spinners" tabindex="-1" type="button" (click)="changeMinute(minuteStep)"
             class="btn btn-link" [class.btn-sm]="isSmallSize" [class.btn-lg]="isLargeSize" [class.disabled]="disabled"
             [disabled]="disabled">
             <span class="chevron ngb-tp-chevron"></span>
@@ -61,8 +62,9 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
             maxlength="2" placeholder="MM" i18n-placeholder="@@ngb.timepicker.MM"
             [value]="formatMinSec(model?.minute)" (change)="updateMinute($event.target.value)"
             [readonly]="readonlyInputs" [disabled]="disabled" aria-label="Minutes" i18n-aria-label="@@ngb.timepicker.minutes"
-            (keydown.ArrowUp)="changeMinute(minuteStep)" (keydown.ArrowDown)="changeMinute(-minuteStep)">
-          <button *ngIf="spinners" type="button" (click)="changeMinute(-minuteStep)"
+            (keydown.ArrowUp)="changeMinute(minuteStep); $event.preventDefault()"
+            (keydown.ArrowDown)="changeMinute(-minuteStep); $event.preventDefault()">
+          <button *ngIf="spinners" tabindex="-1" type="button" (click)="changeMinute(-minuteStep)"
             class="btn btn-link" [class.btn-sm]="isSmallSize" [class.btn-lg]="isLargeSize"  [class.disabled]="disabled"
             [disabled]="disabled">
             <span class="chevron ngb-tp-chevron bottom"></span>
@@ -71,7 +73,7 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
         </div>
         <div *ngIf="seconds" class="ngb-tp-spacer">:</div>
         <div *ngIf="seconds" class="ngb-tp-input-container ngb-tp-second">
-          <button *ngIf="spinners" type="button" (click)="changeSecond(secondStep)"
+          <button *ngIf="spinners" tabindex="-1" type="button" (click)="changeSecond(secondStep)"
             class="btn btn-link" [class.btn-sm]="isSmallSize" [class.btn-lg]="isLargeSize" [class.disabled]="disabled"
             [disabled]="disabled">
             <span class="chevron ngb-tp-chevron"></span>
@@ -81,8 +83,9 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
             maxlength="2" placeholder="SS" i18n-placeholder="@@ngb.timepicker.SS"
             [value]="formatMinSec(model?.second)" (change)="updateSecond($event.target.value)"
             [readonly]="readonlyInputs" [disabled]="disabled" aria-label="Seconds" i18n-aria-label="@@ngb.timepicker.seconds"
-            (keydown.ArrowUp)="changeSecond(secondStep)" (keydown.ArrowDown)="changeSecond(-secondStep)">
-          <button *ngIf="spinners" type="button" (click)="changeSecond(-secondStep)"
+            (keydown.ArrowUp)="changeSecond(secondStep); $event.preventDefault()"
+            (keydown.ArrowDown)="changeSecond(-secondStep); $event.preventDefault()">
+          <button *ngIf="spinners" tabindex="-1" type="button" (click)="changeSecond(-secondStep)"
             class="btn btn-link" [class.btn-sm]="isSmallSize" [class.btn-lg]="isLargeSize"  [class.disabled]="disabled"
             [disabled]="disabled">
             <span class="chevron ngb-tp-chevron bottom"></span>

--- a/src/timepicker/timepicker.ts
+++ b/src/timepicker/timepicker.ts
@@ -9,8 +9,8 @@ import {
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 
-import {isInteger, isNumber, padNumber, toInteger} from '../util/util';
-import {NgbTime} from './ngb-time';
+import {isInteger, isNumber, padNumber, isDefined, toInteger} from '../util/util';
+import {NgbTime, Part} from './ngb-time';
 import {NgbTimepickerConfig} from './timepicker-config';
 import {NgbTimeAdapter} from './ngb-time-adapter';
 
@@ -19,6 +19,70 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
   useExisting: forwardRef(() => NgbTimepicker),
   multi: true
 };
+
+export interface PartUISpec {
+  getPart: (model: NgbTime) => Part;
+  getStep: () => number;
+
+  formatForField: (value: number) => string;
+  transformFromField?: (value: number) => number;
+
+  getModel: () => NgbTime;
+  afterChange: () => void;
+}
+
+export class PartUI {
+  constructor(private spec: PartUISpec) {}
+
+  private _getPart(): Part | null {
+    const model = this.spec.getModel();
+    if (!isDefined(model)) {
+      return null;
+    }
+    return this.spec.getPart(model);
+  }
+
+  get formattedValue(): string | null {
+    const part = this._getPart();
+    if (!isDefined(part)) {
+      return '';
+    }
+
+    const {value} = part;
+    if (!isDefined(value) || isNaN(value)) {
+      return '';
+    }
+
+    return this.spec.formatForField(value);
+  }
+
+  increment(step?: number) { this._updateRelative(+1, step); }
+  decrement(step?: number) { this._updateRelative(-1, step); }
+  _updateRelative(sign, givenStep) {
+    const part = this._getPart();
+    if (!isDefined(part)) {
+      return;
+    }
+
+    const step = isDefined(givenStep) ? givenStep : this.spec.getStep();
+    part.shift(sign * step);
+    this.spec.afterChange();
+  }
+
+  setFromField(text: string) {
+    const value = toInteger(text);
+    const part = this._getPart();
+    if (!isDefined(part)) {
+      return;
+    }
+
+    const {transformFromField} = this.spec;
+    const finalValue = !isDefined(transformFromField) ? value : transformFromField(value);
+
+    part.set(finalValue);
+    this.spec.afterChange();
+  }
+}
 
 /**
  * A directive that helps with wth picking hours, minutes and seconds.
@@ -30,74 +94,69 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
   template: `
     <fieldset [disabled]="disabled" [class.disabled]="disabled">
       <div class="ngb-tp">
-        <div class="ngb-tp-input-container ngb-tp-hour">
-          <button *ngIf="spinners" tabindex="-1" type="button" (click)="changeHour(hourStep)"
-            class="btn btn-link" [class.btn-sm]="isSmallSize" [class.btn-lg]="isLargeSize" [class.disabled]="disabled"
-            [disabled]="disabled">
-            <span class="chevron ngb-tp-chevron"></span>
-            <span class="sr-only" i18n="@@ngb.timepicker.increment-hours">Increment hours</span>
-          </button>
-          <input type="text" class="ngb-tp-input form-control" [class.form-control-sm]="isSmallSize" [class.form-control-lg]="isLargeSize"
-            maxlength="2" placeholder="HH" i18n-placeholder="@@ngb.timepicker.HH"
-            [value]="formatHour(model?.hour)" (change)="updateHour($event.target.value)"
-            [readonly]="readonlyInputs" [disabled]="disabled" aria-label="Hours" i18n-aria-label="@@ngb.timepicker.hours"
-            (keydown.ArrowUp)="changeHour(hourStep); $event.preventDefault()"
-            (keydown.ArrowDown)="changeHour(-hourStep); $event.preventDefault()">
-          <button *ngIf="spinners" tabindex="-1" type="button" (click)="changeHour(-hourStep)"
-            class="btn btn-link" [class.btn-sm]="isSmallSize" [class.btn-lg]="isLargeSize" [class.disabled]="disabled"
-            [disabled]="disabled">
-            <span class="chevron ngb-tp-chevron bottom"></span>
-            <span class="sr-only" i18n="@@ngb.timepicker.decrement-hours">Decrement hours</span>
-          </button>
-        </div>
+        <ngb-timepicker-part
+          [spinners]="spinners" [disabled]="disabled" [readonly]="readonlyInputs" [size]="size"
+
+          class-part="hour"
+          placeholder="HH" i18n-placeholder="@@ngb.timepicker.HH"
+          aria-label="Hours" i18n-aria-label="@@ngb.timepicker.hours"
+
+          label-increment="Increment hours" i18n-label-increment="@@ngb.timepicker.increment-hours"
+          label-decrement="Decrement hours" i18n-label-decrement="@@ngb.timepicker.decrement-hours"
+
+          [wrapper]="hour"
+        ></ngb-timepicker-part>
+
         <div class="ngb-tp-spacer">:</div>
-        <div class="ngb-tp-input-container ngb-tp-minute">
-          <button *ngIf="spinners" tabindex="-1" type="button" (click)="changeMinute(minuteStep)"
-            class="btn btn-link" [class.btn-sm]="isSmallSize" [class.btn-lg]="isLargeSize" [class.disabled]="disabled"
-            [disabled]="disabled">
-            <span class="chevron ngb-tp-chevron"></span>
-            <span class="sr-only" i18n="@@ngb.timepicker.increment-minutes">Increment minutes</span>
-          </button>
-          <input type="text" class="ngb-tp-input form-control" [class.form-control-sm]="isSmallSize" [class.form-control-lg]="isLargeSize"
-            maxlength="2" placeholder="MM" i18n-placeholder="@@ngb.timepicker.MM"
-            [value]="formatMinSec(model?.minute)" (change)="updateMinute($event.target.value)"
-            [readonly]="readonlyInputs" [disabled]="disabled" aria-label="Minutes" i18n-aria-label="@@ngb.timepicker.minutes"
-            (keydown.ArrowUp)="changeMinute(minuteStep); $event.preventDefault()"
-            (keydown.ArrowDown)="changeMinute(-minuteStep); $event.preventDefault()">
-          <button *ngIf="spinners" tabindex="-1" type="button" (click)="changeMinute(-minuteStep)"
-            class="btn btn-link" [class.btn-sm]="isSmallSize" [class.btn-lg]="isLargeSize"  [class.disabled]="disabled"
-            [disabled]="disabled">
-            <span class="chevron ngb-tp-chevron bottom"></span>
-            <span class="sr-only"  i18n="@@ngb.timepicker.decrement-minutes">Decrement minutes</span>
-          </button>
-        </div>
+
+        <ngb-timepicker-part
+          [spinners]="spinners" [disabled]="disabled" [readonly]="readonlyInputs" [size]="size"
+
+          class-part="minute"
+          placeholder="MM" i18n-placeholder="@@ngb.timepicker.MM"
+          aria-label="Minutes" i18n-aria-label="@@ngb.timepicker.minutes"
+
+          label-increment="Increment minutes" i18n-label-increment="@@ngb.timepicker.increment-minutes"
+          label-decrement="Decrement minutes" i18n-label-decrement="@@ngb.timepicker.decrement-minutes"
+
+          [wrapper]="minute"
+        ></ngb-timepicker-part>
+
         <div *ngIf="seconds" class="ngb-tp-spacer">:</div>
-        <div *ngIf="seconds" class="ngb-tp-input-container ngb-tp-second">
-          <button *ngIf="spinners" tabindex="-1" type="button" (click)="changeSecond(secondStep)"
-            class="btn btn-link" [class.btn-sm]="isSmallSize" [class.btn-lg]="isLargeSize" [class.disabled]="disabled"
-            [disabled]="disabled">
-            <span class="chevron ngb-tp-chevron"></span>
-            <span class="sr-only" i18n="@@ngb.timepicker.increment-seconds">Increment seconds</span>
-          </button>
-          <input type="text" class="ngb-tp-input form-control" [class.form-control-sm]="isSmallSize" [class.form-control-lg]="isLargeSize"
-            maxlength="2" placeholder="SS" i18n-placeholder="@@ngb.timepicker.SS"
-            [value]="formatMinSec(model?.second)" (change)="updateSecond($event.target.value)"
-            [readonly]="readonlyInputs" [disabled]="disabled" aria-label="Seconds" i18n-aria-label="@@ngb.timepicker.seconds"
-            (keydown.ArrowUp)="changeSecond(secondStep); $event.preventDefault()"
-            (keydown.ArrowDown)="changeSecond(-secondStep); $event.preventDefault()">
-          <button *ngIf="spinners" tabindex="-1" type="button" (click)="changeSecond(-secondStep)"
-            class="btn btn-link" [class.btn-sm]="isSmallSize" [class.btn-lg]="isLargeSize"  [class.disabled]="disabled"
-            [disabled]="disabled">
-            <span class="chevron ngb-tp-chevron bottom"></span>
-            <span class="sr-only" i18n="@@ngb.timepicker.decrement-seconds">Decrement seconds</span>
-          </button>
-        </div>
+
+        <ngb-timepicker-part
+          *ngIf="seconds"
+
+          [spinners]="spinners" [disabled]="disabled" [readonly]="readonlyInputs" [size]="size"
+
+          class-part="second"
+          placeholder="SS" i18n-placeholder="@@ngb.timepicker.SS"
+          aria-label="Seconds" i18n-aria-label="@@ngb.timepicker.seconds"
+
+          label-increment="Increment seconds" i18n-label-increment="@@ngb.timepicker.increment-seconds"
+          label-decrement="Decrement seconds" i18n-label-decrement="@@ngb.timepicker.decrement-seconds"
+
+          [wrapper]="second"
+        ></ngb-timepicker-part>
+
         <div *ngIf="meridian" class="ngb-tp-spacer"></div>
+
         <div *ngIf="meridian" class="ngb-tp-meridian">
-          <button type="button" class="btn btn-outline-primary" [class.btn-sm]="isSmallSize" [class.btn-lg]="isLargeSize"
-            [disabled]="disabled" [class.disabled]="disabled"
-                  (click)="toggleMeridian()">
-            <ng-container *ngIf="model?.hour >= 12; else am" i18n="@@ngb.timepicker.PM">PM</ng-container>
+          <button
+            type="button"
+            [disabled]="disabled"
+
+            class="btn btn-outline-primary"
+            [class.btn-sm]="isSmallSize"
+            [class.btn-lg]="isLargeSize"
+            [class.disabled]="disabled"
+
+            (click)="toggleMeridian()"
+          >
+            <ng-container
+              *ngIf="model?.hour >= 12; else am"
+              i18n="@@ngb.timepicker.PM"
+            >PM</ng-container>
             <ng-template #am i18n="@@ngb.timepicker.AM">AM</ng-template>
           </button>
         </div>
@@ -170,6 +229,10 @@ export class NgbTimepicker implements ControlValueAccessor,
    */
   @Input() size: 'small' | 'medium' | 'large';
 
+  hour: PartUI;
+  minute: PartUI;
+  second: PartUI;
+
   constructor(
       private readonly _config: NgbTimepickerConfig, private _ngbTimeAdapter: NgbTimeAdapter<any>,
       private _cd: ChangeDetectorRef) {
@@ -182,6 +245,45 @@ export class NgbTimepicker implements ControlValueAccessor,
     this.disabled = _config.disabled;
     this.readonlyInputs = _config.readonlyInputs;
     this.size = _config.size;
+
+    const getModel = () => this.model;
+    const afterChange = () => this.propagateModelChange();
+
+    this.hour = new PartUI({
+      getModel,
+      afterChange,
+      getStep: () => this.hourStep,
+      getPart: (model) => model.hourPart,
+
+      formatForField: (value: number) => padNumber(!this.meridian ? value % 24 : value % 12 === 0 ? 12 : value % 12),
+
+      transformFromField: (enteredHour: number) => {
+        const isPM = this.model.hour >= 12;
+        const realHourIsHigherThanInputHour =
+            this.meridian && (isPM && enteredHour < 12 || !isPM && enteredHour === 12);
+        return !realHourIsHigherThanInputHour ? enteredHour : enteredHour + 12;
+      },
+    });
+
+    const formatMinSec = (value: number) => padNumber(value);
+
+    this.minute = new PartUI({
+      getModel,
+      afterChange,
+      getPart: (model) => model.minutePart,
+      getStep: () => this.minuteStep,
+
+      formatForField: formatMinSec,
+    });
+
+    this.second = new PartUI({
+      getModel,
+      afterChange,
+      getPart: (model) => model.secondPart,
+      getStep: () => this.secondStep,
+
+      formatForField: formatMinSec,
+    });
   }
 
   onChange = (_: any) => {};
@@ -191,80 +293,28 @@ export class NgbTimepicker implements ControlValueAccessor,
     const structValue = this._ngbTimeAdapter.fromModel(value);
     this.model = structValue ? new NgbTime(structValue.hour, structValue.minute, structValue.second) : new NgbTime();
     if (!this.seconds && (!structValue || !isNumber(structValue.second))) {
-      this.model.second = 0;
+      this.model.setSecond(0, false);
     }
     this._cd.markForCheck();
   }
 
   registerOnChange(fn: (value: any) => any): void { this.onChange = fn; }
-
   registerOnTouched(fn: () => any): void { this.onTouched = fn; }
 
   setDisabledState(isDisabled: boolean) { this.disabled = isDisabled; }
 
-  changeHour(step: number) {
-    this.model.changeHour(step);
-    this.propagateModelChange();
-  }
-
-  changeMinute(step: number) {
-    this.model.changeMinute(step);
-    this.propagateModelChange();
-  }
-
-  changeSecond(step: number) {
-    this.model.changeSecond(step);
-    this.propagateModelChange();
-  }
-
-  updateHour(newVal: string) {
-    const isPM = this.model.hour >= 12;
-    const enteredHour = toInteger(newVal);
-    if (this.meridian && (isPM && enteredHour < 12 || !isPM && enteredHour === 12)) {
-      this.model.updateHour(enteredHour + 12);
-    } else {
-      this.model.updateHour(enteredHour);
-    }
-    this.propagateModelChange();
-  }
-
-  updateMinute(newVal: string) {
-    this.model.updateMinute(toInteger(newVal));
-    this.propagateModelChange();
-  }
-
-  updateSecond(newVal: string) {
-    this.model.updateSecond(toInteger(newVal));
-    this.propagateModelChange();
-  }
-
   toggleMeridian() {
     if (this.meridian) {
-      this.changeHour(12);
+      this.hour.increment(12);
     }
   }
-
-  formatHour(value: number) {
-    if (isNumber(value)) {
-      if (this.meridian) {
-        return padNumber(value % 12 === 0 ? 12 : value % 12);
-      } else {
-        return padNumber(value % 24);
-      }
-    } else {
-      return padNumber(NaN);
-    }
-  }
-
-  formatMinSec(value: number) { return padNumber(value); }
 
   get isSmallSize(): boolean { return this.size === 'small'; }
-
   get isLargeSize(): boolean { return this.size === 'large'; }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['seconds'] && !this.seconds && this.model && !isNumber(this.model.second)) {
-      this.model.second = 0;
+      this.model.setSecond(0, false);
       this.propagateModelChange(false);
     }
   }


### PR DESCRIPTION
Here is a proposed refactoring for the Timepicker, since code and/or logic is duplicated for hour, minute and second. It changes both the UI code and the model.

It is open for discussion, notably regarding the naming and the organization of the code, or any other topic.

PS: it is for now based on a pending PR: [fix(timepicker): fixing tab navigation & handling keyboard arrows by ymeine · Pull Request #2053 · ng-bootstrap/ng-bootstrap](https://github.com/ng-bootstrap/ng-bootstrap/pull/2053).