### PR TITLE
fix(a11y): make datepicker more accessible

### DIFF
--- a/src/datepicker/datepicker-month-view.ts
+++ b/src/datepicker/datepicker-month-view.ts
@@ -12,7 +12,7 @@ import {DayTemplateContext} from './datepicker-day-template-context';
   template: `
     <div *ngIf="showWeekdays" class="ngb-dp-week ngb-dp-weekdays bg-light">
       <div *ngIf="showWeekNumbers" class="ngb-dp-weekday ngb-dp-showweek"></div>
-      <div *ngFor="let w of month.weekdays" class="ngb-dp-weekday small">
+      <div *ngFor="let w of month.weekdays" class="ngb-dp-weekday small" role="columnheader">
         {{ i18n.getWeekdayShortName(w) }}
       </div>
     </div>


### PR DESCRIPTION
A finding of an a11y test on a project, where the Datepicker is used, was that the proposed columnheader role is missing, thus making the datepicker not accessible for blind users.

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [] added/updated any applicable tests.
 - [] added/updated any applicable API documentation.
 - [] added/updated any applicable demos.
