### PR TITLE
fix(datepicker): export NgbDatepickerNavigateEvent correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export {
   NgbDatepickerI18n,
   NgbDatepickerI18nHebrew,
   NgbDatepickerConfig,
+  NgbDatepickerNavigateEvent,
   NgbDateStruct,
   NgbDate,
   NgbDateParserFormatter,


### PR DESCRIPTION
It wasn't exported from `index.ts` -> wasn't available from `@ng-bootstrap/ng-bootstrap`

Fixes #3160