### PR TITLE
docs(table): fixed search for complete example

### DIFF
--- a/demo/src/app/components/table/demos/complete/country.service.ts
+++ b/demo/src/app/components/table/demos/complete/country.service.ts
@@ -37,7 +37,7 @@ function sort(countries: Country[], column: string, direction: string): Country[
 }
 
 function matches(country: Country, term: string, pipe: PipeTransform) {
-  return country.name.toLowerCase().includes(term)
+  return country.name.toLowerCase().includes(term.toLowerCase())
     || pipe.transform(country.area).includes(term)
     || pipe.transform(country.population).includes(term);
 }


### PR DESCRIPTION
I noticed a small inconsistency on the demos for the table component. I searched for the term
"China" and expected it to return exactly one result, but none matched. The other table
demos handle this case correctly, so I thought something must be wrong with the complete example.
Turns out, there was just a `.toLowerCase()` missing, when the name of the country was compared to the search term. 

<hr>

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
