### PR TITLE
test: refactor tests with triggers (tooltip, popover)

### DIFF
--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -1,5 +1,5 @@
 import {TestBed, ComponentFixture, inject, fakeAsync, tick} from '@angular/core/testing';
-import {createGenericTestComponent, createKeyEvent} from '../test/common';
+import {createGenericTestComponent, createKeyEvent, triggerEvent} from '../test/common';
 
 import {By} from '@angular/platform-browser';
 import {
@@ -78,7 +78,7 @@ describe('ngb-popover', () => {
       const fixture = createTestComponent(`<div ngbPopover="Great tip!" popoverTitle="Title"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       const windowEl = getWindow(fixture.nativeElement);
 
@@ -90,7 +90,7 @@ describe('ngb-popover', () => {
       expect(windowEl.parentNode).toBe(fixture.nativeElement);
       expect(directive.nativeElement.getAttribute('aria-describedby')).toBe('ngb-popover-0');
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
       expect(directive.nativeElement.getAttribute('aria-describedby')).toBeNull();
@@ -103,7 +103,7 @@ describe('ngb-popover', () => {
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
       const defaultConfig = new NgbPopoverConfig();
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       const windowEl = getWindow(fixture.nativeElement);
 
@@ -115,7 +115,7 @@ describe('ngb-popover', () => {
       expect(windowEl.parentNode).toBe(fixture.nativeElement);
       expect(directive.nativeElement.getAttribute('aria-describedby')).toBe('ngb-popover-1');
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
       expect(directive.nativeElement.getAttribute('aria-describedby')).toBeNull();
@@ -140,7 +140,7 @@ describe('ngb-popover', () => {
       expect(windowEl.parentNode).toBe(fixture.nativeElement);
       expect(directive.nativeElement.getAttribute('aria-describedby')).toBe('ngb-popover-2');
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
       expect(directive.nativeElement.getAttribute('aria-describedby')).toBeNull();
@@ -151,7 +151,7 @@ describe('ngb-popover', () => {
         <div ngbPopover="Great tip!" popoverTitle="Title" popoverClass="my-custom-class"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       const windowEl = getWindow(fixture.nativeElement);
 
@@ -164,7 +164,7 @@ describe('ngb-popover', () => {
       expect(windowEl.parentNode).toBe(fixture.nativeElement);
       expect(directive.nativeElement.getAttribute('aria-describedby')).toBe('ngb-popover-3');
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
       expect(directive.nativeElement.getAttribute('aria-describedby')).toBeNull();
@@ -177,13 +177,13 @@ describe('ngb-popover', () => {
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
       const spyService = fixture.debugElement.injector.get(SpyService);
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       const windowEl = getWindow(fixture.nativeElement);
       expect(windowEl.textContent.trim()).toBe('Hello, World! Some contentBody');
       expect(spyService.called).toBeFalsy();
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
       expect(spyService.called).toBeTruthy();
@@ -201,7 +201,7 @@ describe('ngb-popover', () => {
       const windowEl = getWindow(fixture.nativeElement);
       expect(windowEl.textContent.trim()).toBe('Bonjour, tout le monde!!!');
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
     });
@@ -213,12 +213,12 @@ describe('ngb-popover', () => {
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
       const spyService = fixture.debugElement.injector.get(SpyService);
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
       expect(spyService.called).toBeFalsy();
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
       expect(spyService.called).toBeTruthy();
@@ -228,7 +228,7 @@ describe('ngb-popover', () => {
       const fixture = createTestComponent(`<div ngbPopover="Great tip!"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       const windowEl = getWindow(fixture.nativeElement);
       expect(windowEl.querySelector('.popover-header')).toBeNull();
@@ -238,7 +238,7 @@ describe('ngb-popover', () => {
       const fixture = createTestComponent(`<div [ngbPopover]="" [popoverTitle]=""></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       const windowEl = getWindow(fixture.nativeElement);
 
@@ -249,7 +249,7 @@ describe('ngb-popover', () => {
       const fixture = createTestComponent(`<div [ngbPopover]="Disabled!" [disablePopover]="true"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       const windowEl = getWindow(fixture.nativeElement);
 
@@ -260,7 +260,7 @@ describe('ngb-popover', () => {
       const fixture = createTestComponent(`<div [ngbPopover]="name" [popoverTitle]="title"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
@@ -274,7 +274,7 @@ describe('ngb-popover', () => {
       const fixture = createTestComponent(`<div [ngbPopover]="" popoverTitle="title"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       const windowEl = getWindow(fixture.nativeElement);
 
@@ -285,7 +285,7 @@ describe('ngb-popover', () => {
       const fixture = createTestComponent(`<div [ngbPopover]="name" popoverTitle="title"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
@@ -298,15 +298,15 @@ describe('ngb-popover', () => {
       const fixture = createTestComponent(`<div ngbPopover="Great tip!" popoverTitle="Title"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
     });
@@ -316,7 +316,7 @@ describe('ngb-popover', () => {
           `<ng-template [ngIf]="show"><div ngbPopover="Great tip!" popoverTitle="Title"></div></ng-template>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
@@ -331,7 +331,7 @@ describe('ngb-popover', () => {
                                         </ng-template>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('mouseenter', {});
+      triggerEvent(directive, 'mouseenter');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
@@ -348,7 +348,7 @@ describe('ngb-popover', () => {
       const fixture = createTestComponent(`<div ngbPopover="Great tip!" placement="left"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       const windowEl = getWindow(fixture.nativeElement);
 
@@ -361,7 +361,7 @@ describe('ngb-popover', () => {
       const fixture = createOnPushTestComponent(`<div ngbPopover="Great tip!" placement="left"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       const windowEl = getWindow(fixture.nativeElement);
 
@@ -374,7 +374,7 @@ describe('ngb-popover', () => {
       const fixture = createTestComponent(`<div ngbPopover="Great tip!" placement="right-top"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       const windowEl = getWindow(fixture.nativeElement);
 
@@ -388,7 +388,7 @@ describe('ngb-popover', () => {
       const fixture = createTestComponent(`<div ngbPopover="Great tip!" [placement]="['left-top','top-left']"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       const windowEl = getWindow(fixture.nativeElement);
 
@@ -402,7 +402,7 @@ describe('ngb-popover', () => {
       const fixture = createTestComponent(`<div ngbPopover="Great tip!" placement="left-top top-left"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       const windowEl = getWindow(fixture.nativeElement);
 
@@ -416,7 +416,7 @@ describe('ngb-popover', () => {
       const fixture = createTestComponent(`<div ngbPopover="Great tip!" placement="auto"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       const windowEl = getWindow(fixture.nativeElement);
 
@@ -435,7 +435,7 @@ describe('ngb-popover', () => {
       const fixture = createTestComponent(`<div ngbPopover="Great tip!" container="` + selector + `"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
       expect(getWindow(window.document.querySelector(selector))).not.toBeNull();
@@ -447,7 +447,7 @@ describe('ngb-popover', () => {
           createTestComponent(`<div *ngIf="show" ngbPopover="Great tip!" container="` + selector + `"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
 
       expect(getWindow(document.querySelector(selector))).not.toBeNull();
@@ -467,12 +467,12 @@ describe('ngb-popover', () => {
       let shownSpy = spyOn(fixture.componentInstance, 'shown');
       let hiddenSpy = spyOn(fixture.componentInstance, 'hidden');
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
       expect(shownSpy).toHaveBeenCalled();
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
       expect(hiddenSpy).toHaveBeenCalled();
@@ -534,11 +534,11 @@ describe('ngb-popover', () => {
       const fixture = createTestComponent(`<div ngbPopover="Great tip!" triggers="click"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
     });
@@ -547,11 +547,11 @@ describe('ngb-popover', () => {
       const fixture = createTestComponent(`<div ngbPopover="Great tip!" triggers="mouseenter:click"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('mouseenter', {});
+      triggerEvent(directive, 'mouseenter');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
     });
@@ -560,11 +560,11 @@ describe('ngb-popover', () => {
       const fixture = createTestComponent(`<div ngbPopover="Great tip!" triggers="mouseenter:mouseleave click"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('mouseenter', {});
+      triggerEvent(directive, 'mouseenter');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
     });
@@ -573,7 +573,7 @@ describe('ngb-popover', () => {
       const fixture = createTestComponent(`<div ngbPopover="Great tip!" triggers="manual"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
-      directive.triggerEventHandler('mouseenter', {});
+      triggerEvent(directive, 'mouseenter');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
     });
@@ -584,11 +584,11 @@ describe('ngb-popover', () => {
                 <button (click)="t.toggle()">T</button>`);
       const button = fixture.nativeElement.querySelector('button');
 
-      button.click();
+      triggerEvent(button, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
-      button.click();
+      triggerEvent(button, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
     });
@@ -599,11 +599,11 @@ describe('ngb-popover', () => {
                 <button (click)="t.close()">C</button>`);
       const buttons = fixture.nativeElement.querySelectorAll('button');
 
-      buttons[0].click();  // open
+      triggerEvent(buttons[0], 'click');  // open
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
-      buttons[1].click();  // close
+      triggerEvent(buttons[1], 'click');  // close
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
     });
@@ -614,11 +614,11 @@ describe('ngb-popover', () => {
                 <button (click)="t.open()">O</button>`);
       const button = fixture.nativeElement.querySelector('button');
 
-      button.click();  // open
+      triggerEvent(button, 'click');  // open
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
-      button.click();  // open
+      triggerEvent(button, 'click');  // open
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
     });
@@ -629,7 +629,7 @@ describe('ngb-popover', () => {
                 <button (click)="t.close()">C</button>`);
       const button = fixture.nativeElement.querySelector('button');
 
-      button.click();  // close
+      triggerEvent(button, 'click');  // close
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
     });
@@ -697,7 +697,7 @@ describe('ngb-popover', () => {
          <button (click)="createAndDestroyTplWithAPopover(tpl)"></button>
        `);
       const buttonEl = fixture.debugElement.query(By.css('button'));
-      buttonEl.triggerEventHandler('click', {});
+      triggerEvent(buttonEl, 'click');
     });
   });
 });

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -1,3 +1,4 @@
+import {DebugElement} from '@angular/core';
 import {TestBed, ComponentFixture} from '@angular/core/testing';
 import {Key} from '../util/key';
 
@@ -72,4 +73,10 @@ export function createKeyEvent(key: Key, options: {type: 'keyup' | 'keydown'} = 
   Object.defineProperties(event, {which: {get: () => key}});
 
   return event;
+}
+
+export function triggerEvent(element: DebugElement | HTMLElement, eventName: string) {
+  const evt = document.createEvent('Event');
+  evt.initEvent(eventName, true, false);
+  (element instanceof DebugElement ? element.nativeElement : element).dispatchEvent(evt);
 }

--- a/src/tooltip/tooltip.spec.ts
+++ b/src/tooltip/tooltip.spec.ts
@@ -1,5 +1,5 @@
 import {TestBed, ComponentFixture, inject, fakeAsync, tick} from '@angular/core/testing';
-import {createGenericTestComponent, createKeyEvent} from '../test/common';
+import {createGenericTestComponent, createKeyEvent, triggerEvent} from '../test/common';
 
 import {By} from '@angular/platform-browser';
 import {Component, ViewChild, ChangeDetectionStrategy, TemplateRef, ViewContainerRef} from '@angular/core';
@@ -61,7 +61,7 @@ describe('ngb-tooltip', () => {
       const directive = fixture.debugElement.query(By.directive(NgbTooltip));
       const defaultConfig = new NgbTooltipConfig();
 
-      directive.triggerEventHandler('mouseenter', {});
+      triggerEvent(directive, 'mouseenter');
       fixture.detectChanges();
       const windowEl = getWindow(fixture.nativeElement);
 
@@ -73,7 +73,7 @@ describe('ngb-tooltip', () => {
       expect(windowEl.parentNode).toBe(fixture.nativeElement);
       expect(directive.nativeElement.getAttribute('aria-describedby')).toBe('ngb-tooltip-0');
 
-      directive.triggerEventHandler('mouseleave', {});
+      triggerEvent(directive, 'mouseleave');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
       expect(directive.nativeElement.getAttribute('aria-describedby')).toBeNull();
@@ -83,7 +83,7 @@ describe('ngb-tooltip', () => {
       const fixture = createTestComponent(`<ng-template #t>Hello, {{name}}!</ng-template><div [ngbTooltip]="t"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-      directive.triggerEventHandler('mouseenter', {});
+      triggerEvent(directive, 'mouseenter');
       fixture.detectChanges();
       const windowEl = getWindow(fixture.nativeElement);
 
@@ -95,7 +95,7 @@ describe('ngb-tooltip', () => {
       expect(windowEl.parentNode).toBe(fixture.nativeElement);
       expect(directive.nativeElement.getAttribute('aria-describedby')).toBe('ngb-tooltip-1');
 
-      directive.triggerEventHandler('mouseleave', {});
+      triggerEvent(directive, 'mouseleave');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
       expect(directive.nativeElement.getAttribute('aria-describedby')).toBeNull();
@@ -117,7 +117,7 @@ describe('ngb-tooltip', () => {
       expect(windowEl.parentNode).toBe(fixture.nativeElement);
       expect(directive.nativeElement.getAttribute('aria-describedby')).toBe('ngb-tooltip-2');
 
-      directive.triggerEventHandler('mouseleave', {});
+      triggerEvent(directive, 'mouseleave');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
       expect(directive.nativeElement.getAttribute('aria-describedby')).toBeNull();
@@ -128,7 +128,7 @@ describe('ngb-tooltip', () => {
         <div ngbTooltip="Great tip!" tooltipClass="my-custom-class"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-      directive.triggerEventHandler('mouseenter', {});
+      triggerEvent(directive, 'mouseenter');
       fixture.detectChanges();
       const windowEl = getWindow(fixture.nativeElement);
 
@@ -141,7 +141,7 @@ describe('ngb-tooltip', () => {
       expect(windowEl.parentNode).toBe(fixture.nativeElement);
       expect(directive.nativeElement.getAttribute('aria-describedby')).toBe('ngb-tooltip-3');
 
-      directive.triggerEventHandler('mouseleave', {});
+      triggerEvent(directive, 'mouseleave');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
       expect(directive.nativeElement.getAttribute('aria-describedby')).toBeNull();
@@ -151,7 +151,7 @@ describe('ngb-tooltip', () => {
       const fixture = createTestComponent(`<div [ngbTooltip]="notExisting"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-      directive.triggerEventHandler('mouseenter', {});
+      triggerEvent(directive, 'mouseenter');
       fixture.detectChanges();
       const windowEl = getWindow(fixture.nativeElement);
 
@@ -162,7 +162,7 @@ describe('ngb-tooltip', () => {
       const fixture = createTestComponent(`<div [ngbTooltip]="name"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-      directive.triggerEventHandler('mouseenter', {});
+      triggerEvent(directive, 'mouseenter');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
@@ -175,7 +175,7 @@ describe('ngb-tooltip', () => {
       const fixture = createTestComponent(`<div [ngbTooltip]="Disabled!" [disableTooltip]="true"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-      directive.triggerEventHandler('mouseenter', {});
+      triggerEvent(directive, 'mouseenter');
       fixture.detectChanges();
       const windowEl = getWindow(fixture.nativeElement);
 
@@ -186,15 +186,15 @@ describe('ngb-tooltip', () => {
       const fixture = createTestComponent(`<div ngbTooltip="Great tip!"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-      directive.triggerEventHandler('mouseenter', {});
+      triggerEvent(directive, 'mouseenter');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
-      directive.triggerEventHandler('mouseleave', {});
+      triggerEvent(directive, 'mouseleave');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
 
-      directive.triggerEventHandler('mouseenter', {});
+      triggerEvent(directive, 'mouseenter');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
     });
@@ -203,7 +203,7 @@ describe('ngb-tooltip', () => {
       const fixture = createTestComponent(`<ng-template [ngIf]="show"><div ngbTooltip="Great tip!"></div></ng-template>`);
       const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-      directive.triggerEventHandler('mouseenter', {});
+      triggerEvent(directive, 'mouseenter');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
@@ -219,7 +219,7 @@ describe('ngb-tooltip', () => {
             </ng-template>`);
       const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-      directive.triggerEventHandler('mouseenter', {});
+      triggerEvent(directive, 'mouseenter');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
@@ -234,7 +234,7 @@ describe('ngb-tooltip', () => {
         const fixture = createTestComponent(`<div ngbTooltip="Great tip!" placement="left"></div>`);
         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-        directive.triggerEventHandler('mouseenter', {});
+        triggerEvent(directive, 'mouseenter');
         fixture.detectChanges();
         const windowEl = getWindow(fixture.nativeElement);
 
@@ -247,7 +247,7 @@ describe('ngb-tooltip', () => {
         const fixture = createOnPushTestComponent(`<div ngbTooltip="Great tip!" placement="left"></div>`);
         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-        directive.triggerEventHandler('mouseenter', {});
+        triggerEvent(directive, 'mouseenter');
         fixture.detectChanges();
         const windowEl = getWindow(fixture.nativeElement);
 
@@ -260,7 +260,7 @@ describe('ngb-tooltip', () => {
         const fixture = createTestComponent(`<div ngbTooltip="Great tip!" placement="right-top"></div>`);
         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-        directive.triggerEventHandler('mouseenter', {});
+        triggerEvent(directive, 'mouseenter');
         fixture.detectChanges();
         const windowEl = getWindow(fixture.nativeElement);
 
@@ -275,7 +275,7 @@ describe('ngb-tooltip', () => {
             createTestComponent(`<div ngbTooltip="Great tip!" [placement]="['left-top','top-left']"></div>`);
         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-        directive.triggerEventHandler('mouseenter', {});
+        triggerEvent(directive, 'mouseenter');
         fixture.detectChanges();
         const windowEl = getWindow(fixture.nativeElement);
 
@@ -289,7 +289,7 @@ describe('ngb-tooltip', () => {
         const fixture = createTestComponent(`<div ngbTooltip="Great tip!" placement="left-top top-left"></div>`);
         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-        directive.triggerEventHandler('mouseenter', {});
+        triggerEvent(directive, 'mouseenter');
         fixture.detectChanges();
         const windowEl = getWindow(fixture.nativeElement);
 
@@ -303,7 +303,7 @@ describe('ngb-tooltip', () => {
         const fixture = createTestComponent(`<div ngbTooltip="Great tip!" placement="auto"></div>`);
         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-        directive.triggerEventHandler('mouseenter', {});
+        triggerEvent(directive, 'mouseenter');
         fixture.detectChanges();
         const windowEl = getWindow(fixture.nativeElement);
 
@@ -321,11 +321,11 @@ describe('ngb-tooltip', () => {
         const fixture = createTestComponent(`<div ngbTooltip="Great tip!"></div>`);
         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-        directive.triggerEventHandler('focusin', {});
+        triggerEvent(directive, 'focusin');
         fixture.detectChanges();
         expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
-        directive.triggerEventHandler('focusout', {});
+        triggerEvent(directive, 'focusout');
         fixture.detectChanges();
         expect(getWindow(fixture.nativeElement)).toBeNull();
       });
@@ -334,11 +334,11 @@ describe('ngb-tooltip', () => {
         const fixture = createTestComponent(`<div ngbTooltip="Great tip!" triggers="click"></div>`);
         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-        directive.triggerEventHandler('click', {});
+        triggerEvent(directive, 'click');
         fixture.detectChanges();
         expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
-        directive.triggerEventHandler('click', {});
+        triggerEvent(directive, 'click');
         fixture.detectChanges();
         expect(getWindow(fixture.nativeElement)).toBeNull();
       });
@@ -347,11 +347,11 @@ describe('ngb-tooltip', () => {
         const fixture = createTestComponent(`<div ngbTooltip="Great tip!" triggers="mouseenter:click"></div>`);
         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-        directive.triggerEventHandler('mouseenter', {});
+        triggerEvent(directive, 'mouseenter');
         fixture.detectChanges();
         expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
-        directive.triggerEventHandler('click', {});
+        triggerEvent(directive, 'click');
         fixture.detectChanges();
         expect(getWindow(fixture.nativeElement)).toBeNull();
       });
@@ -361,11 +361,11 @@ describe('ngb-tooltip', () => {
             createTestComponent(`<div ngbTooltip="Great tip!" triggers="mouseenter:mouseleave click"></div>`);
         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-        directive.triggerEventHandler('mouseenter', {});
+        triggerEvent(directive, 'mouseenter');
         fixture.detectChanges();
         expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
-        directive.triggerEventHandler('click', {});
+        triggerEvent(directive, 'click');
         fixture.detectChanges();
         expect(getWindow(fixture.nativeElement)).toBeNull();
       });
@@ -374,7 +374,7 @@ describe('ngb-tooltip', () => {
         const fixture = createTestComponent(`<div ngbTooltip="Great tip!" triggers="manual"></div>`);
         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-        directive.triggerEventHandler('mouseenter', {});
+        triggerEvent(directive, 'mouseenter');
         fixture.detectChanges();
         expect(getWindow(fixture.nativeElement)).toBeNull();
       });
@@ -447,7 +447,7 @@ describe('ngb-tooltip', () => {
       const fixture = createTestComponent(`<div ngbTooltip="Great tip!" container="` + selector + `"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-      directive.triggerEventHandler('mouseenter', {});
+      triggerEvent(directive, 'mouseenter');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
       expect(getWindow(document.querySelector(selector))).not.toBeNull();
@@ -459,7 +459,7 @@ describe('ngb-tooltip', () => {
           createTestComponent(`<div *ngIf="show" ngbTooltip="Great tip!" container="` + selector + `"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-      directive.triggerEventHandler('mouseenter', {});
+      triggerEvent(directive, 'mouseenter');
       fixture.detectChanges();
 
       expect(getWindow(document.querySelector(selector))).not.toBeNull();
@@ -478,12 +478,12 @@ describe('ngb-tooltip', () => {
       let shownSpy = spyOn(fixture.componentInstance, 'shown');
       let hiddenSpy = spyOn(fixture.componentInstance, 'hidden');
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).not.toBeNull();
       expect(shownSpy).toHaveBeenCalled();
 
-      directive.triggerEventHandler('click', {});
+      triggerEvent(directive, 'click');
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
       expect(hiddenSpy).toHaveBeenCalled();
@@ -601,7 +601,7 @@ describe('ngb-tooltip', () => {
         <button (click)="createAndDestroyTplWithATooltip(tpl)"></button>
       `);
       const buttonEl = fixture.debugElement.query(By.css('button'));
-      buttonEl.triggerEventHandler('click', {});
+      triggerEvent(buttonEl, 'click');
     });
   });
 });


### PR DESCRIPTION
With Ivy, DebugRenderer2 is going away.
It means that listeners added with Renderer2.listen() are no longer added to the DebugElement.
And so, DebugElement.triggerEventHandler() no longer trigger them.
As a consequence, most tooltip and popover tests are failing with Ivy.