### PR TITLE
chore: check for focused tests in e2e application

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -202,7 +202,8 @@
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
             "tsConfig": [
-              "e2e-app/tsconfig.json"
+              "e2e-app/tsconfig.json",
+              "e2e-app/tsconfig.spec.json"
             ],
             "exclude": [
               "**/node_modules/**"

--- a/e2e-app/tsconfig.spec.json
+++ b/e2e-app/tsconfig.spec.json
@@ -9,5 +9,8 @@
       "jasminewd2",
       "node"
     ]
-  }
+  },
+  "include": [
+    "**/*.e2e-spec.ts"
+  ]
 }


### PR DESCRIPTION
TSLint rule was in place, but not activated, because `e2e-app/tsconfig.spec.json` for e2e tests wasn't taken into account.
