### PR TITLE
chore(all): enable "noUnusedLocals" and "noUnusedParameters"

### DIFF
--- a/src/accordion/accordion.spec.ts
+++ b/src/accordion/accordion.spec.ts
@@ -839,6 +839,6 @@ class TestComponent {
     {id: 'two', disabled: false, title: 'Panel 2', content: 'bar', type: ''},
     {id: 'three', disabled: false, title: 'Panel 3', content: 'baz', type: ''}
   ];
-  changeCallback = (event: NgbPanelChangeEvent) => {};
+  changeCallback = (_event: NgbPanelChangeEvent) => {};
   preventDefaultCallback = (event: NgbPanelChangeEvent) => { event.preventDefault(); };
 }

--- a/src/buttons/radio.spec.ts
+++ b/src/buttons/radio.spec.ts
@@ -551,7 +551,6 @@ describe('ngbRadioGroup', () => {
     `);
     fixture.detectChanges();
 
-    const inputs = fixture.nativeElement.querySelectorAll('input');
     expectNameOnAllInputs(fixture.nativeElement, 'foo');
   });
 
@@ -568,7 +567,6 @@ describe('ngbRadioGroup', () => {
     `);
     fixture.detectChanges();
 
-    const inputs = fixture.nativeElement.querySelectorAll('input');
     expectNameOnAllInputs(fixture.nativeElement, 'bar');
   });
 

--- a/src/carousel/carousel.spec.ts
+++ b/src/carousel/carousel.spec.ts
@@ -892,7 +892,7 @@ class TestComponent {
   showNavigationArrows = true;
   showNavigationIndicators = true;
   slides = ['a', 'b'];
-  carouselSlideCallBack = (event: NgbSlideEvent) => {};
+  carouselSlideCallBack = (_event: NgbSlideEvent) => {};
 }
 
 @Component({

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -263,9 +263,9 @@ export class NgbInputDatepicker implements OnChanges,
   constructor(
       private _parserFormatter: NgbDateParserFormatter, private _elRef: ElementRef<HTMLInputElement>,
       private _vcRef: ViewContainerRef, private _renderer: Renderer2, private _cfr: ComponentFactoryResolver,
-      private _ngZone: NgZone, private _service: NgbDatepickerService, private _calendar: NgbCalendar,
-      private _dateAdapter: NgbDateAdapter<any>, @Inject(DOCUMENT) private _document: any,
-      private _changeDetector: ChangeDetectorRef, config: NgbInputDatepickerConfig) {
+      private _ngZone: NgZone, private _calendar: NgbCalendar, private _dateAdapter: NgbDateAdapter<any>,
+      @Inject(DOCUMENT) private _document: any, private _changeDetector: ChangeDetectorRef,
+      config: NgbInputDatepickerConfig) {
     ['autoClose', 'container', 'positionTarget', 'placement'].forEach(input => this[input] = config[input]);
     this._zoneSubscription = _ngZone.onStable.subscribe(() => this._updatePopupPosition());
   }

--- a/src/datepicker/datepicker-month-view.spec.ts
+++ b/src/datepicker/datepicker-month-view.spec.ts
@@ -1,5 +1,5 @@
 import {TestBed, ComponentFixture} from '@angular/core/testing';
-import {createGenericTestComponent, isBrowser} from '../test/common';
+import {createGenericTestComponent} from '../test/common';
 
 import {Component} from '@angular/core';
 

--- a/src/datepicker/datepicker-service.spec.ts
+++ b/src/datepicker/datepicker-service.spec.ts
@@ -1200,9 +1200,7 @@ describe('ngb-datepicker-service', () => {
     });
 
     it(`should not emit selection event for null values`, () => {
-      const date = new NgbDate(2017, 5, 5);
       service.select(null, {emitEvent: true});
-
       expect(mockSelect.onNext).not.toHaveBeenCalled();
     });
 

--- a/src/datepicker/datepicker-service.ts
+++ b/src/datepicker/datepicker-service.ts
@@ -1,4 +1,4 @@
-import {NgbCalendar, NgbPeriod} from './ngb-calendar';
+import {NgbCalendar} from './ngb-calendar';
 import {NgbDate} from './ngb-date';
 import {NgbDateStruct} from './ngb-date-struct';
 import {DatepickerViewModel, NgbDayTemplateData, NgbMarkDisabled} from './datepicker-view-model';

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -852,7 +852,6 @@ describe('ngb-datepicker', () => {
     it('should contains aria-label on the days', () => {
       const fixture = createTestComponent(template);
 
-      const datepicker = fixture.debugElement.query(By.directive(NgbDatepicker));
       const dates = getDates(fixture.nativeElement);
 
       dates.forEach(function(date) {

--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -327,7 +327,6 @@ describe('ngb-dropdown-toggle', () => {
       </div>`;
 
     const fixture = createTestComponent(html);
-    const compiled = fixture.nativeElement;
     const dropdown = fixture.debugElement.query(By.directive(NgbDropdown)).injector.get(NgbDropdown);
     dropdown.open();
     fixture.detectChanges();

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed, ComponentFixture, inject, fakeAsync, tick} from '@angular/core/testing';
+import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
 import {createGenericTestComponent, createKeyEvent, triggerEvent} from '../test/common';
 
 import {By} from '@angular/platform-browser';
@@ -18,10 +18,6 @@ import {Key} from '../util/key';
 import {NgbPopoverModule} from './popover.module';
 import {NgbPopoverWindow, NgbPopover} from './popover';
 import {NgbPopoverConfig} from './popover-config';
-
-function dispatchEscapeKeyUpEvent() {
-  document.dispatchEvent(createKeyEvent(Key.Escape));
-}
 
 @Injectable()
 class SpyService {

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -31,6 +31,9 @@ import {PopupService} from '../util/popup';
 
 import {NgbTooltipConfig} from './tooltip-config';
 
+const createTestComponent = (html: string) =>
+    createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
+
 let nextId = 0;
 
 @Component({

--- a/src/typeahead/typeahead-window.spec.ts
+++ b/src/typeahead/typeahead-window.spec.ts
@@ -179,11 +179,8 @@ describe('ngb-typeahead-window', () => {
 
   describe('accessibility', () => {
 
-    function getWindow(element): HTMLDivElement {
-      return <HTMLDivElement>element.querySelector('ngb-typeahead-window.dropdown-menu');
-    }
-
     it('should add correct ARIA attributes', () => {
+      const a = '';
       const fixture = createTestComponent(
           '<ngb-typeahead-window id="test-typeahead" [results]="results" [term]="term"></ngb-typeahead-window>');
       const compiled = fixture.nativeElement.querySelector('ngb-typeahead-window.dropdown-menu');

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -192,7 +192,7 @@ export class NgbTypeahead implements ControlValueAccessor,
       private _elementRef: ElementRef<HTMLInputElement>, private _viewContainerRef: ViewContainerRef,
       private _renderer: Renderer2, private _injector: Injector, componentFactoryResolver: ComponentFactoryResolver,
       config: NgbTypeaheadConfig, ngZone: NgZone, private _live: Live, @Inject(DOCUMENT) private _document: any,
-      private _ngZone: NgZone, private _changeDetector: ChangeDetectorRef, private _applicationRef: ApplicationRef) {
+      private _ngZone: NgZone, private _changeDetector: ChangeDetectorRef, applicationRef: ApplicationRef) {
     this.container = config.container;
     this.editable = config.editable;
     this.focusFirst = config.focusFirst;
@@ -205,7 +205,7 @@ export class NgbTypeahead implements ControlValueAccessor,
     this._resubscribeTypeahead = new BehaviorSubject(null);
 
     this._popupService = new PopupService<NgbTypeaheadWindow>(
-        NgbTypeaheadWindow, _injector, _viewContainerRef, _renderer, componentFactoryResolver, _applicationRef);
+        NgbTypeaheadWindow, _injector, _viewContainerRef, _renderer, componentFactoryResolver, applicationRef);
 
     this._zoneSubscription = ngZone.onStable.subscribe(() => {
       if (this.isPopupOpen()) {

--- a/src/util/positioning.spec.ts
+++ b/src/util/positioning.spec.ts
@@ -1,6 +1,5 @@
 import {Positioning} from './positioning';
-import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {createGenericTestComponent} from 'src/test/common';
+import {TestBed} from '@angular/core/testing';
 import {Component} from '@angular/core';
 
 describe('Positioning', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,8 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "noEmitOnError": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "outDir": "temp",
     "declaration": false,
     "sourceMap": true


### PR DESCRIPTION
Enable flags noUnusedLocals and noUnusedLocals.
These flags raise errors when there are unused imports. At the same time the raise error if there is an unused local, instance variable or an unused injection.

Also, it enforced _<name> naming for unused arguments in functions.

The aim of this commit is to make development independent of the IDE used.