### PR TITLE
fix(modal): readd modal generic with a fix for noImplicitAny

### DIFF
--- a/src/modal/modal-config.ts
+++ b/src/modal/modal-config.ts
@@ -1,10 +1,11 @@
 import { Injectable, Injector } from '@angular/core';
 import { NgbConfig } from '../ngb-config';
+import { NgbModalRef } from './modal-ref';
 
 /**
  * Options available when opening new modal windows with `NgbModal.open()` method.
  */
-export interface NgbModalOptions {
+export interface NgbModalOptions<T = any> {
 	/**
 	 * If `true`, modal opening and closing will be animated.
 	 *
@@ -45,7 +46,7 @@ export interface NgbModalOptions {
 	 *
 	 * then the modal won't be dismissed.
 	 */
-	beforeDismiss?: () => boolean | Promise<boolean>;
+	beforeDismiss?: (modalRef: NgbModalRef<T>) => boolean | Promise<boolean>;
 
 	/**
 	 * If `true`, the modal will be centered vertically.
@@ -151,7 +152,7 @@ export class NgbModalConfig implements Required<NgbModalOptions> {
 	ariaLabelledBy: string;
 	ariaDescribedBy: string;
 	backdrop: boolean | 'static' = true;
-	beforeDismiss: () => boolean | Promise<boolean>;
+	beforeDismiss: (modalRef: NgbModalRef<any>) => boolean | Promise<boolean>;
 	centered: boolean;
 	container: string | HTMLElement;
 	fullscreen: 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | boolean | string = false;

--- a/src/modal/modal-ref.ts
+++ b/src/modal/modal-ref.ts
@@ -160,7 +160,7 @@ export class NgbModalRef<T = any> {
 		private _windowCmptRef: ComponentRef<NgbModalWindow>,
 		private _contentRef: ContentRef,
 		private _backdropCmptRef?: ComponentRef<NgbModalBackdrop>,
-		private _beforeDismiss?: () => boolean | Promise<boolean>,
+		private _beforeDismiss?: (modalRef: NgbModalRef<any>) => boolean | Promise<boolean>,
 	) {
 		_windowCmptRef.instance.dismissEvent.subscribe((reason: any) => {
 			this.dismiss(reason);
@@ -202,7 +202,7 @@ export class NgbModalRef<T = any> {
 			if (!this._beforeDismiss) {
 				this._dismiss(reason);
 			} else {
-				const dismiss = this._beforeDismiss();
+				const dismiss = this._beforeDismiss(this);
 				if (isPromise(dismiss)) {
 					dismiss.then(
 						(result) => {

--- a/src/modal/modal-ref.ts
+++ b/src/modal/modal-ref.ts
@@ -101,6 +101,7 @@ export class NgbModalRef<T = any> {
 		if (this._contentRef && this._contentRef.componentRef) {
 			return this._contentRef.componentRef.instance;
 		}
+		return undefined as any;
 	}
 
 	/**

--- a/src/modal/modal-ref.ts
+++ b/src/modal/modal-ref.ts
@@ -57,7 +57,7 @@ const BACKDROP_ATTRIBUTES: string[] = ['animation', 'backdropClass'];
 /**
  * A reference to the newly opened modal returned by the `NgbModal.open()` method.
  */
-export class NgbModalRef {
+export class NgbModalRef<T = any> {
 	private _closed = new Subject<any>();
 	private _dismissed = new Subject<any>();
 	private _hidden = new Subject<void>();
@@ -97,7 +97,7 @@ export class NgbModalRef {
 	 *
 	 * When a `TemplateRef` is used as the content or when the modal is closed, will return `undefined`.
 	 */
-	get componentInstance(): any {
+	get componentInstance(): T extends new (...args: any[]) => any ? InstanceType<T> : undefined {
 		if (this._contentRef && this._contentRef.componentRef) {
 			return this._contentRef.componentRef.instance;
 		}

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -1501,7 +1501,7 @@ export class WithSkipTabindexFirstFocusableModalCmpt {}
 })
 class TestComponent {
 	name = 'World';
-	openedModal: NgbModalRef;
+	openedModal: NgbModalRef<string>;
 	show = true;
 	@ViewChild('content', { static: true }) tplContent;
 	@ViewChild('destroyableContent', { static: true }) tplDestroyableContent;

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -23,7 +23,7 @@ export class NgbModal {
 	 *
 	 * Also see the [`NgbModalOptions`](#/components/modal/api#NgbModalOptions) for the list of supported options.
 	 */
-	open(content: any, options: NgbModalOptions = {}): NgbModalRef {
+	open<T>(content: T, options: NgbModalOptions = {}): NgbModalRef<T> {
 		const combinedOptions = { ...this._config, animation: this._config.animation, ...options };
 		return this._modalStack.open(this._injector, content, combinedOptions);
 	}

--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -23,7 +23,7 @@ export class NgbModal {
 	 *
 	 * Also see the [`NgbModalOptions`](#/components/modal/api#NgbModalOptions) for the list of supported options.
 	 */
-	open<T>(content: T, options: NgbModalOptions = {}): NgbModalRef<T> {
+	open<T>(content: T, options: NgbModalOptions<T> = {}): NgbModalRef<T> {
 		const combinedOptions = { ...this._config, animation: this._config.animation, ...options };
 		return this._modalStack.open(this._injector, content, combinedOptions);
 	}


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.

Another attempt on #2479.
Pullrequest #2815 was rolled back because of a bug with `noImplicitAny` (#3464).
In this request I'm putting it back with one addition: modal is now passed as an argument into `beforeDismiss`, which allows to write
```typescript
const modalRef = this.modalService.open(NgbdModalContent, {
  beforeDismiss: modal => modal.componentInstance.canDismiss(),
});
```
which compiles correctly without any additional type annotations.

CC @nseni , @michaeljota
