### PR TITLE
chore: use es2015 lib version in tsconfig.json

### DIFF
--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "temp",
+    "lib": ["es2017", "dom"],
     "paths": {
       "@ng-bootstrap/ng-bootstrap": ["../src/index"]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "target": "es5",
-    "lib": ["es2017", "dom"],
+    "lib": ["es2015", "dom"],
     "module": "es2015",
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
Fixes #3174 

For the demo, we're actually sing `Object.values` polyfill and `es2017`