### PR TITLE
test(ie): local configuration for InternetExplorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "karma-chrome-launcher": "~2.2.0",
     "karma-coverage-istanbul-reporter": "~2.0.1",
     "karma-firefox-launcher": "^1.0.0",
+    "karma-ie-launcher": "^1.0.0",
     "karma-jasmine": "~2.0.1",
     "karma-sauce-launcher": "^2.0.2",
     "marked": "^0.7.0",

--- a/src/karma.conf.js
+++ b/src/karma.conf.js
@@ -12,6 +12,7 @@ module.exports = function (config) {
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
       require('karma-firefox-launcher'),
+      require('karma-ie-launcher'),
       require('karma-coverage-istanbul-reporter'),
       require('@angular-devkit/build-angular/plugins/karma')
     ],
@@ -31,6 +32,10 @@ module.exports = function (config) {
       ChromeNoExtensions: {
         base: 'Chrome',
         flags: ['--disable-extensions']
+      },
+      IENoExtensions: {
+        base: 'IE',
+        flags: ['-extoff', '-k']
       }
     },
     reporters,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5480,6 +5480,13 @@ karma-firefox-launcher@^1.0.0:
   dependencies:
     is-wsl "^2.1.0"
 
+karma-ie-launcher@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/karma-ie-launcher/-/karma-ie-launcher-1.0.0.tgz#497986842c490190346cd89f5494ca9830c6d59c"
+  integrity sha1-SXmGhCxJAZA0bNifVJTKmDDG1Zw=
+  dependencies:
+    lodash "^4.6.1"
+
 karma-jasmine@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/karma-jasmine/-/karma-jasmine-2.0.1.tgz#26e3e31f2faf272dd80ebb0e1898914cc3a19763"
@@ -5748,7 +5755,7 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash@^4.14.14, lodash@^4.16.6, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1:
+lodash@^4.14.14, lodash@^4.16.6, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.6.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
The project comes with confgiguration for local IE build supporting ES5
and for SouceLabs remote configuration for IE browsers, but it has no
relevant entry to allow tests on local setup. This are minimal changes
to allow local tests with IE on Windows box.
Example syntax:
```bash
yarn test --browsers IENoExtensions --configuration ie
```
There is no configuration for size of the launched IE instance, so in
order to have tests depending on the viewport size - like overlays
positioning on top/left/right/bottom, the IE instance has been
configured to run in the kiosk mode ('-k').

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.

Aftermant of the discussion here:
https://github.com/ng-bootstrap/ng-bootstrap/pull/3406#issuecomment-539904150

```cmd
 yarn test --browsers IENoExtensions --configuration ie
yarn run v1.19.1
$ yarn check-format && yarn ngb:lint && yarn ngb:test --browsers IENoExtensions --configuration ie
$ ts-node --project misc/tsconfig.json misc/check-format.ts
$ ng lint ng-bootstrap
Linting "ng-bootstrap"...
All files pass linting.
$ ng test ng-bootstrap --code-coverage --source-map true --progress false --watch false --browsers IENoExtensions --configuration ie
12 10 2019 22:53:25.150:INFO [karma-server]: Karma v4.1.0 server started at http://0.0.0.0:9876/
12 10 2019 22:53:25.165:INFO [launcher]: Launching browsers IENoExtensions with concurrency unlimited
12 10 2019 22:53:25.250:INFO [launcher]: Starting browser IE
12 10 2019 22:53:46.341:INFO [IE 11.0.0 (Windows 10.0.0)]: Connected on socket NBxsVB1-gl2i6UQbAAAA with id 29134295
IE 11.0.0 (Windows 10.0.0): Executed 1268 of 1268 SUCCESS (2 mins 11.087 secs / 2 mins 3.148 secs)
TOTAL: 1268 SUCCESS
TOTAL: 1268 SUCCESS
Done in 194.15s
```
