### PR TITLE
fix(dropdown): export `NgbNavbar` correctly

### DIFF
--- a/src/dropdown/dropdown.module.ts
+++ b/src/dropdown/dropdown.module.ts
@@ -8,7 +8,14 @@ import {
   NgbNavbar
 } from './dropdown';
 
-export {NgbDropdown, NgbDropdownAnchor, NgbDropdownToggle, NgbDropdownMenu, NgbDropdownItem} from './dropdown';
+export {
+  NgbDropdown,
+  NgbDropdownAnchor,
+  NgbDropdownToggle,
+  NgbDropdownMenu,
+  NgbDropdownItem,
+  NgbNavbar
+} from './dropdown';
 export {NgbDropdownConfig} from './dropdown-config';
 
 const NGB_DROPDOWN_DIRECTIVES =

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,8 @@ export {
   NgbDropdownItem,
   NgbDropdownMenu,
   NgbDropdownModule,
-  NgbDropdownToggle
+  NgbDropdownToggle,
+  NgbNavbar
 } from './dropdown/dropdown.module';
 export {
   ModalDismissReasons,


### PR DESCRIPTION
Building with NG9 produced a warning for the forgotten export