### PR TITLE
fix(positioning): window resize listener and peformance optimisation

### DIFF
--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -26,10 +26,12 @@ import {DOCUMENT} from '@angular/common';
 
 import {listenToTriggers} from '../util/triggers';
 import {ngbAutoClose} from '../util/autoclose';
+import {ngbWindowResize} from '../util/resize';
 import {positionElements, PlacementArray} from '../util/positioning';
 import {PopupService} from '../util/popup';
 
 import {NgbTooltipConfig} from './tooltip-config';
+import {take} from 'rxjs/operators';
 
 let nextId = 0;
 
@@ -138,7 +140,6 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
   private _popupService: PopupService<NgbTooltipWindow>;
   private _windowRef: ComponentRef<NgbTooltipWindow>| null = null;
   private _unregisterListenersFn;
-  private _zoneSubscription: any;
 
   constructor(
       private _elementRef: ElementRef<HTMLElement>, private _renderer: Renderer2, injector: Injector,
@@ -155,14 +156,6 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
     this.closeDelay = config.closeDelay;
     this._popupService = new PopupService<NgbTooltipWindow>(
         NgbTooltipWindow, injector, viewContainerRef, _renderer, componentFactoryResolver, applicationRef);
-
-    this._zoneSubscription = _ngZone.onStable.subscribe(() => {
-      if (this._windowRef) {
-        positionElements(
-            this._elementRef.nativeElement, this._windowRef.location.nativeElement, this.placement,
-            this.container === 'body', 'bs-tooltip');
-      }
-    });
   }
 
   /**
@@ -196,7 +189,10 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 
       if (this.container === 'body') {
         this._document.querySelector(this.container).appendChild(this._windowRef.location.nativeElement);
+        ngbWindowResize(this._ngZone, () => this.position(), this.hidden);
       }
+
+      this._ngZone.onStable.asObservable().pipe(take(1)).subscribe(() => this.position());
 
       // We need to detect changes, because we don't know where .open() might be called from.
       // Ex. opening tooltip from one of lifecycle hooks that run after the CD
@@ -270,6 +266,16 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
     if (this._unregisterListenersFn) {
       this._unregisterListenersFn();
     }
-    this._zoneSubscription.unsubscribe();
+  }
+
+  /**
+   * Trigger a repositioning of the tooltip
+   */
+  position() {
+    if (this._windowRef) {
+      positionElements(
+          this._elementRef.nativeElement, this._windowRef.location.nativeElement, this.placement,
+          this.container === 'body', 'bs-tooltip');
+    }
   }
 }

--- a/src/util/resize.ts
+++ b/src/util/resize.ts
@@ -1,0 +1,10 @@
+import {NgZone} from '@angular/core';
+import {fromEvent, Observable} from 'rxjs';
+import {takeUntil, throttleTime} from 'rxjs/operators';
+
+
+export function ngbWindowResize(zone: NgZone, callback: () => void, unsubscribe$: Observable<any>) {
+  zone.runOutsideAngular(() => {
+    fromEvent(window, 'resize').pipe(takeUntil(unsubscribe$), throttleTime(10)).subscribe(() => callback());
+  });
+}


### PR DESCRIPTION
The purpose of this PR is a proposal for fixing #3199 and fixing #3241 

 - It's a partial fix as it comes complementary to #3018
 - ngZone.onStable is no longer use (the root cause of performance issue)
 - The 'position' method in tooltip and popover has been publicly  open in case of content change, in charge of the app to call it when needed.
 - window resize is listen to reposition the tooltip and popover

fix #3382 