### PR TITLE
fix(datepicker): don't change month content if navigation is prevented

### DIFF
--- a/src/datepicker/datepicker-service.spec.ts
+++ b/src/datepicker/datepicker-service.spec.ts
@@ -1416,24 +1416,4 @@ describe('ngb-datepicker-service', () => {
       expect(service.toValidDate(null, null)).toEqual(null);
     });
   });
-
-  describe('reset()', () => {
-
-    it('should reset the service state', () => {
-      // open 2017
-      service.focus(new NgbDate(2017, 5, 1));
-      const oldDate = getDay(0).date;
-      const oldModel = model;
-      expect(oldDate).toEqual(new NgbDate(2017, 5, 1));
-
-      // open 2018
-      service.focus(new NgbDate(2018, 1, 1));
-      expect(getDay(0).date).toEqual(new NgbDate(2018, 1, 1));
-
-      // reset and update something that doesn't trigger navigation and month change
-      service.reset(oldModel);
-      service.navigation = 'none';
-      expect(getDay(0).date).toEqual(oldDate);
-    });
-  });
 });

--- a/src/datepicker/datepicker-service.ts
+++ b/src/datepicker/datepicker-service.ts
@@ -133,8 +133,6 @@ export class NgbDatepickerService {
     }
   }
 
-  reset(state: DatepickerViewModel) { this._state = state; }
-
   select(date: NgbDate, options: {emitEvent?: boolean} = {}) {
     const selectedDate = this.toValidDate(date, null);
     if (!this._state.disabled) {

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -540,10 +540,11 @@ describe('ngb-datepicker', () => {
   it('should prevent navigation when calling preventDefault()', () => {
     const fixture = createTestComponent(
         `<ngb-datepicker #dp [startDate]="date" (navigate)="onPreventableNavigate($event)"></ngb-datepicker>
-       <button id="btn"(click)="dp.navigateTo({year: 2015, month: 7})"></button>`);
+       <button id="btn" (click)="dp.navigateTo({year: 2015, month: 7})"></button>`);
 
     expect(getMonthSelect(fixture.nativeElement).value).toBe('8');
     expect(getYearSelect(fixture.nativeElement).value).toBe('2016');
+    expect(getDay(fixture.nativeElement, 0).innerText).toBe('1');
 
     const button = fixture.nativeElement.querySelector('button#btn');
     button.click();
@@ -551,6 +552,7 @@ describe('ngb-datepicker', () => {
 
     expect(getMonthSelect(fixture.nativeElement).value).toBe('8');
     expect(getYearSelect(fixture.nativeElement).value).toBe('2016');
+    expect(getDay(fixture.nativeElement, 0).innerText).toBe('1');
   });
 
   it('should not focus day initially', () => {

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -271,7 +271,7 @@ export class NgbDatepicker implements OnDestroy,
 
         // can't prevent the very first navigation
         if (navigationPrevented && oldDate !== null) {
-          this._service.reset(this.model);
+          this._service.open(oldDate);
           return;
         }
       }


### PR DESCRIPTION
Previous attempt in navigation cancellation changed was buggy → #3044

After cancellation year and month select boxes stayed unchanged, but the actual month content changed. 

Test expectations were incomplete.