### PR TITLE
fix(positioning): put the popup in a separate layer

### DIFF
--- a/src/util/positioning.ts
+++ b/src/util/positioning.ts
@@ -220,8 +220,7 @@ export function positionElements(
   style.position = 'absolute';
   style.top = '0';
   style.left = '0';
-  // The translate3d/gpu acceleration render a blurry text on chrome, the next line is commented until a browser fix
-  // style['will-change'] = 'transform';
+  style['will-change'] = 'transform';
 
   let testPlacement: Placement;
   let isInViewport = false;


### PR DESCRIPTION
Without forcing the popup in a separate layer, Safari and Firefox are doing a lot more work than necessary.

Example: trying to reposition datepicker 3 times, before finding an optimal position.

Quite significant changes in Safari → removes full page layout and compositing.

Safari Before:

![Screen Shot 2019-05-23 at 15 11 59](https://user-images.githubusercontent.com/8074436/58256477-5f95b780-7d6f-11e9-947b-c82e9011409c.png)

Safari After:

![Screen Shot 2019-05-23 at 15 13 32](https://user-images.githubusercontent.com/8074436/58256523-72a88780-7d6f-11e9-835a-f2054f4e71f6.png)

In Firefox it removes unnecessary paints as well.

---

Concerning the `The translate3d/gpu acceleration render a blurry text on chrome, the next line is commented until a browser fix` → we're not using `translate3d`, but `translate`. And it looks fine in Chrome.

Related to #3199 