### PR TITLE
fix(popover): apply arrow styles to direct descendant

### DIFF
--- a/src/popover/popover.scss
+++ b/src/popover/popover.scss
@@ -2,36 +2,36 @@
 $arrow-size: 1rem;
 
 ngb-popover-window {
-  &.bs-popover-top .arrow,
-  &.bs-popover-bottom .arrow {
+  &.bs-popover-top > .arrow,
+  &.bs-popover-bottom > .arrow {
     left: 50%;
     margin-left: -$arrow-size / 2;
   }
 
-  &.bs-popover-top-left .arrow,
-  &.bs-popover-bottom-left .arrow {
+  &.bs-popover-top-left > .arrow,
+  &.bs-popover-bottom-left > .arrow {
     left: 2em;
   }
 
-  &.bs-popover-top-right .arrow,
-  &.bs-popover-bottom-right .arrow {
+  &.bs-popover-top-right > .arrow,
+  &.bs-popover-bottom-right > .arrow {
     left: auto;
     right: 2em;
   }
 
-  &.bs-popover-left .arrow,
-  &.bs-popover-right .arrow {
+  &.bs-popover-left > .arrow,
+  &.bs-popover-right > .arrow {
     top: 50%;
     margin-top: -$arrow-size / 2;
   }
 
-  &.bs-popover-left-top .arrow,
-  &.bs-popover-right-top .arrow {
+  &.bs-popover-left-top > .arrow,
+  &.bs-popover-right-top > .arrow {
     top: 0.7em;
   }
 
-  &.bs-popover-left-bottom .arrow,
-  &.bs-popover-right-bottom .arrow {
+  &.bs-popover-left-bottom > .arrow,
+  &.bs-popover-right-bottom > .arrow {
     top: auto;
     bottom: 0.7em;
   }


### PR DESCRIPTION
To stick with Bootstrap, since https://github.com/twbs/bootstrap/pull/27750

It hasn't been done for the tooltip, I just do the change for the popover.