### PR TITLE
fix(dropdown): remove x-placement inside a navbar

### DIFF
--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -368,6 +368,7 @@ describe('ngb-dropdown-toggle', () => {
       const dropdownEl: HTMLElement = compiled.querySelector('[ngbdropdownmenu]');
 
       expect(dropdownEl.getAttribute('style')).toBeNull(`The dropdown element shouldn't have calculated styles`);
+      expect(dropdownEl.getAttribute('x-placement')).toBeNull(`The dropdown element shouldn't have x-placement set`);
 
     });
 

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -407,7 +407,7 @@ export class NgbDropdown implements OnInit, OnDestroy {
       // remove the current placement classes
       renderer.removeClass(dropdownElement, 'dropup');
       renderer.removeClass(dropdownElement, 'dropdown');
-      this._menu.placement = placement;
+      this._menu.placement = this.display === 'static' ? null : placement;
 
       /*
       * apply the new placement


### PR DESCRIPTION
fix #3269 when the dropdown is inside a navbar