### PR TITLE
fix(datepicker): access view child from ngAfterViewInit

### DIFF
--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -1,6 +1,7 @@
 import {fromEvent, merge, Subject} from 'rxjs';
 import {filter, take, takeUntil} from 'rxjs/operators';
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
@@ -119,7 +120,7 @@ export interface NgbDatepickerNavigateEvent {
   providers: [NGB_DATEPICKER_VALUE_ACCESSOR, NgbDatepickerService, NgbDatepickerKeyMapService]
 })
 export class NgbDatepicker implements OnDestroy,
-    OnChanges, OnInit, ControlValueAccessor {
+    OnChanges, OnInit, AfterViewInit, ControlValueAccessor {
   model: DatepickerViewModel;
 
   @ViewChild('months') private _monthsEl: ElementRef<HTMLElement>;
@@ -319,7 +320,7 @@ export class NgbDatepicker implements OnDestroy,
     this._service.open(NgbDate.from(date ? date.day ? date as NgbDateStruct : {...date, day: 1} : null));
   }
 
-  ngAfterContentInit() {
+  ngAfterViewInit() {
     this._ngZone.runOutsideAngular(() => {
       const focusIns$ = fromEvent<FocusEvent>(this._monthsEl.nativeElement, 'focusin');
       const focusOuts$ = fromEvent<FocusEvent>(this._monthsEl.nativeElement, 'focusout');


### PR DESCRIPTION
datepicker accessed a view child from the ngAfterContentInit hook instead of accessing it from the ngAfterViewInit hook.
This doesn't work anymore with Ivy. That is a regression in Ivy, but is also an issue with ng-bootstrap which doesn't respect the standard life-cycle.
Besides, the component didn't implement the AfterContentInit interface.
It now implements the AfterViewInit interface.

fix #3150

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.
