### PR TITLE
docs(collapse): add example for responsive navbar (#2928)

### DIFF
--- a/demo/src/app/components/collapse/collapse.module.ts
+++ b/demo/src/app/components/collapse/collapse.module.ts
@@ -7,6 +7,8 @@ import { NgbdApiPage } from '../shared/api-page/api.component';
 import { NgbdExamplesPage } from '../shared/examples-page/examples.component';
 import { NgbdCollapseBasic } from './demos/basic/collapse-basic';
 import { NgbdCollapseBasicModule } from './demos/basic/collapse-basic.module';
+import { NgbdCollapseNavbar } from './demos/navbar/collapse-navbar';
+import { NgbdCollapseNavbarModule } from './demos/navbar/collapse-navbar.module';
 
 const DEMOS = {
   basic: {
@@ -14,6 +16,12 @@ const DEMOS = {
     type: NgbdCollapseBasic,
     code: require('!!raw-loader!./demos/basic/collapse-basic').default,
     markup: require('!!raw-loader!./demos/basic/collapse-basic.html').default
+  },
+  navbar: {
+    title: 'Responsive Navbar',
+    type: NgbdCollapseNavbar,
+    code: require('!!raw-loader!./demos/navbar/collapse-navbar').default,
+    markup: require('!!raw-loader!./demos/navbar/collapse-navbar.html').default
   }
 };
 
@@ -33,7 +41,8 @@ export const ROUTES = [
   imports: [
     NgbdSharedModule,
     NgbdComponentsSharedModule,
-    NgbdCollapseBasicModule
+    NgbdCollapseBasicModule,
+    NgbdCollapseNavbarModule
   ]
 })
 export class NgbdCollapseModule {

--- a/demo/src/app/components/collapse/demos/navbar/collapse-navbar.html
+++ b/demo/src/app/components/collapse/demos/navbar/collapse-navbar.html
@@ -1,0 +1,57 @@
+<p>
+  A responsive navbar can be achieved with an <code>ngbCollapse</code> directive.
+</p>
+
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-3">
+  <a class="navbar-brand" [routerLink]="'.'">Responsive navbar</a>
+
+  <!-- Step 3: Toggle the value of the property when the toggler button is clicked. -->
+  <button class="navbar-toggler" type="button" (click)="isMenuCollapsed = !isMenuCollapsed">
+    &#9776;
+  </button>
+
+  <!-- Step 2: Add the ngbCollapse directive to the element below. -->
+  <div [ngbCollapse]="isMenuCollapsed" class="collapse navbar-collapse">
+    <ul class="navbar-nav">
+      <li class="nav-item active">
+        <!-- Step 4: Close the menu when a link is clicked. -->
+        <a class="nav-link" [routerLink]="'.'" (click)="isMenuCollapsed = true">Features</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" [routerLink]="'.'" (click)="isMenuCollapsed = true">Examples</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" [routerLink]="'.'" (click)="isMenuCollapsed = true">About</a>
+      </li>
+    </ul>
+  </div>
+</nav>
+
+<p>
+  These steps were used to create this responsive navbar.
+</p>
+
+<ol>
+  <li>
+    Add a property to the component to track whether the menu is open.
+    In this example, the property is called <code>isMenuCollapsed</code>.
+  </li>
+  <li>
+    Add an <code>ngbCollapse</code> directive to the element
+    with the <code>navbar-collapse</code> CSS class. Use the
+    property in the component as the value for the directive.
+  </li>
+  <li>
+    When the navbar toggler button is clicked, toggle the
+    value of the property in the component.
+  </li>
+  <li>
+    If you would like the menu to close when a link is clicked,
+    add a <code>(click)</code> handler to each link and set the
+    property on the component to true to hide the menu.
+  </li>
+</ol>
+
+<p>
+  Resize your browser window to see it in action!
+</p>

--- a/demo/src/app/components/collapse/demos/navbar/collapse-navbar.module.ts
+++ b/demo/src/app/components/collapse/demos/navbar/collapse-navbar.module.ts
@@ -6,7 +6,7 @@ import {NgbdCollapseNavbar} from './collapse-navbar';
 import {RouterModule} from '@angular/router';
 
 @NgModule({
-  imports: [BrowserModule, NgbModule, RouterModule],
+  imports: [BrowserModule, NgbModule, RouterModule.forRoot([])],
   declarations: [NgbdCollapseNavbar],
   exports: [NgbdCollapseNavbar],
   bootstrap: [NgbdCollapseNavbar]

--- a/demo/src/app/components/collapse/demos/navbar/collapse-navbar.module.ts
+++ b/demo/src/app/components/collapse/demos/navbar/collapse-navbar.module.ts
@@ -1,0 +1,15 @@
+import {NgModule} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
+
+import {NgbdCollapseNavbar} from './collapse-navbar';
+import {RouterModule} from '@angular/router';
+
+@NgModule({
+  imports: [BrowserModule, NgbModule, RouterModule],
+  declarations: [NgbdCollapseNavbar],
+  exports: [NgbdCollapseNavbar],
+  bootstrap: [NgbdCollapseNavbar]
+})
+export class NgbdCollapseNavbarModule {
+}

--- a/demo/src/app/components/collapse/demos/navbar/collapse-navbar.ts
+++ b/demo/src/app/components/collapse/demos/navbar/collapse-navbar.ts
@@ -1,0 +1,10 @@
+import {Component} from '@angular/core';
+
+@Component({selector: 'ngbd-collapse-navbar', templateUrl: './collapse-navbar.html'})
+export class NgbdCollapseNavbar {
+  // Step 1:
+  // Create a property to track whether the menu is open.
+  // Start with the menu collapsed so that it does not
+  // appear initially when the page loads on a small screen!
+  public isMenuCollapsed = true;
+}


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.

I've created a basic responsive navbar example using an `ngbCollapse` directive.

Fixes #2928. 