### PR TITLE
fix(dropdown): remove aria-haspop for accessibility

### DIFF
--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -279,7 +279,6 @@ describe('ngb-dropdown-toggle', () => {
     let buttonEl = compiled.querySelector('button');
 
     expect(dropdownEl).not.toHaveCssClass('show');
-    expect(buttonEl.getAttribute('aria-haspopup')).toBe('true');
     expect(buttonEl.getAttribute('aria-expanded')).toBe('false');
 
     buttonEl.click();

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -86,10 +86,8 @@ export class NgbDropdownMenu {
  *
  * @since 1.1.0
  */
-@Directive({
-  selector: '[ngbDropdownAnchor]',
-  host: {'class': 'dropdown-toggle', 'aria-haspopup': 'true', '[attr.aria-expanded]': 'dropdown.isOpen()'}
-})
+@Directive(
+    {selector: '[ngbDropdownAnchor]', host: {'class': 'dropdown-toggle', '[attr.aria-expanded]': 'dropdown.isOpen()'}})
 export class NgbDropdownAnchor {
   anchorEl;
 
@@ -109,7 +107,6 @@ export class NgbDropdownAnchor {
   selector: '[ngbDropdownToggle]',
   host: {
     'class': 'dropdown-toggle',
-    'aria-haspopup': 'true',
     '[attr.aria-expanded]': 'dropdown.isOpen()',
     '(click)': 'dropdown.toggle()',
     '(keydown.ArrowUp)': 'dropdown.onKeyDown($event)',


### PR DESCRIPTION
Closes #3331

To remove aria-haspop from the dropdown component to allow the component to
be read by screen reader like NVDA/JAWS. To make the dropdown component
more accessible

BREAKING CHANGE: None

Before submitting a pull request, please make sure you have at least performed the following:

 - [] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [] built and tested the changes locally.
 - [] added/updated any applicable tests.
 - [] added/updated any applicable API documentation.
 - [] added/updated any applicable demos.
