### PR TITLE
feat(pagination): accept an "align" attribute

### DIFF
--- a/src/pagination/pagination-config.spec.ts
+++ b/src/pagination/pagination-config.spec.ts
@@ -4,9 +4,10 @@ describe('ngb-pagination-config', () => {
   it('should have sensible default values', () => {
     const config = new NgbPaginationConfig();
 
-    expect(config.disabled).toBe(false);
+    expect(config.align).toBe('');
     expect(config.boundaryLinks).toBe(false);
     expect(config.directionLinks).toBe(true);
+    expect(config.disabled).toBe(false);
     expect(config.ellipses).toBe(true);
     expect(config.maxSize).toBe(0);
     expect(config.pageSize).toBe(10);

--- a/src/pagination/pagination-config.ts
+++ b/src/pagination/pagination-config.ts
@@ -8,9 +8,10 @@ import {Injectable} from '@angular/core';
  */
 @Injectable({providedIn: 'root'})
 export class NgbPaginationConfig {
-  disabled = false;
+  align = '';
   boundaryLinks = false;
   directionLinks = true;
+  disabled = false;
   ellipses = true;
   maxSize = 0;
   pageSize = 10;

--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -60,9 +60,10 @@ function normalizeText(txt: string): string {
 }
 
 function expectSameValues(pagination: NgbPagination, config: NgbPaginationConfig) {
-  expect(pagination.disabled).toBe(config.disabled);
+  expect(pagination.align).toBe(config.align);
   expect(pagination.boundaryLinks).toBe(config.boundaryLinks);
   expect(pagination.directionLinks).toBe(config.directionLinks);
+  expect(pagination.disabled).toBe(config.disabled);
   expect(pagination.ellipses).toBe(config.ellipses);
   expect(pagination.maxSize).toBe(config.maxSize);
   expect(pagination.pageSize).toBe(config.pageSize);
@@ -301,6 +302,32 @@ describe('ngb-pagination', () => {
          expectPages(fixture.nativeElement, ['«', '1', '+2', '-»']);
          expect(fixture.componentInstance.page).toBe(2);
        }));
+
+    it('should render and respond to align change', () => {
+      const html = '<ngb-pagination [collectionSize]="20" [page]="1" [align]="align"></ngb-pagination>';
+
+      const fixture = createTestComponent(html);
+      const listEl = getList(fixture.nativeElement);
+
+      // justify-content-center
+      fixture.componentInstance.align = 'justify-content-center';
+      fixture.detectChanges();
+      expect(listEl).toHaveCssClass('pagination');
+      expect(listEl).toHaveCssClass('justify-content-center');
+
+      // removing justify-content-center
+      fixture.componentInstance.align = '';
+      fixture.detectChanges();
+      expect(listEl).toHaveCssClass('pagination');
+      expect(listEl).not.toHaveCssClass('justify-content-center');
+
+      // complex alignment
+      fixture.componentInstance.align = 'align-content-start flex-wrap';
+      fixture.detectChanges();
+      expect(listEl).toHaveCssClass('pagination');
+      expect(listEl).toHaveCssClass('align-content-start');
+      expect(listEl).toHaveCssClass('flex-wrap');
+    });
 
     it('should render and respond to size change', () => {
       const html = '<ngb-pagination [collectionSize]="20" [page]="1" [size]="size"></ngb-pagination>';
@@ -725,6 +752,7 @@ describe('ngb-pagination', () => {
 
     beforeEach(inject([NgbPaginationConfig], (c: NgbPaginationConfig) => {
       config = c;
+      config.align = 'justify-content-center';
       config.boundaryLinks = true;
       config.directionLinks = false;
       config.ellipses = false;
@@ -745,9 +773,10 @@ describe('ngb-pagination', () => {
 
   describe('Custom config as provider', () => {
     let config = new NgbPaginationConfig();
-    config.disabled = true;
+    config.align = 'justify-content-center';
     config.boundaryLinks = true;
     config.directionLinks = false;
+    config.disabled = true;
     config.ellipses = false;
     config.maxSize = 42;
     config.pageSize = 7;
@@ -771,16 +800,17 @@ describe('ngb-pagination', () => {
 
 @Component({selector: 'test-cmp', template: ''})
 class TestComponent {
-  disabled = false;
-  pageSize = 10;
-  collectionSize = 100;
-  page = 1;
+  align = '';
   boundaryLinks = false;
+  collectionSize = 100;
   directionLinks = false;
-  size = '';
-  maxSize = 0;
+  disabled = false;
   ellipses = true;
+  maxSize = 0;
+  page = 1;
+  pageSize = 10;
   rotate = false;
+  size = '';
 
   onPageChange = () => {};
 }

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -128,7 +128,7 @@ export class NgbPaginationPrevious {
       {{ page }}
       <span *ngIf="page === currentPage" class="sr-only">(current)</span>
     </ng-template>
-    <ul [class]="'pagination' + (size ? ' pagination-' + size : '')">
+    <ul [class]="'pagination' + (size ? ' pagination-' + size : '') + (align ? ' ' + align : '')">
       <li *ngIf="boundaryLinks" class="page-item"
         [class.disabled]="previousDisabled()">
         <a aria-label="First" i18n-aria-label="@@ngb.pagination.first-aria" class="page-link" href
@@ -190,6 +190,13 @@ export class NgbPagination implements OnChanges {
   @ContentChild(NgbPaginationNext, {static: false}) tplNext: NgbPaginationNext;
   @ContentChild(NgbPaginationNumber, {static: false}) tplNumber: NgbPaginationNumber;
   @ContentChild(NgbPaginationPrevious, {static: false}) tplPrevious: NgbPaginationPrevious;
+
+  /**
+   * The pagination alignment.
+   *
+   * Any of the Bootstrap flex utilties (i.e. "justify-content-center").
+   */
+  @Input() align: string;
 
   /**
    * If `true`, pagination links will be disabled.
@@ -261,6 +268,7 @@ export class NgbPagination implements OnChanges {
   @Input() size: 'sm' | 'lg';
 
   constructor(config: NgbPaginationConfig) {
+    this.align = config.align;
     this.disabled = config.disabled;
     this.boundaryLinks = config.boundaryLinks;
     this.directionLinks = config.directionLinks;


### PR DESCRIPTION
Currently because there is no validation on "size" you can stuff additional classes into the "size" attribute to perform Bootstrap alignment on the pagination component. This change allows a user to easily, and in a supported manner, pass flexbox utility classes such as "justify-content-center" to the pagination component.

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.
