### PR TITLE
test: fix flaky e2e keyboard tests

### DIFF
--- a/e2e-app/src/app/tools.po.ts
+++ b/e2e-app/src/app/tools.po.ts
@@ -8,6 +8,7 @@ import {$, browser, Button, ElementFinder, Key, protractor, WebElement} from 'pr
 export const sendKey = async(...keys: string[]) => {
   const focused = await browser.driver.switchTo().activeElement();
   await focused.sendKeys(Key.chord(...keys));
+  await browser.sleep(0);
 };
 
 /**


### PR DESCRIPTION
Some of the components use `requestAnimationFrame()` as a part of keyboard handling.
This might make some tests flaky when doing for example:

```ts
await sendKey(Keys.ESC);
expect(await page.getSomeElement());
```

Expectation in this case might fail or it might not.
So this commit forces tick in the the `sendKeys()` systematically after sending the key.
