### PR TITLE
fix(positioning): cache management

### DIFF
--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -525,6 +525,8 @@ export class NgbInputDatepicker implements OnChanges,
       throw new Error('ngbDatepicker could not find element declared in [positionTarget] to position against.');
     }
 
-    positionElements(hostElement, this._cRef.location.nativeElement, this.placement, this.container === 'body');
+    positionElements(
+        hostElement, this._cRef.location.nativeElement, this.placement, this.container === 'body', undefined,
+        this.closed);
   }
 }

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -369,7 +369,7 @@ export class NgbDropdown implements AfterContentInit, OnDestroy {
           this.display === 'dynamic' ?
               positionElements(
                   this._anchor.anchorEl, this._bodyContainer || this._menuElement.nativeElement, this.placement,
-                  this.container === 'body') :
+                  this.container === 'body', undefined, this._closed$) :
               this._getFirstPlacement(this.placement));
     }
   }

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -193,7 +193,7 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
       if (this._windowRef) {
         positionElements(
             this._elementRef.nativeElement, this._windowRef.location.nativeElement, this.placement,
-            this.container === 'body', 'bs-popover');
+            this.container === 'body', 'bs-popover', this.hidden);
       }
     });
   }

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -211,7 +211,7 @@ export class NgbTypeahead implements ControlValueAccessor,
       if (this.isPopupOpen()) {
         positionElements(
             this._elementRef.nativeElement, this._windowRef !.location.nativeElement, this.placement,
-            this.container === 'body');
+            this.container === 'body', undefined, this._closed$);
       }
     });
   }

--- a/src/util/positioning.spec.ts
+++ b/src/util/positioning.spec.ts
@@ -1,4 +1,4 @@
-import {Positioning} from './positioning';
+import {Positioning, positionElements} from './positioning';
 import {TestBed} from '@angular/core/testing';
 import {Component} from '@angular/core';
 
@@ -122,86 +122,86 @@ describe('Positioning', () => {
 
   it('should position the element top-left', () => {
 
-    let isInViewport = positioning.positionElements(element, targetElement, 'top-left');
+    let placement = positionElements(element, targetElement, 'top-left');
 
-    expect(isInViewport).toBe(true);
+    expect(placement).toBe('top-left');
     checkPosition(targetElement, 40, 150);
   });
 
   it('should position the element top-center', () => {
-    let isInViewport = positioning.positionElements(element, targetElement, 'top');
+    let placement = positionElements(element, targetElement, 'top');
 
-    expect(isInViewport).toBe(true);
+    expect(placement).toBe('top');
     checkPosition(targetElement, 40, 250);
   });
 
   it('should position the element top-right', () => {
-    let isInViewport = positioning.positionElements(element, targetElement, 'top-right');
+    let placement = positionElements(element, targetElement, 'top-right');
 
-    expect(isInViewport).toBe(true);
+    expect(placement).toBe('top-right');
     checkPosition(targetElement, 40, 350);
   });
 
   it('should position the element bottom-left', () => {
-    let isInViewport = positioning.positionElements(element, targetElement, 'bottom-left');
+    let placement = positionElements(element, targetElement, 'bottom-left');
 
-    expect(isInViewport).toBe(true);
+    expect(placement).toBe('bottom-left');
     checkPosition(targetElement, 300, 150);
   });
 
   it('should position the element bottom-center', () => {
-    let isInViewport = positioning.positionElements(element, targetElement, 'bottom');
+    let placement = positionElements(element, targetElement, 'bottom');
 
-    expect(isInViewport).toBe(true);
+    expect(placement).toBe('bottom');
     checkPosition(targetElement, 300, 250);
   });
 
   it('should position the element bottom-right', () => {
-    let isInViewport = positioning.positionElements(element, targetElement, 'bottom-right');
+    let placement = positionElements(element, targetElement, 'bottom-right');
 
-    expect(isInViewport).toBe(true);
+    expect(placement).toBe('bottom-right');
     checkPosition(targetElement, 300, 350);
   });
 
   it('should position the element left-top', () => {
-    let isInViewport = positioning.positionElements(element, targetElement, 'left-top');
+    let placement = positionElements(element, targetElement, 'left-top');
 
-    expect(isInViewport).toBe(true);
+    expect(placement).toBe('left-top');
     checkPosition(targetElement, 100, 30);
   });
 
   it('should position the element left-center', () => {
-    let isInViewport = positioning.positionElements(element, targetElement, 'left');
+    let placement = positionElements(element, targetElement, 'left');
 
-    expect(isInViewport).toBe(true);
+    expect(placement).toBe('left');
     checkPosition(targetElement, 175, 30);
   });
 
   it('should position the element left-bottom', () => {
-    let isInViewport = positioning.positionElements(element, targetElement, 'left-bottom');
+    let placement = positionElements(element, targetElement, 'left-bottom');
 
-    expect(isInViewport).toBe(true);
+    expect(placement).toBe('left-bottom');
     checkPosition(targetElement, 250, 30);
   });
 
   it('should position the element right-top', () => {
-    let isInViewport = positioning.positionElements(element, targetElement, 'right-top');
+    let placement = positionElements(element, targetElement, 'right-top');
 
-    expect(isInViewport).toBe(true);
+    expect(placement).toBe('right-top');
     checkPosition(targetElement, 100, 450);
   });
 
   it('should position the element right-center', () => {
-    let isInViewport = positioning.positionElements(element, targetElement, 'right');
+    let placement = positionElements(element, targetElement, 'right');
 
-    expect(isInViewport).toBe(true);
+    expect(placement).toBe('right');
     checkPosition(targetElement, 175, 450);
   });
 
   it('should position the element right-bottom', () => {
-    let isInViewport = positioning.positionElements(element, targetElement, 'right-bottom');
+    let placement = positionElements(element, targetElement, 'right-bottom');
 
-    expect(isInViewport).toBe(true);
+    expect(placement).toBe('right-bottom');
     checkPosition(targetElement, 250, 450);
   });
 


### PR DESCRIPTION
The purpose of this PR is to increase performance of re-positioning popup by caching the popup dimension values.

It can partially fixed #3199 

This is not intended to be straightly merged, as we need to investigate the implications. For example when the popup content changes while it's open (for example, the typeahead).