### PR TITLE
fix(tooltip): prevent autoclose with default triggers on iPadOS 13

### DIFF
--- a/src/util/autoclose.ts
+++ b/src/util/autoclose.ts
@@ -12,13 +12,17 @@ const matchesSelectorIfAny = (element: HTMLElement, selector?: string) =>
 
 // we have to add a more significant delay to avoid re-opening when handling (click) on a toggling element
 // TODO: use proper Angular platform detection when NgbAutoClose becomes a service and we can inject PLATFORM_ID
-const isMobile = () => typeof navigator !== 'undefined' ?
-    !!navigator.userAgent && /iPad|iPhone|iPod|Android/.test(navigator.userAgent) :
-    false;
+const isMobile = (() => {
+  const isIOS = () => /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+      (/Macintosh/.test(navigator.userAgent) && navigator.maxTouchPoints && navigator.maxTouchPoints > 2);
+  const isAndroid = () => /Android/.test(navigator.userAgent);
+
+  return typeof navigator !== 'undefined' ? !!navigator.userAgent && (isIOS() || isAndroid()) : false;
+})();
 
 // setting 'ngbAutoClose' synchronously on mobile results in immediate popup closing
 // when tapping on the triggering element
-const wrapAsyncForMobile = fn => isMobile() ? () => setTimeout(() => fn(), 100) : fn;
+const wrapAsyncForMobile = fn => isMobile ? () => setTimeout(() => fn(), 100) : fn;
 
 export function ngbAutoClose(
     zone: NgZone, document: any, type: boolean | 'inside' | 'outside', close: () => void, closed$: Observable<any>,


### PR DESCRIPTION
Same as #3582, but for the iPadOS 13

Fixes #3591