### PR TITLE
demo(accordion): add the `[cardClass]` usage example

### DIFF
--- a/demo/src/app/components/accordion/demos/header/accordion-header.html
+++ b/demo/src/app/components/accordion/demos/header/accordion-header.html
@@ -37,7 +37,7 @@
       labore sustainable VHS.
     </ng-template>
   </ngb-panel>
-  <ngb-panel [disabled]="disabled">
+  <ngb-panel [disabled]="disabled" [cardClass]="disabled ? 'disabled' : ''">
     <ng-template ngbPanelHeader>
       <div class="d-flex align-items-center justify-content-between">
         <button ngbPanelToggle class="btn btn-link container-fluid text-left pl-0">Third panel</button>

--- a/demo/src/app/components/accordion/demos/header/accordion-header.ts
+++ b/demo/src/app/components/accordion/demos/header/accordion-header.ts
@@ -1,8 +1,14 @@
-import { Component } from '@angular/core';
+import {Component, ViewEncapsulation} from '@angular/core';
 
 @Component({
   selector: 'ngbd-accordion-header',
-  templateUrl: './accordion-header.html'
+  templateUrl: './accordion-header.html',
+  encapsulation: ViewEncapsulation.None,
+  styles: [`
+    .card.disabled {
+      opacity: 0.5;
+    }
+  `]
 })
 export class NgbdAccordionHeader {
   disabled = false;


### PR DESCRIPTION
Adds opacity to this demo:

<img width="791" alt="Screen Shot 2020-02-13 at 11 30 30" src="https://user-images.githubusercontent.com/8074436/74425640-4f20f200-4e54-11ea-9d55-98827eb0b725.png">
