### PR TITLE
fix(autoclose): fix popup components auto closing in Safari 13

### DIFF
--- a/demo/src/app/components/dropdown/demos/navbar/dropdown-navbar.html
+++ b/demo/src/app/components/dropdown/demos/navbar/dropdown-navbar.html
@@ -37,9 +37,9 @@
           Static
         </a>
         <div ngbDropdownMenu aria-labelledby="navbarDropdown1" class="dropdown-menu">
-          <a class="dropdown-item" href="#" (click)="$event.preventDefault()">Action</a>
-          <a class="dropdown-item" href="#" (click)="$event.preventDefault()">Another action</a>
-          <a class="dropdown-item" href="#" (click)="$event.preventDefault()">Something else here</a>
+          <a ngbDropdownItem href="#" (click)="$event.preventDefault()">Action</a>
+          <a ngbDropdownItem href="#" (click)="$event.preventDefault()">Another action</a>
+          <a ngbDropdownItem href="#" (click)="$event.preventDefault()">Something else here</a>
         </div>
       </li>
 
@@ -48,9 +48,9 @@
           Static right
         </a>
         <div ngbDropdownMenu aria-labelledby="navbarDropdown2" class="dropdown-menu dropdown-menu-right">
-          <a class="dropdown-item" href="#" (click)="$event.preventDefault()">Action</a>
-          <a class="dropdown-item" href="#" (click)="$event.preventDefault()">Another action</a>
-          <a class="dropdown-item" href="#" (click)="$event.preventDefault()">Something else here</a>
+          <a ngbDropdownItem href="#" (click)="$event.preventDefault()">Action</a>
+          <a ngbDropdownItem href="#" (click)="$event.preventDefault()">Another action</a>
+          <a ngbDropdownItem href="#" (click)="$event.preventDefault()">Something else here</a>
         </div>
       </li>
 
@@ -59,9 +59,9 @@
           Dynamic
         </a>
         <div ngbDropdownMenu aria-labelledby="navbarDropdown3" class="dropdown-menu">
-          <a class="dropdown-item" href="#" (click)="$event.preventDefault()">Action</a>
-          <a class="dropdown-item" href="#" (click)="$event.preventDefault()">Another action</a>
-          <a class="dropdown-item" href="#" (click)="$event.preventDefault()">Something else here</a>
+          <a ngbDropdownItem href="#" (click)="$event.preventDefault()">Action</a>
+          <a ngbDropdownItem href="#" (click)="$event.preventDefault()">Another action</a>
+          <a ngbDropdownItem href="#" (click)="$event.preventDefault()">Something else here</a>
         </div>
       </li>
     </ul>


### PR DESCRIPTION
This fixes multiple issues related to popup components auto closing.
Don't use touch events anymore as everything works fine with `mouseup/down`

Fixes #3446
Fixes #3437
Fixes #3412
Fixes #3192
Fixes #3145
Fixes #3024