### PR TITLE
fix(datepicker): refine focus state checks

### DIFF
--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -388,7 +388,9 @@ export class NgbDatepicker implements OnDestroy,
           .pipe(
               filter(
                   ({target, relatedTarget}) =>
-                      !(hasClassName(target, 'ngb-dp-day') && hasClassName(relatedTarget, 'ngb-dp-day'))),
+                      !(hasClassName(target, 'ngb-dp-day') && hasClassName(relatedTarget, 'ngb-dp-day') &&
+                        this._elementRef.nativeElement.contains(target as Node) &&
+                        this._elementRef.nativeElement.contains(relatedTarget as Node))),
               takeUntil(this._destroyed$))
           .subscribe(({type}) => this._ngZone.run(() => this._service.focusVisible = type === 'focusin'));
     });


### PR DESCRIPTION
This adds additional condition to restrict focus in/out to instance of
the datepicker by verifyng if focus event target and related targets are
descendants of the datepicker element. This removes false results based
only on the class name checks, which fail when focus is switched between
datepicker instances.

Closes #3494

/cc
@gpolychronisAmadeus

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.