### PR TITLE
IE11, Edge: This change ensures the arrow icon on selects doesn't disappears on focus

### DIFF
--- a/src/datepicker/datepicker-navigation-select.scss
+++ b/src/datepicker/datepicker-navigation-select.scss
@@ -7,4 +7,9 @@ ngb-datepicker-navigation-select > .custom-select {
   &:focus {
     z-index: 1;
   }
+
+  // IE11, Edge: Fix arrow icon disappears on focus
+  &::-ms-value {
+    background-color: transparent !important;
+  }
 }


### PR DESCRIPTION
 This change ensures the arrow icon on selects doesn't disappear when it gains focus, issue #3526

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
