### PR TITLE
chore: removes `ModuleWithProviders` unused import

### DIFF
--- a/src/accordion/accordion.module.ts
+++ b/src/accordion/accordion.module.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NgbAccordion, NgbPanel, NgbPanelTitle, NgbPanelContent, NgbPanelHeader, NgbPanelToggle} from './accordion';

--- a/src/alert/alert.module.ts
+++ b/src/alert/alert.module.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NgbAlert} from './alert';

--- a/src/buttons/buttons.module.ts
+++ b/src/buttons/buttons.module.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {NgbButtonLabel} from './label';
 import {NgbCheckBox} from './checkbox';
 import {NgbRadio, NgbRadioGroup} from './radio';

--- a/src/carousel/carousel.module.ts
+++ b/src/carousel/carousel.module.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NGB_CAROUSEL_DIRECTIVES} from './carousel';

--- a/src/collapse/collapse.module.ts
+++ b/src/collapse/collapse.module.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {NgbCollapse} from './collapse';
 
 export {NgbCollapse} from './collapse';

--- a/src/datepicker/datepicker.module.ts
+++ b/src/datepicker/datepicker.module.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';
 import {NgbDatepicker} from './datepicker';

--- a/src/dropdown/dropdown.module.ts
+++ b/src/dropdown/dropdown.module.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {
   NgbDropdown,
   NgbDropdownAnchor,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {ModuleWithProviders, NgModule} from '@angular/core';
+import {NgModule} from '@angular/core';
 
 import {NgbAccordionModule} from './accordion/accordion.module';
 import {NgbAlertModule} from './alert/alert.module';

--- a/src/modal/modal.module.ts
+++ b/src/modal/modal.module.ts
@@ -1,4 +1,4 @@
-import {ModuleWithProviders, NgModule} from '@angular/core';
+import {NgModule} from '@angular/core';
 
 import {NgbModal} from './modal';
 import {NgbModalBackdrop} from './modal-backdrop';

--- a/src/pagination/pagination.module.ts
+++ b/src/pagination/pagination.module.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {

--- a/src/popover/popover.module.ts
+++ b/src/popover/popover.module.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 
 import {NgbPopover, NgbPopoverWindow} from './popover';
 import {CommonModule} from '@angular/common';

--- a/src/progressbar/progressbar.module.ts
+++ b/src/progressbar/progressbar.module.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NgbProgressbar} from './progressbar';

--- a/src/rating/rating.module.ts
+++ b/src/rating/rating.module.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NgbRating} from './rating';

--- a/src/tabset/tabset.module.ts
+++ b/src/tabset/tabset.module.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NgbTabset, NgbTab, NgbTabContent, NgbTabTitle} from './tabset';

--- a/src/timepicker/timepicker.module.ts
+++ b/src/timepicker/timepicker.module.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NgbTimepicker} from './timepicker';

--- a/src/tooltip/tooltip.module.ts
+++ b/src/tooltip/tooltip.module.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 
 import {NgbTooltip, NgbTooltipWindow} from './tooltip';
 

--- a/src/typeahead/typeahead.module.ts
+++ b/src/typeahead/typeahead.module.ts
@@ -1,4 +1,4 @@
-import {NgModule, ModuleWithProviders} from '@angular/core';
+import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 import {NgbHighlight} from './highlight';


### PR DESCRIPTION
With #3231 (via 83f79cf) when all `.forRoot()` methods have been removed, cleaning unused imports has not been done.

→ `ModuleWithProviders` is not needed anymore.
