### PR TITLE
test(tabset): test oriantation default value

### DIFF
--- a/src/tabset/tabset-config.spec.ts
+++ b/src/tabset/tabset-config.spec.ts
@@ -6,5 +6,6 @@ describe('ngb-tabset-config', () => {
 
     expect(config.type).toBe('tabs');
     expect(config.justify).toBe('start');
+    expect(config.orientation).toBe('horizontal');
   });
 });


### PR DESCRIPTION
This minor change make sure test covers all default properties of the
tabset configuration.


This reflect the tests from:
https://github.com/ng-bootstrap/ng-bootstrap/blob/abfe76c5cd7d26673ca7d31c143c9f26e5dc0bb7/src/nav/nav-config.spec.ts

Thanks!