### PR TITLE
docs(typeahead): refine http example inline layout

### DIFF
--- a/demo/src/app/components/typeahead/demos/http/typeahead-http.html
+++ b/demo/src/app/components/typeahead/demos/http/typeahead-http.html
@@ -8,12 +8,13 @@ A typeahead example that gets values from the <code>WikipediaService</code>
   <li><code>catch</code> operator to display an error message in case of connectivity issue</li>
 </ul>
 
-<div class="form-group">
-  <label for="typeahead-http">Search for a wiki page:</label>
-  <input id="typeahead-http" type="text" class="form-control" [class.is-invalid]="searchFailed" [(ngModel)]="model" [ngbTypeahead]="search" placeholder="Wikipedia search" />
-  <span *ngIf="searching">searching...</span>
-  <div class="invalid-feedback" *ngIf="searchFailed">Sorry, suggestions could not be loaded.</div>
-</div>
-
+<fieldset class="form-inline">
+  <div class="form-group">
+    <label for="typeahead-http">Search for a wiki page:</label>
+    <input id="typeahead-http" type="text" class="form-control mx-sm-3" [class.is-invalid]="searchFailed" [(ngModel)]="model" [ngbTypeahead]="search" placeholder="Wikipedia search" />
+    <small *ngIf="searching" class="form-text text-muted">searching...</small>
+    <div class="invalid-feedback" *ngIf="searchFailed">Sorry, suggestions could not be loaded.</div>
+  </div>
+</fieldset>
 <hr>
 <pre>Model: {{ model | json }}</pre>

--- a/demo/src/app/components/typeahead/demos/http/typeahead-http.ts
+++ b/demo/src/app/components/typeahead/demos/http/typeahead-http.ts
@@ -32,7 +32,7 @@ export class WikipediaService {
   selector: 'ngbd-typeahead-http',
   templateUrl: './typeahead-http.html',
   providers: [WikipediaService],
-  styles: [`.form-control { width: 300px; display: inline; }`]
+  styles: [`.form-control { width: 300px; }`]
 })
 export class NgbdTypeaheadHttp {
   model: any;


### PR DESCRIPTION
This wraps the form control into the container to properly render inline
form controls and also replaces span with help small text for activity
status hint.

Before:
<img width="709" alt="Screenshot 2019-12-01 at 20 37 40" src="https://user-images.githubusercontent.com/14539/69919300-bfd28800-147b-11ea-9cc6-beb0c214c4ff.png">

After:
<img width="709" alt="Screenshot 2019-12-01 at 20 39 17" src="https://user-images.githubusercontent.com/14539/69919308-c6f99600-147b-11ea-84d1-0f7866468b70.png">

Thanks!

Before submitting a pull request, please make sure you have at least performed the following:
 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable demos.
