### PR TITLE
chore(datepicker): native date adapter defaults to midnight

### DIFF
--- a/src/datepicker/adapters/ngb-date-native-adapter.spec.ts
+++ b/src/datepicker/adapters/ngb-date-native-adapter.spec.ts
@@ -35,12 +35,12 @@ describe('ngb-date-native model adapter', () => {
     });
 
     it('should convert a valid date',
-       () => { expect(adapter.toModel({year: 2016, month: 10, day: 15})).toEqual(new Date(2016, 9, 15, 12)); });
+       () => { expect(adapter.toModel({year: 2016, month: 10, day: 15})).toEqual(new Date(2016, 9, 15)); });
 
     it('should convert years between 0 and 99 correctly', () => {
 
       function jsDate(jsYear: number, jsMonth: number, jsDay: number): Date {
-        const date = new Date(jsYear, jsMonth, jsDay, 12);
+        const date = new Date(jsYear, jsMonth, jsDay);
         if (jsYear >= 0 && jsYear <= 99) {
           date.setFullYear(jsYear);
         }

--- a/src/datepicker/adapters/ngb-date-native-adapter.ts
+++ b/src/datepicker/adapters/ngb-date-native-adapter.ts
@@ -29,7 +29,7 @@ export class NgbDateNativeAdapter extends NgbDateAdapter<Date> {
   }
 
   protected _toNativeDate(date: NgbDateStruct): Date {
-    const jsDate = new Date(date.year, date.month - 1, date.day, 12);
+    const jsDate = new Date(date.year, date.month - 1, date.day);
     // avoid 30 -> 1930 conversion
     jsDate.setFullYear(date.year);
     return jsDate;


### PR DESCRIPTION
This changes the default time hour computed by native date adapter to be
a midnight, which is default for default Date object when no hours are
set and aligns the behaviour with the UTC date adapter one.

The current behaviour (being changed by this PR), has been introduced without a comment here, changing the default `Date` object constructor defaulting to midnight, instead defaulting to noon:
https://github.com/ng-bootstrap/ng-bootstrap/commit/83930cd84190a077f0305b4f450b1485546bd874#diff-9f982ce59e7ca1c194d2a43bd90a2e4fR13


Fixes: #3340