### PR TITLE
chore(ci): travis update for xvfb initialisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 node_js:
   - "10"
 
+services:
+  - xvfb
+
 env:
   global:
     - SAUCE_USERNAME=pkozlowski
@@ -11,11 +14,7 @@ env:
 
 addons:
   chrome: stable
-
-before_install:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-
+  
 install:
   - yarn
 


### PR DESCRIPTION
According to https://benlimmer.com/2019/01/14/travis-ci-xvfb/ `before_script` usage to start xvfb should not be used anymore.