### PR TITLE
fix(popover): make tooltip and popover work on the same element

### DIFF
--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -16,6 +16,7 @@ import {
 import {NgbPopoverModule} from './popover.module';
 import {NgbPopoverWindow, NgbPopover} from './popover';
 import {NgbPopoverConfig} from './popover-config';
+import {NgbTooltip, NgbTooltipModule} from '..';
 
 @Injectable()
 class SpyService {
@@ -727,6 +728,28 @@ describe('ngb-popover', () => {
       const buttonEl = fixture.debugElement.query(By.css('button'));
       triggerEvent(buttonEl, 'click');
     });
+  });
+});
+
+describe('popover-tooltip', () => {
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPopoverModule, NgbTooltipModule]});
+  });
+
+  it(`should work when attached on the same element and container='body'`, () => {
+    const fixture = createTestComponent(`<button ngbPopover="Popover" ngbTooltip="Tooltip" container="body"></button>`);
+    const button = fixture.nativeElement.querySelector('button');
+    const tooltip = fixture.debugElement.query(By.directive(NgbTooltip)).injector.get(NgbTooltip);
+    const popover = fixture.debugElement.query(By.directive(NgbPopover)).injector.get(NgbPopover);
+
+    tooltip.open();
+    expect(tooltip.isOpen()).toBe(true);
+    expect(popover.isOpen()).toBe(false);
+
+    // this should open the popover and have produced the "Error: Failed to execute 'insertBefore' on 'Node':
+    // The node before which the new node is to be inserted is not a child of this node." exception with ivy
+    button.click();
   });
 });
 

--- a/src/util/popup.ts
+++ b/src/util/popup.ts
@@ -26,8 +26,8 @@ export class PopupService<T> {
     if (!this._windowRef) {
       this._contentRef = this._getContentRef(content, context);
       this._windowRef = this._viewContainerRef.createComponent(
-          this._componentFactoryResolver.resolveComponentFactory<T>(this._type), 0, this._injector,
-          this._contentRef.nodes);
+          this._componentFactoryResolver.resolveComponentFactory<T>(this._type), this._viewContainerRef.length,
+          this._injector, this._contentRef.nodes);
     }
 
     return this._windowRef;


### PR DESCRIPTION
Fixes a regression in the popup service after migrating to ivy

Fixes #3602