### PR TITLE
feat(modal): allow any string as modal size option

### DIFF
--- a/demo/src/app/components/modal/demos/options/modal-options.ts
+++ b/demo/src/app/components/modal/demos/options/modal-options.ts
@@ -39,7 +39,9 @@ export class NgbdModalOptions {
     this.modalService.open(content, { size: 'lg' });
   }
 
-  openXl(content) { this.modalService.open(content, {size: 'xl'}); }
+  openXl(content) {
+    this.modalService.open(content, { size: 'xl' });
+  }
 
   openVerticallyCentered(content) {
     this.modalService.open(content, { centered: true });

--- a/misc/api-doc-test-cases/interface-with-properties.ts
+++ b/misc/api-doc-test-cases/interface-with-properties.ts
@@ -16,5 +16,5 @@ export interface NgbModalOptions {
   /**
    * Size of a new modal window.
    */
-  size?: 'sm' | 'lg' | 'xl';
+  size?: 'sm' | 'lg' | 'xl' | string;
 }

--- a/misc/api-doc.spec.ts
+++ b/misc/api-doc.spec.ts
@@ -171,7 +171,7 @@ describe('APIDocVisitor', () => {
     expect(interfaceDocs.properties[0].name).toBe('backdrop');
     expect(interfaceDocs.properties[0].description)
         .toContain('Weather a backdrop element should be created for a given modal (true by default).');
-    expect(interfaceDocs.properties[0].type).toBe('boolean | "static"');
+    expect(interfaceDocs.properties[0].type).toBe(`boolean | 'static'`);
     expect(interfaceDocs.properties[0].defaultValue).toBeUndefined();
 
     expect(interfaceDocs.properties[1].name).toBe('keyboard');
@@ -182,7 +182,7 @@ describe('APIDocVisitor', () => {
 
     expect(interfaceDocs.properties[2].name).toBe('size');
     expect(interfaceDocs.properties[2].description).toBe('<p>Size of a new modal window.</p>');
-    expect(interfaceDocs.properties[2].type).toBe('"sm" | "lg" | "xl"');
+    expect(interfaceDocs.properties[2].type).toBe(`'sm' | 'lg' | 'xl' | string`);
     expect(interfaceDocs.properties[2].defaultValue).toBeUndefined();
   });
 

--- a/misc/api-doc.ts
+++ b/misc/api-doc.ts
@@ -325,7 +325,13 @@ class APIDocVisitor {
     };
   }
 
-  visitType(node) { return node ? this.typeChecker.typeToString(this.typeChecker.getTypeAtLocation(node)) : 'void'; }
+  visitType(node) {
+    if (node && node.type) {
+      return node.type.getText();
+    }
+
+    return node ? this.typeChecker.typeToString(this.typeChecker.getTypeAtLocation(node)) : 'void';
+  }
 
   isDirectiveDecorator(decorator) {
     const decoratorIdentifierText = decorator.expression.expression.text;

--- a/src/modal/modal-config.ts
+++ b/src/modal/modal-config.ts
@@ -70,7 +70,7 @@ export interface NgbModalOptions {
   /**
    * Size of a new modal window.
    */
-  size?: 'sm' | 'lg' | 'xl';
+  size?: 'sm' | 'lg' | 'xl' | string;
 
   /**
    * A custom class to append to the modal window.
@@ -103,7 +103,7 @@ export class NgbModalConfig implements Required<NgbModalOptions> {
   injector: Injector;
   keyboard = true;
   scrollable: boolean;
-  size: 'sm' | 'lg' | 'xl';
+  size: 'sm' | 'lg' | 'xl' | string;
   windowClass: string;
   backdropClass: string;
 }

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -482,6 +482,17 @@ describe('ngb-modal', () => {
         expect(fixture.nativeElement).not.toHaveModal();
       });
 
+      it('should accept any strings as modal size', () => {
+        const modalInstance = fixture.componentInstance.open('foo', {size: 'ginormous'});
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveModal('foo');
+        expect(document.querySelector('.modal-dialog')).toHaveCssClass('modal-ginormous');
+
+        modalInstance.close();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveModal();
+      });
+
     });
 
     describe('window custom class options', () => {


### PR DESCRIPTION
Size type now incudes 'string' and changes to `size?: 'sm' | 'lg' | 'xl' | string;`

Main issue was to extract documentation correctly:

![Screen Shot 2020-01-10 at 12 08 28](https://user-images.githubusercontent.com/8074436/72148864-1ea3ef00-33a2-11ea-8fd2-28338edc1abd.png)

Fixes #3013

P.S. Two commits here