### PR TITLE
fix(modal): add missing fields to `NgbModalConfig`

### DIFF
--- a/src/modal/modal-config.spec.ts
+++ b/src/modal/modal-config.spec.ts
@@ -1,0 +1,21 @@
+import {inject} from '@angular/core/testing';
+
+import {NgbModalConfig} from './modal-config';
+
+describe('NgbModalConfig', () => {
+
+  it('should have sensible default values', inject([NgbModalConfig], (config: NgbModalConfig) => {
+
+       expect(config.ariaLabelledBy).toBeUndefined();
+       expect(config.backdrop).toBe(true);
+       expect(config.backdropClass).toBeUndefined();
+       expect(config.beforeDismiss).toBeUndefined();
+       expect(config.centered).toBeUndefined();
+       expect(config.container).toBeUndefined();
+       expect(config.injector).toBeUndefined();
+       expect(config.keyboard).toBe(true);
+       expect(config.scrollable).toBeUndefined();
+       expect(config.size).toBeUndefined();
+       expect(config.windowClass).toBeUndefined();
+     }));
+});

--- a/src/modal/modal-config.ts
+++ b/src/modal/modal-config.ts
@@ -95,6 +95,15 @@ export interface NgbModalOptions {
 */
 @Injectable({providedIn: 'root'})
 export class NgbModalConfig implements NgbModalOptions {
+  ariaLabelledBy?: string;
   backdrop: boolean | 'static' = true;
+  beforeDismiss?: () => boolean | Promise<boolean>;
+  centered?: boolean;
+  container?: string;
+  injector?: Injector;
   keyboard = true;
+  scrollable?: boolean;
+  size?: 'sm' | 'lg' | 'xl';
+  windowClass?: string;
+  backdropClass?: string;
 }

--- a/src/modal/modal-config.ts
+++ b/src/modal/modal-config.ts
@@ -94,16 +94,16 @@ export interface NgbModalOptions {
 * @since 3.1.0
 */
 @Injectable({providedIn: 'root'})
-export class NgbModalConfig implements NgbModalOptions {
-  ariaLabelledBy?: string;
+export class NgbModalConfig implements Required<NgbModalOptions> {
+  ariaLabelledBy: string;
   backdrop: boolean | 'static' = true;
-  beforeDismiss?: () => boolean | Promise<boolean>;
-  centered?: boolean;
-  container?: string;
-  injector?: Injector;
+  beforeDismiss: () => boolean | Promise<boolean>;
+  centered: boolean;
+  container: string;
+  injector: Injector;
   keyboard = true;
-  scrollable?: boolean;
-  size?: 'sm' | 'lg' | 'xl';
-  windowClass?: string;
-  backdropClass?: string;
+  scrollable: boolean;
+  size: 'sm' | 'lg' | 'xl';
+  windowClass: string;
+  backdropClass: string;
 }


### PR DESCRIPTION
This fixes compile error when a user tries to set any of this fields in a `NgbModalConfig` instance.

![изображение](https://user-images.githubusercontent.com/1297574/66420928-919e7200-ea0f-11e9-887d-37a79355920a.png)


Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.
