### PR TITLE
fix(datepicker): NgbCalendarIslamicUmalqura.fromGregorian with date in the afternoon

### DIFF
--- a/src/datepicker/hijri/ngb-calendar-islamic-umalqura.spec.ts
+++ b/src/datepicker/hijri/ngb-calendar-islamic-umalqura.spec.ts
@@ -868,6 +868,16 @@ describe('ngb-calendar-islamic-umalqura', () => {
             .toBeTruthy(`Gregorian ${gDate} should be Hijri ${iDate.year}-${iDate.month}-${iDate.day}`);
       });
     });
+
+    it('should convert correctly from Gregorian to Hijri with time 23:59:59.999', () => {
+      DATE_TABLE.forEach(element => {
+        const iDate = new NgbDate(element[3], element[4], element[5]);
+        const gDate = new Date(element[0], element[1], element[2], 23, 59, 59, 999);
+        const iDate2 = calendar.fromGregorian(gDate);
+        expect(iDate2.equals(iDate))
+            .toBeTruthy(`Gregorian ${gDate} should be Hijri ${iDate.year}-${iDate.month}-${iDate.day}`);
+      });
+    });
   });
 
   it('should return number of days per week', () => { expect(calendar.getDaysPerWeek()).toBe(7); });

--- a/src/datepicker/hijri/ngb-calendar-islamic-umalqura.ts
+++ b/src/datepicker/hijri/ngb-calendar-islamic-umalqura.ts
@@ -141,7 +141,10 @@ const MONTH_LENGTH = [
 ];
 
 function getDaysDiff(date1: Date, date2: Date): number {
-  const diff = Math.abs(date1.getTime() - date2.getTime());
+  // Ignores the time part in date1 and date2:
+  const time1 = Date.UTC(date1.getFullYear(), date1.getMonth(), date1.getDate());
+  const time2 = Date.UTC(date2.getFullYear(), date2.getMonth(), date2.getDate());
+  const diff = Math.abs(time1 - time2);
   return Math.round(diff / ONE_DAY);
 }
 


### PR DESCRIPTION
`NgbCalendarIslamicUmalqura.fromGregorian` returned a date one day after the correct date for dates containing a time in the afternoon.

Fixes #3237

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
