### PR TITLE
feat(datepicker): place active day above its siblings

### DIFF
--- a/src/datepicker/datepicker-month-view.scss
+++ b/src/datepicker/datepicker-month-view.scss
@@ -34,5 +34,9 @@ ngb-datepicker-month-view {
     &.hidden {
       cursor: default;
     }
+
+    &[tabindex="0"] {
+      z-index: 1;
+    }
   }
 }


### PR DESCRIPTION
This is minor change that moves currently focus day within month view
above its siblings to let its outline be correctly rendered.
This is similar to minor stylistic corrections found in the BS:
https://git.io/fjyfh

The before rendering (Chrome/Mac OS):

<img width="480" alt="Screenshot 2019-07-25 at 22 13 59" src="https://user-images.githubusercontent.com/14539/61905616-c2e7c580-af29-11e9-8f65-de271c68492b.png">

And after the change:
<img width="480" alt="Screenshot 2019-07-25 at 22 14 23" src="https://user-images.githubusercontent.com/14539/61905636-cbd89700-af29-11e9-9c39-280c3eb672da.png">



Thanks!
