### PR TITLE
chore: add demo serve configuration for IE/es5

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -102,6 +102,9 @@
               "extractLicenses": true,
               "vendorChunk": false,
               "buildOptimizer": true
+            },
+            "ie": {
+              "tsConfig": "demo/tsconfig.ie.json"
             }
           }
         },
@@ -113,6 +116,9 @@
           "configurations": {
             "production": {
               "browserTarget": "demo:build:production"
+            },
+            "ie": {
+              "browserTarget": "demo:build:ie"
             }
           }
         },

--- a/demo/tsconfig.ie.json
+++ b/demo/tsconfig.ie.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "es5"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "tdd": "yarn ngb:tdd",
     "e2e": "yarn e2e-app:lint && yarn ngb:e2e && yarn demo:e2e",
     "demo": "yarn demo:docs && yarn demo:stackblitzes && yarn demo:serve",
+    "demo:ie": "yarn demo -c ie",
     "ssr": "yarn ssr-app:lint && yarn ssr-app:build && yarn ssr-app:e2e",
     "changelog": "conventional-changelog --preset angular --infile CHANGELOG.md --same-file --release-count 1",
     "check-format": "ts-node --project misc/tsconfig.json misc/check-format.ts",


### PR DESCRIPTION
Apparently, a separate build configuration is required for Angular CLI 8 targeting `es5` for serving during development. Production build is unchanged.