### PR TITLE
fix(modal): component based content was not scrollable

### DIFF
--- a/src/modal/modal-window.ts
+++ b/src/modal/modal-window.ts
@@ -8,7 +8,8 @@ import {
   Input,
   OnDestroy,
   OnInit,
-  Output
+  Output,
+  ViewEncapsulation,
 } from '@angular/core';
 
 import {getFocusableBoundaryElements} from '../util/focus-trap';
@@ -30,7 +31,9 @@ import {ModalDismissReasons} from './modal-dismiss-reasons';
      (scrollable ? ' modal-dialog-scrollable' : '')" role="document">
         <div class="modal-content"><ng-content></ng-content></div>
     </div>
-    `
+    `,
+  encapsulation: ViewEncapsulation.None,
+  styleUrls: ['./modal.scss']
 })
 export class NgbModalWindow implements OnInit,
     AfterViewInit, OnDestroy {

--- a/src/modal/modal.scss
+++ b/src/modal/modal.scss
@@ -1,0 +1,7 @@
+ngb-modal-window {
+  .component-host-scrollable {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+}

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -10,10 +10,8 @@ import {
   ViewChild
 } from '@angular/core';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-
 import {NgbModalConfig} from './modal-config';
 import {NgbActiveModal, NgbModal, NgbModalModule, NgbModalRef} from './modal.module';
-
 
 const NOOP = () => {};
 
@@ -810,6 +808,16 @@ describe('ngb-modal', () => {
         fixture.detectChanges();
         expect(fixture.nativeElement).toHaveModal('foo');
         expect(document.querySelector('.modal-dialog')).toHaveCssClass('modal-dialog-scrollable');
+
+        modalInstance.close();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveModal();
+      });
+
+      it('should add specific styling to content component host', () => {
+        const modalInstance = fixture.componentInstance.openCmpt(DestroyableCmpt, {scrollable: true});
+        fixture.detectChanges();
+        expect(document.querySelector('destroyable-cmpt')).toHaveCssClass('component-host-scrollable');
 
         modalInstance.close();
         fixture.detectChanges();


### PR DESCRIPTION
In `5.0.0` we introduced the bootstrap scrollable content feature.
This behaviour appears to be broken with modal that have content generated
from a component. Overall styling is wrong, resulting in a broken modal
not scrollable.

~~The fix is duplicating the `.modal-content` css class on the component
host itself that will thus act as the
original `<div class="modal-content">`~~

~~**EDIT** after 32c400f : The fix is adding some extra styling in order to force the component
host to fit inside the parent `.model-content` flex display.~~

**EDIT** after 222752d: The fix is now adding some styling via a class to benefit from autoprefixer as IE10 does not understand `display: flex`

Fixes #3281