### PR TITLE
chore(demos): replaces social links buttons with static ones

### DIFF
--- a/demo/src/app/app.component.html
+++ b/demo/src/app/app.component.html
@@ -33,11 +33,17 @@
     </ul>
   </div>
 
-  <ul class="social-buttons navbar-nav flex-row ml-md-auto d-none d-lg-flex align-items-center">
-    <a class="github-button" href="https://github.com/ng-bootstrap/ng-bootstrap" rel="noopener" target="_blank" data-size="large" data-show-count="true"
-        data-count-aria-label="# stargazers on GitHub" aria-label="Star ng-bootstrap/ng-bootstrap on GitHub">Star</a>
-    <a href="https://twitter.com/intent/tweet?button_hashtag=ngbootstrap" rel="noopener" class="twitter-hashtag-button" data-size="large" data-text="I&#39;m checking out ng-bootstrap, THE Angular UI framework for Bootstrap CSS"
-        data-url="https://ng-bootstrap.github.io" data-show-count="true">Tweet #ngbootstrap</a>
+  <ul class="social-buttons navbar-nav flex-row ml-md-auto d-none d-md-flex align-items-center">
+    <a
+      href="https://github.com/ng-bootstrap/ng-bootstrap"
+      rel="nofollow noopener noreferrer" target="_blank"
+      title="Open ng-bootstrap/ng-bootstrap on GitHub"
+    ><svg:svg aria-hidden="true" ngbdIcon="github"></svg:svg></a>
+    <a
+      href="https://twitter.com/intent/tweet?text=I&#39;m+checking+out+&#23;ng-bootstrap,+THE+Angular+UI+framework+for+Bootstrap+CSS&url=https%3A%2F%2Fng-bootstrap.github.io%2F&hashtags=ng-bootstrap,angular,bootstrap"
+      rel="nofollow noopener noreferrer" target="_blank"
+      title="Tweet #ngbootstrap"
+    ><svg:svg aria-hidden="true" ngbdIcon="twitter"></svg:svg></a>
   </ul>
 
   <button class="navbar-toggler navbar-toggler-right" type="button" (click)="navbarCollapsed = !navbarCollapsed" [attr.aria-expanded]="!navbarCollapsed"

--- a/demo/src/public/index.html
+++ b/demo/src/public/index.html
@@ -46,6 +46,4 @@
   <body>
     <ngbd-app></ngbd-app>
   </body>
-  <script async defer id="github-bjs" src="https://buttons.github.io/buttons.js"></script>
-  <script async defer src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </html>

--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -27,8 +27,11 @@ header.navbar {
   }
 }
 
-.social-buttons > iframe {
-  margin-left: 0.75rem;
+.social-buttons {
+  svg {
+    margin-left: 1rem;
+    fill: #fff;
+  }
 }
 
 .sidebar-collapsed {


### PR DESCRIPTION
Simply removes both social links buttons for Github and Twitter.
Replaces them with static links, pointing to the right location.

Both links have the proper `target="_blank"` associated with the `rel="nofollow noopener noreferrer"` combo.

Visual aspect of the new look

![image](https://user-images.githubusercontent.com/1152740/60332832-e6a20500-9997-11e9-96be-1eadee2f99e2.png)

Twitter link is still using the [Web Intent](https://developer.twitter.com/en/docs/twitter-for-websites/tweet-button/guides/web-intent.html) API, and clicking it will forward you to Twitter with

![image](https://user-images.githubusercontent.com/1152740/60333242-c9216b00-9998-11e9-999d-36c5c95382d0.png)


Fixes #3254