### PR TITLE
fix(toast): export NgbToastModule publicly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ export {
   NgbTimepickerModule,
   NgbTimeStruct
 } from './timepicker/timepicker.module';
-export {NgbToast, NgbToastConfig, NgbToastHeader} from './toast/toast.module';
+export {NgbToast, NgbToastConfig, NgbToastHeader, NgbToastModule} from './toast/toast.module';
 export {NgbTooltip, NgbTooltipConfig, NgbTooltipModule} from './tooltip/tooltip.module';
 export {
   NgbHighlight,


### PR DESCRIPTION
Main export of NgbToastModule was missing, which basically prevented
people to write

```typescript
import {NgbToastModule} from "@ng-bootstrap/ng-bootstrap";
```

Fixes #3258
