### PR TITLE
chore: missing 'core-js' for StackBlitz to work.

### DIFF
--- a/misc/generate-stackblitzes.ts
+++ b/misc/generate-stackblitzes.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 
 import {parseDemo} from './parse-demo';
 
+
 const stackblitzUrl = 'https://stackblitz.com/run';
 const packageJson = fs.readJsonSync('package.json');
 
@@ -14,6 +15,7 @@ const versions = {
   typescript: getVersion('typescript'),
   rxjs: getVersion('rxjs'),
   zoneJs: getVersion('zone.js'),
+  coreJs: getVersion('core-js'),
   bootstrap: getVersion('bootstrap'),
   prismjs: getVersion('prismjs')
 };
@@ -58,6 +60,7 @@ const initialData = {
     '@angular/router': versions.angular,
     '@angular/forms': versions.angular,
     '@ng-bootstrap/ng-bootstrap': versions.ngBootstrap,
+    'core-js': versions.coreJs,
     'rxjs': versions.rxjs,
     'zone.js': versions.zoneJs,
   }),

--- a/misc/stackblitzes-templates/polyfills.ts
+++ b/misc/stackblitzes-templates/polyfills.ts
@@ -31,36 +31,37 @@
 // import 'core-js/es6/array';
 // import 'core-js/es6/regexp';
 // import 'core-js/es6/map';
-// import 'core-js/es6/weak-map';
 // import 'core-js/es6/set';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
-/** IE10 and IE11 requires the following for the Reflect API. */
-// import 'core-js/es6/reflect';
+/** IE10 and IE11 requires the following to support `@angular/animation`. */
+// import 'web-animations-js';  // Run `npm install --save web-animations-js`.
 
 
 /** Evergreen browsers require these. **/
-// Used for reflect-metadata in JIT. If you use AOT (and only Angular decorators), you can remove.
+import 'core-js/es6/reflect';
 import 'core-js/es7/reflect';
 
 
-/**
- * Required to support Web Animations `@angular/platform-browser/animations`.
- * Needed for: All but Chrome, Firefox and Opera. http://caniuse.com/#feat=web-animation
- **/
+/** ALL Firefox browsers require the following to support `@angular/animation`. **/
 // import 'web-animations-js';  // Run `npm install --save web-animations-js`.
 
 
 
 /***************************************************************************************************
- * Zone JS is required by default for Angular itself.
+ * Zone JS is required by Angular itself.
  */
 import 'zone.js/dist/zone';  // Included with Angular CLI.
-
 
 
 /***************************************************************************************************
  * APPLICATION IMPORTS
  */
+
+/**
+ * Date, currency, decimal and percent pipes.
+ * Needed for: All but Chrome, Firefox, Edge, IE11 and Safari 10
+ */
+// import 'intl';  // Run `npm install --save intl`.

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "clang-format": "1.0.35",
     "concurrently": "^4.1.0",
     "conventional-changelog-cli": "^2.0.12",
+    "core-js": "^2",
     "ejs": "2.6.1",
     "express": "^4.16.4",
     "fs-extra": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2273,7 +2273,7 @@ core-js@3.0.1:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.0.1.tgz#1343182634298f7f38622f95e73f54e48ddf4738"
   integrity sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==
 
-core-js@^2.2.0, core-js@^2.4.0:
+core-js@^2, core-js@^2.2.0, core-js@^2.4.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==


### PR DESCRIPTION
Finally, for Angular 8 migration, we removed a bit eagerly all
references to 'core-js' due to differential loading being shipped.
According to Angular default scaffolded app generated from StackBlitz
it is still needed somehow.

Fixes #3251

