### PR TITLE
feat(datepicker): correct zindex of month selects

### DIFF
--- a/src/datepicker/datepicker-navigation-select.scss
+++ b/src/datepicker/datepicker-navigation-select.scss
@@ -3,4 +3,8 @@ ngb-datepicker-navigation-select > .custom-select {
   padding: 0 0.5rem;
   font-size: 0.875rem;
   height: 1.85rem;
+
+  &:focus {
+    z-index: 1;
+  }
 }


### PR DESCRIPTION
This is a minor change that corrects rendering of the focus outline of
the custom select used for month selection.

Before:
<img width="592" alt="Screenshot 2019-11-16 at 23 20 51" src="https://user-images.githubusercontent.com/14539/68999930-1a8ab200-08c8-11ea-83e2-5585446f2cd9.png">
After:
<img width="592" alt="Screenshot 2019-11-16 at 23 21 02" src="https://user-images.githubusercontent.com/14539/68999932-1eb6cf80-08c8-11ea-9683-cee2d3c814a5.png">

Minor `z-index` change is used to correct rendering as BS' docs outlines in the closing paragraph:
https://getbootstrap.com/docs/4.3/layout/overview/#z-index

Thanks!