### PR TITLE
demo: use `ViewportScroller` to adjust scroll position

### DIFF
--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -1,6 +1,6 @@
-import { DOCUMENT } from '@angular/common';
-import { Component, Inject, OnInit } from '@angular/core';
-import { NavigationEnd, Router } from '@angular/router';
+import { ViewportScroller } from '@angular/common';
+import { Component, NgZone, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { filter } from 'rxjs/operators';
 
 import { componentsList } from './shared';
@@ -17,24 +17,13 @@ export class AppComponent implements OnInit {
 
   constructor(
     private _analytics: Analytics,
-    router: Router,
-    @Inject(DOCUMENT) document: any
+    route: ActivatedRoute,
+    vps: ViewportScroller,
+    zone: NgZone
   ) {
-    router.events
-      .pipe(filter(event => event instanceof NavigationEnd))
-      .subscribe(event => {
-        const { fragment } = router.parseUrl(router.url);
-        if (fragment) {
-          setTimeout(() => {
-            const element = document.querySelector(`#${fragment}`);
-            if (element) {
-              element.scrollIntoView();
-            }
-          }, 0);
-        } else {
-          window.scrollTo({ top: 0 });
-        }
-      });
+    route.fragment
+      .pipe(filter(fragment => !!fragment))
+      .subscribe(fragment => zone.runOutsideAngular(() => requestAnimationFrame(() => vps.scrollToAnchor(fragment))));
   }
 
   ngOnInit(): void {

--- a/demo/src/app/app.routing.ts
+++ b/demo/src/app/app.routing.ts
@@ -52,5 +52,6 @@ const routes: Routes = [
 
 export const routing: ModuleWithProviders = RouterModule.forRoot(routes, {
   enableTracing: false,
-  useHash: true
+  useHash: true,
+  scrollPositionRestoration: 'enabled'
 });


### PR DESCRIPTION
Fixes the way anchor scrolling is handled in demo application:
- does NOTHING, if there is no fragment in the url (no scroll → no style/layout)
- uses `RAF` to adjust scroll **right before** the first paint
- uses standard `ViewportScroller`
- runs all outside of the zone
- removes this layout/style recalculation from the JS block

![Screen Shot 2019-11-19 at 15 16 13](https://user-images.githubusercontent.com/8074436/69159334-0a511d80-0ae8-11ea-8577-088c97f6c475.png)
