### PR TITLE
Add name attribute to checkbox example

### DIFF
--- a/demo/src/app/components/buttons/demos/checkbox/buttons-checkbox.html
+++ b/demo/src/app/components/buttons/demos/checkbox/buttons-checkbox.html
@@ -1,12 +1,12 @@
 <div class="btn-group btn-group-toggle">
   <label class="btn-primary" ngbButtonLabel>
-    <input type="checkbox" ngbButton [(ngModel)]="model.left"> Left (pre-checked)
+    <input type="checkbox" ngbButton [(ngModel)]="model.left" name="model.left"> Left (pre-checked)
   </label>
   <label class="btn-primary" ngbButtonLabel>
-    <input type="checkbox" ngbButton [(ngModel)]="model.middle"> Middle
+    <input type="checkbox" ngbButton [(ngModel)]="model.middle" name="model.middle"> Middle
   </label>
   <label class="btn-primary" ngbButtonLabel>
-    <input type="checkbox" ngbButton [(ngModel)]="model.right"> Right
+    <input type="checkbox" ngbButton [(ngModel)]="model.right" name="model.right> Right
   </label>
 </div>
 <hr>


### PR DESCRIPTION
If ngForm is used, all the input fields which has [(ngModel)]="" must have an attribute name with a value.

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
