### PR TITLE
demo: provide a scrollbar on the sidebar for short height

### DIFF
--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -44,6 +44,9 @@ header.navbar {
 .sidebar {
   position: sticky;
   top: 1rem;
+  max-height: 100vh;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 header.title {


### PR DESCRIPTION
The side bar is not easily usable when the device height is too short, on laptop for example.