### PR TITLE
feat(pagination): `aria-current` attribute support

### DIFF
--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -22,10 +22,12 @@ function expectPages(nativeEl: HTMLElement, pagesDef: string[], ellipsis = '...'
     if (classIndicator === '+') {
       expect(pages[i]).toHaveCssClass('active');
       expect(pages[i]).not.toHaveCssClass('disabled');
+      expect(pages[i].getAttribute('aria-current')).toBe('page');
       expect(normalizeText(pages[i].textContent)).toEqual(pageDef.substr(1) + ' (current)');
     } else if (classIndicator === '-') {
       expect(pages[i]).not.toHaveCssClass('active');
       expect(pages[i]).toHaveCssClass('disabled');
+      expect(pages[i].getAttribute('aria-current')).toBeNull();
       expect(normalizeText(pages[i].textContent)).toEqual(pageDef.substr(1));
       if (normalizeText(pages[i].textContent) !== ellipsis) {
         expect(pages[i].querySelector('a').getAttribute('tabindex')).toEqual('-1');
@@ -33,6 +35,7 @@ function expectPages(nativeEl: HTMLElement, pagesDef: string[], ellipsis = '...'
     } else {
       expect(pages[i]).not.toHaveCssClass('active');
       expect(pages[i]).not.toHaveCssClass('disabled');
+      expect(pages[i].getAttribute('aria-current')).toBeNull();
       expect(normalizeText(pages[i].textContent)).toEqual(pageDef);
       if (normalizeText(pages[i].textContent) !== ellipsis) {
         expect(pages[i].querySelector('a').hasAttribute('tabindex')).toBeFalsy();

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -147,7 +147,7 @@ export class NgbPaginationPrevious {
         </a>
       </li>
       <li *ngFor="let pageNumber of pages" class="page-item" [class.active]="pageNumber === page"
-        [class.disabled]="isEllipsis(pageNumber) || disabled">
+        [class.disabled]="isEllipsis(pageNumber) || disabled" [attr.aria-current]="(pageNumber === page ? 'page' : null)">
         <a *ngIf="isEllipsis(pageNumber)" class="page-link" [attr.tabindex]="(disabled ? '-1' : null)">
           <ng-template [ngTemplateOutlet]="tplEllipsis?.templateRef || ellipsis"
                        [ngTemplateOutletContext]="{disabled: true, currentPage: page}"></ng-template>


### PR DESCRIPTION
This commit adds support for aria-current attribute as per:
https://getbootstrap.com/docs/4.3/components/pagination/#disabled-and-active-states
https://developer.mozilla.org/en-US/docs/Web/CSS/Layout_cookbook/Pagination

Thanks!