### PR TITLE
feat(typeahead): add emitted event example

### DIFF
--- a/demo/src/app/components/typeahead/demos/template/typeahead-template.html
+++ b/demo/src/app/components/typeahead/demos/template/typeahead-template.html
@@ -9,6 +9,6 @@
 
 <label for="typeahead-template">Search for a state:</label>
 <input id="typeahead-template" type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search" [resultTemplate]="rt"
-  [inputFormatter]="formatter" />
+  [inputFormatter]="formatter" (selectItem)="selectItem($event)" />
 <hr>
 <pre>Model: {{ model | json }}</pre>

--- a/demo/src/app/components/typeahead/demos/template/typeahead-template.ts
+++ b/demo/src/app/components/typeahead/demos/template/typeahead-template.ts
@@ -75,4 +75,6 @@ export class NgbdTypeaheadTemplate {
 
   formatter = (x: {name: string}) => x.name;
 
+  selectItem = (event) => console.log(event.item);
+
 }


### PR DESCRIPTION
Add an example of the emitted event (selectItem) to save learning time. If I knew this custom event existed in an example I would have saved time hunting through existing events for one that works like that. 

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
