### PR TITLE
chore(toast): remove unused css host class binding

### DIFF
--- a/src/toast/toast.spec.ts
+++ b/src/toast/toast.spec.ts
@@ -35,6 +35,8 @@ describe('ngb-toast', () => {
       const body = getToastBodyElement(fixture);
 
       expect(toast).toBeDefined();
+      expect(toast).toHaveCssClass('toast');
+      expect(toast).toHaveCssClass('show');
       expect(header).toBeDefined();
       expect(body).toBeDefined();
     });

--- a/src/toast/toast.ts
+++ b/src/toast/toast.ts
@@ -41,7 +41,6 @@ export class NgbToastHeader {
     'aria-atomic': 'true',
     '[class.toast]': 'true',
     '[class.show]': 'true',
-    '[class.autohide]': 'autohide',
   },
   template: `
     <ng-template #headerTpl>


### PR DESCRIPTION
This is cleanup change, removing unused binding from source code.

Closes: #3383

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.