### PR TITLE
test(ngbtime): fix test wording mistake

### DIFF
--- a/src/timepicker/ngb-time.spec.ts
+++ b/src/timepicker/ngb-time.spec.ts
@@ -119,7 +119,7 @@ describe('NgbTime', () => {
     expect(t.toString()).toBe('10:30:30');
   });
 
-  it('should properly change undefined minutes', () => {
+  it('should properly change undefined seconds', () => {
     const t = new NgbTime(1, 20, undefined);
 
     t.changeSecond(30);


### PR DESCRIPTION
This is minor, cosmetic change in output of the tests fixing obvious mistake

Thanks!
