### PR TITLE
fix(modal): remove key/mouse handlers only when modal is destroyed

### DIFF
--- a/e2e-app/src/app/app.module.ts
+++ b/e2e-app/src/app/app.module.ts
@@ -17,6 +17,7 @@ import {ModalAutoCloseComponent} from './modal/autoclose/modal-autoclose.compone
 import {ModalFocusComponent} from './modal/focus/modal-focus.component';
 import {ModalNestingComponent} from './modal/nesting/modal-nesting.component';
 import {ModalStackComponent} from './modal/stack/modal-stack.component';
+import {ModalStackConfirmationComponent} from './modal/stack-confirmation/modal-stack-confirmation.component';
 import {PopoverAutocloseComponent} from './popover/autoclose/popover-autoclose.component';
 import {TooltipAutocloseComponent} from './tooltip/autoclose/tooltip-autoclose.component';
 import {TooltipFocusComponent} from './tooltip/focus/tooltip-focus.component';
@@ -41,6 +42,7 @@ import {TypeaheadValidationComponent} from './typeahead/validation/typeahead-val
     ModalFocusComponent,
     ModalNestingComponent,
     ModalStackComponent,
+    ModalStackConfirmationComponent,
     PopoverAutocloseComponent,
     TooltipAutocloseComponent,
     TooltipFocusComponent,

--- a/e2e-app/src/app/app.routing.ts
+++ b/e2e-app/src/app/app.routing.ts
@@ -5,10 +5,12 @@ import {DatepickerAutoCloseComponent} from './datepicker/autoclose/datepicker-au
 import {DatepickerFocusComponent} from './datepicker/focus/datepicker-focus.component';
 import {DropdownAutoCloseComponent} from './dropdown/autoclose/dropdown-autoclose.component';
 import {DropdownFocusComponent} from './dropdown/focus/dropdown-focus.component';
+import {DropdownPositionComponent} from './dropdown/position/dropdown-position.component';
 import {ModalAutoCloseComponent} from './modal/autoclose/modal-autoclose.component';
 import {ModalFocusComponent} from './modal/focus/modal-focus.component';
 import {ModalNestingComponent} from './modal/nesting/modal-nesting.component';
 import {ModalStackComponent} from './modal/stack/modal-stack.component';
+import {ModalStackConfirmationComponent} from './modal/stack-confirmation/modal-stack-confirmation.component';
 import {PopoverAutocloseComponent} from './popover/autoclose/popover-autoclose.component';
 import {TooltipAutocloseComponent} from './tooltip/autoclose/tooltip-autoclose.component';
 import {TooltipFocusComponent} from './tooltip/focus/tooltip-focus.component';
@@ -18,7 +20,6 @@ import {TypeaheadFocusComponent} from './typeahead/focus/typeahead-focus.compone
 import {TimepickerFilterComponent} from './timepicker/filter/timepicker-filter.component';
 import {TimepickerNavigationComponent} from './timepicker/navigation/timepicker-navigation.component';
 import {TypeaheadValidationComponent} from './typeahead/validation/typeahead-validation.component';
-import {DropdownPositionComponent} from './dropdown/position/dropdown-position.component';
 
 
 export const routes: Routes = [
@@ -36,6 +37,7 @@ export const routes: Routes = [
       {path: 'focus', component: ModalFocusComponent},
       {path: 'nesting', component: ModalNestingComponent},
       {path: 'stack', component: ModalStackComponent},
+      {path: 'stack-confirmation', component: ModalStackConfirmationComponent},
     ]
   },
   {

--- a/e2e-app/src/app/modal/stack-confirmation/modal-stack-confirmation.component.html
+++ b/e2e-app/src/app/modal/stack-confirmation/modal-stack-confirmation.component.html
@@ -1,0 +1,27 @@
+<h3>Modal closure confirmation test</h3>
+
+<ng-template #modal let-modal>
+  <div class="modal-header">
+    <h4 class="modal-title">Modal with closure confirmation</h4>
+    <button id="close" type="button" class="close" aria-label="Close" (click)="modal.dismiss()">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <div class="modal-body">
+    <p>This modal will trigger confirmation</p>
+  </div>
+</ng-template>
+
+<ng-template #confirmation let-modal>
+  <div class="modal-header">
+    <h4 class="modal-title">Are you sure you want to close the modal?</h4>
+    <button id="dismiss" type="button" class="close" aria-label="Close" (click)="modal.dismiss()">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <div class="modal-body">
+    <button id="confirm" class="btn btn-primary" (click)="modal.close()">Yep</button>
+  </div>
+</ng-template>
+
+<button class="btn btn-outline-secondary ml-2" type="button" id="open-modal" (click)="openModal(modal)">Open Modal</button>

--- a/e2e-app/src/app/modal/stack-confirmation/modal-stack-confirmation.component.ts
+++ b/e2e-app/src/app/modal/stack-confirmation/modal-stack-confirmation.component.ts
@@ -1,0 +1,13 @@
+import {Component, TemplateRef, ViewChild} from '@angular/core';
+import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
+
+@Component({templateUrl: './modal-stack-confirmation.component.html'})
+export class ModalStackConfirmationComponent {
+  @ViewChild('confirmation', {static: true, read: TemplateRef}) confirmationTpl: TemplateRef<any>;
+
+  constructor(private modalService: NgbModal) {}
+
+  openModal(content: TemplateRef<any>) {
+    this.modalService.open(content, {beforeDismiss: () => this.modalService.open(this.confirmationTpl).result});
+  }
+}

--- a/e2e-app/src/app/modal/stack-confirmation/modal-stack-confirmation.e2e-spec.ts
+++ b/e2e-app/src/app/modal/stack-confirmation/modal-stack-confirmation.e2e-spec.ts
@@ -1,0 +1,71 @@
+import {expectNoOpenModals, openUrl, sendKey} from '../../tools.po';
+import {ModalStackConfirmationPage} from './modal-stack-confirmation.po';
+import {Key} from 'protractor';
+
+describe('Modal stacked with confirmation', () => {
+  let page: ModalStackConfirmationPage;
+
+  beforeAll(() => { page = new ModalStackConfirmationPage(); });
+
+  beforeEach(async() => await openUrl('modal/stack-confirmation'));
+
+  afterEach(async() => { await expectNoOpenModals(); });
+
+  it('should close modals correctly using close button', async() => {
+    await page.openModal();
+
+    // close with button
+    await page.getModalClose().click();
+    expect(await page.getOpenModals().count()).toBe(2, 'Confirmation modal should be opened');
+
+    // cancel closure with button
+    await page.getDismissalButton().click();
+    expect(await page.getOpenModals().count()).toBe(1, 'Confirmation modal should be dismissed');
+
+    // close again
+    await page.getModalClose().click();
+    expect(await page.getOpenModals().count()).toBe(2, 'Confirmation modal should be re-opened');
+
+    // close all modals
+    await page.getConfirmationButton().click();
+  });
+
+  it('should close modals correctly using ESC', async() => {
+    await page.openModal();
+
+    // close with Escape
+    await sendKey(Key.ESCAPE);
+    expect(await page.getOpenModals().count()).toBe(2, 'Confirmation modal should be opened');
+
+    // cancel closure with Escape
+    await sendKey(Key.ESCAPE);
+    expect(await page.getOpenModals().count()).toBe(1, 'Confirmation modal should be dismissed');
+
+    // close again
+    await sendKey(Key.ESCAPE);
+    expect(await page.getOpenModals().count()).toBe(2, 'Confirmation modal should be re-opened');
+
+    // close all modals
+    await page.getConfirmationButton().click();
+  });
+
+  it('should close modals correctly using backdrop click', async() => {
+    await page.openModal();
+
+    // close with click
+    await page.getModal(0).click();
+    expect(await page.getOpenModals().count()).toBe(2, 'Confirmation modal should be opened');
+
+    // cancel closure with click
+    await page.getModal(1).click();
+    expect(await page.getOpenModals().count()).toBe(1, 'Confirmation modal should be dismissed');
+
+    // close again
+    await page.getModal(0).click();
+    expect(await page.getOpenModals().count()).toBe(2, 'Confirmation modal should be re-opened');
+
+    // close all modals
+    await page.getConfirmationButton().click();
+  });
+
+});

--- a/e2e-app/src/app/modal/stack-confirmation/modal-stack-confirmation.po.ts
+++ b/e2e-app/src/app/modal/stack-confirmation/modal-stack-confirmation.po.ts
@@ -1,0 +1,22 @@
+import {$, $$} from 'protractor';
+
+export class ModalStackConfirmationPage {
+  getOpenModals() { return $$('ngb-modal-window'); }
+
+  getModal(index) { return this.getOpenModals().get(index); }
+
+  getModalButton() { return $('#open-modal'); }
+
+  getModalClose() { return $('#close'); }
+
+  getConfirmationButton() { return $('#confirm'); }
+
+  getDismissalButton() { return $('#dismiss'); }
+
+  async openModal() {
+    await this.getModalButton().click();
+    const modal = this.getModal(0);
+    expect(await modal.isPresent()).toBeTruthy(`A modal should have been opened`);
+    return modal;
+  }
+}


### PR DESCRIPTION
At the moment key/mouse handlers are removed when modal triggers dismiss event. The problem is that modal closure could be cancelled with `beforeDismiss` and modal will stay opened, but handlers will be removed.

This commit introduces `closed$` event triggered inside `onDestroy` to clean up handlers.

Fixes #3515