### PR TITLE
fix(demo): missing `Object.values()` polyfill for IE.

### DIFF
--- a/demo/src/polyfills.ts
+++ b/demo/src/polyfills.ts
@@ -17,7 +17,7 @@
 /***************************************************************************************************
  * BROWSER POLYFILLS
  */
-
+import 'core-js/fn/object/values';
 
 /**
  * Required to support Web Animations `@angular/platform-browser/animations`.


### PR DESCRIPTION
`Object.values` is used at runtime to compute all the table of content navigation.

Polyfill has been accidentally removed recently, crashing demo website on all IE browsers