### PR TITLE
fix(progressbar): display progressbar correctly for invalid max value

### DIFF
--- a/src/progressbar/progressbar.spec.ts
+++ b/src/progressbar/progressbar.spec.ts
@@ -58,6 +58,48 @@ describe('ngb-progressbar', () => {
       expect(progressCmp.getPercentValue()).toBe(20);
     });
 
+    it('should calculate the percentage (custom max size of null)', () => {
+      progressCmp.max = null;
+
+      progressCmp.value = 25;
+      expect(progressCmp.getPercentValue()).toBe(25);
+    });
+
+    it('should calculate the percentage (custom max size of undefined)', () => {
+      progressCmp.max = undefined;
+
+      progressCmp.value = 25;
+      expect(progressCmp.getPercentValue()).toBe(25);
+    });
+
+    it('should calculate the percentage (custom max size of zero)', () => {
+      progressCmp.max = 0;
+
+      progressCmp.value = 25;
+      expect(progressCmp.getPercentValue()).toBe(25);
+    });
+
+    it('should calculate the percentage (custom negative max size)', () => {
+      progressCmp.max = -10;
+
+      progressCmp.value = 25;
+      expect(progressCmp.getPercentValue()).toBe(25);
+    });
+
+    it('should calculate the percentage (custom max size of positive infinity)', () => {
+      progressCmp.max = Number.POSITIVE_INFINITY;
+
+      progressCmp.value = 25;
+      expect(progressCmp.getPercentValue()).toBe(25);
+    });
+
+    it('should calculate the percentage (custom max size of negative infinity)', () => {
+      progressCmp.max = Number.NEGATIVE_INFINITY;
+
+      progressCmp.value = 25;
+      expect(progressCmp.getPercentValue()).toBe(25);
+    });
+
     it('should set the value to 0 for negative numbers', () => {
       progressCmp.value = -20;
       expect(progressCmp.getValue()).toBe(0);

--- a/src/progressbar/progressbar.ts
+++ b/src/progressbar/progressbar.ts
@@ -1,5 +1,5 @@
 import {Component, Input, ChangeDetectionStrategy} from '@angular/core';
-import {getValueInRange} from '../util/util';
+import {getValueInRange, isNumber} from '../util/util';
 import {NgbProgressbarConfig} from './progressbar-config';
 
 /**
@@ -19,10 +19,17 @@ import {NgbProgressbarConfig} from './progressbar-config';
   `
 })
 export class NgbProgressbar {
+  private _max: number;
+
   /**
    * The maximal value to be displayed in the progress bar.
    */
-  @Input() max: number;
+  @Input()
+  set max(max: number) {
+    this._max = !isNumber(max) || max <= 0 ? 100 : max;
+  }
+
+  get max(): number { return this._max; }
 
   /**
    * If `true`, the stripes on the progress bar are animated.

--- a/src/progressbar/progressbar.ts
+++ b/src/progressbar/progressbar.ts
@@ -23,6 +23,8 @@ export class NgbProgressbar {
 
   /**
    * The maximal value to be displayed in the progress bar.
+   *
+   * Should be a positive number. Will default to 100 otherwise.
    */
   @Input()
   set max(max: number) {


### PR DESCRIPTION
closes #3386

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.

Currently the following is displayed when max is set to 0, null or undefined:
![image](https://user-images.githubusercontent.com/11138584/66216433-c1731000-e6c5-11e9-9b7e-73813328d31d.png)

After this change the max value will be set to 100 if it is invalid so that a progressbar with a valid value can be displayed.