### PR TITLE
feat(carousel): stay paused after calling `pause()` until `cycle()` is called

### DIFF
--- a/demo/src/app/components/carousel/carousel.module.ts
+++ b/demo/src/app/components/carousel/carousel.module.ts
@@ -11,6 +11,8 @@ import { NgbdCarouselConfig } from './demos/config/carousel-config';
 import { NgbdCarouselConfigModule } from './demos/config/carousel-config.module';
 import { NgbdCarouselNavigation } from './demos/navigation/carousel-navigation';
 import { NgbdCarouselNavigationModule } from './demos/navigation/carousel-navigation.module';
+import { NgbdCarouselPause } from './demos/pause/carousel-pause';
+import { NgbdCarouselPauseModule } from './demos/pause/carousel-pause.module';
 
 const DEMOS = {
   basic: {
@@ -24,6 +26,12 @@ const DEMOS = {
     type: NgbdCarouselNavigation,
     code: require('!!raw-loader!./demos/navigation/carousel-navigation'),
     markup: require('!!raw-loader!./demos/navigation/carousel-navigation.html')
+  },
+  pause: {
+    title: 'Pause/cycle',
+    type: NgbdCarouselPause,
+    code: require('!!raw-loader!./demos/pause/carousel-pause'),
+    markup: require('!!raw-loader!./demos/pause/carousel-pause.html')
   },
   config: {
     title: 'Global configuration of carousels',
@@ -51,7 +59,8 @@ export const ROUTES = [
     NgbdComponentsSharedModule,
     NgbdCarouselBasicModule,
     NgbdCarouselConfigModule,
-    NgbdCarouselNavigationModule
+    NgbdCarouselNavigationModule,
+    NgbdCarouselPauseModule
   ]
 })
 export class NgbdCarouselModule {

--- a/demo/src/app/components/carousel/demos/pause/carousel-pause.html
+++ b/demo/src/app/components/carousel/demos/pause/carousel-pause.html
@@ -1,0 +1,30 @@
+<ngb-carousel #carousel interval="1000" [pauseOnHover]="pauseOnHover" (slide)="onSlide($event)">
+  <ng-template ngbSlide *ngFor="let img of images; index as i">
+    <div class="carousel-caption">
+      <h3>My slide {{i + 1}} title</h3>
+    </div>
+    <a href="https://www.google.fr/?q=Number+{{i+1}}" target="_blank" rel="nofollow noopener noreferrer">
+      <div class="picsum-img-wrapper">
+        <img [src]="img" alt="My image {{i + 1}} description">
+      </div>
+    </a>
+  </ng-template>
+</ngb-carousel>
+
+<hr>
+
+<div class="form-check">
+  <input type="checkbox" class="form-check-input" id="pauseOnHover" [(ngModel)]="pauseOnHover">
+  <label class="form-check-label" for="pauseOnHover">Pause on hover</label>
+</div>
+<div class="form-check">
+  <input type="checkbox" class="form-check-input" id="unpauseOnArrow" [(ngModel)]="unpauseOnArrow">
+  <label class="form-check-label" for="unpauseOnArrow">Unpause when clicking on arrows</label>
+</div>
+<div class="form-check">
+  <input type="checkbox" class="form-check-input" id="pauseOnIndicator" [(ngModel)]="pauseOnIndicator">
+  <label class="form-check-label" for="pauseOnIndicator">Pause when clicking on navigation indicator</label>
+</div>
+<button type="button" (click)="togglePaused()" class="btn btn-outline-dark btn-sm">
+  {{paused ? 'Cycle' : 'Pause' }}
+</button>

--- a/demo/src/app/components/carousel/demos/pause/carousel-pause.module.ts
+++ b/demo/src/app/components/carousel/demos/pause/carousel-pause.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { BrowserModule } from '@angular/platform-browser';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+
+import { NgbdCarouselPause } from './carousel-pause';
+
+@NgModule({
+  imports: [BrowserModule, FormsModule, NgbModule],
+  declarations: [NgbdCarouselPause],
+  exports: [NgbdCarouselPause],
+  bootstrap: [NgbdCarouselPause]
+})
+export class NgbdCarouselPauseModule {}

--- a/demo/src/app/components/carousel/demos/pause/carousel-pause.ts
+++ b/demo/src/app/components/carousel/demos/pause/carousel-pause.ts
@@ -1,0 +1,34 @@
+import { Component, ViewChild } from '@angular/core';
+import { NgbCarousel, NgbSlideEvent, NgbSlideEventSource } from '@ng-bootstrap/ng-bootstrap';
+
+
+@Component({selector: 'ngbd-carousel-pause', templateUrl: './carousel-pause.html'})
+export class NgbdCarouselPause {
+  images = [1, 2, 3, 4, 5, 6, 7].map(() => `https://picsum.photos/900/500?random&t=${Math.random()}`);
+
+  paused = false;
+  unpauseOnArrow = false;
+  pauseOnIndicator = false;
+  pauseOnHover = true;
+
+  @ViewChild('carousel', {static : true}) carousel: NgbCarousel;
+
+  togglePaused() {
+    if (this.paused) {
+      this.carousel.cycle();
+    } else {
+      this.carousel.pause();
+    }
+    this.paused = !this.paused;
+  }
+
+  onSlide(slideEvent: NgbSlideEvent) {
+    if (this.unpauseOnArrow && slideEvent.paused &&
+      (slideEvent.source === NgbSlideEventSource.ARROW_LEFT || slideEvent.source === NgbSlideEventSource.ARROW_RIGHT)) {
+      this.togglePaused();
+    }
+    if (this.pauseOnIndicator && !slideEvent.paused && slideEvent.source === NgbSlideEventSource.INDICATOR) {
+      this.togglePaused();
+    }
+  }
+}

--- a/src/carousel/carousel.module.ts
+++ b/src/carousel/carousel.module.ts
@@ -3,7 +3,7 @@ import {CommonModule} from '@angular/common';
 
 import {NGB_CAROUSEL_DIRECTIVES} from './carousel';
 
-export {NgbCarousel, NgbSlide, NgbSlideEvent} from './carousel';
+export {NgbCarousel, NgbSlide, NgbSlideEvent, NgbSlideEventDirection, NgbSlideEventSource} from './carousel';
 export {NgbCarouselConfig} from './carousel-config';
 
 @NgModule({declarations: NGB_CAROUSEL_DIRECTIVES, exports: NGB_CAROUSEL_DIRECTIVES, imports: [CommonModule]})

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,15 @@ export {
 } from './accordion/accordion.module';
 export {NgbAlert, NgbAlertConfig, NgbAlertModule} from './alert/alert.module';
 export {NgbButtonLabel, NgbButtonsModule, NgbCheckBox, NgbRadio, NgbRadioGroup} from './buttons/buttons.module';
-export {NgbCarousel, NgbCarouselConfig, NgbCarouselModule, NgbSlide} from './carousel/carousel.module';
+export {
+  NgbCarousel,
+  NgbCarouselConfig,
+  NgbCarouselModule,
+  NgbSlide,
+  NgbSlideEvent,
+  NgbSlideEventDirection,
+  NgbSlideEventSource
+} from './carousel/carousel.module';
 export {NgbCollapse, NgbCollapseModule} from './collapse/collapse.module';
 export {
   NgbCalendar,


### PR DESCRIPTION
After setting the carousel on pause through its `pause()` method and clicking on navigation arrows, the carousel no longer automatically restarts. Calling the `cycle()` method is needed to undo the effect of the `pause()` method.
When `pauseOnHover` is true, hovering on the carousel no longer uses the `pause()` and `cycle()` methods. The hover status is stored separately, so that calling `pause()` and removing the mouse from the carousel no longer restarts it automatically.

The slide event now has a "source" property allowing to know what triggered the event: "timer", "arrowLeft", "arrowRight" or "indicator".
The "pause" boolean status is now also included in the slide event.

Closes #3188

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
