### PR TITLE
test(rating): removed attribute can be null or undefined

### DIFF
--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -441,7 +441,7 @@ describe('ngb-rating', () => {
       const fixture = createTestComponent('<ngb-rating></ngb-rating>');
       let ratingEl = fixture.debugElement.query(By.directive(NgbRating));
       fixture.detectChanges();
-      expect(ratingEl.attributes['aria-disabled']).toBeNull();
+      expect(ratingEl.attributes['aria-disabled'] == null).toBeTruthy();
 
       let ratingComp = <NgbRating>ratingEl.componentInstance;
       ratingComp.readonly = true;


### PR DESCRIPTION
In VE, DebugElement.attributes reads values from an internal map which is updated by the the DebugRenderer2. It Ivy, it reads the DOM directly.
When an attribute is removed, DebugRenderer2 sets the value to null in the internal map. But reading it from the DOM returns undefined.
Tests relying on that null value fails in Ivy.