### PR TITLE
docs: update installation section

### DIFF
--- a/demo/src/app/pages/getting-started/getting-started.component.html
+++ b/demo/src/app/pages/getting-started/getting-started.component.html
@@ -60,6 +60,14 @@
 
   <ngbd-page-header title="Installation" fragment="installation"></ngbd-page-header>
 
+  <p>You need to have an Angular project with the supported Angular version. We strongly recommend using <a href="https://cli.angular.io" rel="nofollow" target="_blank">Angular CLI</a> for this.</p>
+
+  <p>You also need to add Bootstrap 4 CSS to your application by using your preferred way (it really depends on the setup you're using). Ex. for Angular CLI you can <a href="https://www.npmjs.com/package/bootstrap" rel="nofollow" target="_blank">get Bootstrap from npm</a> and update your <code>angular.json</code> with something like:</p>
+
+  <ngbd-code [snippet]="bootstrapInstall"></ngbd-code>
+
+  <p>Please note that you need only CSS and <strong>should not</strong> add other JavaScript dependencies like <code>bootstrap.js</code>, <code>jQuery</code> or <code>popper.js</code> as ng-bootstrap's goal is to completely replace them.</p>
+
   <p>After installing the above dependencies, install <code>ng-bootstrap</code> via:</p>
 
   <ngbd-code [snippet]="codeInstall"></ngbd-code>

--- a/demo/src/app/pages/getting-started/getting-started.component.ts
+++ b/demo/src/app/pages/getting-started/getting-started.component.ts
@@ -5,6 +5,15 @@ import {Snippet} from '../../shared/code/snippet';
   templateUrl: './getting-started.component.html'
 })
 export class GettingStartedPage {
+  bootstrapInstall = Snippet({
+    lang: 'json',
+    code: `
+      "styles": [
+        "node_modules/bootstrap/dist/css/bootstrap.min.css"
+      ]
+    `,
+  });
+
   codeInstall = Snippet({
     lang: 'bash',
     code: `npm install --save @ng-bootstrap/ng-bootstrap`,

--- a/demo/src/app/shared/code/code-highlight.service.ts
+++ b/demo/src/app/shared/code/code-highlight.service.ts
@@ -3,6 +3,7 @@ import {Injectable} from '@angular/core';
 import * as prism from 'prismjs';
 import 'prismjs/components/prism-typescript';
 import 'prismjs/components/prism-bash';
+import 'prismjs/components/prism-json';
 
 // Prism tries to highlight the whole document on DOMContentLoad.
 // Unfortunately with webpack the only way of disabling it

--- a/demo/src/app/shared/code/snippet.ts
+++ b/demo/src/app/shared/code/snippet.ts
@@ -1,5 +1,5 @@
 export interface ISnippet {
-  lang: 'html' | 'typescript' | 'css' | 'bash';
+  lang: 'html' | 'typescript' | 'css' | 'bash' | 'json';
   code: string;
 }
 


### PR DESCRIPTION
This PR:

- adds support for `json` PrismJS language support in highlighter service used in generated content
- updates content of the installation section with the content already used on the landing page

<img width="846" alt="Screenshot 2019-06-08 at 22 46 46" src="https://user-images.githubusercontent.com/14539/59152194-b07c0000-8a3f-11e9-9ff7-ddd1f2eff8b3.png">

Thanks!