### PR TITLE
fix(dropdown): continuous repositioning can lead to freezes in Safari

### DIFF
--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -19,6 +19,7 @@ import {
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {Subject, Subscription} from 'rxjs';
+import {first} from 'rxjs/operators';
 
 import {Placement, PlacementArray, positionElements} from '../util/positioning';
 import {ngbAutoClose} from '../util/autoclose';
@@ -202,7 +203,7 @@ export class NgbDropdown implements OnInit, OnDestroy {
 
     this.display = ngbNavbar ? 'static' : 'dynamic';
 
-    this._zoneSubscription = _ngZone.onStable.subscribe(() => { this._positionMenu(); });
+    this._zoneSubscription = _ngZone.onStable.pipe(first()).subscribe(() => { this._positionMenu(); });
   }
 
   ngOnInit() {


### PR DESCRIPTION
The `this._positionMenu()` has to be called once when the dropdown is fully rendered. 
`_ngZone.onStable` helps us here but we only need to subscribe to the first event. Otherwise, we perform repositioning multiple times (in a complex app, there are quite many and frequent calls of the method).

### Additional info ###
NgZone#onStable is fired when the microtask queue is empty and Angular does not plan to enqueue any more.