### PR TITLE
fix(nav): don't emit '(navChange)' when 'activeId' is not set initially

### DIFF
--- a/src/nav/nav.spec.ts
+++ b/src/nav/nav.spec.ts
@@ -200,7 +200,7 @@ describe('nav', () => {
     expectLinks(fixture, [true, false]);
     expectContents(fixture, ['content 1']);
     expect(activeIdChangeSpy).toHaveBeenCalledWith(1);
-    expect(navChangeSpy).toHaveBeenCalledWith({activeId: undefined, nextId: 1, preventDefault: jasmine.any(Function)});
+    expect(navChangeSpy).toHaveBeenCalledTimes(0);
   });
 
   it(`should initially select nothing, if [activeId] provided is incorrect`, () => {

--- a/src/nav/nav.ts
+++ b/src/nav/nav.ts
@@ -201,7 +201,7 @@ export class NgbNav implements AfterContentInit {
     if (!isDefined(this.activeId)) {
       const nextId = this.items.first ? this.items.first.id : null;
       if (nextId) {
-        this._updateActiveId(nextId);
+        this._updateActiveId(nextId, false);
         this._cd.detectChanges();
       }
     }


### PR DESCRIPTION
Fixes #3564