### PR TITLE
docs(tabset): deprecate NgbTabset component

### DIFF
--- a/demo/src/app/components/tabset/demos/config/tabset-config.ts
+++ b/demo/src/app/components/tabset/demos/config/tabset-config.ts
@@ -1,3 +1,4 @@
+// tslint:disable:deprecation
 import {Component} from '@angular/core';
 import {NgbTabsetConfig} from '@ng-bootstrap/ng-bootstrap';
 

--- a/demo/src/app/components/tabset/demos/preventchange/tabset-preventchange.ts
+++ b/demo/src/app/components/tabset/demos/preventchange/tabset-preventchange.ts
@@ -1,3 +1,4 @@
+// tslint:disable:deprecation
 import {Component} from '@angular/core';
 import {NgbTabChangeEvent} from '@ng-bootstrap/ng-bootstrap';
 

--- a/demo/src/app/components/tabset/tabset-warning.component.ts
+++ b/demo/src/app/components/tabset/tabset-warning.component.ts
@@ -1,16 +1,17 @@
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 
 @Component({
   selector: 'ngbd-tabset-warning',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <ngb-alert type="warning" [dismissible]="false" class="mb-5 d-flex flex-row">
+    <ngb-alert type="danger" [dismissible]="false" class="mb-5 d-flex flex-row">
       <div class="mr-2">
         <svg:svg ngbdIcon="lightbulb" fill="currentColor" />
       </div>
       <div>
-        Since version <span class="badge badge-info" >5.2.0</span> please consider using
-        <a routerLink="/components/nav">Nav directives</a> as a more flexible alternative.
-        Tabset will not be supported anymore and will be deprecated.
+        Tabset is deprecated since version <span class="badge badge-info">6.0.0</span>
+        and is not supported anymore. Please use <a routerLink="/components/nav">Nav directives</a>
+        as a more flexible alternative.
       </div>
     </ngb-alert>
   `

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,9 @@ export {Placement} from './util/positioning';
 const NGB_MODULES = [
   NgbAccordionModule, NgbAlertModule, NgbButtonsModule, NgbCarouselModule, NgbCollapseModule, NgbDatepickerModule,
   NgbDropdownModule, NgbModalModule, NgbNavModule, NgbPaginationModule, NgbPopoverModule, NgbProgressbarModule,
-  NgbRatingModule, NgbTabsetModule, NgbTimepickerModule, NgbToastModule, NgbTooltipModule, NgbTypeaheadModule
+  NgbRatingModule, NgbTimepickerModule, NgbToastModule, NgbTooltipModule, NgbTypeaheadModule,
+  // tslint:disable-next-line:deprecation
+  NgbTabsetModule
 ];
 
 @NgModule({imports: NGB_MODULES, exports: NGB_MODULES})

--- a/src/tabset/tabset-config.spec.ts
+++ b/src/tabset/tabset-config.spec.ts
@@ -1,3 +1,4 @@
+// tslint:disable:deprecation
 import {NgbTabsetConfig} from './tabset-config';
 
 describe('ngb-tabset-config', () => {

--- a/src/tabset/tabset-config.ts
+++ b/src/tabset/tabset-config.ts
@@ -1,3 +1,4 @@
+// tslint:disable:deprecation
 import {Injectable} from '@angular/core';
 
 /**
@@ -5,6 +6,8 @@ import {Injectable} from '@angular/core';
  *
  * You can inject this service, typically in your root component, and customize the values of its properties in
  * order to provide default values for all the tabsets used in the application.
+ *
+ * @deprecated 6.0.0 Please use NgbNav instead
  */
 @Injectable({providedIn: 'root'})
 export class NgbTabsetConfig {

--- a/src/tabset/tabset.module.ts
+++ b/src/tabset/tabset.module.ts
@@ -1,6 +1,6 @@
+// tslint:disable:deprecation
 import {NgModule} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {NgbNavModule} from '../nav/nav.module';
 
 import {NgbTabset, NgbTab, NgbTabContent, NgbTabTitle} from './tabset';
 
@@ -9,6 +9,9 @@ export {NgbTabsetConfig} from './tabset-config';
 
 const NGB_TABSET_DIRECTIVES = [NgbTabset, NgbTab, NgbTabContent, NgbTabTitle];
 
-@NgModule({declarations: NGB_TABSET_DIRECTIVES, exports: NGB_TABSET_DIRECTIVES, imports: [CommonModule, NgbNavModule]})
+/**
+ * @deprecated 6.0.0 Please use NgbNavModule instead
+ */
+@NgModule({declarations: NGB_TABSET_DIRECTIVES, exports: NGB_TABSET_DIRECTIVES, imports: [CommonModule]})
 export class NgbTabsetModule {
 }

--- a/src/tabset/tabset.spec.ts
+++ b/src/tabset/tabset.spec.ts
@@ -1,3 +1,4 @@
+// tslint:disable:deprecation
 import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
 import {createGenericTestComponent} from '../test/common';
 

--- a/src/tabset/tabset.ts
+++ b/src/tabset/tabset.ts
@@ -1,3 +1,4 @@
+// tslint:disable:deprecation
 import {
   AfterContentChecked,
   Component,
@@ -18,6 +19,8 @@ let nextId = 0;
  * A directive to wrap tab titles that need to contain HTML markup or other directives.
  *
  * Alternatively you could use the `NgbTab.title` input for string titles.
+ *
+ * @deprecated 6.0.0 Please use NgbNav instead
  */
 @Directive({selector: 'ng-template[ngbTabTitle]'})
 export class NgbTabTitle {
@@ -26,6 +29,8 @@ export class NgbTabTitle {
 
 /**
  * A directive to wrap content to be displayed in a tab.
+ *
+ * @deprecated 6.0.0 Please use NgbNav instead
  */
 @Directive({selector: 'ng-template[ngbTabContent]'})
 export class NgbTabContent {
@@ -34,6 +39,8 @@ export class NgbTabContent {
 
 /**
  * A directive representing an individual tab.
+ *
+ * @deprecated 6.0.0 Please use NgbNav instead
  */
 @Directive({selector: 'ngb-tab'})
 export class NgbTab implements AfterContentChecked {
@@ -74,6 +81,8 @@ export class NgbTab implements AfterContentChecked {
 
 /**
  * The payload of the change event fired right before the tab change.
+ *
+ * @deprecated 6.0.0 Please use NgbNav instead
  */
 export interface NgbTabChangeEvent {
   /**
@@ -94,6 +103,8 @@ export interface NgbTabChangeEvent {
 
 /**
  * A component that makes it easy to create tabbed interface.
+ *
+ * @deprecated 6.0.0 Please use NgbNav instead
  */
 @Component({
   selector: 'ngb-tabset',


### PR DESCRIPTION
`NgbTabset` is deprecated and will no longer be supported. Please use `NgbNav` instead as a more flexible alternative

Demo looks like this:
<img width="887" alt="Screen Shot 2020-02-20 at 16 29 28" src="https://user-images.githubusercontent.com/8074436/74949573-35f0e600-53fe-11ea-9a97-c8d208542bbd.png">
