### PR TITLE
Removes forRoot() from modules

### DIFF
--- a/src/accordion/accordion.module.ts
+++ b/src/accordion/accordion.module.ts
@@ -20,11 +20,4 @@ const NGB_ACCORDION_DIRECTIVES =
 
 @NgModule({declarations: NGB_ACCORDION_DIRECTIVES, exports: NGB_ACCORDION_DIRECTIVES, imports: [CommonModule]})
 export class NgbAccordionModule {
-  /**
-   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
-   * Will be removed in 4.0.0.
-   *
-   * @deprecated 3.0.0
-   */
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbAccordionModule}; }
 }

--- a/src/alert/alert.module.ts
+++ b/src/alert/alert.module.ts
@@ -8,11 +8,4 @@ export {NgbAlertConfig} from './alert-config';
 
 @NgModule({declarations: [NgbAlert], exports: [NgbAlert], imports: [CommonModule], entryComponents: [NgbAlert]})
 export class NgbAlertModule {
-  /**
-   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
-   * Will be removed in 4.0.0.
-   *
-   * @deprecated 3.0.0
-   */
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbAlertModule}; }
 }

--- a/src/buttons/buttons.module.ts
+++ b/src/buttons/buttons.module.ts
@@ -12,11 +12,4 @@ const NGB_BUTTON_DIRECTIVES = [NgbButtonLabel, NgbCheckBox, NgbRadioGroup, NgbRa
 
 @NgModule({declarations: NGB_BUTTON_DIRECTIVES, exports: NGB_BUTTON_DIRECTIVES})
 export class NgbButtonsModule {
-  /**
-   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
-   * Will be removed in 4.0.0.
-   *
-   * @deprecated 3.0.0
-   */
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbButtonsModule}; }
 }

--- a/src/carousel/carousel.module.ts
+++ b/src/carousel/carousel.module.ts
@@ -8,11 +8,4 @@ export {NgbCarouselConfig} from './carousel-config';
 
 @NgModule({declarations: NGB_CAROUSEL_DIRECTIVES, exports: NGB_CAROUSEL_DIRECTIVES, imports: [CommonModule]})
 export class NgbCarouselModule {
-  /**
-   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
-   * Will be removed in 4.0.0.
-   *
-   * @deprecated 3.0.0
-   */
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbCarouselModule}; }
 }

--- a/src/collapse/collapse.module.ts
+++ b/src/collapse/collapse.module.ts
@@ -5,11 +5,4 @@ export {NgbCollapse} from './collapse';
 
 @NgModule({declarations: [NgbCollapse], exports: [NgbCollapse]})
 export class NgbCollapseModule {
-  /**
-   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
-   * Will be removed in 4.0.0.
-   *
-   * @deprecated 3.0.0
-   */
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbCollapseModule}; }
 }

--- a/src/datepicker/datepicker.module.ts
+++ b/src/datepicker/datepicker.module.ts
@@ -39,11 +39,4 @@ export {NgbDateParserFormatter} from './ngb-date-parser-formatter';
   entryComponents: [NgbDatepicker]
 })
 export class NgbDatepickerModule {
-  /**
-   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
-   * Will be removed in 4.0.0.
-   *
-   * @deprecated 3.0.0
-   */
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbDatepickerModule}; }
 }

--- a/src/dropdown/dropdown.module.ts
+++ b/src/dropdown/dropdown.module.ts
@@ -16,11 +16,4 @@ const NGB_DROPDOWN_DIRECTIVES =
 
 @NgModule({declarations: NGB_DROPDOWN_DIRECTIVES, exports: NGB_DROPDOWN_DIRECTIVES})
 export class NgbDropdownModule {
-  /**
-   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
-   * Will be removed in 4.0.0.
-   *
-   * @deprecated 3.0.0
-   */
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbDropdownModule}; }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,11 +122,4 @@ const NGB_MODULES = [
 
 @NgModule({imports: NGB_MODULES, exports: NGB_MODULES})
 export class NgbModule {
-  /**
-   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
-   * Will be removed in 4.0.0.
-   *
-   * @deprecated 3.0.0
-   */
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbModule}; }
 }

--- a/src/modal/modal.module.ts
+++ b/src/modal/modal.module.ts
@@ -15,11 +15,4 @@ export {ModalDismissReasons} from './modal-dismiss-reasons';
   providers: [NgbModal]
 })
 export class NgbModalModule {
-  /**
-   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
-   * Will be removed in 4.0.0.
-   *
-   * @deprecated 3.0.0
-   */
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbModalModule}; }
 }

--- a/src/pagination/pagination.module.ts
+++ b/src/pagination/pagination.module.ts
@@ -29,11 +29,4 @@ const DIRECTIVES = [
 
 @NgModule({declarations: DIRECTIVES, exports: DIRECTIVES, imports: [CommonModule]})
 export class NgbPaginationModule {
-  /**
-   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
-   * Will be removed in 4.0.0.
-   *
-   * @deprecated 3.0.0
-   */
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbPaginationModule}; }
 }

--- a/src/popover/popover.module.ts
+++ b/src/popover/popover.module.ts
@@ -14,11 +14,4 @@ export {Placement} from '../util/positioning';
   entryComponents: [NgbPopoverWindow]
 })
 export class NgbPopoverModule {
-  /**
-   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
-   * Will be removed in 4.0.0.
-   *
-   * @deprecated 3.0.0
-   */
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbPopoverModule}; }
 }

--- a/src/progressbar/progressbar.module.ts
+++ b/src/progressbar/progressbar.module.ts
@@ -8,11 +8,4 @@ export {NgbProgressbarConfig} from './progressbar-config';
 
 @NgModule({declarations: [NgbProgressbar], exports: [NgbProgressbar], imports: [CommonModule]})
 export class NgbProgressbarModule {
-  /**
-   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
-   * Will be removed in 4.0.0.
-   *
-   * @deprecated 3.0.0
-   */
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbProgressbarModule}; }
 }

--- a/src/rating/rating.module.ts
+++ b/src/rating/rating.module.ts
@@ -8,11 +8,4 @@ export {NgbRatingConfig} from './rating-config';
 
 @NgModule({declarations: [NgbRating], exports: [NgbRating], imports: [CommonModule]})
 export class NgbRatingModule {
-  /**
-   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
-   * Will be removed in 4.0.0.
-   *
-   * @deprecated 3.0.0
-   */
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbRatingModule}; }
 }

--- a/src/tabset/tabset.module.ts
+++ b/src/tabset/tabset.module.ts
@@ -10,11 +10,4 @@ const NGB_TABSET_DIRECTIVES = [NgbTabset, NgbTab, NgbTabContent, NgbTabTitle];
 
 @NgModule({declarations: NGB_TABSET_DIRECTIVES, exports: NGB_TABSET_DIRECTIVES, imports: [CommonModule]})
 export class NgbTabsetModule {
-  /**
-   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
-   * Will be removed in 4.0.0.
-   *
-   * @deprecated 3.0.0
-   */
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbTabsetModule}; }
 }

--- a/src/timepicker/timepicker.module.ts
+++ b/src/timepicker/timepicker.module.ts
@@ -10,11 +10,4 @@ export {NgbTimeAdapter} from './ngb-time-adapter';
 
 @NgModule({declarations: [NgbTimepicker], exports: [NgbTimepicker], imports: [CommonModule]})
 export class NgbTimepickerModule {
-  /**
-   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
-   * Will be removed in 4.0.0.
-   *
-   * @deprecated 3.0.0
-   */
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbTimepickerModule}; }
 }

--- a/src/tooltip/tooltip.module.ts
+++ b/src/tooltip/tooltip.module.ts
@@ -8,10 +8,4 @@ export {Placement} from '../util/positioning';
 
 @NgModule({declarations: [NgbTooltip, NgbTooltipWindow], exports: [NgbTooltip], entryComponents: [NgbTooltipWindow]})
 export class NgbTooltipModule {
-  /**
-   * No need in forRoot anymore with tree-shakeable services
-   *
-   * @deprecated 3.0.0
-   */
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbTooltipModule}; }
 }

--- a/src/typeahead/typeahead.module.ts
+++ b/src/typeahead/typeahead.module.ts
@@ -17,11 +17,4 @@ export {NgbTypeahead, NgbTypeaheadSelectItemEvent} from './typeahead';
   entryComponents: [NgbTypeaheadWindow]
 })
 export class NgbTypeaheadModule {
-  /**
-   * Importing with '.forRoot()' is no longer necessary, you can simply import the module.
-   * Will be removed in 4.0.0.
-   *
-   * @deprecated 3.0.0
-   */
-  static forRoot(): ModuleWithProviders { return {ngModule: NgbTypeaheadModule}; }
 }


### PR DESCRIPTION
Deprecated in 3.0.0 and due removal since 4.0.0.