### PR TITLE
refactor(pagination): simplify the way disabled links are handled

### DIFF
--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -29,19 +29,20 @@ function expectPages(nativeEl: HTMLElement, pagesDef: string[], ellipsis = '...'
       expect(pages[i]).toHaveCssClass('disabled');
       expect(pages[i].getAttribute('aria-current')).toBeNull();
       expect(normalizeText(pages[i].textContent)).toEqual(pageDef.substr(1));
-      if (normalizeText(pages[i].textContent) !== ellipsis) {
-        expect(pages[i].querySelector('a').getAttribute('tabindex')).toEqual('-1');
-        expect(pages[i].querySelector('a').hasAttribute('aria-disabled')).toBeTruthy();
-      }
     } else {
       expect(pages[i]).not.toHaveCssClass('active');
       expect(pages[i]).not.toHaveCssClass('disabled');
       expect(pages[i].getAttribute('aria-current')).toBeNull();
       expect(normalizeText(pages[i].textContent)).toEqual(pageDef);
-      if (normalizeText(pages[i].textContent) !== ellipsis) {
-        expect(pages[i].querySelector('a').hasAttribute('tabindex')).toBeFalsy();
-        expect(pages[i].querySelector('a').hasAttribute('aria-disabled')).toBeFalsy();
-      }
+    }
+
+    // ellipsis is always disabled
+    if (normalizeText(pages[i].textContent) === ellipsis) {
+      expect(pages[i]).not.toHaveCssClass('active');
+      expect(pages[i]).toHaveCssClass('disabled');
+      expect(pages[i].getAttribute('aria-current')).toBeNull();
+      expect(pages[i].querySelector('a').getAttribute('tabindex')).toEqual('-1');
+      expect(pages[i].querySelector('a').hasAttribute('aria-disabled')).toBeTruthy();
     }
   }
 }
@@ -52,10 +53,6 @@ function getLink(nativeEl: HTMLElement, idx: number): HTMLAnchorElement {
 
 function getList(nativeEl: HTMLElement) {
   return <HTMLUListElement>nativeEl.querySelector('ul');
-}
-
-function getSpan(nativeEl: HTMLElement): HTMLSpanElement {
-  return <HTMLSpanElement>nativeEl.querySelector('span');
 }
 
 function normalizeText(txt: string): string {

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -132,8 +132,8 @@ export class NgbPaginationPrevious {
       <li *ngIf="boundaryLinks" class="page-item"
         [class.disabled]="previousDisabled()">
         <a aria-label="First" i18n-aria-label="@@ngb.pagination.first-aria" class="page-link" href
-          (click)="selectPage(1); $event.preventDefault()" [attr.tabindex]="(hasPrevious() && !disabled ? null : '-1')"
-          [attr.aria-disabled]="(previousDisabled() ? 'true' : null)">
+          (click)="selectPage(1); $event.preventDefault()" [attr.tabindex]="previousDisabled() ? '-1' : null"
+          [attr.aria-disabled]="previousDisabled() ? 'true' : null">
           <ng-template [ngTemplateOutlet]="tplFirst?.templateRef || first"
                        [ngTemplateOutletContext]="{disabled: previousDisabled(), currentPage: page}"></ng-template>
         </a>
@@ -142,29 +142,28 @@ export class NgbPaginationPrevious {
       <li *ngIf="directionLinks" class="page-item"
         [class.disabled]="previousDisabled()">
         <a aria-label="Previous" i18n-aria-label="@@ngb.pagination.previous-aria" class="page-link" href
-          (click)="selectPage(page-1); $event.preventDefault()" [attr.tabindex]="(hasPrevious() && !disabled ? null : '-1')"
-          [attr.aria-disabled]="(previousDisabled() ? 'true' : null)">
+          (click)="selectPage(page-1); $event.preventDefault()" [attr.tabindex]="previousDisabled() ? '-1' : null"
+          [attr.aria-disabled]="previousDisabled() ? 'true' : null">
           <ng-template [ngTemplateOutlet]="tplPrevious?.templateRef || previous"
                        [ngTemplateOutletContext]="{disabled: previousDisabled()}"></ng-template>
         </a>
       </li>
       <li *ngFor="let pageNumber of pages" class="page-item" [class.active]="pageNumber === page"
         [class.disabled]="isEllipsis(pageNumber) || disabled" [attr.aria-current]="(pageNumber === page ? 'page' : null)">
-        <a *ngIf="isEllipsis(pageNumber)" class="page-link" [attr.tabindex]="(disabled ? '-1' : null)"
-          [attr.aria-disabled]="(isEllipsis(pageNumber) || disabled ? 'true' : null)">
+        <a *ngIf="isEllipsis(pageNumber)" class="page-link" tabindex="-1" aria-disabled="true">
           <ng-template [ngTemplateOutlet]="tplEllipsis?.templateRef || ellipsis"
                        [ngTemplateOutletContext]="{disabled: true, currentPage: page}"></ng-template>
         </a>
-        <a *ngIf="!isEllipsis(pageNumber)" class="page-link" href (click)="selectPage(pageNumber); $event.preventDefault()" [attr.tabindex]="(disabled ? '-1' : null)"
-          [attr.aria-disabled]="(disabled ? 'true' : null)">
+        <a *ngIf="!isEllipsis(pageNumber)" class="page-link" href (click)="selectPage(pageNumber); $event.preventDefault()" [attr.tabindex]="disabled ? '-1' : null"
+          [attr.aria-disabled]="disabled ? 'true' : null">
           <ng-template [ngTemplateOutlet]="tplNumber?.templateRef || defaultNumber"
                        [ngTemplateOutletContext]="{disabled: disabled, $implicit: pageNumber, currentPage: page}"></ng-template>
         </a>
       </li>
       <li *ngIf="directionLinks" class="page-item" [class.disabled]="nextDisabled()">
         <a aria-label="Next" i18n-aria-label="@@ngb.pagination.next-aria" class="page-link" href
-          (click)="selectPage(page+1); $event.preventDefault()" [attr.tabindex]="(hasNext() && !disabled ? null : '-1')"
-          [attr.aria-disabled]="(nextDisabled() ? 'true' : null)">
+          (click)="selectPage(page+1); $event.preventDefault()" [attr.tabindex]="nextDisabled() ? '-1' : null"
+          [attr.aria-disabled]="nextDisabled() ? 'true' : null">
           <ng-template [ngTemplateOutlet]="tplNext?.templateRef || next"
                        [ngTemplateOutletContext]="{disabled: nextDisabled(), currentPage: page}"></ng-template>
         </a>
@@ -172,8 +171,8 @@ export class NgbPaginationPrevious {
 
       <li *ngIf="boundaryLinks" class="page-item" [class.disabled]="nextDisabled()">
         <a aria-label="Last" i18n-aria-label="@@ngb.pagination.last-aria" class="page-link" href
-          (click)="selectPage(pageCount); $event.preventDefault()" [attr.tabindex]="(hasNext() && !disabled ? null : '-1')"
-          [attr.aria-disabled]="(nextDisabled() ? 'true' : null)">
+          (click)="selectPage(pageCount); $event.preventDefault()" [attr.tabindex]="nextDisabled() ? '-1' : null"
+          [attr.aria-disabled]="nextDisabled() ? 'true' : null">
           <ng-template [ngTemplateOutlet]="tplLast?.templateRef || last"
                        [ngTemplateOutletContext]="{disabled: nextDisabled(), currentPage: page}"></ng-template>
         </a>


### PR DESCRIPTION
Small refactoring after #3468 and #3471:
- ellipsis should always be disabled
- use `prevDisabled()` and `nextDisabled()` where possible