### PR TITLE
test(rating): add missing coverage block

### DIFF
--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -484,6 +484,14 @@ describe('ngb-rating', () => {
       fixture.detectChanges();
       expect(getState(element.nativeElement)).toEqual([true, true, true, false, false]);
       expect(event.preventDefault).toHaveBeenCalled();
+
+      // any other -> 0
+      event = createKeyDownEvent(Key.Space);
+      const expectedState = getState(element.nativeElement);
+      element.triggerEventHandler('keydown', event);
+      fixture.detectChanges();
+      expect(getState(element.nativeElement)).toEqual(expectedState);
+      expect(event.preventDefault).not.toHaveBeenCalled();
     });
 
     it('should handle home/end keys', () => {


### PR DESCRIPTION
This should cover missing block in the coverage for `rating.ts`.

Thanks!
