### PR TITLE
feat(popover): allow specifying target for popover

### DIFF
--- a/demo/src/app/components/popover/demos/custom-target/popover-target.html
+++ b/demo/src/app/components/popover/demos/custom-target/popover-target.html
@@ -1,0 +1,11 @@
+<p>
+  You can choose a dynamic target with manual triggers. This is useful when adding tooltips
+  to dynamic html content.
+</p>
+
+<ng-template #popContent let-text="text" let-href="href"><a [attr.href]="href" target="_blank">open {{text}} in a new window</a></ng-template>
+
+<p [ngbPopover]="popContent" autoClose="outside" triggers="manual" #paragraphElement>
+  Add tooltips to dynamic html that contains links like <a data-description="Angular Framework" href="https://angular.io">angular</a> or <a data-description="Angular Bootstrap Components" href="https://ng-bootstrap.github.io">ng-bootstrap</a>
+</p>
+

--- a/demo/src/app/components/popover/demos/custom-target/popover-target.html
+++ b/demo/src/app/components/popover/demos/custom-target/popover-target.html
@@ -1,11 +1,17 @@
 <p>
-  You can choose a dynamic target with manual triggers. This is useful when adding tooltips
-  to dynamic html content.
+  You can choose a custom popover target. It works best when using manual triggers.
 </p>
 
-<ng-template #popContent let-text="text" let-href="href"><a [attr.href]="href" target="_blank">open {{text}} in a new window</a></ng-template>
+<div class="d-flex align-items-baseline">
 
-<p [ngbPopover]="popContent" autoClose="outside" triggers="manual" #paragraphElement>
-  Add tooltips to dynamic html that contains links like <a data-description="Angular Framework" href="https://angular.io">angular</a> or <a data-description="Angular Bootstrap Components" href="https://ng-bootstrap.github.io">ng-bootstrap</a>
-</p>
+  <p>
+    You can click
+  </p>
 
+  <button class="btn btn-outline-secondary ms-2" ngbPopover="Told you so!" [positionTarget]="target">this button,</button>
+
+  <p class="ms-2">
+    but popover will appear <b #target>here</b>.
+  </p>
+
+</div>

--- a/demo/src/app/components/popover/demos/custom-target/popover-target.module.ts
+++ b/demo/src/app/components/popover/demos/custom-target/popover-target.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+
+import {NgbdPopoverTarget} from './popover-target';
+
+@NgModule({
+  imports: [BrowserModule, NgbModule],
+  declarations: [NgbdPopoverTarget],
+  exports: [NgbdPopoverTarget],
+  bootstrap: [NgbdPopoverTarget]
+})
+export class NgbdPopoverTargetModule {}

--- a/demo/src/app/components/popover/demos/custom-target/popover-target.ts
+++ b/demo/src/app/components/popover/demos/custom-target/popover-target.ts
@@ -1,0 +1,21 @@
+import {Component, HostListener, ViewChild} from '@angular/core';
+import {NgbPopover} from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+  selector: 'ngbd-popover-target',
+  templateUrl: './popover-target.html'
+})
+export class NgbdPopoverTarget {
+  @ViewChild(NgbPopover, {static: false}) popover: NgbPopover;
+
+  @HostListener('mouseover', ['$event.target'])
+  onMouseOver(el: HTMLAnchorElement) {
+    if (el.dataset.description) {
+      if (this.popover.isOpen() && this.popover.target !== el) {
+        this.popover.close();
+      }
+      this.popover.target = el;
+      this.popover.open({text: el.dataset.description, href: el.href});
+    }
+  }
+}

--- a/demo/src/app/components/popover/demos/custom-target/popover-target.ts
+++ b/demo/src/app/components/popover/demos/custom-target/popover-target.ts
@@ -1,21 +1,8 @@
-import {Component, HostListener, ViewChild} from '@angular/core';
-import {NgbPopover} from '@ng-bootstrap/ng-bootstrap';
+import {Component} from '@angular/core';
 
 @Component({
   selector: 'ngbd-popover-target',
   templateUrl: './popover-target.html'
 })
 export class NgbdPopoverTarget {
-  @ViewChild(NgbPopover, {static: false}) popover: NgbPopover;
-
-  @HostListener('mouseover', ['$event.target'])
-  onMouseOver(el: HTMLAnchorElement) {
-    if (el.dataset.description) {
-      if (this.popover.isOpen() && this.popover.target !== el) {
-        this.popover.close();
-      }
-      this.popover.target = el;
-      this.popover.open({text: el.dataset.description, href: el.href});
-    }
-  }
 }

--- a/demo/src/app/components/popover/popover.module.ts
+++ b/demo/src/app/components/popover/popover.module.ts
@@ -26,6 +26,8 @@ import { NgbdPopoverTriggers } from './demos/triggers/popover-triggers';
 import { NgbdPopoverTriggersModule } from './demos/triggers/popover-triggers.module';
 import { NgbdPopoverVisibility } from './demos/visibility/popover-visibility';
 import { NgbdPopoverVisibilityModule } from './demos/visibility/popover-visibility.module';
+import { NgbdPopoverTarget} from './demos/custom-target/popover-target';
+import { NgbdPopoverTargetModule } from './demos/custom-target/popover-target.module';
 import { Routes } from '@angular/router';
 
 const DEMOS = {
@@ -58,6 +60,12 @@ const DEMOS = {
     type: NgbdPopoverTplwithcontext,
     code: require('!!raw-loader!./demos/tplwithcontext/popover-tplwithcontext').default,
     markup: require('!!raw-loader!./demos/tplwithcontext/popover-tplwithcontext.html').default
+  },
+  target: {
+    title: 'Custom target',
+    type: NgbdPopoverTarget,
+    code: require('!!raw-loader!./demos/custom-target/popover-target').default,
+    markup: require('!!raw-loader!./demos/custom-target/popover-target.html').default
   },
   delay: {
     title: 'Open and close delays',
@@ -116,6 +124,7 @@ export const ROUTES: Routes = [
     NgbdPopoverTriggersModule,
     NgbdPopoverAutocloseModule,
     NgbdPopoverVisibilityModule,
+    NgbdPopoverTargetModule,
     NgbdPopoverContainerModule,
     NgbdPopoverCustomClassModule,
     NgbdPopoverDelayModule,

--- a/demo/src/app/components/tooltip/demos/custom-target/tooltip-target.html
+++ b/demo/src/app/components/tooltip/demos/custom-target/tooltip-target.html
@@ -1,0 +1,17 @@
+<p>
+  You can choose a custom tooltip target. It works best when using manual triggers.
+</p>
+
+<div class="d-flex align-items-baseline">
+
+  <p>
+    You can hover
+  </p>
+
+  <button class="btn btn-outline-secondary ms-2" ngbTooltip="Told you so!" [positionTarget]="target">this button,</button>
+
+  <p class="ms-2">
+    but tooltip will appear <b #target>here</b>.
+  </p>
+
+</div>

--- a/demo/src/app/components/tooltip/demos/custom-target/tooltip-target.module.ts
+++ b/demo/src/app/components/tooltip/demos/custom-target/tooltip-target.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+
+import {NgbdTooltipTarget} from './tooltip-target';
+
+@NgModule({
+  imports: [BrowserModule, NgbModule],
+  declarations: [NgbdTooltipTarget],
+  exports: [NgbdTooltipTarget],
+  bootstrap: [NgbdTooltipTarget]
+})
+export class NgbdTooltipTargetModule {}

--- a/demo/src/app/components/tooltip/demos/custom-target/tooltip-target.ts
+++ b/demo/src/app/components/tooltip/demos/custom-target/tooltip-target.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'ngbd-tooltip-target',
+  templateUrl: './tooltip-target.html'
+})
+export class NgbdTooltipTarget {
+}

--- a/demo/src/app/components/tooltip/tooltip.module.ts
+++ b/demo/src/app/components/tooltip/tooltip.module.ts
@@ -18,6 +18,7 @@ import { NgbdTooltipCustomClassModule } from './demos/customclass/tooltip-custom
 import { NgbdTooltipCustomclass } from './demos/customclass/tooltip-customclass';
 import { NgbdTooltipDelay } from './demos/delay/tooltip-delay';
 import { NgbdTooltipDelayModule } from './demos/delay/tooltip-delay.module';
+import { NgbdTooltipTarget } from './demos/custom-target/tooltip-target';
 import { NgbdTooltipTplContentModule } from './demos/tplcontent/tooltip-tpl-content.module';
 import { NgbdTooltipTplcontent } from './demos/tplcontent/tooltip-tplcontent';
 import { NgbdTooltipTplWithContextModule } from './demos/tplwithcontext/tooltip-tpl-with-context.module';
@@ -25,6 +26,7 @@ import { NgbdTooltipTplwithcontext } from './demos/tplwithcontext/tooltip-tplwit
 import { NgbdTooltipTriggers } from './demos/triggers/tooltip-triggers';
 import { NgbdTooltipTriggersModule } from './demos/triggers/tooltip-triggers.module';
 import { Routes } from '@angular/router';
+import {NgbdTooltipTargetModule} from './demos/custom-target/tooltip-target.module';
 
 const DEMOS = {
   basic: {
@@ -56,6 +58,12 @@ const DEMOS = {
     type: NgbdTooltipTplwithcontext,
     code: require('!!raw-loader!./demos/tplwithcontext/tooltip-tplwithcontext').default,
     markup: require('!!raw-loader!./demos/tplwithcontext/tooltip-tplwithcontext.html').default
+  },
+  target: {
+    title: 'Custom target',
+    type: NgbdTooltipTarget,
+    code: require('!!raw-loader!./demos/custom-target/tooltip-target').default,
+    markup: require('!!raw-loader!./demos/custom-target/tooltip-target.html').default
   },
   delay: {
     title: 'Open and close delays',
@@ -106,6 +114,7 @@ export const ROUTES: Routes = [
     NgbdTooltipContainerModule,
     NgbdTooltipCustomClassModule,
     NgbdTooltipDelayModule,
+    NgbdTooltipTargetModule,
     NgbdTooltipTplContentModule,
     NgbdTooltipTriggersModule,
     NgbdTooltipAutocloseModule,

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -416,7 +416,6 @@ describe('ngb-popover', () => {
     });
   });
 
-
   describe('positioning', () => {
 
     it('should use requested position', fakeAsync(() => {
@@ -799,6 +798,99 @@ describe('ngb-popover', () => {
       triggerEvent(buttonEl, 'click');
     });
   });
+});
+
+describe('popover positionTarget', () => {
+  beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPopoverModule]}); });
+
+  function expectPopoverBePositionedAtHeightPx(heightPx: number) {
+    expect(Math.abs(heightPx - window.document.querySelector('ngb-popover-window') !.getBoundingClientRect().top))
+        .toBeLessThan(10);
+  }
+
+  it(`should be 'undefined' by default`, fakeAsync(() => {
+       const fixture = createTestComponent(`
+        <div style="height: 50px" ngbPopover="Great tip!" placement="bottom">Popover positionTarget</div>
+    `);
+
+       const popoverElement = fixture.debugElement.query(By.directive(NgbPopover));
+       const popover = popoverElement.injector.get(NgbPopover);
+       expect(popover.positionTarget).toBeUndefined();
+
+       popover.open();
+       tick();
+
+       // window should be positioned at the bottom of the target element
+       expectPopoverBePositionedAtHeightPx(50);
+       popover.close();
+     }));
+
+  it(`should be positioned against element reference`, fakeAsync(() => {
+       const fixture = createTestComponent(`
+        <div style="height: 50px" ngbPopover="Great tip!" placement="bottom" [positionTarget]="t">Popover positionTarget</div>
+        <div class="target" #t style="height: 50px"></div>
+    `);
+
+       const popoverElement = fixture.debugElement.query(By.directive(NgbPopover));
+       const popover = popoverElement.injector.get(NgbPopover);
+       expect(popover.positionTarget).toBe(fixture.nativeElement.querySelector('.target'));
+
+       popover.open();
+       tick();
+
+       // window should be positioned at the bottom of the target element
+       expectPopoverBePositionedAtHeightPx(100);
+       popover.close();
+     }));
+
+  it(`should be positioned against element selector`, fakeAsync(() => {
+       const fixture = createTestComponent(`
+        <div style="height: 50px" ngbPopover="Great tip!" placement="bottom" positionTarget=".target">Popover positionTarget</div>
+        <div class="target" style="height: 50px"></div>
+    `);
+
+       const popoverElement = fixture.debugElement.query(By.directive(NgbPopover));
+       const popover = popoverElement.injector.get(NgbPopover);
+
+       popover.open();
+       tick();
+
+       // window should be positioned at the bottom of the target element
+       expectPopoverBePositionedAtHeightPx(100);
+       popover.close();
+     }));
+
+  it(`should fallback to initial position with invalid selector target`, fakeAsync(() => {
+       const fixture = createTestComponent(`
+        <div style="height: 50px" ngbPopover="Great tip!" placement="bottom" positionTarget=".invalid-selector">Popover positionTarget</div>
+    `);
+
+       const popoverElement = fixture.debugElement.query(By.directive(NgbPopover));
+       const popover = popoverElement.injector.get(NgbPopover);
+
+       popover.open();
+       tick();
+
+       // window should be positioned at the bottom of the target element
+       expectPopoverBePositionedAtHeightPx(50);
+       popover.close();
+     }));
+
+  it(`should fallback to initial position with invalid element target`, fakeAsync(() => {
+       const fixture = createTestComponent(`
+        <div style="height: 50px" ngbPopover="Great tip!" placement="bottom" [positionTarget]="null">Popover positionTarget</div>
+    `);
+
+       const popoverElement = fixture.debugElement.query(By.directive(NgbPopover));
+       const popover = popoverElement.injector.get(NgbPopover);
+
+       popover.open();
+       tick();
+
+       // window should be positioned at the bottom of the target element
+       expectPopoverBePositionedAtHeightPx(50);
+       popover.close();
+     }));
 });
 
 describe('popover-tooltip', () => {

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -132,6 +132,12 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
   @Input() triggers: string;
 
   /**
+   * Specifies the target element for the popover. If empty, uses host element.
+   * Only works with manual trigger.
+   */
+  @Input() target: HTMLElement;
+
+  /**
    * A selector specifying the element the popover should be appended to.
    *
    * Currently only supports `body`.
@@ -232,7 +238,8 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
       this._windowRef.setInput('popoverClass', this.popoverClass);
       this._windowRef.setInput('id', this._ngbPopoverWindowId);
 
-      this._renderer.setAttribute(this._elementRef.nativeElement, 'aria-describedby', this._ngbPopoverWindowId);
+      this._renderer.setAttribute(
+          this.target || this._elementRef.nativeElement, 'aria-describedby', this._ngbPopoverWindowId);
 
       if (this.container === 'body') {
         this._document.querySelector(this.container).appendChild(this._windowRef.location.nativeElement);
@@ -253,7 +260,7 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
       // Setting up popper and scheduling updates when zone is stable
       this._ngZone.runOutsideAngular(() => {
         this._positioning.createPopper({
-          hostElement: this._elementRef.nativeElement,
+          hostElement: this.target || this._elementRef.nativeElement,
           targetElement: this._windowRef !.location.nativeElement,
           placement: this.placement,
           appendToBody: this.container === 'body',
@@ -283,7 +290,7 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
    */
   close(animation = this.animation) {
     if (this._windowRef) {
-      this._renderer.removeAttribute(this._elementRef.nativeElement, 'aria-describedby');
+      this._renderer.removeAttribute(this.target || this._elementRef.nativeElement, 'aria-describedby');
       this._popupService.close(animation).subscribe(() => {
         this._windowRef = null;
         this._positioning.destroy();

--- a/src/tooltip/tooltip.spec.ts
+++ b/src/tooltip/tooltip.spec.ts
@@ -713,6 +713,99 @@ describe('ngb-tooltip', () => {
   });
 });
 
+describe('tooltip positionTarget', () => {
+  beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTooltipModule]}); });
+
+  function expectTooltipBePositionedAtHeightPx(heightPx: number) {
+    expect(Math.abs(heightPx - window.document.querySelector('ngb-tooltip-window') !.getBoundingClientRect().top))
+        .toBeLessThan(10);
+  }
+
+  it(`should be 'undefined' by default`, fakeAsync(() => {
+       const fixture = createTestComponent(`
+        <div style="height: 50px" ngbTooltip="Great tip!" placement="bottom">Tooltip positionTarget</div>
+    `);
+
+       const popoverElement = fixture.debugElement.query(By.directive(NgbTooltip));
+       const popover = popoverElement.injector.get(NgbTooltip);
+       expect(popover.positionTarget).toBeUndefined();
+
+       popover.open();
+       tick();
+
+       // window should be positioned at the bottom of the target element
+       expectTooltipBePositionedAtHeightPx(50);
+       popover.close();
+     }));
+
+  it(`should be positioned against element reference`, fakeAsync(() => {
+       const fixture = createTestComponent(`
+        <div style="height: 50px" ngbTooltip="Great tip!" placement="bottom" [positionTarget]="t">Tooltip positionTarget</div>
+        <div class="target" #t style="height: 50px"></div>
+    `);
+
+       const popoverElement = fixture.debugElement.query(By.directive(NgbTooltip));
+       const popover = popoverElement.injector.get(NgbTooltip);
+       expect(popover.positionTarget).toBe(fixture.nativeElement.querySelector('.target'));
+
+       popover.open();
+       tick();
+
+       // window should be positioned at the bottom of the target element
+       expectTooltipBePositionedAtHeightPx(100);
+       popover.close();
+     }));
+
+  it(`should be positioned against element selector`, fakeAsync(() => {
+       const fixture = createTestComponent(`
+        <div style="height: 50px" ngbTooltip="Great tip!" placement="bottom" positionTarget=".target">Tooltip positionTarget</div>
+        <div class="target" style="height: 50px"></div>
+    `);
+
+       const popoverElement = fixture.debugElement.query(By.directive(NgbTooltip));
+       const popover = popoverElement.injector.get(NgbTooltip);
+
+       popover.open();
+       tick();
+
+       // window should be positioned at the bottom of the target element
+       expectTooltipBePositionedAtHeightPx(100);
+       popover.close();
+     }));
+
+  it(`should fallback to initial position with invalid selector target`, fakeAsync(() => {
+       const fixture = createTestComponent(`
+        <div style="height: 50px" ngbTooltip="Great tip!" placement="bottom" positionTarget=".invalid-selector">Tooltip positionTarget</div>
+    `);
+
+       const popoverElement = fixture.debugElement.query(By.directive(NgbTooltip));
+       const popover = popoverElement.injector.get(NgbTooltip);
+
+       popover.open();
+       tick();
+
+       // window should be positioned at the bottom of the target element
+       expectTooltipBePositionedAtHeightPx(50);
+       popover.close();
+     }));
+
+  it(`should fallback to initial position with invalid element target`, fakeAsync(() => {
+       const fixture = createTestComponent(`
+        <div style="height: 50px" ngbTooltip="Great tip!" placement="bottom" [positionTarget]="null">Tooltip positionTarget</div>
+    `);
+
+       const popoverElement = fixture.debugElement.query(By.directive(NgbTooltip));
+       const popover = popoverElement.injector.get(NgbTooltip);
+
+       popover.open();
+       tick();
+
+       // window should be positioned at the bottom of the target element
+       expectTooltipBePositionedAtHeightPx(50);
+       popover.close();
+     }));
+});
+
 if (isBrowserVisible('ngb-tooltip animations')) {
   describe('ngb-tooltip animations', () => {
 


### PR DESCRIPTION
This is incomplete, looking for feedback on whether this would get merged if it were completed. My use case is around providing popovers inside dynamic content. In my case I want to add popovers for user mentions inside content produced from [quill](https://quilljs.com/) and [quill-mention](https://github.com/afconsult/quill-mention). This is similar to the popover github uses when mentioning issues/prs/users in content. If there's an easier way to do this, let me know.

 - [] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [] built and tested the changes locally.
 - [] added/updated any applicable tests.
 - [] added/updated any applicable API documentation.
 - [] added/updated any applicable demos.
