### PR TITLE
docs(datepicker): example svg symbol icon with states

### DIFF
--- a/demo/src/app/components/datepicker/demos/adapter/datepicker-adapter.html
+++ b/demo/src/app/components/datepicker/demos/adapter/datepicker-adapter.html
@@ -20,7 +20,11 @@ In this example we are converting from and to a JS native Date object</p>
           <input class="form-control" placeholder="yyyy-mm-dd"
                  name="d2" #c2="ngModel" [(ngModel)]="model2" ngbDatepicker #d2="ngbDatepicker">
           <div class="input-group-append">
-            <button class="btn btn-outline-secondary calendar" (click)="d2.toggle()" type="button"></button>
+            <button class="btn btn-outline-secondary calendar" (click)="d2.toggle()" type="button">
+                <svg>
+                  <use xlink:href="#dp-calendar"></use>
+                </svg>
+            </button>
           </div>
         </div>
       </div>

--- a/demo/src/app/components/datepicker/demos/customday/datepicker-customday.html
+++ b/demo/src/app/components/datepicker/demos/customday/datepicker-customday.html
@@ -6,7 +6,11 @@
       <input class="form-control" placeholder="yyyy-mm-dd"
              name="dp" [(ngModel)]="model" ngbDatepicker [dayTemplate]="customDay" [markDisabled]="isDisabled" #d="ngbDatepicker">
       <div class="input-group-append">
-        <button class="btn btn-outline-secondary calendar" (click)="d.toggle()" type="button"></button>
+        <button class="btn btn-outline-secondary calendar" (click)="d.toggle()" type="button">
+            <svg>
+                <use xlink:href="#dp-calendar"></use>
+            </svg>
+        </button>
       </div>
     </div>
   </div>

--- a/demo/src/app/components/datepicker/demos/footertemplate/datepicker-footertemplate.html
+++ b/demo/src/app/components/datepicker/demos/footertemplate/datepicker-footertemplate.html
@@ -6,7 +6,11 @@
       <input class="form-control" placeholder="yyyy-mm-dd"
              name="dp" [(ngModel)]="model" ngbDatepicker [footerTemplate]="footerTemplate" #d="ngbDatepicker">
       <div class="input-group-append">
-        <button class="btn btn-outline-secondary calendar" (click)="d.toggle()" type="button"></button>
+        <button class="btn btn-outline-secondary calendar" (click)="d.toggle()" type="button">
+            <svg>
+                <use xlink:href="#dp-calendar"></use>
+            </svg>
+        </button>
       </div>
     </div>
   </div>

--- a/demo/src/app/components/datepicker/demos/multiple/datepicker-multiple.html
+++ b/demo/src/app/components/datepicker/demos/multiple/datepicker-multiple.html
@@ -12,7 +12,11 @@
              name="dp" [displayMonths]="displayMonths" [navigation]="navigation" [outsideDays]="outsideDays"
              [showWeekNumbers]="showWeekNumbers" ngbDatepicker #d="ngbDatepicker">
       <div class="input-group-append">
-        <button class="btn btn-outline-secondary calendar" (click)="d.toggle()" type="button"></button>
+        <button class="btn btn-outline-secondary calendar" (click)="d.toggle()" type="button">
+            <svg>
+                <use xlink:href="#dp-calendar"></use>
+            </svg>
+        </button>
       </div>
     </div>
   </div>

--- a/demo/src/app/components/datepicker/demos/popup/datepicker-popup.html
+++ b/demo/src/app/components/datepicker/demos/popup/datepicker-popup.html
@@ -4,7 +4,11 @@
       <input class="form-control" placeholder="yyyy-mm-dd"
              name="dp" [(ngModel)]="model" ngbDatepicker #d="ngbDatepicker">
       <div class="input-group-append">
-        <button class="btn btn-outline-secondary calendar" (click)="d.toggle()" type="button"></button>
+        <button class="btn btn-outline-secondary calendar" (click)="d.toggle()" type="button">
+            <svg>
+                <use xlink:href="#dp-calendar"></use>
+            </svg>
+        </button>
       </div>
     </div>
   </div>

--- a/demo/src/app/components/datepicker/demos/positiontarget/datepicker-positiontarget.html
+++ b/demo/src/app/components/datepicker/demos/positiontarget/datepicker-positiontarget.html
@@ -7,7 +7,11 @@
              name="dp" [(ngModel)]="model" ngbDatepicker #d="ngbDatepicker"
              [placement]="placement" [positionTarget]="buttonEl">
       <div class="input-group-append">
-        <button #buttonEl class="btn btn-outline-secondary calendar" (click)="d.toggle()" type="button"></button>
+        <button #buttonEl class="btn btn-outline-secondary calendar" (click)="d.toggle()" type="button">
+            <svg>
+                <use xlink:href="#dp-calendar"></use>
+            </svg>
+        </button>
       </div>
     </div>
   </div>

--- a/demo/src/app/components/modal/demos/basic/modal-basic.html
+++ b/demo/src/app/components/modal/demos/basic/modal-basic.html
@@ -12,7 +12,11 @@
         <div class="input-group">
           <input id="dateOfBirth" class="form-control" placeholder="yyyy-mm-dd" name="dp" ngbDatepicker #dp="ngbDatepicker">
           <div class="input-group-append">
-            <button class="btn btn-outline-secondary calendar" (click)="dp.toggle()" type="button"></button>
+            <button class="btn btn-outline-secondary calendar" (click)="dp.toggle()" type="button">
+                <svg>
+                    <use xlink:href="#dp-calendar"></use>
+                </svg>
+            </button>
           </div>
         </div>
       </div>

--- a/demo/src/app/shared/component-wrapper/component-wrapper.component.html
+++ b/demo/src/app/shared/component-wrapper/component-wrapper.component.html
@@ -1,3 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="d-none">
+  <!-- definitions of svg sumbols reused here and in child components -->
+  <defs>
+      <symbol id="dp-calendar" viewBox="0 0 24 24">
+          <path d="M20 20h-4v-4h4v4zm-6-10h-4v4h4v-4zm6 0h-4v4h4v-4zm-12 6h-4v4h4v-4zm6 0h-4v4h4v-4zm-6-6h-4v4h4v-4zm16-8v22h-24v-22h3v1c0 1.103.897 2 2 2s2-.897 2-2v-1h10v1c0 1.103.897 2 2 2s2-.897 2-2v-1h3zm-2 6h-20v14h20v-14zm-2-7c0-.552-.447-1-1-1s-1 .448-1 1v2c0 .552.447 1 1 1s1-.448 1-1v-2zm-14 2c0 .552-.447 1-1 1s-1-.448-1-1v-2c0-.552.447-1 1-1s1 .448 1 1v2z"/>
+      </symbol>
+  </defs>
+</svg>
 <div class="container-fluid">
   <div class="row flex-xl-nowrap">
     <div class="col-12 col-lg-2"

--- a/demo/src/style/demos.css
+++ b/demo/src/style/demos.css
@@ -1,11 +1,17 @@
 /* Datepicker popup icon */
 
-button.calendar, button.calendar:active {
+button.calendar {
   width: 2.75rem;
-  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACIAAAAcCAYAAAAEN20fAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAOxAAADsQBlSsOGwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAEUSURBVEiJ7ZQxToVAEIY/YCHGxN6XGOIpnpaEsBSeQC9ArZbm9TZ6ADyBNzAhQGGl8Riv4BLAWAgmkpBYkH1b8FWT2WK/zJ8ZJ4qiI6XUI3ANnGKWBnht2/ZBDRK3hgVGNsCd7/ui+JkEIrKtqurLpEWaphd933+IyI3LEIdpCYCiKD6HcuOa/nwOa0ScJEnk0BJg0UTUWJRl6RxCYEzEmomsIlPU3IPW+grIAbquy+q6fluy/28RIBeRMwDXdXMgXLj/B2uimRXpui4D9sBeRLKl+1N+L+t6RwbWrZliTTTr1oxYtzVWiTQAcRxvTX+eJMnlUDaO1vpZRO5NS0x48sIwfPc87xg4B04MCzQi8hIEwe4bl1DnFMCN2zsAAAAASUVORK5CYII=') !important;
-  background-repeat: no-repeat;
-  background-size: 23px;
-  background-position: center;
+}
+
+button.calendar svg {
+  position: relative;
+  top: -.125em;
+  display: inline-flex;
+  align-self: center;
+  width: 1.25em;
+  height: 1.25em;
+  fill: currentColor;
 }
 
 /* Sortable table demo */


### PR DESCRIPTION
This commit introduces SVG based calendar icon that follows colors of
the current theme by using `fill` with `currentColor`. This provides
usage scenario of the icon similar to real life ones.

Calendar icon svg picked as replacement from png file content comes from icon library referenced in the project: https://iconmonstr.com/calendar-4-svg/

Closes 3313

If accepted, it could be used as the base of the sample note on how to  provide custom icons for datepicker component as didscussed e.g. in #3306 and also to move other icons reused in wrapper template into definition section and reuse them in the page.
Relying on the current color allows to use any theme from Bootstrap palette, e.g.:

<img width="749" alt="Screenshot 2019-07-27 at 22 57 10" src="https://user-images.githubusercontent.com/14539/61999475-ee9db380-b0c1-11e9-987b-f19ff1e3df56.png">

