### PR TITLE
docs(datepicker): add information about datepicker icon (#3306)

### DIFF
--- a/demo/src/app/components/datepicker/demos/popup/datepicker-popup.html
+++ b/demo/src/app/components/datepicker/demos/popup/datepicker-popup.html
@@ -12,3 +12,9 @@
 
 <hr/>
 <pre>Model: {{ model | json }}</pre>
+
+<ngb-alert class="mt-3 mb-0" type="info" [dismissible]="false">
+  You must provide the icon for the button. This allows you
+  to choose an icon that matches your application's style.
+  In this example, the icon is set via a CSS class.
+</ngb-alert>

--- a/demo/src/app/components/datepicker/overview/datepicker-overview.component.html
+++ b/demo/src/app/components/datepicker/overview/datepicker-overview.component.html
@@ -67,6 +67,13 @@
     a date is selected via keyboard or mouse.
     It can stay open after date selection if you set <code>[autoClose]</code> input to <code>false</code>
   </p>
+
+  <p>
+    When using a button (or any other element) to open the popup, the styling and content of the button
+    is left up to you. In the example above, the button is simply given the text "Toggle", but you
+    could also use an icon, or even group the <code>input</code> and <code>button</code> with an
+    <a href="https://getbootstrap.com/docs/{{ bootstrapVersion }}/components/input-group/#button-addons">input group</a>.
+  </p>
 </ngbd-overview-section>
 
 

--- a/demo/src/app/components/datepicker/overview/datepicker-overview.component.ts
+++ b/demo/src/app/components/datepicker/overview/datepicker-overview.component.ts
@@ -1,5 +1,7 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 
+import { environment } from '../../../../environments/environment';
+
 import {Snippet} from '../../../shared/code/snippet';
 import { NgbdDemoList } from '../../shared';
 import { NgbdOverview } from '../../shared/overview';
@@ -177,6 +179,8 @@ export class NgbdDatepickerOverviewComponent {
       `,
     }),
   };
+
+  bootstrapVersion = environment.bootstrap;
 
   sections: NgbdOverview = {};
 


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.

Fixes #3306 by adding an "info" alert below the "Datepicker in a popup" demo explaining that you must provide the icon yourself.