### PR TITLE
feat(timepicker): activate type="number" for inputs

### DIFF
--- a/e2e-app/src/app/timepicker/navigation/timepicker-navigation.e2e-spec.ts
+++ b/e2e-app/src/app/timepicker/navigation/timepicker-navigation.e2e-spec.ts
@@ -1,4 +1,4 @@
-import {Key, ElementFinder} from 'protractor';
+import {Key, ElementFinder, browser} from 'protractor';
 
 import {openUrl, expectFocused, sendKey, getCaretPosition} from '../../tools.po';
 
@@ -45,6 +45,16 @@ describe('Timepicker', () => {
   describe('arrow keys', () => {
     it(`should keep caret at the end of the input`, async() => {
       const testField = async(fieldElement: ElementFinder) => {
+
+        const type = await browser.executeScript(
+            `
+          var element = arguments[0];
+          var type = element.getAttribute('type');
+          element.setAttribute('type', 'text');
+          return type;
+        `,
+            fieldElement.getWebElement());
+
         await fieldElement.click();
 
         const endPosition = 2;
@@ -67,6 +77,9 @@ describe('Timepicker', () => {
 
         await sendKey(Key.ARROW_DOWN);
         await expectCaretAtEnd();
+
+        await browser.executeScript(
+            `arguments[0].setAttribute('type', arguments[1]);`, fieldElement.getWebElement(), type);
       };
 
       for (const fieldElement of page.getFields()) {

--- a/src/timepicker/timepicker.scss
+++ b/src/timepicker/timepicker.scss
@@ -33,6 +33,13 @@ ngb-timepicker {
 
   &-input {
     text-align: center;
+    appearance: textfield;
+
+    &::-webkit-inner-spin-button,
+    &::-webkit-outer-spin-button {
+      appearance: none;
+      margin: 0;
+    }
   }
 
   &-hour,

--- a/src/timepicker/timepicker.ts
+++ b/src/timepicker/timepicker.ts
@@ -37,7 +37,7 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
             <span class="chevron ngb-tp-chevron"></span>
             <span class="sr-only" i18n="@@ngb.timepicker.increment-hours">Increment hours</span>
           </button>
-          <input type="text" class="ngb-tp-input form-control" [class.form-control-sm]="isSmallSize" [class.form-control-lg]="isLargeSize"
+          <input type="number" class="ngb-tp-input form-control" [class.form-control-sm]="isSmallSize" [class.form-control-lg]="isLargeSize"
             maxlength="2" placeholder="HH" i18n-placeholder="@@ngb.timepicker.HH"
             [value]="formatHour(model?.hour)" (change)="updateHour($event.target.value)"
             [readOnly]="readonlyInputs" [disabled]="disabled" aria-label="Hours" i18n-aria-label="@@ngb.timepicker.hours"
@@ -58,7 +58,7 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
             <span class="chevron ngb-tp-chevron"></span>
             <span class="sr-only" i18n="@@ngb.timepicker.increment-minutes">Increment minutes</span>
           </button>
-          <input type="text" class="ngb-tp-input form-control" [class.form-control-sm]="isSmallSize" [class.form-control-lg]="isLargeSize"
+          <input type="number" class="ngb-tp-input form-control" [class.form-control-sm]="isSmallSize" [class.form-control-lg]="isLargeSize"
             maxlength="2" placeholder="MM" i18n-placeholder="@@ngb.timepicker.MM"
             [value]="formatMinSec(model?.minute)" (change)="updateMinute($event.target.value)"
             [readOnly]="readonlyInputs" [disabled]="disabled" aria-label="Minutes" i18n-aria-label="@@ngb.timepicker.minutes"
@@ -79,7 +79,7 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
             <span class="chevron ngb-tp-chevron"></span>
             <span class="sr-only" i18n="@@ngb.timepicker.increment-seconds">Increment seconds</span>
           </button>
-          <input type="text" class="ngb-tp-input form-control" [class.form-control-sm]="isSmallSize" [class.form-control-lg]="isLargeSize"
+          <input type="number" class="ngb-tp-input form-control" [class.form-control-sm]="isSmallSize" [class.form-control-lg]="isLargeSize"
             maxlength="2" placeholder="SS" i18n-placeholder="@@ngb.timepicker.SS"
             [value]="formatMinSec(model?.second)" (change)="updateSecond($event.target.value)"
             [readOnly]="readonlyInputs" [disabled]="disabled" aria-label="Seconds" i18n-aria-label="@@ngb.timepicker.seconds"


### PR DESCRIPTION
fix #2334 

input type as number is more appropriate for the timepicker, although the behavior is different depending on the browser:

- Chrome filter characters to only accept numbers,
- FF does not filter characters, but put a red border on blur if the value is not valid
- IE set the field empty on blur if the value is not valid
- Edge do nothing

The inner arrows have been removed by css, as the timepicker already provides

Even with these discrepancies, the big advantage is to get the numeric keypad on mobile. For this, the property "inputmode" is more appropriate (as we don't need the arrows), but it's not fully supported on mobile: https://caniuse.com/#feat=input-inputmode

In this PR, the tests on navigation had to be tweak a little, as it's not possible to use selectionStart and selectionEnd on inputs with type="number". I didn't find another way to change the type before testing the navigation.
