### PR TITLE
fix(typeahead): for editable false clear the value on input change

### DIFF
--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -219,17 +219,10 @@ export class NgbTypeahead implements ControlValueAccessor,
   ngOnInit(): void {
     const inputValues$ = this._valueChanges.pipe(tap(value => {
       this._inputValueBackup = this.showHint ? value : null;
-      if (this.editable) {
-        this._onChange(value);
-      }
+      this._onChange(this.editable ? value : undefined);
     }));
     const results$ = inputValues$.pipe(this.ngbTypeahead);
-    const processedResults$ = results$.pipe(tap(() => {
-      if (!this.editable) {
-        this._onChange(undefined);
-      }
-    }));
-    const userInput$ = this._resubscribeTypeahead.pipe(switchMap(() => processedResults$));
+    const userInput$ = this._resubscribeTypeahead.pipe(switchMap(() => results$));
     this._subscription = this._subscribeToUserInput(userInput$);
   }
 


### PR DESCRIPTION
- for editable false clear the value on input change instead of on suggestions fetched

Closes #3262

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated any applicable tests. - I feel like for the code left there is good coverage. The code that was deleted was not covered properly
 - [ ] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.
