### PR TITLE
Open tooltip and popover correctly from hooks

### DIFF
--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -9,7 +9,8 @@ import {
   Injectable,
   OnDestroy,
   TemplateRef,
-  ViewContainerRef
+  ViewContainerRef,
+  AfterViewInit
 } from '@angular/core';
 
 import {Key} from '../util/key';
@@ -73,7 +74,7 @@ describe('ngb-popover', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TestComponent, TestOnPushComponent, DestroyableCmpt],
+      declarations: [TestComponent, TestOnPushComponent, DestroyableCmpt, TestHooksComponent],
       imports: [NgbPopoverModule],
       providers: [SpyService]
     });
@@ -348,6 +349,14 @@ describe('ngb-popover', () => {
       fixture.componentInstance.show = false;
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
+    });
+
+    it('should open popover from hooks', () => {
+      const fixture = TestBed.createComponent(TestHooksComponent);
+      fixture.detectChanges();
+
+      const popoverWindow = fixture.debugElement.query(By.directive(NgbPopoverWindow));
+      expect(popoverWindow.nativeElement).toHaveCssClass('popover');
     });
   });
 
@@ -743,4 +752,11 @@ export class DestroyableCmpt implements OnDestroy {
   constructor(private _spyService: SpyService) {}
 
   ngOnDestroy(): void { this._spyService.called = true; }
+}
+
+@Component({selector: 'test-hooks', template: `<div ngbPopover="popover"></div>`})
+export class TestHooksComponent implements AfterViewInit {
+  @ViewChild(NgbPopover) popover;
+
+  ngAfterViewInit() { this.popover.open(); }
 }

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -212,7 +212,16 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
         this._document.querySelector(this.container).appendChild(this._windowRef.location.nativeElement);
       }
 
-      // apply styling to set basic css-classes on target element, before going for positioning
+      // We need to detect changes, because we don't know where .open() might be called from.
+      // Ex. opening popover from one of lifecycle hooks that run after the CD
+      // (say from ngAfterViewInit) will result in 'ExpressionHasChanged' exception
+      this._windowRef.changeDetectorRef.detectChanges();
+
+      // We need to mark for check, because popover won't work inside the OnPush component.
+      // Ex. when we use expression like `{{ popover.isOpen() : 'opened' : 'closed' }}`
+      // inside the template of an OnPush component and we change the popover from
+      // open -> closed, the expression in question won't be updated unless we explicitly
+      // mark the parent component to be checked.
       this._windowRef.changeDetectorRef.markForCheck();
 
       ngbAutoClose(

--- a/src/tooltip/tooltip.spec.ts
+++ b/src/tooltip/tooltip.spec.ts
@@ -2,7 +2,14 @@ import {TestBed, ComponentFixture, inject, fakeAsync, tick} from '@angular/core/
 import {createGenericTestComponent, createKeyEvent} from '../test/common';
 
 import {By} from '@angular/platform-browser';
-import {Component, ViewChild, ChangeDetectionStrategy, TemplateRef, ViewContainerRef} from '@angular/core';
+import {
+  Component,
+  ViewChild,
+  ChangeDetectionStrategy,
+  TemplateRef,
+  ViewContainerRef,
+  AfterViewInit
+} from '@angular/core';
 
 import {Key} from '../util/key';
 
@@ -58,7 +65,8 @@ describe('ngb-tooltip-window', () => {
 describe('ngb-tooltip', () => {
 
   beforeEach(() => {
-    TestBed.configureTestingModule({declarations: [TestComponent, TestOnPushComponent], imports: [NgbTooltipModule]});
+    TestBed.configureTestingModule(
+        {declarations: [TestComponent, TestOnPushComponent, TestHooksComponent], imports: [NgbTooltipModule]});
   });
 
   function getWindow(element) { return element.querySelector('ngb-tooltip-window'); }
@@ -237,6 +245,15 @@ describe('ngb-tooltip', () => {
       fixture.componentInstance.show = false;
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
+    });
+
+    it('should open tooltip from hooks', () => {
+      const fixture = TestBed.createComponent(TestHooksComponent);
+      fixture.detectChanges();
+
+      const tooltipWindow = fixture.debugElement.query(By.directive(NgbTooltipWindow));
+      expect(tooltipWindow.nativeElement).toHaveCssClass('tooltip');
+      expect(tooltipWindow.nativeElement).toHaveCssClass('show');
     });
 
     describe('positioning', () => {
@@ -638,4 +655,11 @@ export class TestComponent {
 
 @Component({selector: 'test-onpush-cmpt', changeDetection: ChangeDetectionStrategy.OnPush, template: ``})
 export class TestOnPushComponent {
+}
+
+@Component({selector: 'test-hooks', template: `<div ngbTooltip="tooltip"></div>`})
+export class TestHooksComponent implements AfterViewInit {
+  @ViewChild(NgbTooltip) tooltip;
+
+  ngAfterViewInit() { this.tooltip.open(); }
 }

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -190,7 +190,16 @@ export class NgbTooltip implements OnInit, OnDestroy {
         this._document.querySelector(this.container).appendChild(this._windowRef.location.nativeElement);
       }
 
-      // apply styling to set basic css-classes on target element, before going for positioning
+      // We need to detect changes, because we don't know where .open() might be called from.
+      // Ex. opening tooltip from one of lifecycle hooks that run after the CD
+      // (say from ngAfterViewInit) will result in 'ExpressionHasChanged' exception
+      this._windowRef.changeDetectorRef.detectChanges();
+
+      // We need to mark for check, because tooltip won't work inside the OnPush component.
+      // Ex. when we use expression like `{{ tooltip.isOpen() : 'opened' : 'closed' }}`
+      // inside the template of an OnPush component and we change the tooltip from
+      // open -> closed, the expression in question won't be updated unless we explicitly
+      // mark the parent component to be checked.
       this._windowRef.changeDetectorRef.markForCheck();
 
       ngbAutoClose(


### PR DESCRIPTION
Forces change detection run on `.open()` to avoid having `ExpressionHasChanged` exception when opened after change detection was run (ex. from hooks)

Fixes #3130 