### PR TITLE
ci: add 'demo' type to commit messages

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -184,8 +184,20 @@ For Conventional Commit Messages to be working with [CommitLint](https://commitl
 
 In both cases you can validate your local installation by trying to commit something. (guides available [here](https://commitlint.js.org/#/guides-local-setup))
 
-#### Scopes
+#### Commit types and scopes 
 
-We maintain dynamic custom scopes on the project. Valid scopes correspond to the name of our widgets or the 2 generic terms _"demo"_ & _"demos"_.
+We maintain dynamic custom scopes for the project. Valid scopes correspond to the name of our widgets: `alert`, `accordion`, etc.
+
+Examples:
+- `feat(datepicker): ...` &rarr; a new feature for the datepicker 
+- `fix(datepicker): ...` &rarr; a bug fix for the datepicker
+- `test(datepicker): ... ` &rarr; an update to one of the datepicker unit or e2e tests
+- `docs(datepicker): ...` &rarr; a datepicker documentation update
+- `refactor(datepicker): ... ` &rarr; an internal datepicker refactoring without public functionality changes
+- `demo(datepicker): ... ` &rarr; an update to one of the datepicker demos
+- `demo: ...` &rarr; any change for the demo site
+- `build: ...` &rarr; any change for the utility scripts, configurations, dependencies, etc.
+- `ci: ...` &rarr; any change for CI related configuration
+- `revert: ...` &rarr; revert an older commit
 
 Anything else won't pass commitlint validation.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,17 +1,22 @@
 const fs = require('fs');
+const angularTypes = require('@commitlint/config-angular-type-enum').value();
 
 /*
   Let's get widget names as valid list of scopes.
-  Adding also demo & demos as valid too.
 */
 const scopes = [
-  "demo", "demos", ...fs.readdirSync("./src", {withFileTypes: true})
-                       .filter(d => d.isDirectory())
-                       .filter(d => !["test", "util"].includes(d.name))
-                       .map(d => d.name)
+  ...fs.readdirSync("./src", {withFileTypes: true})
+    .filter(d => d.isDirectory())
+    .filter(d => !["test", "util"].includes(d.name))
+    .map(d => d.name)
 ];
+
+const types = ['demo', ...angularTypes];
 
 module.exports = {
   extends: ['@commitlint/config-angular'],
-  rules: {"scope-enum": [2, 'always', scopes]}
+  rules: {
+    "scope-enum": [2, 'always', scopes],
+    "type-enum": [2, 'always', types]
+  }
 };


### PR DESCRIPTION
Currently the `'demo'` is part of the scopes, not types in commit linting.

So if I want to update one of the accordion demos, it is only possible to have commits like:

```
fix(demo): ...
docs(accordion): ...
```

Also `'fix'` commits would end up in release notes.

I would expect to have commits like:

```
demo(accordion): ...
demo(datepicker): ...
```

That would have a demo site as the scope.

WDYT?