### PR TITLE
chore(demo): use Snippet model for ngbd-code

### DIFF
--- a/demo/src/app/components/datepicker/calendars/datepicker-calendars.component.ts
+++ b/demo/src/app/components/datepicker/calendars/datepicker-calendars.component.ts
@@ -1,5 +1,6 @@
 import {Component} from '@angular/core';
 
+import {Snippet} from '../../../shared/code/snippet';
 import {NgbdExamplesPage} from '../../shared/examples-page/examples.component';
 import {NgbdDatepickerHebrew} from '../demos/hebrew/datepicker-hebrew';
 import {NgbdDatepickerHebrewModule} from '../demos/hebrew/datepicker-hebrew.module';
@@ -76,7 +77,7 @@ const DEMOS = [
       to override the way day/week/year numerals and weekday/month names are displayed.
     </p>
 
-    <ngbd-code lang="typescript" [code]="snippets.calendars"></ngbd-code>
+    <ngbd-code [snippet]="snippets.calendars"></ngbd-code>
 
     <br>
 
@@ -99,11 +100,14 @@ export class NgbdDatepickerCalendarsComponent extends NgbdExamplesPage {
   demos = DEMOS;
 
   snippets = {
-    calendars: `
-providers: [
-  {provide: NgbCalendar, useClass: NgbCalendarHebrew},
-  {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nHebrew}
-]
-`
+    calendars: Snippet({
+      lang: 'typescript',
+      code: `
+        providers: [
+          {provide: NgbCalendar, useClass: NgbCalendarHebrew},
+          {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nHebrew}
+      ]
+      `,
+    }),
   };
 }

--- a/demo/src/app/components/datepicker/overview/datepicker-overview.component.html
+++ b/demo/src/app/components/datepicker/overview/datepicker-overview.component.html
@@ -23,7 +23,7 @@
     Datepicker can be used either inline or inside of the popup.
   </p>
 
-  <ngbd-code lang="html" [code]="snippets.basic"></ngbd-code>
+  <ngbd-code [snippet]="snippets.basic"></ngbd-code>
 
   <p>
     In the example above the template variable <code>#d</code> will point
@@ -60,7 +60,7 @@
     <code>[container]</code> input to <code>'body'</code>
   </p>
 
-  <ngbd-code lang="html" [code]="snippets.popup"></ngbd-code>
+  <ngbd-code [snippet]="snippets.popup"></ngbd-code>
 
   <p>
     The popup will be closed with <code>Escape</code> key and when
@@ -91,7 +91,7 @@
     <a routerLink="./" [fragment]="sections['date-model'].fragment">Date Model</a> section for more info.
   </p>
 
-  <ngbd-code lang="html" [code]="snippets.form"></ngbd-code>
+  <ngbd-code [snippet]="snippets.form"></ngbd-code>
 
   <p>
     Alternatively you could use the <code>(dateSelect)</code> or <code>(select)</code> outputs.
@@ -99,7 +99,7 @@
     if user clicks on the same date. <code>NgModel</code> will do it only once.
   </p>
 
-  <ngbd-code lang="html" [code]="snippets.selection"></ngbd-code>
+  <ngbd-code [snippet]="snippets.selection"></ngbd-code>
 </ngbd-overview-section>
 
 
@@ -112,7 +112,7 @@
     It's a simple data structure with 3 fields, but note that months start with 1 (as in ISO 8601).
   </p>
 
-  <ngbd-code lang="typescript" [code]="snippets.dateStruct"></ngbd-code>
+  <ngbd-code [snippet]="snippets.dateStruct"></ngbd-code>
 
   <p>
     All datepicker APIs will consume <code>NgbDateStruct</code>, but will produce it's implementation
@@ -122,7 +122,7 @@
     of the date-related calculations.
   </p>
 
-  <ngbd-code lang="typescript" [code]="snippets.date"></ngbd-code>
+  <ngbd-code [snippet]="snippets.date"></ngbd-code>
 
   <h4>Adapters</h4>
 
@@ -133,14 +133,14 @@
     will return a native date object. All other APIs continue to use <code>NgbDateStruct</code>.
   </p>
 
-  <ngbd-code lang="typescript" [code]="snippets.nativeAdapter"></ngbd-code>
+  <ngbd-code [snippet]="snippets.nativeAdapter"></ngbd-code>
 
   <p>
     You can also create your own adapters if necessary by extending and implementing the
     <code>NgbDateAdapter</code> methods.
   </p>
 
-  <ngbd-code lang="typescript" [code]="snippets.adapter"></ngbd-code>
+  <ngbd-code [snippet]="snippets.adapter"></ngbd-code>
 
   <h4>Input date parsing and formatting</h4>
 
@@ -151,7 +151,7 @@
     For now internally there is a service that does default formatting using ISO 8601 format.
   </p>
 
-  <ngbd-code lang="typescript" [code]="snippets.formatter"></ngbd-code>
+  <ngbd-code [snippet]="snippets.formatter"></ngbd-code>
 
   <p>
     If the entered input value is invalid, the form model will contain the entered text.
@@ -180,7 +180,7 @@
     via the <code>[startDate]</code> input or go to any month via the <code>.navigateTo()</code> method
   </p>
 
-  <ngbd-code lang="html" [code]="snippets.navigation"></ngbd-code>
+  <ngbd-code [snippet]="snippets.navigation"></ngbd-code>
 </ngbd-overview-section>
 
 
@@ -201,8 +201,8 @@
     between months.
   </p>
 
-  <ngbd-code style="position: relative; top: 0.25rem" lang="typescript" [code]="snippets.disablingTS"></ngbd-code>
-  <ngbd-code style="position: relative; bottom: 0.25rem" lang="html" [code]="snippets.disablingHTML"></ngbd-code>
+  <ngbd-code style="position: relative; top: 0.25rem" [snippet]="snippets.disablingTS"></ngbd-code>
+  <ngbd-code style="position: relative; bottom: 0.25rem" [snippet]="snippets.disablingHTML"></ngbd-code>
 </ngbd-overview-section>
 
 
@@ -220,7 +220,7 @@
     see the <a routerLink="../api" fragment="DayTemplateContext">DayTemplateContext API</a>
   </p>
 
-  <ngbd-code lang="html" [code]="snippets.dayTemplate"></ngbd-code>
+  <ngbd-code [snippet]="snippets.dayTemplate"></ngbd-code>
 
   <ngb-alert class="mt-3" [dismissible]="false">
     Note that before v3.3.0 there is no <code>$implicit</code> template property and you have to specify
@@ -246,14 +246,14 @@
     You would see something like this in the resulting markup
   </p>
 
-  <ngbd-code lang="html" [code]="snippets.todayHTML"></ngbd-code>
+  <ngbd-code [snippet]="snippets.todayHTML"></ngbd-code>
 
   <p>
     You can also access this information from the <a routerLink="../api" fragment="DayTemplateContext">DayTemplateContext API</a>
     if you're using a custom day template. It contains a <code>today: boolean</code> flag since v4.1.0
   </p>
 
-  <ngbd-code lang="html" [code]="snippets.todayTemplate"></ngbd-code>
+  <ngbd-code [snippet]="snippets.todayTemplate"></ngbd-code>
 
 </ngbd-overview-section>
 
@@ -264,7 +264,7 @@
     You can insert anything you want in a datepicker footer by providing a template.
   </p>
 
-  <ngbd-code lang="html" [code]="snippets.footerTemplate"></ngbd-code>
+  <ngbd-code [snippet]="snippets.footerTemplate"></ngbd-code>
 </ngbd-overview-section>
 
 
@@ -302,7 +302,7 @@
     if necessary.
   </p>
 
-  <ngbd-code lang="typescript" [code]="snippets.i18n"></ngbd-code>
+  <ngbd-code [snippet]="snippets.i18n"></ngbd-code>
 
   <p>
     The next/previous button labels can be translated using the standard Angular i18n

--- a/demo/src/app/components/datepicker/overview/datepicker-overview.component.ts
+++ b/demo/src/app/components/datepicker/overview/datepicker-overview.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 
+import {Snippet} from '../../../shared/code/snippet';
 import { NgbdDemoList } from '../../shared';
 import { NgbdOverview } from '../../shared/overview';
 
@@ -15,115 +16,166 @@ import { NgbdOverview } from '../../shared/overview';
 export class NgbdDatepickerOverviewComponent {
 
   snippets = {
-    basic: `
-<!-- 1. inline datepicker -->
-<ngb-datepicker #d></ngb-datepicker>
+    basic: Snippet({
+      lang: 'html',
+      code: `
+        <!-- 1. inline datepicker -->
+        <ngb-datepicker #d></ngb-datepicker>
 
-<!-- 2. datepicker in the popup -->
-<input type="text" ngbDatepicker #d="ngbDatepicker"/>
-`,
-    popup: `
-<input type="text" ngbDatepicker #d="ngbDatepicker"/>
-<button (click)="d.toggle()">Toggle</button>
-`,
-    form: `
-<input type="text" ngbDatepicker [(ngModel)]="date"/>
-`,
-    selection: `
-<!-- inline -->
-<ngb-datepicker (select)="onDateSelect($event)"></ngb-datepicker>
+        <!-- 2. datepicker in the popup -->
+        <input type="text" ngbDatepicker #d="ngbDatepicker"/>
+      `,
+    }),
+    popup: Snippet({
+      lang: 'html',
+      code: `
+        <input type="text" ngbDatepicker #d="ngbDatepicker"/>
+        <button (click)="d.toggle()">Toggle</button>
+      `,
+    }),
+    form: Snippet({
+      lang: 'html',
+      code: `
+        <input type="text" ngbDatepicker [(ngModel)]="date"/>
+      `,
+    }),
+    selection: Snippet({
+      lang: 'html',
+      code: `
+        <!-- inline -->
+        <ngb-datepicker (select)="onDateSelect($event)"></ngb-datepicker>
 
-<!-- in the popup -->
-<input type="text" ngbDatepicker (dateSelect)="onDateSelect($event)"/>
-`,
-    navigation: `
-<ngb-datepicker #d [startDate]="{year: 1789, month: 7}"></ngb-datepicker>
-<button (click)="d.navigateTo({year: 2048, month: 1})">Goto JAN 2048</button>
-`,
-    dateStruct: `
-const date: NgbDateStruct = { year: 1789, month: 7, day: 14 }; // July, 14 1789
-`,
-date: `
-const date: NgbDate = new NgbDate(1789, 7, 14);                // July, 14 1789
+        <!-- in the popup -->
+        <input type="text" ngbDatepicker (dateSelect)="onDateSelect($event)"/>
+      `,
+    }),
+    navigation: Snippet({
+      lang: 'html',
+      code: `
+        <ngb-datepicker #d [startDate]="{year: 1789, month: 7}"></ngb-datepicker>
+        <button (click)="d.navigateTo({year: 2048, month: 1})">Goto JAN 2048</button>
+      `,
+    }),
+    dateStruct: Snippet({
+      lang: 'typescript',
+      code: `
+        const date: NgbDateStruct = { year: 1789, month: 7, day: 14 }; // July, 14 1789
+      `,
+    }),
+    date: Snippet({
+      lang: 'typescript',
+      code: `
+        const date: NgbDate = new NgbDate(1789, 7, 14);                // July, 14 1789
 
-date.before({ year: 1789, month: 7, day: 14 });                // compare to a structure
-date.equals(NgbDate.from({ year: 1789, month: 7, day: 14 }));  // or to another date object
-`,
-    nativeAdapter: `
-// native adapter is bundled with library
-providers: [{provide: NgbDateAdapter, useClass: NgbDateNativeAdapter}]
+        date.before({ year: 1789, month: 7, day: 14 });                // compare to a structure
+        date.equals(NgbDate.from({ year: 1789, month: 7, day: 14 }));  // or to another date object
+      `,
+    }),
+    nativeAdapter: Snippet({
+      lang: 'typescript',
+      code: `
+        // native adapter is bundled with library
+        providers: [{provide: NgbDateAdapter, useClass: NgbDateNativeAdapter}]
 
-// or another native adapter that works with UTC dates
-providers: [{provide: NgbDateAdapter, useClass: NgbDateNativeUTCAdapter}]
-`,
-    adapter: `
-@Injectable()
-export abstract class NgbDateAdapter<D> {
-  abstract fromModel(value: D): NgbDateStruct; // from your model -> internal model
-  abstract toModel(date: NgbDateStruct): D; // from internal model -> your mode
-}
+        // or another native adapter that works with UTC dates
+        providers: [{provide: NgbDateAdapter, useClass: NgbDateNativeUTCAdapter}]
+      `,
+    }),
+    adapter: Snippet({
+      lang: 'typescript',
+      code: `
+        @Injectable()
+        export abstract class NgbDateAdapter<D> {
+          abstract fromModel(value: D): NgbDateStruct; // from your model -> internal model
+          abstract toModel(date: NgbDateStruct): D; // from internal model -> your mode
+        }
 
-// create your own if necessary
-providers: [{provide: NgbDateAdapter, useClass: YourOwnDateAdapter}]
-`,
-    formatter: `
-@Injectable()
-export abstract class NgbDateParserFormatter {
-  abstract parse(value: string): NgbDateStruct; // from input -> internal model
-  abstract format(date: NgbDateStruct): string; // from internal model -> string
-}
+        // create your own if necessary
+        providers: [{provide: NgbDateAdapter, useClass: YourOwnDateAdapter}]
+      `,
+    }),
+    formatter: Snippet({
+      lang: 'typescript',
+      code: `
+        @Injectable()
+        export abstract class NgbDateParserFormatter {
+          abstract parse(value: string): NgbDateStruct; // from input -> internal model
+          abstract format(date: NgbDateStruct): string; // from internal model -> string
+        }
 
-// create your own if necessary
-providers: [{provide: NgbDateParserFormatter, useClass: YourOwnParserFormatter}]
-`,
-    dayTemplate: `
-<ng-template #t let-date>
-	{{ date.day }}
-</ng-template>
+        // create your own if necessary
+        providers: [{provide: NgbDateParserFormatter, useClass: YourOwnParserFormatter}]
+      `,
+    }),
+    dayTemplate: Snippet({
+      lang: 'html',
+      code: `
+        <ng-template #t let-date>
+        	{{ date.day }}
+        </ng-template>
 
-<ngbDatepicker [dayTemplate]=“t”/>
-`,
-    todayHTML: `
-<div class="ngb-dp-day ngb-dp-today">
-  <!-- day cell content omitted -->
-</div>
-`,
-    todayTemplate: `
-<ng-template #t let-today="today">
-  <span *ngIf="today">...</span>
-</ng-template>
+        <ngbDatepicker [dayTemplate]=“t”/>
+      `,
+    }),
+    todayHTML: Snippet({
+      lang: 'html',
+      code: `
+        <div class="ngb-dp-day ngb-dp-today">
+          <!-- day cell content omitted -->
+        </div>
+      `,
+    }),
+    todayTemplate: Snippet({
+      lang: 'html',
+      code: `
+        <ng-template #t let-today="today">
+          <span *ngIf="today">...</span>
+        </ng-template>
 
-<ngbDatepicker [dayTemplate]=“t”/>
-`,
-    footerTemplate: `
-<ng-template #t>
-  <button (click)="model = today">Today</button>
-</ng-template>
+        <ngbDatepicker [dayTemplate]=“t”/>
+      `,
+    }),
+    footerTemplate: Snippet({
+      lang: 'html',
+      code: `
+        <ng-template #t>
+          <button (click)="model = today">Today</button>
+        </ng-template>
 
-<ngbDatepicker [footerTemplate]=“t”/>
-`,
-  disablingTS: `
-// disable the 13th of each month
-const isDisabled = (date: NgbDate, current: {month: number}) => date.day === 13;
-`,
-  disablingHTML: `
-<ngb-datepicker [minDate]="{year: 2010, month: 1, day: 1}"
-                [maxDate]="{year: 2048, month: 12, day: 31}"
-                [markDisabled]="isDisabled">
-</ngb-datepicker>
-`,
-  i18n: `
-@Injectable()
-export abstract class NgbDatepickerI18n {
-  abstract getWeekdayShortName(weekday: number): string;
-  abstract getMonthShortName(month: number): string;
-  abstract getMonthFullName(month: number): string;
-  abstract getDayAriaLabel(date: NgbDateStruct): string;
-}
+        <ngbDatepicker [footerTemplate]=“t”/>
+      `,
+    }),
+    disablingTS: Snippet({
+      lang: 'typescript',
+      code: `
+        // disable the 13th of each month
+        const isDisabled = (date: NgbDate, current: {month: number}) => date.day === 13;
+      `,
+    }),
+    disablingHTML: Snippet({
+      lang: 'html',
+      code: `
+        <ngb-datepicker [minDate]="{year: 2010, month: 1, day: 1}"
+                        [maxDate]="{year: 2048, month: 12, day: 31}"
+                        [markDisabled]="isDisabled">
+        </ngb-datepicker>
+      `,
+    }),
+    i18n: Snippet({
+      lang: 'typescript',
+      code: `
+        @Injectable()
+        export abstract class NgbDatepickerI18n {
+          abstract getWeekdayShortName(weekday: number): string;
+          abstract getMonthShortName(month: number): string;
+          abstract getMonthFullName(month: number): string;
+          abstract getDayAriaLabel(date: NgbDateStruct): string;
+        }
 
-// provide your own if necessary
-providers: [{provide: NgbDatepickerI18n, useClass: YourOwnDatepickerI18n}]
-`
+        // provide your own if necessary
+        providers: [{provide: NgbDatepickerI18n, useClass: YourOwnDatepickerI18n}]
+      `,
+    }),
   };
 
   sections: NgbdOverview = {};

--- a/demo/src/app/components/pagination/overview/pagination-overview.component.html
+++ b/demo/src/app/components/pagination/overview/pagination-overview.component.html
@@ -21,9 +21,9 @@
       rel="no-opener no-referer"><code>slice</code></a> pipe to extract (or <em>slice</em>) a sub-part of it.</p>
 
   <p>Corresponding code could be something like:</p>
-  <ngbd-code lang="html" [code]="NGFOR"></ngbd-code>
+  <ngbd-code [snippet]="NGFOR"></ngbd-code>
   <p>and the associated <code>&lt;ngb-pagination&gt;</code> would be like:</p>
-  <ngbd-code lang="html" [code]="NGB_PAGINATION"></ngbd-code>
+  <ngbd-code [snippet]="NGB_PAGINATION"></ngbd-code>
 
   <br />
   <ngb-alert type="warning" [dismissible]="false">
@@ -58,7 +58,7 @@
     You could also override the CSS to hide the default <code>span</code> and provide an alternative content.
     For example for the previous arrow:
   </p>
-  <ngbd-code lang="css" [code]="CUSTOM_CSS"></ngbd-code>
+  <ngbd-code [snippet]="CUSTOM_CSS"></ngbd-code>
 
   <h4>
     Using templates
@@ -69,7 +69,7 @@
     Sometimes you would want to display an icon, an image or any arbitrary markup instead of the page number.
     In this case since you could use the template-based API to override any pagination link:
   </p>
-  <ngbd-code lang="html" [code]="CUSTOM_TPL"></ngbd-code>
+  <ngbd-code [snippet]="CUSTOM_TPL"></ngbd-code>
 
   <p>
     In this case we customize all pagination links, but you can pick only the ones you need of course.

--- a/demo/src/app/components/pagination/overview/pagination-overview.component.ts
+++ b/demo/src/app/components/pagination/overview/pagination-overview.component.ts
@@ -1,5 +1,6 @@
 import {Component} from '@angular/core';
 
+import {Snippet} from '../../../shared/code/snippet';
 import {NgbdDemoList} from '../../shared';
 import {NgbdOverview} from '../../shared/overview';
 
@@ -10,40 +11,56 @@ import {NgbdOverview} from '../../shared/overview';
   host: {'[class.overview]': 'true'}
 })
 export class NgbdPaginationOverviewComponent {
-  NGFOR = `<table>
-  <tr *ngFor="let item of items | slice: (page-1) * pageSize : (page-1) * pageSize + pageSize">
-    <!-- content here -->
-  </tr>
-</table>`;
+  NGFOR = Snippet({
+    lang: 'html',
+    code: `
+      <table>
+        <tr *ngFor="let item of items | slice: (page-1) * pageSize : (page-1) * pageSize + pageSize">
+          <!-- content here -->
+        </tr>
+      </table>
+    `,
+  });
 
-  NGB_PAGINATION = `<ngb-pagination
-  [(page)]="page"
-  [pageSize]="pageSize"
-  [collectionSize]="items.length"></ngb-pagination>`;
+  NGB_PAGINATION = Snippet({
+    lang: 'html',
+    code: `
+      <ngb-pagination
+        [(page)]="page"
+        [pageSize]="pageSize"
+        [collectionSize]="items.length"></ngb-pagination>
+    `,
+  });
 
-  CUSTOM_CSS = `
-ngb-pagination li {
-  &:first-child a {
-    span {
-      display: none;
-    }
-    &:before {
-      /* provide your content here */
-    }
-  }
-}
-`;
+  CUSTOM_CSS = Snippet({
+    lang: 'css',
+    code: `
+      ngb-pagination li {
+        &:first-child a {
+          span {
+            display: none;
+          }
+          &:before {
+            /* provide your content here */
+          }
+        }
+      }
+    `,
+  });
 
-  CUSTOM_TPL = `
-<ngb-pagination>
-  <ng-template ngbPaginationFirst>First</ng-template>
-  <ng-template ngbPaginationLast>Last</ng-template>
-  <ng-template ngbPaginationPrevious>Prev</ng-template>
-  <ng-template ngbPaginationNext>Next</ng-template>
-  <ng-template ngbPaginationEllipsis>...</ng-template>
-  <ng-template ngbPaginationNumber let-page>{{ page }}</ng-template>
-</ngb-pagination>
-`;
+  CUSTOM_TPL = Snippet({
+    lang: 'html',
+    code: `
+      <ngb-pagination>
+        <ng-template ngbPaginationFirst>First</ng-template>
+        <ng-template ngbPaginationLast>Last</ng-template>
+        <ng-template ngbPaginationPrevious>Prev</ng-template>
+        <ng-template ngbPaginationNext>Next</ng-template>
+        <ng-template ngbPaginationEllipsis>...</ng-template>
+        <ng-template ngbPaginationNumber let-page>{{ page }}</ng-template>
+      </ngb-pagination>
+    `,
+  });
 
   sections: NgbdOverview = {};
 

--- a/demo/src/app/components/shared/examples-page/demo.component.html
+++ b/demo/src/app/components/shared/examples-page/demo.component.html
@@ -29,7 +29,7 @@
               <span class="text-truncate" [title]="tabType(file.name)">{{file.name}}</span>
             </ng-template>
             <ng-template ngbTabContent>
-              <ngbd-code [code]="file.source" [lang]="file.name.split('.').pop()"></ngbd-code>
+              <ngbd-code [snippet]="getFileSnippet(file)"></ngbd-code>
             </ng-template>
           </ngb-tab>
         </ng-template>
@@ -40,7 +40,7 @@
               <span class="ml-2">{{component}}-{{id}}.html</span>
             </ng-template>
             <ng-template ngbTabContent>
-              <ngbd-code [code]="markup" lang="html"></ngbd-code>
+              <ngbd-code [snippet]="markupSnippet"></ngbd-code>
             </ng-template>
           </ngb-tab>
           <ngb-tab id="{{component}}-{{id}}-typescript">
@@ -48,7 +48,7 @@
               <span class="ml-2">{{component}}-{{id}}.ts</span>
             </ng-template>
             <ng-template ngbTabContent>
-              <ngbd-code [code]="code" lang="typescript"></ngbd-code>
+              <ngbd-code [snippet]="codeSnippet"></ngbd-code>
             </ng-template>
           </ngb-tab>
         </ng-template>

--- a/demo/src/app/components/shared/examples-page/demo.component.ts
+++ b/demo/src/app/components/shared/examples-page/demo.component.ts
@@ -1,6 +1,7 @@
 import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 
 import {Analytics} from '../../../shared/analytics/analytics';
+import {Snippet} from '../../../shared/code/snippet';
 
 @Component({
   selector: 'ngbd-widget-demo',
@@ -15,6 +16,13 @@ export class NgbdWidgetDemoComponent {
   @Input() markup: string;
   @Input() files: { name: string; source: string }[];
   @Input() showCode = false;
+
+  get markupSnippet() { return Snippet({lang: 'html', code: this.markup}); }
+  get codeSnippet() { return Snippet({lang: 'typescript', code: this.code}); }
+
+  getFileSnippet({name, source}) {
+    return Snippet({code: source, lang: name.split('.').pop()});
+  }
 
   get hasManyFiles() {
     return this.files && this.files.length > 5;

--- a/demo/src/app/getting-started/getting-started.component.html
+++ b/demo/src/app/getting-started/getting-started.component.html
@@ -62,16 +62,16 @@
 
   <p>After installing the above dependencies, install <code>ng-bootstrap</code> via:</p>
 
-  <ngbd-code [code]="codeInstall" lang="bash"></ngbd-code>
+  <ngbd-code [snippet]="codeInstall"></ngbd-code>
 
   <p>Once installed you need to import our main module.</p>
 
-  <ngbd-code [code]="codeRoot" lang="typescript"></ngbd-code>
+  <ngbd-code [snippet]="codeRoot"></ngbd-code>
 
   <p>Alternatively you could only import modules with components you need, ex. pagination and alert.
     The resulting bundle will be smaller in this case.</p>
 
-  <ngbd-code [code]="codeOther" lang="typescript"></ngbd-code>
+  <ngbd-code [snippet]="codeOther"></ngbd-code>
   <br>
 
   <h4>
@@ -84,7 +84,7 @@
     In your SystemJS config file, <code>map</code> needs to tell the System loader where to look for <code>ng-bootstrap</code>:
   </p>
 
-  <ngbd-code [code]="codeSystem" lang="typescript"></ngbd-code>
+  <ngbd-code [snippet]="codeSystem"></ngbd-code>
   <br>
 
   <ngbd-page-header title="Internationalization" fragment="i18n"></ngbd-page-header>

--- a/demo/src/app/getting-started/getting-started.component.ts
+++ b/demo/src/app/getting-started/getting-started.component.ts
@@ -1,37 +1,52 @@
 import {Component} from '@angular/core';
+import {Snippet} from '../shared/code/snippet';
 
 @Component({
   selector: 'ngbd-getting-started',
   templateUrl: './getting-started.component.html'
 })
 export class GettingStarted {
+  codeInstall = Snippet({
+    lang: 'bash',
+    code: `npm install --save @ng-bootstrap/ng-bootstrap`,
+  });
 
-  codeInstall = `npm install --save @ng-bootstrap/ng-bootstrap`;
+  codeRoot = Snippet({
+    lang: 'typescript',
+    code: `
+      import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 
-  codeRoot = `
-import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
+      @NgModule({
+        ...
+        imports: [NgbModule, ...],
+        ...
+      })
+      export class YourAppModule {
+      }
+    `,
+  });
 
-@NgModule({
-  ...
-  imports: [NgbModule, ...],
-  ...
-})
-export class YourAppModule {
-}`;
+  codeOther = Snippet({
+    lang: 'typescript',
+    code: `
+      import {NgbPaginationModule, NgbAlertModule} from '@ng-bootstrap/ng-bootstrap';
 
-  codeOther = `
-import {NgbPaginationModule, NgbAlertModule} from '@ng-bootstrap/ng-bootstrap';
+      @NgModule({
+        ...
+        imports: [NgbPaginationModule, NgbAlertModule, ...],
+        ...
+      })
+      export class YourAppModule {
+      }
+    `,
+  });
 
-@NgModule({
-  ...
-  imports: [NgbPaginationModule, NgbAlertModule, ...],
-  ...
-})
-export class YourAppModule {
-}`;
-
-  codeSystem = `
-map: {
-  '@ng-bootstrap/ng-bootstrap': 'node_modules/@ng-bootstrap/ng-bootstrap/bundles/ng-bootstrap.js',
-}`;
+  codeSystem = Snippet({
+    lang: 'typescript',
+    code: `
+      map: {
+        '@ng-bootstrap/ng-bootstrap': 'node_modules/@ng-bootstrap/ng-bootstrap/bundles/ng-bootstrap.js',
+      }
+    `,
+  });
 }

--- a/demo/src/app/shared/code/code.component.ts
+++ b/demo/src/app/shared/code/code.component.ts
@@ -1,24 +1,24 @@
 import {AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, Input, ViewChild} from '@angular/core';
 
+import {ISnippet} from './snippet';
 import {CodeHighlightService} from './code-highlight.service';
 
 @Component({
   selector: 'ngbd-code',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <pre class="language-{{ lang }}"><code #code class="language-{{ lang }}"></code></pre>
+    <pre class="language-{{ snippet.lang }}"><code #code class="language-{{ snippet.lang }}"></code></pre>
   `
 })
 export class NgbdCodeComponent implements AfterViewInit {
 
   @ViewChild('code') codeEl: ElementRef<HTMLElement>;
 
-  @Input() code = '';
-  @Input() lang = '';
+  @Input() snippet: ISnippet;
 
   constructor(private _service: CodeHighlightService) { }
 
   ngAfterViewInit() {
-    this.codeEl.nativeElement.innerHTML = this._service.highlight(this.code, this.lang);
+    this.codeEl.nativeElement.innerHTML = this._service.highlight(this.snippet.code, this.snippet.lang);
   }
 }

--- a/demo/src/app/shared/code/snippet.ts
+++ b/demo/src/app/shared/code/snippet.ts
@@ -1,0 +1,36 @@
+export interface ISnippet {
+  lang: 'html' | 'typescript' | 'css' | 'bash';
+  code: string;
+}
+
+function removeEmptyLineAtIndex(lines: string[], index: number) {
+  if (lines[index].trim().length === 0) {
+    lines.splice(index, 1);
+  }
+}
+
+function findIndentLevel(lines): number {
+  return Math.min(...lines
+    .map(line => {
+      const result = /( *)[^ ]+/g.exec(line);
+      return result == null ? null : result[1].length;
+    })
+    .filter(value => value != null)
+  );
+}
+
+function fixIndent(lines: string[]): string[] {
+  removeEmptyLineAtIndex(lines, 0);
+  removeEmptyLineAtIndex(lines, lines.length - 1);
+  const indentLevel = findIndentLevel(lines);
+
+  return lines.map(line => line.substring(indentLevel));
+}
+
+
+export function Snippet({lang, code}: ISnippet): ISnippet {
+  return {
+    lang,
+    code: fixIndent(code.split(/(?:\r\n)|\n|\r/gi)).join('\n'),
+  };
+}


### PR DESCRIPTION
To define snippet information all in one place for clarity, avoid the multiplication of input properties on the `ngbd-code` component, and have common processing such as a handy indentation cleaner (common issue when defining multi-line strings with template strings).
