### PR TITLE
chore: update project name to allow Github `Used by` feature to work…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ng-bootstrap",
+  "name": "@ng-bootstrap/ng-bootstrap",
   "version": "4.1.3",
   "description": "Angular powered Bootstrap",
   "author": "https://github.com/ng-bootstrap/ng-bootstrap/graphs/contributors",


### PR DESCRIPTION
… properly

Github released a new feature called `Used by` that list all repository that have a given package as a dependency.

Today our name is wrong in the root `package.json` (the one that Github uses) hence we get some wrong metrics.
On top of that, Github provides some help to install the package, which in our case is wrong and misleading, as it actually exists, and point to our previous old version.

<img width="410" alt="image" src="https://user-images.githubusercontent.com/1152740/58474853-9fccaf80-814c-11e9-823a-2ad0dbf1ff89.png">

