### PR TITLE
chore: add strict unused imports/variables check at TS level

### DIFF
--- a/demo/src/app/components/alert/demos/closeable/alert-closeable.ts
+++ b/demo/src/app/components/alert/demos/closeable/alert-closeable.ts
@@ -1,4 +1,4 @@
-import { Input, Component } from '@angular/core';
+import { Component } from '@angular/core';
 
 interface Alert {
   type: string;

--- a/demo/src/app/components/components.e2e-spec.ts
+++ b/demo/src/app/components/components.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { browser, $ } from 'protractor';
+import { browser } from 'protractor';
 import { getLinkElement, getComponentTabsLinks, getCodeToggleElement, getCodeElements } from '../tools.po';
 
 

--- a/demo/src/app/components/pagination/demos/disabled/pagination-disabled.ts
+++ b/demo/src/app/components/pagination/demos/disabled/pagination-disabled.ts
@@ -1,5 +1,4 @@
 import {Component} from '@angular/core';
-import {NgbPaginationConfig} from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
   selector: 'ngbd-pagination-disabled',

--- a/e2e-app/src/app/datepicker/focus/datepicker-focus.e2e-spec.ts
+++ b/e2e-app/src/app/datepicker/focus/datepicker-focus.e2e-spec.ts
@@ -1,4 +1,4 @@
-import {$, Key} from 'protractor';
+import {Key} from 'protractor';
 import {expectFocused, sendKey, openUrl} from '../../tools.po';
 import {DatepickerFocusPage} from './datepicker-focus.po';
 

--- a/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.component.ts
+++ b/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.component.ts
@@ -1,4 +1,3 @@
-import {ActivatedRoute} from '@angular/router';
 import {Component, ChangeDetectionStrategy} from '@angular/core';
 
 @Component({templateUrl: './dropdown-autoclose.component.html', changeDetection: ChangeDetectionStrategy.OnPush})

--- a/e2e-app/src/app/dropdown/position/dropdown-position.e2e-spec.ts
+++ b/e2e-app/src/app/dropdown/position/dropdown-position.e2e-spec.ts
@@ -1,4 +1,4 @@
-import {browser, by} from 'protractor';
+import {by} from 'protractor';
 import {openUrl} from '../../tools.po';
 import {DropdownPage} from '../dropdown.po';
 import {DropdownPositionPage} from './dropdown-position.po';

--- a/e2e-app/src/app/typeahead/validation/typeahead-validation.e2e-spec.ts
+++ b/e2e-app/src/app/typeahead/validation/typeahead-validation.e2e-spec.ts
@@ -1,6 +1,5 @@
 import {TypeaheadPage} from '../typeahead.po';
 import {openUrl} from '../../tools.po';
-import {browser} from 'protractor';
 
 describe('Typeahead', () => {
   let page: TypeaheadPage;

--- a/misc/check-ts.ts
+++ b/misc/check-ts.ts
@@ -1,0 +1,39 @@
+import {join} from 'path';
+import {spawn} from 'cross-spawn';
+import {ChildProcess, SpawnOptions} from 'child_process';
+
+const options: SpawnOptions = {
+  cwd: join(__dirname, '..')
+};
+
+const tsConfigs = [
+  'src/tsconfig.json', 'src/tsconfig.spec.json', 'demo/tsconfig.json', 'e2e-app/tsconfig.json',
+  'e2e-app/tsconfig.spec.json'
+];
+
+const args = ['--pretty', '--noEmit', '--noUnusedLocals'];
+
+const messages = new Set<string>();
+const running = new Set<ChildProcess>();
+
+tsConfigs.forEach(tsConfig => {
+  const child = spawn('npx', ['tsc', ...args, `--project`, tsConfig], options);
+  running.add(child);
+
+  child.stdout.on('data', chunk => {
+    chunk.toString().split('\n').filter(message => message.length > 0).forEach(message => messages.add(message));
+  });
+
+  child.on('exit', () => {
+    running.delete(child);
+    if (running.size === 0 && messages.size > 0) {
+      messages.forEach(message => console.error(`\x1b[31m${message}`, '\x1b[0m'));
+      process.exit(1);
+    }
+  });
+
+  child.stderr.on('data', e => console.error(`tsc error:\n${e}`));
+  child.on('error', e => console.error(`tsc error:\n${e}`));
+});
+
+console.log('Checking for unused code...');

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "ssr": "yarn ssr-app:lint && yarn ssr-app:build && yarn ssr-app:e2e",
     "changelog": "conventional-changelog --preset angular --infile CHANGELOG.md --same-file --release-count 1",
     "check-format": "ts-node --project misc/tsconfig.json misc/check-format.ts",
+    "check-ts": "yarn demo:docs && ts-node --project misc/tsconfig.json misc/check-ts.ts",
     "saucelabs": "ng test ng-bootstrap -c saucelabs",
     "saucelabs:ie": "ng test ng-bootstrap -c saucelabs-ie",
     "scripts:tdd": "ts-node-dev --respawn --project misc/tsconfig.json node_modules/jasmine/bin/jasmine misc/*.spec.ts",
@@ -46,7 +47,7 @@
     "ssr-app:e2e": "concurrently --success first --kill-others --names \"express,protractor\" \"yarn ssr-app:serve-express\" \"ng e2e ssr-app\"",
     "ssr-app:build": "ng build ssr-app --prod && ng run ssr-app:server:production && yarn ssr-app:build-server",
     "ssr-app:build-server": "webpack --config ssr-app/webpack.server.config.js --colors",
-    "ci": "yarn test && yarn e2e && yarn build --progress false && yarn ssr"
+    "ci": "yarn check-ts && yarn test && yarn e2e && yarn build --progress false && yarn ssr"
   },
   "repository": {
     "type": "git",
@@ -88,6 +89,7 @@
     "concurrently": "^4.1.0",
     "conventional-changelog-cli": "^2.0.12",
     "core-js": "^2",
+    "cross-spawn": "^7.0.1",
     "ejs": "2.6.1",
     "express": "^4.16.4",
     "fs-extra": "^8.0.0",

--- a/src/buttons/radio.spec.ts
+++ b/src/buttons/radio.spec.ts
@@ -551,7 +551,6 @@ describe('ngbRadioGroup', () => {
     `);
     fixture.detectChanges();
 
-    const inputs = fixture.nativeElement.querySelectorAll('input');
     expectNameOnAllInputs(fixture.nativeElement, 'foo');
   });
 
@@ -568,7 +567,6 @@ describe('ngbRadioGroup', () => {
     `);
     fixture.detectChanges();
 
-    const inputs = fixture.nativeElement.querySelectorAll('input');
     expectNameOnAllInputs(fixture.nativeElement, 'bar');
   });
 

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -27,7 +27,6 @@ import {PlacementArray, positionElements} from '../util/positioning';
 import {NgbDateAdapter} from './adapters/ngb-date-adapter';
 import {NgbDatepicker, NgbDatepickerNavigateEvent} from './datepicker';
 import {DayTemplateContext} from './datepicker-day-template-context';
-import {NgbDatepickerService} from './datepicker-service';
 import {NgbCalendar} from './ngb-calendar';
 import {NgbDate} from './ngb-date';
 import {NgbDateParserFormatter} from './ngb-date-parser-formatter';
@@ -63,7 +62,7 @@ const NGB_DATEPICKER_VALIDATOR = {
     '[disabled]': 'disabled'
   },
   providers: [
-    NGB_DATEPICKER_VALUE_ACCESSOR, NGB_DATEPICKER_VALIDATOR, NgbDatepickerService,
+    NGB_DATEPICKER_VALUE_ACCESSOR, NGB_DATEPICKER_VALIDATOR,
     {provide: NgbDatepickerConfig, useExisting: NgbInputDatepickerConfig}
   ],
 })
@@ -263,9 +262,9 @@ export class NgbInputDatepicker implements OnChanges,
   constructor(
       private _parserFormatter: NgbDateParserFormatter, private _elRef: ElementRef<HTMLInputElement>,
       private _vcRef: ViewContainerRef, private _renderer: Renderer2, private _cfr: ComponentFactoryResolver,
-      private _ngZone: NgZone, private _service: NgbDatepickerService, private _calendar: NgbCalendar,
-      private _dateAdapter: NgbDateAdapter<any>, @Inject(DOCUMENT) private _document: any,
-      private _changeDetector: ChangeDetectorRef, config: NgbInputDatepickerConfig) {
+      private _ngZone: NgZone, private _calendar: NgbCalendar, private _dateAdapter: NgbDateAdapter<any>,
+      @Inject(DOCUMENT) private _document: any, private _changeDetector: ChangeDetectorRef,
+      config: NgbInputDatepickerConfig) {
     ['autoClose', 'container', 'positionTarget', 'placement'].forEach(input => this[input] = config[input]);
     this._zoneSubscription = _ngZone.onStable.subscribe(() => this._updatePopupPosition());
   }

--- a/src/datepicker/datepicker-month-view.spec.ts
+++ b/src/datepicker/datepicker-month-view.spec.ts
@@ -1,5 +1,5 @@
 import {TestBed, ComponentFixture} from '@angular/core/testing';
-import {createGenericTestComponent, isBrowser} from '../test/common';
+import {createGenericTestComponent} from '../test/common';
 
 import {Component} from '@angular/core';
 

--- a/src/datepicker/datepicker-service.spec.ts
+++ b/src/datepicker/datepicker-service.spec.ts
@@ -1200,7 +1200,6 @@ describe('ngb-datepicker-service', () => {
     });
 
     it(`should not emit selection event for null values`, () => {
-      const date = new NgbDate(2017, 5, 5);
       service.select(null, {emitEvent: true});
 
       expect(mockSelect.onNext).not.toHaveBeenCalled();

--- a/src/datepicker/datepicker-service.ts
+++ b/src/datepicker/datepicker-service.ts
@@ -1,4 +1,4 @@
-import {NgbCalendar, NgbPeriod} from './ngb-calendar';
+import {NgbCalendar} from './ngb-calendar';
 import {NgbDate} from './ngb-date';
 import {NgbDateStruct} from './ngb-date-struct';
 import {DatepickerViewModel, NgbDayTemplateData, NgbMarkDisabled} from './datepicker-view-model';

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -852,7 +852,6 @@ describe('ngb-datepicker', () => {
     it('should contains aria-label on the days', () => {
       const fixture = createTestComponent(template);
 
-      const datepicker = fixture.debugElement.query(By.directive(NgbDatepicker));
       const dates = getDates(fixture.nativeElement);
 
       dates.forEach(function(date) {
@@ -1202,7 +1201,6 @@ describe('ngb-datepicker', () => {
 
     let mockState: NgbDatepickerState;
     let dp: NgbDatepicker;
-    let keyboardService: NgbDatepickerKeyboardService;
     const mockKeyboardService: NgbDatepickerKeyboardService = {
       processKey(event: KeyboardEvent, datepicker: NgbDatepicker, calendar: NgbCalendar) {
         mockState = datepicker.state;
@@ -1217,7 +1215,6 @@ describe('ngb-datepicker', () => {
       const fixture = createTestComponent(
           `<ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate"></ngb-datepicker>`);
       fixture.detectChanges();
-      keyboardService = TestBed.get(NgbDatepickerKeyboardService);
       dp = <NgbDatepicker>fixture.debugElement.query(By.directive(NgbDatepicker)).componentInstance;
     });
 

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -279,10 +279,10 @@ export class NgbDatepicker implements OnDestroy,
   onTouched = () => {};
 
   constructor(
-      public _service: NgbDatepickerService, private _calendar: NgbCalendar, public i18n: NgbDatepickerI18n,
-      config: NgbDatepickerConfig, private _keyboardService: NgbDatepickerKeyboardService,
-      private _cd: ChangeDetectorRef, private _elementRef: ElementRef<HTMLElement>,
-      private _ngbDateAdapter: NgbDateAdapter<any>, private _ngZone: NgZone) {
+      private _service: NgbDatepickerService, private _calendar: NgbCalendar, public i18n: NgbDatepickerI18n,
+      config: NgbDatepickerConfig, private _keyboardService: NgbDatepickerKeyboardService, cd: ChangeDetectorRef,
+      private _elementRef: ElementRef<HTMLElement>, private _ngbDateAdapter: NgbDateAdapter<any>,
+      private _ngZone: NgZone) {
     ['dayTemplate', 'dayTemplateData', 'displayMonths', 'firstDayOfWeek', 'footerTemplate', 'markDisabled', 'minDate',
      'maxDate', 'navigation', 'outsideDays', 'showWeekdays', 'showWeekNumbers', 'startDate']
         .forEach(input => this[input] = config[input]);
@@ -336,7 +336,7 @@ export class NgbDatepicker implements OnDestroy,
         this.focus();
       }
 
-      _cd.markForCheck();
+      cd.markForCheck();
     });
   }
 

--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -327,7 +327,6 @@ describe('ngb-dropdown-toggle', () => {
       </div>`;
 
     const fixture = createTestComponent(html);
-    const compiled = fixture.nativeElement;
     const dropdown = fixture.debugElement.query(By.directive(NgbDropdown)).injector.get(NgbDropdown);
     dropdown.open();
     fixture.detectChanges();

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -1,5 +1,5 @@
-import {TestBed, ComponentFixture, inject, fakeAsync, tick} from '@angular/core/testing';
-import {createGenericTestComponent, createKeyEvent, triggerEvent} from '../test/common';
+import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
+import {createGenericTestComponent, triggerEvent} from '../test/common';
 
 import {By} from '@angular/platform-browser';
 import {
@@ -13,15 +13,9 @@ import {
   AfterViewInit
 } from '@angular/core';
 
-import {Key} from '../util/key';
-
 import {NgbPopoverModule} from './popover.module';
 import {NgbPopoverWindow, NgbPopover} from './popover';
 import {NgbPopoverConfig} from './popover-config';
-
-function dispatchEscapeKeyUpEvent() {
-  document.dispatchEvent(createKeyEvent(Key.Escape));
-}
 
 @Injectable()
 class SpyService {

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -175,7 +175,7 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
       private _elementRef: ElementRef<HTMLElement>, private _renderer: Renderer2, injector: Injector,
       componentFactoryResolver: ComponentFactoryResolver, viewContainerRef: ViewContainerRef, config: NgbPopoverConfig,
       private _ngZone: NgZone, @Inject(DOCUMENT) private _document: any, private _changeDetector: ChangeDetectorRef,
-      private _applicationRef: ApplicationRef) {
+      applicationRef: ApplicationRef) {
     this.autoClose = config.autoClose;
     this.placement = config.placement;
     this.triggers = config.triggers;
@@ -185,7 +185,7 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
     this.openDelay = config.openDelay;
     this.closeDelay = config.closeDelay;
     this._popupService = new PopupService<NgbPopoverWindow>(
-        NgbPopoverWindow, injector, viewContainerRef, _renderer, componentFactoryResolver, _applicationRef);
+        NgbPopoverWindow, injector, viewContainerRef, _renderer, componentFactoryResolver, applicationRef);
 
     this._zoneSubscription = _ngZone.onStable.subscribe(() => {
       if (this._windowRef) {

--- a/src/tooltip/tooltip.spec.ts
+++ b/src/tooltip/tooltip.spec.ts
@@ -1,5 +1,5 @@
-import {TestBed, ComponentFixture, inject, fakeAsync, tick} from '@angular/core/testing';
-import {createGenericTestComponent, createKeyEvent, triggerEvent} from '../test/common';
+import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
+import {createGenericTestComponent, triggerEvent} from '../test/common';
 
 import {By} from '@angular/platform-browser';
 import {
@@ -11,15 +11,10 @@ import {
   ViewContainerRef
 } from '@angular/core';
 
-import {Key} from '../util/key';
 
 import {NgbTooltipModule} from './tooltip.module';
 import {NgbTooltipWindow, NgbTooltip} from './tooltip';
 import {NgbTooltipConfig} from './tooltip-config';
-
-function dispatchEscapeKeyUpEvent() {
-  document.dispatchEvent(createKeyEvent(Key.Escape));
-}
 
 const createTestComponent =
     (html: string) => <ComponentFixture<TestComponent>>createGenericTestComponent(html, TestComponent);

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -142,7 +142,7 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
       private _elementRef: ElementRef<HTMLElement>, private _renderer: Renderer2, injector: Injector,
       componentFactoryResolver: ComponentFactoryResolver, viewContainerRef: ViewContainerRef, config: NgbTooltipConfig,
       private _ngZone: NgZone, @Inject(DOCUMENT) private _document: any, private _changeDetector: ChangeDetectorRef,
-      private _applicationRef: ApplicationRef) {
+      applicationRef: ApplicationRef) {
     this.autoClose = config.autoClose;
     this.placement = config.placement;
     this.triggers = config.triggers;
@@ -152,7 +152,7 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
     this.openDelay = config.openDelay;
     this.closeDelay = config.closeDelay;
     this._popupService = new PopupService<NgbTooltipWindow>(
-        NgbTooltipWindow, injector, viewContainerRef, _renderer, componentFactoryResolver, _applicationRef);
+        NgbTooltipWindow, injector, viewContainerRef, _renderer, componentFactoryResolver, applicationRef);
 
     this._zoneSubscription = _ngZone.onStable.subscribe(() => {
       if (this._windowRef) {

--- a/src/typeahead/typeahead-window.spec.ts
+++ b/src/typeahead/typeahead-window.spec.ts
@@ -179,10 +179,6 @@ describe('ngb-typeahead-window', () => {
 
   describe('accessibility', () => {
 
-    function getWindow(element): HTMLDivElement {
-      return <HTMLDivElement>element.querySelector('ngb-typeahead-window.dropdown-menu');
-    }
-
     it('should add correct ARIA attributes', () => {
       const fixture = createTestComponent(
           '<ngb-typeahead-window id="test-typeahead" [results]="results" [term]="term"></ngb-typeahead-window>');

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -669,7 +669,6 @@ describe('ngb-typeahead', () => {
 
     it('should raise select event when a result is selected', () => {
       const fixture = createTestComponent('<input [ngbTypeahead]="find" (selectItem)="onSelect($event.item)"/>');
-      const input = getNativeInput(fixture.nativeElement);
 
       // clicking selected
       changeInput(fixture.nativeElement, 'o');
@@ -683,7 +682,6 @@ describe('ngb-typeahead', () => {
     it('should not propagate model when preventDefault() is called on selectEvent', async(() => {
          const fixture = createTestComponent(
              '<input [(ngModel)]="model" [ngbTypeahead]="find" (selectItem)="$event.preventDefault()"/>');
-         const input = getNativeInput(fixture.nativeElement);
 
          // clicking selected
          changeInput(fixture.nativeElement, 'o');

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -189,10 +189,10 @@ export class NgbTypeahead implements ControlValueAccessor,
   private _onChange = (_: any) => {};
 
   constructor(
-      private _elementRef: ElementRef<HTMLInputElement>, private _viewContainerRef: ViewContainerRef,
-      private _renderer: Renderer2, private _injector: Injector, componentFactoryResolver: ComponentFactoryResolver,
+      private _elementRef: ElementRef<HTMLInputElement>, viewContainerRef: ViewContainerRef,
+      private _renderer: Renderer2, injector: Injector, componentFactoryResolver: ComponentFactoryResolver,
       config: NgbTypeaheadConfig, ngZone: NgZone, private _live: Live, @Inject(DOCUMENT) private _document: any,
-      private _ngZone: NgZone, private _changeDetector: ChangeDetectorRef, private _applicationRef: ApplicationRef) {
+      private _ngZone: NgZone, private _changeDetector: ChangeDetectorRef, applicationRef: ApplicationRef) {
     this.container = config.container;
     this.editable = config.editable;
     this.focusFirst = config.focusFirst;
@@ -205,7 +205,7 @@ export class NgbTypeahead implements ControlValueAccessor,
     this._resubscribeTypeahead = new BehaviorSubject(null);
 
     this._popupService = new PopupService<NgbTypeaheadWindow>(
-        NgbTypeaheadWindow, _injector, _viewContainerRef, _renderer, componentFactoryResolver, _applicationRef);
+        NgbTypeaheadWindow, injector, viewContainerRef, _renderer, componentFactoryResolver, applicationRef);
 
     this._zoneSubscription = ngZone.onStable.subscribe(() => {
       if (this.isPopupOpen()) {

--- a/src/util/positioning.spec.ts
+++ b/src/util/positioning.spec.ts
@@ -1,6 +1,5 @@
 import {Positioning} from './positioning';
-import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {createGenericTestComponent} from 'src/test/common';
+import {TestBed} from '@angular/core/testing';
 import {Component} from '@angular/core';
 
 describe('Positioning', () => {
@@ -27,13 +26,11 @@ describe('Positioning', () => {
     expect(transform).toBe(`translate(${left}px, ${top}px)`);
   }
 
-  let element, targetElement, positioning, documentMargin, bodyMargin, bodyHeight, bodyWidth;
+  let element, targetElement, positioning, documentMargin, bodyMargin;
   beforeAll(() => {
     positioning = new Positioning();
     documentMargin = document.documentElement.style.margin;
     bodyMargin = document.body.style.margin;
-    bodyHeight = document.body.style.height;
-    bodyWidth = document.body.style.width;
 
     document.documentElement.style.margin = '0';
     document.body.style.margin = '0';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2922,6 +2922,15 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
+  integrity sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 crypto-browserify@^3.11.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/crypto-browserify/-/crypto-browserify-3.12.0.tgz#396cf9f3137f03e4b8e532c58f698254e00f80ec"
@@ -6972,6 +6981,11 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
 path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
@@ -8161,10 +8175,22 @@ shebang-command@^1.2.0:
   dependencies:
     shebang-regex "^1.0.0"
 
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shellwords@^0.1.1:
   version "0.1.1"
@@ -9627,6 +9653,13 @@ which@^1.2.1, which@^1.2.14, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
Adds TS level checking for unused imports as a part of CI

Just adding `noUnusedLocals` to the `tsconfig.json` might be too restrictive during development and ng-packagr doesn't build the library correctly when it is activated.