### PR TITLE
docs: fix 'Code conventions' link in contribution doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,4 +9,4 @@ We are always looking for quality contributions and will be happy to accept your
   * your component has accompanying tests and all the tests are passing
   * your PR doesn't break the build; check the Travis-CI build status after opening a PR and push corrective commits if anything goes wrong
   * your commits conform to the conventions established [here](https://github.com/stevemao/conventional-changelog-angular/blob/master/convention.md)
-  * your component follows all the conventions stated [here](https://github.com/ng-bootstrap/ng-bootstrap/wiki/Code-conventions)
+  * your component follows all the conventions stated [here](https://github.com/ng-bootstrap/ng-bootstrap/wiki/Contributions%3A-Code-conventions)


### PR DESCRIPTION
Fixes #3153
