### PR TITLE
Enable strict null checks

### DIFF
--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -24,7 +24,7 @@ export class AppComponent implements OnInit {
         .subscribe(fragment => zone.runOutsideAngular(() => requestAnimationFrame(() => vps.scrollToAnchor(fragment))));
 
     if (environment.production) {
-      httpClient.get('https://api.npmjs.org/downloads/point/last-month/@ng-bootstrap/ng-bootstrap')
+      httpClient.get<{downloads: string}>('https://api.npmjs.org/downloads/point/last-month/@ng-bootstrap/ng-bootstrap')
           .pipe(pluck('downloads'))
           .subscribe(count => this.downloadCount = count.toLocaleString(), () => of(''));
     }

--- a/demo/src/app/components/alert/demos/selfclosing/alert-selfclosing.html
+++ b/demo/src/app/components/alert/demos/selfclosing/alert-selfclosing.html
@@ -8,7 +8,7 @@
 <p>
   Show a self-closing success message that disappears after 5 seconds.
 </p>
-<ngb-alert *ngIf="successMessage" type="success" (close)="successMessage = null">{{ successMessage }}</ngb-alert>
+<ngb-alert *ngIf="successMessage" type="success" (close)="successMessage = ''">{{ successMessage }}</ngb-alert>
 <p>
   <button class="btn btn-primary" (click)="changeSuccessMessage()">Change message</button>
 </p>

--- a/demo/src/app/components/alert/demos/selfclosing/alert-selfclosing.ts
+++ b/demo/src/app/components/alert/demos/selfclosing/alert-selfclosing.ts
@@ -10,15 +10,15 @@ export class NgbdAlertSelfclosing implements OnInit {
   private _success = new Subject<string>();
 
   staticAlertClosed = false;
-  successMessage: string;
+  successMessage = '';
 
   ngOnInit(): void {
     setTimeout(() => this.staticAlertClosed = true, 20000);
 
-    this._success.subscribe((message) => this.successMessage = message);
+    this._success.subscribe(message => this.successMessage = message);
     this._success.pipe(
       debounceTime(5000)
-    ).subscribe(() => this.successMessage = null);
+    ).subscribe(() => this.successMessage = '');
   }
 
   public changeSuccessMessage() {

--- a/demo/src/app/components/datepicker/demos/adapter/datepicker-adapter.ts
+++ b/demo/src/app/components/datepicker/demos/adapter/datepicker-adapter.ts
@@ -1,10 +1,5 @@
 import {Component, Injectable} from '@angular/core';
-import {
-  NgbCalendar,
-  NgbDateAdapter,
-  NgbDateStruct,
-  NgbDateParserFormatter
-} from '@ng-bootstrap/ng-bootstrap';
+import {NgbCalendar, NgbDateAdapter, NgbDateParserFormatter, NgbDateStruct} from '@ng-bootstrap/ng-bootstrap';
 
 /**
  * This Service handles how the date is represented in scripts i.e. ngModel.
@@ -14,25 +9,20 @@ export class CustomAdapter extends NgbDateAdapter<string> {
 
   readonly DELIMITER = '-';
 
-  fromModel(value: string): NgbDateStruct {
-    let result: NgbDateStruct = null;
+  fromModel(value: string | null): NgbDateStruct | null {
     if (value) {
       let date = value.split(this.DELIMITER);
-      result = {
+      return {
         day : parseInt(date[0], 10),
         month : parseInt(date[1], 10),
         year : parseInt(date[2], 10)
       };
     }
-    return result;
+    return null;
   }
 
-  toModel(date: NgbDateStruct): string {
-    let result: string = null;
-    if (date) {
-      result = date.day + this.DELIMITER + date.month + this.DELIMITER + date.year;
-    }
-    return result;
+  toModel(date: NgbDateStruct | null): string | null {
+    return date ? date.day + this.DELIMITER + date.month + this.DELIMITER + date.year : null;
   }
 }
 
@@ -44,25 +34,20 @@ export class CustomDateParserFormatter extends NgbDateParserFormatter {
 
   readonly DELIMITER = '/';
 
-  parse(value: string): NgbDateStruct {
-    let result: NgbDateStruct = null;
+  parse(value: string): NgbDateStruct | null {
     if (value) {
       let date = value.split(this.DELIMITER);
-      result = {
+      return {
         day : parseInt(date[0], 10),
         month : parseInt(date[1], 10),
         year : parseInt(date[2], 10)
       };
     }
-    return result;
+    return null;
   }
 
-  format(date: NgbDateStruct): string {
-    let result: string = null;
-    if (date) {
-      result = date.day + this.DELIMITER + date.month + this.DELIMITER + date.year;
-    }
-    return result;
+  format(date: NgbDateStruct | null): string {
+    return date ? date.day + this.DELIMITER + date.month + this.DELIMITER + date.year : '';
   }
 }
 
@@ -85,6 +70,6 @@ export class NgbdDatepickerAdapter {
   constructor(private ngbCalendar: NgbCalendar, private dateAdapter: NgbDateAdapter<string>) {}
 
   get today() {
-    return this.dateAdapter.toModel(this.ngbCalendar.getToday());
+    return this.dateAdapter.toModel(this.ngbCalendar.getToday())!;
   }
 }

--- a/demo/src/app/components/datepicker/demos/customday/datepicker-customday.ts
+++ b/demo/src/app/components/datepicker/demos/customday/datepicker-customday.ts
@@ -31,6 +31,6 @@ export class NgbdDatepickerCustomday {
   constructor(private calendar: NgbCalendar) {
   }
 
-  isDisabled = (date: NgbDate, current: {month: number}) => date.month !== current.month;
+  isDisabled = (date: NgbDate, current: {month: number, year: number}) => date.month !== current.month;
   isWeekend = (date: NgbDate) =>  this.calendar.getWeekday(date) >= 6;
 }

--- a/demo/src/app/components/datepicker/demos/popup/datepicker-popup.ts
+++ b/demo/src/app/components/datepicker/demos/popup/datepicker-popup.ts
@@ -1,9 +1,10 @@
 import {Component} from '@angular/core';
+import {NgbDateStruct} from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
   selector: 'ngbd-datepicker-popup',
   templateUrl: './datepicker-popup.html'
 })
 export class NgbdDatepickerPopup {
-  model;
+  model: NgbDateStruct;
 }

--- a/demo/src/app/components/datepicker/demos/range-popup/datepicker-range-popup.html
+++ b/demo/src/app/components/datepicker/demos/range-popup/datepicker-range-popup.html
@@ -10,7 +10,7 @@
              [displayMonths]="2"
              [dayTemplate]="t"
              outsideDays="hidden"
-             [startDate]="fromDate">
+             [startDate]="fromDate!">
       <ng-template #t let-date let-focused="focused">
         <span class="custom-day"
               [class.focused]="focused"

--- a/demo/src/app/components/datepicker/demos/range-popup/datepicker-range-popup.ts
+++ b/demo/src/app/components/datepicker/demos/range-popup/datepicker-range-popup.ts
@@ -32,10 +32,10 @@ import {NgbDate, NgbCalendar, NgbDateParserFormatter} from '@ng-bootstrap/ng-boo
 })
 export class NgbdDatepickerRangePopup {
 
-  hoveredDate: NgbDate;
+  hoveredDate: NgbDate | null = null;
 
-  fromDate: NgbDate;
-  toDate: NgbDate;
+  fromDate: NgbDate | null;
+  toDate: NgbDate | null;
 
   constructor(private calendar: NgbCalendar, public formatter: NgbDateParserFormatter) {
     this.fromDate = calendar.getToday();
@@ -45,7 +45,7 @@ export class NgbdDatepickerRangePopup {
   onDateSelection(date: NgbDate) {
     if (!this.fromDate && !this.toDate) {
       this.fromDate = date;
-    } else if (this.fromDate && !this.toDate && date.after(this.fromDate)) {
+    } else if (this.fromDate && !this.toDate && date && date.after(this.fromDate)) {
       this.toDate = date;
     } else {
       this.toDate = null;
@@ -58,14 +58,14 @@ export class NgbdDatepickerRangePopup {
   }
 
   isInside(date: NgbDate) {
-    return date.after(this.fromDate) && date.before(this.toDate);
+    return this.toDate && date.after(this.fromDate) && date.before(this.toDate);
   }
 
   isRange(date: NgbDate) {
-    return date.equals(this.fromDate) || date.equals(this.toDate) || this.isInside(date) || this.isHovered(date);
+    return date.equals(this.fromDate) || (this.toDate && date.equals(this.toDate)) || this.isInside(date) || this.isHovered(date);
   }
 
-  validateInput(currentValue: NgbDate, input: string): NgbDate {
+  validateInput(currentValue: NgbDate | null, input: string): NgbDate | null {
     const parsed = this.formatter.parse(input);
     return parsed && this.calendar.isValid(NgbDate.from(parsed)) ? NgbDate.from(parsed) : currentValue;
   }

--- a/demo/src/app/components/datepicker/demos/range/datepicker-range.ts
+++ b/demo/src/app/components/datepicker/demos/range/datepicker-range.ts
@@ -26,10 +26,10 @@ import {NgbDate, NgbCalendar} from '@ng-bootstrap/ng-bootstrap';
 })
 export class NgbdDatepickerRange {
 
-  hoveredDate: NgbDate;
+  hoveredDate: NgbDate | null = null;
 
   fromDate: NgbDate;
-  toDate: NgbDate;
+  toDate: NgbDate | null = null;
 
   constructor(calendar: NgbCalendar) {
     this.fromDate = calendar.getToday();
@@ -52,10 +52,10 @@ export class NgbdDatepickerRange {
   }
 
   isInside(date: NgbDate) {
-    return date.after(this.fromDate) && date.before(this.toDate);
+    return this.toDate && date.after(this.fromDate) && date.before(this.toDate);
   }
 
   isRange(date: NgbDate) {
-    return date.equals(this.fromDate) || date.equals(this.toDate) || this.isInside(date) || this.isHovered(date);
+    return date.equals(this.fromDate) || (this.toDate && date.equals(this.toDate)) || this.isInside(date) || this.isHovered(date);
   }
 }

--- a/demo/src/app/components/datepicker/overview/demo/datepicker-overview-demo.component.ts
+++ b/demo/src/app/components/datepicker/overview/demo/datepicker-overview-demo.component.ts
@@ -73,12 +73,12 @@ export class NgbdDatepickerOverviewDemoComponent {
 
   today: NgbDate;
 
-  hoveredDate: NgbDate;
+  hoveredDate: NgbDate | null = null;
 
   fromDate: NgbDate;
-  toDate: NgbDate;
+  toDate: NgbDate | null = null;
 
-  holidays: {month, day, text}[] = [
+  holidays: {month: number, day: number, text: string}[] = [
     {month: 1, day: 1, text: 'New Years Day'},
     {month: 3, day: 30, text: 'Good Friday (hi, Alsace!)'},
     {month: 5, day: 1, text: 'Labour Day'},
@@ -117,7 +117,7 @@ export class NgbdDatepickerOverviewDemoComponent {
     }
   }
 
-  getTooltip(date: NgbDate) {
+  getTooltip(date: NgbDate): string {
     const holidayTooltip = this.isHoliday(date);
 
     if (holidayTooltip) {
@@ -129,7 +129,7 @@ export class NgbdDatepickerOverviewDemoComponent {
     }
   }
 
-  getFirstAvailableDate(date): NgbDate {
+  getFirstAvailableDate(date: NgbDate): NgbDate {
     while (this.isWeekend(date) || this.isHoliday(date)) {
       date = this.calendar.getNext(date, 'd', 1);
     }
@@ -141,7 +141,7 @@ export class NgbdDatepickerOverviewDemoComponent {
   }
 
   isRange(date: NgbDate) {
-    return date.equals(this.fromDate) || date.equals(this.toDate) || this.isInside(date) || this.isHovered(date);
+    return date.equals(this.fromDate) || (this.toDate && date.equals(this.toDate)) || this.isInside(date) || this.isHovered(date);
   }
 
   isHovered(date: NgbDate) {
@@ -149,6 +149,6 @@ export class NgbdDatepickerOverviewDemoComponent {
   }
 
   isInside(date: NgbDate) {
-    return date.after(this.fromDate) && date.before(this.toDate);
+    return this.toDate && date.after(this.fromDate) && date.before(this.toDate);
   }
 }

--- a/demo/src/app/components/modal/demos/basic/modal-basic.html
+++ b/demo/src/app/components/modal/demos/basic/modal-basic.html
@@ -27,4 +27,4 @@
 
 <hr>
 
-<pre>{{closeResult}}</pre>
+<pre>{{ closeResult }}</pre>

--- a/demo/src/app/components/modal/demos/basic/modal-basic.ts
+++ b/demo/src/app/components/modal/demos/basic/modal-basic.ts
@@ -7,7 +7,7 @@ import {NgbModal, ModalDismissReasons} from '@ng-bootstrap/ng-bootstrap';
   templateUrl: './modal-basic.html'
 })
 export class NgbdModalBasic {
-  closeResult: string;
+  closeResult = '';
 
   constructor(private modalService: NgbModal) {}
 
@@ -25,7 +25,7 @@ export class NgbdModalBasic {
     } else if (reason === ModalDismissReasons.BACKDROP_CLICK) {
       return 'by clicking on a backdrop';
     } else {
-      return  `with: ${reason}`;
+      return `with: ${reason}`;
     }
   }
 }

--- a/demo/src/app/components/modal/demos/focus/modal-focus.ts
+++ b/demo/src/app/components/modal/demos/focus/modal-focus.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import {Component, Type} from '@angular/core';
 import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
@@ -51,7 +51,7 @@ export class NgbdModalConfirmAutofocus {
   constructor(public modal: NgbActiveModal) {}
 }
 
-const MODALS = {
+const MODALS: {[name: string]: Type<any>} = {
   focusFirst: NgbdModalConfirm,
   autofocus: NgbdModalConfirmAutofocus
 };

--- a/demo/src/app/components/shared/api-docs/api-docs-badge.component.ts
+++ b/demo/src/app/components/shared/api-docs/api-docs-badge.component.ts
@@ -22,12 +22,12 @@ const BADGES = {
 })
 export class NgbdApiDocsBadge {
 
-  badgeClass;
-  text;
+  badgeClass: string;
+  text: string;
 
-  @Input() deprecated: {version: string};
+  @Input() deprecated?: {version: string};
 
-  @Input() since: {version: string};
+  @Input() since?: {version: string};
 
   @Input()
   set type(type: string) {

--- a/demo/src/app/components/shared/api-docs/api-docs-class.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs-class.component.html
@@ -2,7 +2,7 @@
   <h3>
     <a
       class="title-fragment"
-      [routerLink]=""
+      routerLink
       fragment="{{apiDocs.className}}" ngbdFragment
       title="Anchor link to: {{apiDocs.className}}"
     >

--- a/demo/src/app/components/shared/api-docs/api-docs-config.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs-config.component.html
@@ -2,7 +2,7 @@
   <h3>
     <a
       class="title-fragment"
-      [routerLink]=""
+      routerLink
       fragment="{{apiDocs.className}}"
       ngbdFragment
       title="Anchor link to: {{apiDocs.className}}"
@@ -33,7 +33,7 @@
           <code class="pr-2">{{ property.name }}</code>&ngsp;
         </ng-template>
       </p>
-      <p class="mt-3">Documentation available in <a [routerLink]="" fragment="{{directiveName}}">{{ directiveName }}</a></p>
+      <p class="mt-3">Documentation available in <a routerLink fragment="{{directiveName}}">{{ directiveName }}</a></p>
     </section>
   </ng-template>
 </div>

--- a/demo/src/app/components/shared/api-docs/api-docs.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs.component.html
@@ -1,7 +1,7 @@
 <div class="api-doc-component" [class.deprecated]="apiDocs.deprecated">
   <h3 class="title">
     <a
-      [routerLink]=""
+      routerLink
       [fragment]="apiDocs.className" ngbdFragment
       title="Anchor link to: {{apiDocs.className}}"
     >

--- a/demo/src/app/components/shared/api-docs/api-docs.component.ts
+++ b/demo/src/app/components/shared/api-docs/api-docs.component.ts
@@ -55,7 +55,7 @@ export class NgbdApiDocs {
    */
   defaultInputValue(input: InputDesc): string {
     const configProperty = this._configProperties[input.name];
-    return configProperty ? configProperty.defaultValue : input.defaultValue;
+    return (configProperty ? configProperty.defaultValue : input.defaultValue) || '';
   }
 
   /**

--- a/demo/src/app/components/shared/api-page/api.component.ts
+++ b/demo/src/app/components/shared/api-page/api.component.ts
@@ -3,10 +3,10 @@ import { ActivatedRoute } from '@angular/router';
 
 import apiDocs from '../../../../api-docs';
 
-export function getApis(component) {
-  const components = [];
-  const classes = [];
-  const configs = [];
+export function getApis(component: string) {
+  const components: any[]  = [];
+  const classes: any[] = [];
+  const configs: any[] = [];
   Object.values(apiDocs)
     .filter(entity => entity.fileName.startsWith(`src/${component}`))
     .forEach(entity => {
@@ -45,7 +45,7 @@ export class NgbdApiPage {
   configs: string[];
 
   constructor(route: ActivatedRoute) {
-    const component = route.parent.parent.snapshot.url[1].path;
+    const component = route.parent!.parent!.snapshot.url[1].path;
     const apis = getApis(component);
     this.components = apis.components.sort();
     this.classes = apis.classes.sort();

--- a/demo/src/app/components/shared/demo-list.ts
+++ b/demo/src/app/components/shared/demo-list.ts
@@ -1,6 +1,7 @@
 import {Injectable} from '@angular/core';
 
 export interface NgbdDemoConfig {
+  id?: string;
   title: string;
   code?: string;
   markup?: string;

--- a/demo/src/app/components/shared/examples-page/demo.component.html
+++ b/demo/src/app/components/shared/examples-page/demo.component.html
@@ -1,7 +1,7 @@
 <div class="component-demo">
   <a [id]="id"></a>
   <h2>
-    <a [routerLink]="" [fragment]="id" ngbdFragment title="Anchor link to demo: {{id}}">
+    <a routerLink [fragment]="id" ngbdFragment title="Anchor link to demo: {{id}}">
       <img src="img/link-symbol.svg" alt="Anchor link to: {{id}}" />
     </a>
     <span>{{ demoTitle }}</span>

--- a/demo/src/app/components/shared/examples-page/demo.component.ts
+++ b/demo/src/app/components/shared/examples-page/demo.component.ts
@@ -1,7 +1,14 @@
 import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 
 import {Analytics} from '../../../shared/analytics/analytics';
-import {Snippet} from '../../../shared/code/snippet';
+import {ISnippet, Snippet} from '../../../shared/code/snippet';
+
+const TYPES: {[name: string]: string} = {
+  html: 'HTML',
+  scss: 'Style (SCSS)',
+  css: 'Style (CSS)',
+  ts: 'Typescript'
+};
 
 @Component({
   selector: 'ngbd-widget-demo',
@@ -20,8 +27,8 @@ export class NgbdWidgetDemoComponent {
   get markupSnippet() { return Snippet({lang: 'html', code: this.markup}); }
   get codeSnippet() { return Snippet({lang: 'typescript', code: this.code}); }
 
-  getFileSnippet({name, source}) {
-    return Snippet({code: source, lang: name.split('.').pop()});
+  getFileSnippet({name, source}): ISnippet {
+    return Snippet({code: source, lang: name.split('.').pop() || ''});
   }
 
   get hasManyFiles() {
@@ -31,15 +38,7 @@ export class NgbdWidgetDemoComponent {
   constructor(private _analytics: Analytics) {}
 
   tabType(name: string) {
-    const ext = name.split('.').pop();
-    return (
-      {
-        html: 'HTML',
-        scss: 'Style (SCSS)',
-        css: 'Style (CSS)',
-        ts: 'Typescript'
-      }[ext] || 'Code'
-    );
+    return TYPES[(name.split('.').pop() || '')] || 'Code';
   }
 
   trackStackBlitzClick() {

--- a/demo/src/app/components/shared/examples-page/examples.component.ts
+++ b/demo/src/app/components/shared/examples-page/examples.component.ts
@@ -21,13 +21,13 @@ import {NgbdDemoList} from '../demo-list';
 })
 export class NgbdExamplesPage {
   component: string;
-  demos = [];
+  demos: any = [];
 
   constructor(route: ActivatedRoute, demoList: NgbdDemoList) {
     // We go up to parent route defining /components/:widget to read the widget name
     // This route is declared in root app.routing.ts.
     const componentName = (this.component =
-      route.parent.parent.snapshot.url[1].path);
+      route.parent!.parent!.snapshot.url[1].path);
     if (componentName) {
       const demos = demoList.getDemos(componentName);
       if (demos) {

--- a/demo/src/app/components/shared/overview/overview-section.component.ts
+++ b/demo/src/app/components/shared/overview/overview-section.component.ts
@@ -10,7 +10,7 @@ import { NgbdOverviewSection } from './overview';
   },
   template: `
     <h2>
-      <a class="title-fragment" [routerLink]="" [fragment]="section.fragment" ngbdFragment>
+      <a class="title-fragment" routerLink [fragment]="section.fragment" ngbdFragment>
         <img src="img/link-symbol.svg" />
       </a>
       {{ section.title }}

--- a/demo/src/app/components/shared/overview/overview.ts
+++ b/demo/src/app/components/shared/overview/overview.ts
@@ -1,6 +1,6 @@
 export interface NgbdOverviewSection {
   title: string | false;
-  fragment?: string;
+  fragment: string;
 }
 
 export interface NgbdOverview {

--- a/demo/src/app/components/table/demos/complete/country.service.ts
+++ b/demo/src/app/components/table/demos/complete/country.service.ts
@@ -6,7 +6,7 @@ import {Country} from './country';
 import {COUNTRIES} from './countries';
 import {DecimalPipe} from '@angular/common';
 import {debounceTime, delay, switchMap, tap} from 'rxjs/operators';
-import {SortDirection} from './sortable.directive';
+import {SortColumn, SortDirection} from './sortable.directive';
 
 interface SearchResult {
   countries: Country[];
@@ -17,20 +17,18 @@ interface State {
   page: number;
   pageSize: number;
   searchTerm: string;
-  sortColumn: string;
+  sortColumn: SortColumn;
   sortDirection: SortDirection;
 }
 
-function compare(v1, v2) {
-  return v1 < v2 ? -1 : v1 > v2 ? 1 : 0;
-}
+const compare = (v1: string, v2: string) => v1 < v2 ? -1 : v1 > v2 ? 1 : 0;
 
-function sort(countries: Country[], column: string, direction: string): Country[] {
-  if (direction === '') {
+function sort(countries: Country[], column: SortColumn, direction: string): Country[] {
+  if (direction === '' || column === '') {
     return countries;
   } else {
     return [...countries].sort((a, b) => {
-      const res = compare(a[column], b[column]);
+      const res = compare(`${a[column]}`, `${b[column]}`);
       return direction === 'asc' ? res : -res;
     });
   }
@@ -82,7 +80,7 @@ export class CountryService {
   set page(page: number) { this._set({page}); }
   set pageSize(pageSize: number) { this._set({pageSize}); }
   set searchTerm(searchTerm: string) { this._set({searchTerm}); }
-  set sortColumn(sortColumn: string) { this._set({sortColumn}); }
+  set sortColumn(sortColumn: SortColumn) { this._set({sortColumn}); }
   set sortDirection(sortDirection: SortDirection) { this._set({sortDirection}); }
 
   private _set(patch: Partial<State>) {

--- a/demo/src/app/components/table/demos/complete/sortable.directive.ts
+++ b/demo/src/app/components/table/demos/complete/sortable.directive.ts
@@ -1,10 +1,12 @@
 import {Directive, EventEmitter, Input, Output} from '@angular/core';
+import {Country} from './country';
 
+export type SortColumn = keyof Country | '';
 export type SortDirection = 'asc' | 'desc' | '';
 const rotate: {[key: string]: SortDirection} = { 'asc': 'desc', 'desc': '', '': 'asc' };
 
 export interface SortEvent {
-  column: string;
+  column: SortColumn;
   direction: SortDirection;
 }
 
@@ -18,7 +20,7 @@ export interface SortEvent {
 })
 export class NgbdSortableHeader {
 
-  @Input() sortable: string;
+  @Input() sortable: SortColumn = '';
   @Input() direction: SortDirection = '';
   @Output() sort = new EventEmitter<SortEvent>();
 

--- a/demo/src/app/components/table/demos/complete/table-complete.html
+++ b/demo/src/app/components/table/demos/complete/table-complete.html
@@ -37,7 +37,7 @@
 
   <div class="d-flex justify-content-between p-2">
     <ngb-pagination
-      [collectionSize]="total$ | async" [(page)]="service.page" [pageSize]="service.pageSize">
+      [collectionSize]="(total$ | async)!" [(page)]="service.page" [pageSize]="service.pageSize">
     </ngb-pagination>
 
     <select class="custom-select" style="width: auto" name="pageSize" [(ngModel)]="service.pageSize">

--- a/demo/src/app/components/table/demos/sortable/table-sortable.ts
+++ b/demo/src/app/components/table/demos/sortable/table-sortable.ts
@@ -39,12 +39,13 @@ const COUNTRIES: Country[] = [
   }
 ];
 
+export type SortColumn = keyof Country | '';
 export type SortDirection = 'asc' | 'desc' | '';
 const rotate: {[key: string]: SortDirection} = { 'asc': 'desc', 'desc': '', '': 'asc' };
-export const compare = (v1, v2) => v1 < v2 ? -1 : v1 > v2 ? 1 : 0;
+const compare = (v1: string, v2: string) => v1 < v2 ? -1 : v1 > v2 ? 1 : 0;
 
 export interface SortEvent {
-  column: string;
+  column: SortColumn;
   direction: SortDirection;
 }
 
@@ -58,7 +59,7 @@ export interface SortEvent {
 })
 export class NgbdSortableHeader {
 
-  @Input() sortable: string;
+  @Input() sortable: SortColumn = '';
   @Input() direction: SortDirection = '';
   @Output() sort = new EventEmitter<SortEvent>();
 
@@ -88,11 +89,11 @@ export class NgbdTableSortable {
     });
 
     // sorting countries
-    if (direction === '') {
+    if (direction === '' || column === '') {
       this.countries = COUNTRIES;
     } else {
       this.countries = [...COUNTRIES].sort((a, b) => {
-        const res = compare(a[column], b[column]);
+        const res = compare(`${a[column]}`, `${b[column]}`);
         return direction === 'asc' ? res : -res;
       });
     }

--- a/demo/src/app/components/timepicker/demos/adapter/timepicker-adapter.ts
+++ b/demo/src/app/components/timepicker/demos/adapter/timepicker-adapter.ts
@@ -1,13 +1,15 @@
 import {Component, Injectable} from '@angular/core';
 import {NgbTimeStruct, NgbTimeAdapter} from '@ng-bootstrap/ng-bootstrap';
 
+const pad = (i: number): string => i < 10 ? `0${i}` : `${i}`;
+
 /**
  * Example of a String Time adapter
  */
 @Injectable()
 export class NgbTimeStringAdapter extends NgbTimeAdapter<string> {
 
-  fromModel(value: string): NgbTimeStruct {
+  fromModel(value: string| null): NgbTimeStruct | null {
     if (!value) {
       return null;
     }
@@ -19,15 +21,8 @@ export class NgbTimeStringAdapter extends NgbTimeAdapter<string> {
     };
   }
 
-  toModel(time: NgbTimeStruct): string {
-    if (!time) {
-      return null;
-    }
-    return `${this.pad(time.hour)}:${this.pad(time.minute)}:${this.pad(time.second)}`;
-  }
-
-  private pad(i: number): string {
-    return i < 10 ? `0${i}` : `${i}`;
+  toModel(time: NgbTimeStruct | null): string | null {
+    return time != null ? `${pad(time.hour)}:${pad(time.minute)}:${pad(time.second)}` : null;
   }
 }
 

--- a/demo/src/app/components/timepicker/demos/validation/timepicker-validation.html
+++ b/demo/src/app/components/timepicker/demos/validation/timepicker-validation.html
@@ -3,7 +3,7 @@
 <div class="form-group">
   <ngb-timepicker [formControl]="ctrl" required></ngb-timepicker>
   <div *ngIf="ctrl.valid" class="small form-text text-success">Great choice</div>
-  <div class="small form-text text-danger" *ngIf="!ctrl.valid">
+  <div *ngIf="ctrl.errors" class="small form-text text-danger">
     <div *ngIf="ctrl.errors['required']">Select some time during lunchtime</div>
     <div *ngIf="ctrl.errors['tooLate']">Oh no, it's way too late</div>
     <div *ngIf="ctrl.errors['tooEarly']">It's a bit too early</div>

--- a/demo/src/app/shared/code/snippet.ts
+++ b/demo/src/app/shared/code/snippet.ts
@@ -1,5 +1,5 @@
 export interface ISnippet {
-  lang: 'html' | 'typescript' | 'css' | 'bash';
+  lang: 'html' | 'typescript' | 'css' | 'bash' | string;
   code: string;
 }
 
@@ -9,13 +9,13 @@ function removeEmptyLineAtIndex(lines: string[], index: number) {
   }
 }
 
-function findIndentLevel(lines): number {
+function findIndentLevel(lines: string[]): number {
   return Math.min(...lines
     .map(line => {
       const result = /( *)[^ ]+/g.exec(line);
       return result == null ? null : result[1].length;
     })
-    .filter(value => value != null)
+    .filter(value => value != null) as number[]
   );
 }
 

--- a/demo/src/app/shared/component-wrapper/component-wrapper.component.html
+++ b/demo/src/app/shared/component-wrapper/component-wrapper.component.html
@@ -30,16 +30,16 @@
 
         <ul ngbNav [activeId]="this.activeTab" class="nav-tabs px-4 px-lg-5 content-tabset justify-content-md-start justify-content-end">
 
-          <li [ngbNavItem]="childRoute.path" *ngFor="let childRoute of route.routeConfig.children">
+          <li [ngbNavItem]="childRoute.path" *ngFor="let childRoute of route.routeConfig!.children">
             <a ngbNavLink [routerLink]="['.', childRoute.path]">
-              {{ childRoute.path | titlecase }}
+              {{ childRoute.path || '' | titlecase }}
             </a>
           </li>
 
           <li ngbNavItem
             ngbDropdown placement="bottom-right"
             class="align-self-center ml-0 ml-md-auto navigation-dropdown"
-            *ngIf="tableOfContent.length && isLargeScreenOrLess"
+            *ngIf="tableOfContents.length && isLargeScreenOrLess"
           >
             <span ngbDropdownToggle class="nav-link" title="Table of content">
               <span class="sr-only">Table of content</span>
@@ -47,7 +47,7 @@
             </span>
 
             <div class="dropdown-menu-right" ngbDropdownMenu>
-              <ng-template ngFor [ngForOf]="tableOfContent" let-topic>
+              <ng-template ngFor [ngForOf]="tableOfContents" let-topic>
                 <a
                   *ngIf="topic.title else divider"
                   class="dropdown-item"
@@ -61,13 +61,13 @@
 
       <section class="row py-5 px-2 px-md-4 px-lg-5">
         <div class="col-12 col-xl-9 px-md-0 pr-xl-4">
-          <ng-template [ngComponentOutlet]="headerComponentType$ | async"></ng-template>
+          <ng-template [ngComponentOutlet]="(headerComponentType$ | async)!"></ng-template>
           <router-outlet (activate)="updateNavigation($event)"></router-outlet>
         </div>
 
         <div class="col-12 col-xl-3 d-none d-xl-block contextual-nav" *ngIf="!isLargeScreenOrLess">
           <ul class="nav flex-column text-muted pt-4">
-            <li *ngFor="let topic of tableOfContent" class="nav-item">
+            <li *ngFor="let topic of tableOfContents" class="nav-item">
               <a *ngIf="topic.title else divider" class="nav-link" [routerLink]="['.', this.activeTab]" [fragment]="topic.fragment">{{topic.title}}</a>
             </li>
             <ng-template #divider>&nbsp;</ng-template>

--- a/demo/src/app/shared/page-wrapper/page-header.component.ts
+++ b/demo/src/app/shared/page-wrapper/page-header.component.ts
@@ -9,7 +9,7 @@ import {NgbdOverviewSection} from '../../components/shared/overview';
   },
   template: `
     <h2>
-      <a [routerLink]="" [fragment]="fragment" ngbdFragment>
+      <a routerLink [fragment]="fragment" ngbdFragment>
         <img src="img/link-symbol.svg" />
       </a>
       {{ title }}

--- a/demo/src/app/shared/page-wrapper/page-wrapper.component.html
+++ b/demo/src/app/shared/page-wrapper/page-wrapper.component.html
@@ -42,7 +42,7 @@
 
             <div class="dropdown-menu-right" ngbDropdownMenu>
               <a *ngFor="let topic of tableOfContents"
-                 class="dropdown-item" [routerLink]="" [fragment]="topic.fragment">{{topic.title}}</a>
+                 class="dropdown-item" routerLink [fragment]="topic.fragment">{{topic.title}}</a>
             </div>
           </li>
         </ul>
@@ -56,7 +56,7 @@
         <div class="col-12 col-xl-3 d-none d-xl-block contextual-nav">
           <ul class="nav flex-column text-muted pt-4">
             <li *ngFor="let topic of tableOfContents" class="nav-item">
-              <a [id]="topic.fragment" class="nav-link" [fragment]="topic.fragment" [routerLink]="">{{topic.title}}</a>
+              <a routerLink [id]="topic.fragment" class="nav-link" [fragment]="topic.fragment">{{topic.title}}</a>
             </li>
           </ul>
         </div>

--- a/demo/src/app/shared/page-wrapper/page-wrapper.component.ts
+++ b/demo/src/app/shared/page-wrapper/page-wrapper.component.ts
@@ -1,5 +1,6 @@
 import {Component, ContentChildren, Input, NgZone, QueryList} from '@angular/core';
 import {NgbdPageHeaderComponent} from './page-header.component';
+import {TableOfContents} from '../component-wrapper/component-wrapper.component';
 
 @Component({
   selector: 'ngbd-page-wrapper',
@@ -20,7 +21,7 @@ export class PageWrapper {
     largeScreenQL.addListener((event) => ngZone.run(() => this.isLargeScreenOrLess = event.matches));
   }
 
-  get tableOfContents() {
+  get tableOfContents(): TableOfContents {
     return this._tableOfContents ? this._tableOfContents.toArray() : [];
   }
 }

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -17,8 +17,5 @@
   "exclude": [
     "src/**/*.po.ts",
     "src/**/*.e2e-spec.ts"
-  ],
-  "angularCompilerOptions": {
-    "strictTemplates": true
-  }
+  ]
 }

--- a/e2e-app/src/app/modal/autoclose/modal-autoclose.component.ts
+++ b/e2e-app/src/app/modal/autoclose/modal-autoclose.component.ts
@@ -3,7 +3,7 @@ import {ModalDismissReasons, NgbModal, NgbModalRef} from '@ng-bootstrap/ng-boots
 
 @Component({templateUrl: './modal-autoclose.component.html', changeDetection: ChangeDetectionStrategy.OnPush})
 export class ModalAutoCloseComponent {
-  private modalRef: NgbModalRef = null;
+  private modalRef: NgbModalRef | null = null;
   reason = '';
   options = {};
 

--- a/e2e-app/src/app/timepicker/filter/timepicker-filter.e2e-spec.ts
+++ b/e2e-app/src/app/timepicker/filter/timepicker-filter.e2e-spec.ts
@@ -11,7 +11,7 @@ describe('Timepicker', () => {
   async function expectValue(expectedValue) {
     const inputs = page.getFields();
 
-    const values = [];
+    const values: string[] = [];
     for (let i = 0; i < inputs.length; i++) {
       values[i] = await inputs[i].getAttribute('value');
     }

--- a/e2e-app/src/app/tooltip/position/tooltip-position.e2e-spec.ts
+++ b/e2e-app/src/app/tooltip/position/tooltip-position.e2e-spec.ts
@@ -11,7 +11,7 @@ const roundLocation = function(location) {
 describe('Tooltip Position', () => {
   let page: TooltipPositionPage;
 
-  const expectTooltipsPosition = async(type: string, expectedPlacement: string, excludedPlacements = []) => {
+  const expectTooltipsPosition = async(type: string, expectedPlacement: string, excludedPlacements: string[] = []) => {
 
 
     const btn = page.getTooltipButton(type);
@@ -32,7 +32,7 @@ describe('Tooltip Position', () => {
     excludedPlacements.forEach(
         (placement) => { expect(classname).not.toContain(`bs-tooltip-${placement}`, 'Unexpected class'); });
 
-    let yDiff: number, xDiff: number;
+    let yDiff = 0, xDiff = 0;
 
     if (primary === 'top') {
       yDiff = (tooltipLocation.y + tooltipSize.height) - btnLocation.y;

--- a/src/accordion/accordion.spec.ts
+++ b/src/accordion/accordion.spec.ts
@@ -17,8 +17,12 @@ function getPanelsContent(element: HTMLElement): HTMLDivElement[] {
   return <HTMLDivElement[]>Array.from(element.querySelectorAll('.card > .collapse'));
 }
 
-function getPanelsTitle(element: HTMLElement): HTMLButtonElement[] {
+function getPanelsButton(element: HTMLElement): HTMLButtonElement[] {
   return <HTMLButtonElement[]>Array.from(element.querySelectorAll('.card > .card-header button'));
+}
+
+function getPanelsTitle(element: HTMLElement): string[] {
+  return getPanelsButton(element).map(button => button.textContent !.trim());
 }
 
 function getButton(element: HTMLElement, index: number): HTMLButtonElement {
@@ -30,16 +34,15 @@ function expectOpenPanels(nativeEl: HTMLElement, openPanelsDef: boolean[]) {
   const panels = getPanels(nativeEl);
   expect(panels.length).toBe(openPanelsDef.length);
 
-  const panelsTitles = getPanelsTitle(nativeEl);
-  const result = panelsTitles.map((titleEl: HTMLButtonElement) => {
+  const panelsButton = getPanelsButton(nativeEl);
+  const result = panelsButton.map(titleEl => {
     const isAriaExpanded = titleEl.getAttribute('aria-expanded') === 'true';
     const isCSSCollapsed = titleEl.classList.contains('collapsed');
     return isAriaExpanded === !isCSSCollapsed ? isAriaExpanded : fail('inconsistent state');
   });
 
   const panelContents = getPanelsContent(nativeEl);
-  panelContents.forEach(
-      (panelContent: HTMLDivElement) => { expect(panelContent.classList.contains('show')).toBeTruthy(); });
+  panelContents.forEach(panelContent => { expect(panelContent.classList.contains('show')).toBeTruthy(); });
 
   expect(panelContents.length).toBe(noOfOpenPanels);
   expect(result).toEqual(openPanelsDef);
@@ -203,8 +206,7 @@ describe('ngb-accordion', () => {
 
     const titles = getPanelsTitle(compiled);
     expect(titles.length).not.toBe(0);
-
-    titles.forEach((title: HTMLElement, idx: number) => { expect(title.textContent.trim()).toBe(`Panel ${idx + 1}`); });
+    titles.forEach((title, idx) => { expect(title).toBe(`Panel ${idx + 1}`); });
   });
 
   it('can use a title without template', () => {
@@ -219,8 +221,8 @@ describe('ngb-accordion', () => {
 
     fixture.detectChanges();
 
-    const title: HTMLElement = getPanelsTitle(fixture.nativeElement)[0];
-    expect(title.textContent.trim()).toBe('Panel 1');
+    const title = getPanelsTitle(fixture.nativeElement)[0];
+    expect(title).toBe('Panel 1');
   });
 
   it('can mix title and template', () => {
@@ -240,8 +242,7 @@ describe('ngb-accordion', () => {
     fixture.detectChanges();
 
     const titles = getPanelsTitle(fixture.nativeElement);
-
-    titles.forEach((title: HTMLElement, idx: number) => { expect(title.textContent.trim()).toBe(`Panel ${idx + 1}`); });
+    titles.forEach((title, idx) => { expect(title).toBe(`Panel ${idx + 1}`); });
   });
 
   it('can use header as a template', () => {
@@ -263,10 +264,10 @@ describe('ngb-accordion', () => {
     `;
     const fixture = createTestComponent(testHtml);
     const titles = getPanelsTitle(fixture.nativeElement);
-    titles.forEach((title: HTMLElement, idx: number) => { expect(title.textContent.trim()).toBe(`Title ${idx + 1}`); });
+    titles.forEach((title, idx) => { expect(title).toBe(`Title ${idx + 1}`); });
   });
 
-  it('can should pass context to a header template', () => {
+  it('should pass context to a header template', () => {
     const testHtml = `
     <ngb-accordion [activeIds]="activeIds">
      <ngb-panel id="one">
@@ -278,16 +279,17 @@ describe('ngb-accordion', () => {
     </ngb-accordion>
     `;
     const fixture = createTestComponent(testHtml);
-    const titleButton = getPanelsTitle(fixture.nativeElement)[0];
+    let title = getPanelsTitle(fixture.nativeElement)[0];
 
     expectOpenPanels(fixture.nativeElement, [false]);
-    expect(titleButton.textContent.trim()).toBe(`closed`);
+    expect(title).toBe(`closed`);
 
     fixture.componentInstance.activeIds = 'one';
     fixture.detectChanges();
 
+    title = getPanelsTitle(fixture.nativeElement)[0];
     expectOpenPanels(fixture.nativeElement, [true]);
-    expect(titleButton.textContent.trim()).toBe(`opened`);
+    expect(title).toBe(`opened`);
   });
 
   it('can should prefer header as a template to other ways of providing a title', () => {
@@ -310,8 +312,7 @@ describe('ngb-accordion', () => {
     `;
     const fixture = createTestComponent(testHtml);
     const titles = getPanelsTitle(fixture.nativeElement);
-    titles.forEach(
-        (title: HTMLElement, idx: number) => { expect(title.textContent.trim()).toBe(`Header Title ${idx + 1}`); });
+    titles.forEach((title, idx) => { expect(title).toBe(`Header Title ${idx + 1}`); });
   });
 
   it('should not pick up titles from nested accordions', () => {
@@ -333,9 +334,7 @@ describe('ngb-accordion', () => {
     // additional change detection is required to reproduce the problem in the test environment
     fixture.detectChanges();
 
-    const titles = getPanelsTitle(fixture.nativeElement);
-    const parentTitle = titles[0].textContent.trim();
-    const childTitle = titles[1].textContent.trim();
+    const[parentTitle, childTitle] = getPanelsTitle(fixture.nativeElement);
 
     expect(parentTitle).toContain('parent title');
     expect(parentTitle).not.toContain('child title');
@@ -354,7 +353,7 @@ describe('ngb-accordion', () => {
     const panelsContent = getPanelsContent(fixture.nativeElement);
 
     expect(panelsContent.length).toBe(1);
-    expect(panelsContent[0].textContent.trim()).toBe('');
+    expect(panelsContent[0].textContent !.trim()).toBe('');
   });
 
   it('should have the appropriate content', () => {
@@ -370,9 +369,9 @@ describe('ngb-accordion', () => {
     const contents = getPanelsContent(compiled);
     expect(contents.length).not.toBe(0);
 
-    contents.forEach((content: HTMLElement, idx: number) => {
+    contents.forEach((content, idx) => {
       expect(content.getAttribute('aria-labelledby')).toBe(`${content.id}-header`);
-      expect(content.textContent.trim()).toBe(originalContent[idx].content);
+      expect(content.textContent !.trim()).toBe(originalContent[idx].content);
     });
   });
 
@@ -388,7 +387,7 @@ describe('ngb-accordion', () => {
     const contents = getPanelsContent(compiled);
     expect(contents.length).not.toBe(0);
 
-    contents.forEach((content: HTMLElement) => {
+    contents.forEach(content => {
       expect(content).toHaveCssClass('collapse');
       expect(content).toHaveCssClass('show');
     });
@@ -400,7 +399,7 @@ describe('ngb-accordion', () => {
     tc.closeOthers = true;
     fixture.detectChanges();
 
-    const headingLinks = getPanelsTitle(fixture.nativeElement);
+    const headingLinks = getPanelsButton(fixture.nativeElement);
 
     headingLinks[0].click();
     fixture.detectChanges();
@@ -432,7 +431,7 @@ describe('ngb-accordion', () => {
     tc.panels[0].disabled = true;
     fixture.detectChanges();
 
-    const headingLinks = getPanelsTitle(fixture.nativeElement);
+    const headingLinks = getPanelsButton(fixture.nativeElement);
 
     headingLinks[0].click();
     fixture.detectChanges();
@@ -449,7 +448,7 @@ describe('ngb-accordion', () => {
     fixture.detectChanges();
     expectOpenPanels(el, [false, false, false]);
 
-    const headingLinks = getPanelsTitle(fixture.nativeElement);
+    const headingLinks = getPanelsButton(fixture.nativeElement);
 
     headingLinks[0].click();
     fixture.detectChanges();
@@ -483,7 +482,7 @@ describe('ngb-accordion', () => {
 
     tc.activeIds = ['one'];
     fixture.detectChanges();
-    const headingLinks = getPanelsTitle(fixture.nativeElement);
+    const headingLinks = getPanelsButton(fixture.nativeElement);
     expectOpenPanels(fixture.nativeElement, [true, false, false]);
     expect(headingLinks[0].disabled).toBeFalsy();
 
@@ -578,7 +577,7 @@ describe('ngb-accordion', () => {
     const fixture = TestBed.createComponent(TestComponent);
     fixture.detectChanges();
 
-    let changeEvent = null;
+    let changeEvent: NgbPanelChangeEvent | null = null;
     fixture.componentInstance.changeCallback = event => {
       changeEvent = event;
       event.preventDefault();
@@ -587,7 +586,7 @@ describe('ngb-accordion', () => {
     // Select the first tab -> toggle will be canceled
     getButton(fixture.nativeElement, 0).click();
     fixture.detectChanges();
-    expect(changeEvent).toEqual(jasmine.objectContaining({panelId: 'one', nextState: true}));
+    expect(changeEvent !).toEqual(jasmine.objectContaining({panelId: 'one', nextState: true}));
     expectOpenPanels(fixture.nativeElement, [false, false, false]);
   });
 
@@ -635,10 +634,10 @@ describe('ngb-accordion', () => {
     fixture.detectChanges();
 
     const headers = getPanels(fixture.nativeElement);
-    headers.forEach((header: HTMLElement) => expect(header.getAttribute('role')).toBe('tab'));
+    headers.forEach(header => expect(header.getAttribute('role')).toBe('tab'));
 
     const contents = getPanelsContent(fixture.nativeElement);
-    contents.forEach((content: HTMLElement) => expect(content.getAttribute('role')).toBe('tabpanel'));
+    contents.forEach(content => expect(content.getAttribute('role')).toBe('tabpanel'));
   });
 
   describe('Custom config', () => {

--- a/src/accordion/accordion.ts
+++ b/src/accordion/accordion.ts
@@ -104,9 +104,9 @@ export class NgbPanel implements AfterContentChecked {
    */
   @Input() cardClass: string;
 
-  titleTpl: NgbPanelTitle | null;
-  headerTpl: NgbPanelHeader | null;
-  contentTpl: NgbPanelContent | null;
+  titleTpl: NgbPanelTitle;
+  headerTpl: NgbPanelHeader;
+  contentTpl: NgbPanelContent;
 
   @ContentChildren(NgbPanelTitle, {descendants: false}) titleTpls: QueryList<NgbPanelTitle>;
   @ContentChildren(NgbPanelHeader, {descendants: false}) headerTpls: QueryList<NgbPanelHeader>;
@@ -171,7 +171,7 @@ export interface NgbPanelChangeEvent {
         <div id="{{panel.id}}" role="tabpanel" [attr.aria-labelledby]="panel.id + '-header'"
              class="collapse" [class.show]="panel.isOpen" *ngIf="!destroyOnHide || panel.isOpen">
           <div class="card-body">
-               <ng-template [ngTemplateOutlet]="panel.contentTpl?.templateRef"></ng-template>
+               <ng-template [ngTemplateOutlet]="panel.contentTpl?.templateRef || null"></ng-template>
           </div>
         </div>
       </div>
@@ -290,8 +290,8 @@ export class NgbAccordion implements AfterContentChecked {
     }
   }
 
-  private _changeOpenState(panel: NgbPanel, nextState: boolean) {
-    if (panel && !panel.disabled && panel.isOpen !== nextState) {
+  private _changeOpenState(panel: NgbPanel | null, nextState: boolean) {
+    if (panel != null && !panel.disabled && panel.isOpen !== nextState) {
       let defaultPrevented = false;
 
       this.panelChange.emit(
@@ -316,7 +316,7 @@ export class NgbAccordion implements AfterContentChecked {
     });
   }
 
-  private _findPanelById(panelId: string): NgbPanel | null { return this.panels.find(p => p.id === panelId); }
+  private _findPanelById(panelId: string): NgbPanel | null { return this.panels.find(p => p.id === panelId) || null; }
 
   private _updateActiveIds() {
     this.activeIds = this.panels.filter(panel => panel.isOpen && !panel.disabled).map(panel => panel.id);

--- a/src/alert/alert.ts
+++ b/src/alert/alert.ts
@@ -59,7 +59,7 @@ export class NgbAlert implements OnInit,
     this.type = config.type;
   }
 
-  closeHandler() { this.close.emit(null); }
+  closeHandler() { this.close.emit(); }
 
   ngOnChanges(changes: SimpleChanges) {
     const typeChange = changes['type'];

--- a/src/carousel/carousel.spec.ts
+++ b/src/carousel/carousel.spec.ts
@@ -36,7 +36,7 @@ describe('ngb-carousel', () => {
 
   it('should initialize inputs with default values', () => {
     const defaultConfig = new NgbCarouselConfig();
-    const carousel = new NgbCarousel(new NgbCarouselConfig(), null, null, null);
+    const carousel = new NgbCarousel(new NgbCarouselConfig(), null, <any>null, <any>null);
 
     expect(carousel.interval).toBe(defaultConfig.interval);
     expect(carousel.wrap).toBe(defaultConfig.wrap);

--- a/src/carousel/carousel.ts
+++ b/src/carousel/carousel.ts
@@ -184,7 +184,7 @@ export class NgbCarousel implements AfterContentChecked,
       this._ngZone.runOutsideAngular(() => {
         const hasNextSlide$ = combineLatest([
                                 this.slide.pipe(map(slideEvent => slideEvent.current), startWith(this.activeId)),
-                                this._wrap$, this.slides.changes.pipe(startWith(<{}>null))
+                                this._wrap$, this.slides.changes.pipe(startWith(null))
                               ])
                                   .pipe(
                                       map(([currentSlideId, wrap]) => {
@@ -209,7 +209,7 @@ export class NgbCarousel implements AfterContentChecked,
 
   ngAfterContentChecked() {
     let activeSlide = this._getSlideById(this.activeId);
-    this.activeId = activeSlide ? activeSlide.id : (this.slides.length ? this.slides.first.id : null);
+    this.activeId = activeSlide ? activeSlide.id : (this.slides.length ? this.slides.first.id : '');
   }
 
   ngOnDestroy() { this._destroy$.next(); }
@@ -264,10 +264,13 @@ export class NgbCarousel implements AfterContentChecked,
     return currentActiveSlideIdx > nextActiveSlideIdx ? NgbSlideEventDirection.RIGHT : NgbSlideEventDirection.LEFT;
   }
 
-  private _getSlideById(slideId: string): NgbSlide { return this.slides.find(slide => slide.id === slideId); }
+  private _getSlideById(slideId: string): NgbSlide | null {
+    return this.slides.find(slide => slide.id === slideId) || null;
+  }
 
   private _getSlideIdxById(slideId: string): number {
-    return this.slides.toArray().indexOf(this._getSlideById(slideId));
+    const slide = this._getSlideById(slideId);
+    return slide != null ? this.slides.toArray().indexOf(slide) : -1;
   }
 
   private _getNextSlide(currentSlideId: string): string {

--- a/src/datepicker/adapters/ngb-date-adapter.spec.ts
+++ b/src/datepicker/adapters/ngb-date-adapter.spec.ts
@@ -9,7 +9,7 @@ describe('ngb-date model adapter', () => {
 
     it('should convert invalid and incomplete values to null', () => {
       expect(adapter.fromModel(null)).toBeNull();
-      expect(adapter.fromModel(undefined)).toBeNull();
+      expect(adapter.fromModel(<any>undefined)).toBeNull();
       expect(adapter.fromModel(<any>'')).toBeNull();
       expect(adapter.fromModel(<any>'s')).toBeNull();
       expect(adapter.fromModel(<any>2)).toBeNull();
@@ -33,7 +33,7 @@ describe('ngb-date model adapter', () => {
 
     it('should convert invalid and incomplete values to null', () => {
       expect(adapter.toModel(null)).toBeNull();
-      expect(adapter.toModel(undefined)).toBeNull();
+      expect(adapter.toModel(<any>undefined)).toBeNull();
       expect(adapter.toModel(<any>'')).toBeNull();
       expect(adapter.toModel(<any>'s')).toBeNull();
       expect(adapter.toModel(<any>2)).toBeNull();

--- a/src/datepicker/adapters/ngb-date-adapter.ts
+++ b/src/datepicker/adapters/ngb-date-adapter.ts
@@ -23,12 +23,12 @@ export abstract class NgbDateAdapter<D> {
   /**
    * Converts a user-model date of type `D` to an `NgbDateStruct` for internal use.
    */
-  abstract fromModel(value: D): NgbDateStruct;
+  abstract fromModel(value: D | null): NgbDateStruct | null;
 
   /**
    * Converts an internal `NgbDateStruct` date to a user-model date of type `D`.
    */
-  abstract toModel(date: NgbDateStruct): D;
+  abstract toModel(date: NgbDateStruct | null): D | null;
 }
 
 @Injectable()
@@ -36,7 +36,7 @@ export class NgbDateStructAdapter extends NgbDateAdapter<NgbDateStruct> {
   /**
    * Converts a NgbDateStruct value into NgbDateStruct value
    */
-  fromModel(date: NgbDateStruct): NgbDateStruct {
+  fromModel(date: NgbDateStruct | null): NgbDateStruct | null {
     return (date && isInteger(date.year) && isInteger(date.month) && isInteger(date.day)) ?
         {year: date.year, month: date.month, day: date.day} :
         null;
@@ -45,7 +45,7 @@ export class NgbDateStructAdapter extends NgbDateAdapter<NgbDateStruct> {
   /**
    * Converts a NgbDateStruct value into NgbDateStruct value
    */
-  toModel(date: NgbDateStruct): NgbDateStruct {
+  toModel(date: NgbDateStruct | null): NgbDateStruct | null {
     return (date && isInteger(date.year) && isInteger(date.month) && isInteger(date.day)) ?
         {year: date.year, month: date.month, day: date.day} :
         null;

--- a/src/datepicker/adapters/ngb-date-native-adapter.spec.ts
+++ b/src/datepicker/adapters/ngb-date-native-adapter.spec.ts
@@ -9,7 +9,7 @@ describe('ngb-date-native model adapter', () => {
 
     it('should convert invalid and incomplete values to null', () => {
       expect(adapter.fromModel(null)).toBeNull();
-      expect(adapter.fromModel(undefined)).toBeNull();
+      expect(adapter.fromModel(<any>undefined)).toBeNull();
       expect(adapter.fromModel(<any>'')).toBeNull();
       expect(adapter.fromModel(<any>'s')).toBeNull();
       expect(adapter.fromModel(<any>2)).toBeNull();
@@ -26,7 +26,7 @@ describe('ngb-date-native model adapter', () => {
 
     it('should convert invalid and incomplete values to null', () => {
       expect(adapter.toModel(null)).toBeNull();
-      expect(adapter.toModel(undefined)).toBeNull();
+      expect(adapter.toModel(<any>undefined)).toBeNull();
       expect(adapter.toModel(<any>'')).toBeNull();
       expect(adapter.toModel(<any>'s')).toBeNull();
       expect(adapter.toModel(<any>2)).toBeNull();

--- a/src/datepicker/adapters/ngb-date-native-adapter.ts
+++ b/src/datepicker/adapters/ngb-date-native-adapter.ts
@@ -12,14 +12,14 @@ export class NgbDateNativeAdapter extends NgbDateAdapter<Date> {
   /**
    * Converts a native `Date` to a `NgbDateStruct`.
    */
-  fromModel(date: Date): NgbDateStruct {
+  fromModel(date: Date | null): NgbDateStruct | null {
     return (date instanceof Date && !isNaN(date.getTime())) ? this._fromNativeDate(date) : null;
   }
 
   /**
    * Converts a `NgbDateStruct` to a native `Date`.
    */
-  toModel(date: NgbDateStruct): Date {
+  toModel(date: NgbDateStruct | null): Date | null {
     return date && isInteger(date.year) && isInteger(date.month) && isInteger(date.day) ? this._toNativeDate(date) :
                                                                                           null;
   }

--- a/src/datepicker/adapters/ngb-date-native-utc-adapter.spec.ts
+++ b/src/datepicker/adapters/ngb-date-native-utc-adapter.spec.ts
@@ -9,7 +9,7 @@ describe('ngb-date-native-utc model adapter', () => {
 
     it('should convert invalid and incomplete values to null', () => {
       expect(adapter.fromModel(null)).toBeNull();
-      expect(adapter.fromModel(undefined)).toBeNull();
+      expect(adapter.fromModel(<any>undefined)).toBeNull();
       expect(adapter.fromModel(<any>'')).toBeNull();
       expect(adapter.fromModel(<any>'s')).toBeNull();
       expect(adapter.fromModel(<any>2)).toBeNull();
@@ -26,7 +26,7 @@ describe('ngb-date-native-utc model adapter', () => {
 
     it('should convert invalid and incomplete values to null', () => {
       expect(adapter.toModel(null)).toBeNull();
-      expect(adapter.toModel(undefined)).toBeNull();
+      expect(adapter.toModel(<any>undefined)).toBeNull();
       expect(adapter.toModel(<any>'')).toBeNull();
       expect(adapter.toModel(<any>'s')).toBeNull();
       expect(adapter.toModel(<any>2)).toBeNull();

--- a/src/datepicker/datepicker-config.ts
+++ b/src/datepicker/datepicker-config.ts
@@ -11,11 +11,11 @@ import {NgbDateStruct} from './ngb-date-struct';
 @Injectable({providedIn: 'root'})
 export class NgbDatepickerConfig {
   dayTemplate: TemplateRef<DayTemplateContext>;
-  dayTemplateData: (date: NgbDateStruct, current: {year: number, month: number}) => any;
+  dayTemplateData: (date: NgbDateStruct, current?: {year: number, month: number}) => any;
   footerTemplate: TemplateRef<any>;
   displayMonths = 1;
   firstDayOfWeek = 1;
-  markDisabled: (date: NgbDateStruct, current: {year: number, month: number}) => boolean;
+  markDisabled: (date: NgbDateStruct, current?: {year: number, month: number}) => boolean;
   minDate: NgbDateStruct;
   maxDate: NgbDateStruct;
   navigation: 'select' | 'arrows' | 'none' = 'select';

--- a/src/datepicker/datepicker-i18n.spec.ts
+++ b/src/datepicker/datepicker-i18n.spec.ts
@@ -12,24 +12,24 @@ describe('ngb-datepicker-i18n-default', () => {
   });
 
   it('should return abbreviated month name', () => {
-    expect(i18n.getMonthShortName(0)).toBe(undefined);
+    expect(i18n.getMonthShortName(0)).toBe('');
     expect(i18n.getMonthShortName(1)).toBe('Jan');
     expect(i18n.getMonthShortName(12)).toBe('Dec');
-    expect(i18n.getMonthShortName(13)).toBe(undefined);
+    expect(i18n.getMonthShortName(13)).toBe('');
   });
 
   it('should return wide month name', () => {
-    expect(i18n.getMonthFullName(0)).toBe(undefined);
+    expect(i18n.getMonthFullName(0)).toBe('');
     expect(i18n.getMonthFullName(1)).toBe('January');
     expect(i18n.getMonthFullName(12)).toBe('December');
-    expect(i18n.getMonthFullName(13)).toBe(undefined);
+    expect(i18n.getMonthFullName(13)).toBe('');
   });
 
   it('should return weekday name', () => {
-    expect(i18n.getWeekdayShortName(0)).toBe(undefined);
+    expect(i18n.getWeekdayShortName(0)).toBe('');
     expect(i18n.getWeekdayShortName(1)).toBe('Mo');
     expect(i18n.getWeekdayShortName(7)).toBe('Su');
-    expect(i18n.getWeekdayShortName(8)).toBe(undefined);
+    expect(i18n.getWeekdayShortName(8)).toBe('');
   });
 
   it('should generate aria label for a date',

--- a/src/datepicker/datepicker-i18n.ts
+++ b/src/datepicker/datepicker-i18n.ts
@@ -87,11 +87,11 @@ export class NgbDatepickerI18nDefault extends NgbDatepickerI18n {
     this._monthsFull = getLocaleMonthNames(_locale, FormStyle.Standalone, TranslationWidth.Wide);
   }
 
-  getWeekdayShortName(weekday: number): string { return this._weekdaysShort[weekday - 1]; }
+  getWeekdayShortName(weekday: number): string { return this._weekdaysShort[weekday - 1] || ''; }
 
-  getMonthShortName(month: number): string { return this._monthsShort[month - 1]; }
+  getMonthShortName(month: number): string { return this._monthsShort[month - 1] || ''; }
 
-  getMonthFullName(month: number): string { return this._monthsFull[month - 1]; }
+  getMonthFullName(month: number): string { return this._monthsFull[month - 1] || ''; }
 
   getDayAriaLabel(date: NgbDateStruct): string {
     const jsDate = new Date(date.year, date.month - 1, date.day);

--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -229,7 +229,7 @@ describe('NgbInputDatepicker', () => {
          tick();
          expect(input.value).toBe('');
 
-         fixture.componentInstance.date = null;
+         fixture.componentInstance.date = <any>null;
          fixture.detectChanges();
          tick();
          expect(input.value).toBe('');
@@ -239,7 +239,7 @@ describe('NgbInputDatepicker', () => {
          tick();
          expect(input.value).toBe('');
 
-         fixture.componentInstance.date = undefined;
+         fixture.componentInstance.date = <any>undefined;
          fixture.detectChanges();
          tick();
          expect(input.value).toBe('');
@@ -249,17 +249,17 @@ describe('NgbInputDatepicker', () => {
          tick();
          expect(input.value).toBe('');
 
-         fixture.componentInstance.date = new NgbDate(2017, 2, null);
+         fixture.componentInstance.date = new NgbDate(2017, 2, <any>null);
          fixture.detectChanges();
          tick();
          expect(input.value).toBe('');
 
-         fixture.componentInstance.date = new NgbDate(2017, null, 5);
+         fixture.componentInstance.date = new NgbDate(2017, <any>null, 5);
          fixture.detectChanges();
          tick();
          expect(input.value).toBe('');
 
-         fixture.componentInstance.date = new NgbDate(null, 2, 5);
+         fixture.componentInstance.date = new NgbDate(<any>null, 2, 5);
          fixture.detectChanges();
          tick();
          expect(input.value).toBe('');
@@ -870,7 +870,7 @@ describe('NgbInputDatepicker', () => {
       fixture.detectChanges();
 
       expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
-      expect(document.querySelector(selector).querySelector('ngb-datepicker')).not.toBeNull();
+      expect(document.querySelector(selector) !.querySelector('ngb-datepicker')).not.toBeNull();
     });
 
     it('should properly destroy datepicker window when the "container" option is used', () => {
@@ -887,14 +887,14 @@ describe('NgbInputDatepicker', () => {
       fixture.detectChanges();
 
       expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
-      expect(document.querySelector(selector).querySelector('ngb-datepicker')).not.toBeNull();
+      expect(document.querySelector(selector) !.querySelector('ngb-datepicker')).not.toBeNull();
 
       // close date-picker
       buttons[1].click();  // close button
       fixture.detectChanges();
 
       expect(fixture.nativeElement.querySelector('ngb-datepicker')).toBeNull();
-      expect(document.querySelector(selector).querySelector('ngb-datepicker')).toBeNull();
+      expect(document.querySelector(selector) !.querySelector('ngb-datepicker')).toBeNull();
     });
 
     it('should add .ngb-dp-body class when attached to body', () => {
@@ -1138,12 +1138,12 @@ describe('NgbInputDatepicker', () => {
 
 @Injectable()
 class NgbDateNativeAdapter extends NgbDateAdapter<Date> {
-  fromModel(date: Date): NgbDateStruct {
+  fromModel(date: Date): NgbDateStruct | null {
     return (date && date.getFullYear) ? {year: date.getFullYear(), month: date.getMonth() + 1, day: date.getDate()} :
                                         null;
   }
 
-  toModel(date: NgbDateStruct): Date { return date ? new Date(date.year, date.month - 1, date.day) : null; }
+  toModel(date: NgbDateStruct): Date | null { return date ? new Date(date.year, date.month - 1, date.day) : null; }
 }
 
 @Component({selector: 'test-native-cmp', template: ''})

--- a/src/datepicker/datepicker-keyboard-service.spec.ts
+++ b/src/datepicker/datepicker-keyboard-service.spec.ts
@@ -24,8 +24,8 @@ describe('ngb-datepicker-keyboard-service', () => {
     service = TestBed.inject(NgbDatepickerKeyboardService);
     mock = {state, focusDate: () => {}, focusSelect: () => {}, calendar};
 
-    spyOn(mock, 'focusDate');
-    spyOn(mock, 'focusSelect');
+    spyOn(mock, <any>'focusDate');
+    spyOn(mock, <any>'focusSelect');
     spyOn(calendar, 'getNext');
     spyOn(calendar, 'getPrev');
   });

--- a/src/datepicker/datepicker-navigation.spec.ts
+++ b/src/datepicker/datepicker-navigation.spec.ts
@@ -93,8 +93,8 @@ describe('ngb-datepicker-navigation', () => {
     const fixture =
         createTestComponent(`<ngb-datepicker-navigation (navigate)="onNavigate($event)"></ngb-datepicker-navigation>`);
     const[previousButton, nextButton] = getNavigationLinks(fixture.nativeElement);
-    const previousButtonSpan = previousButton.querySelector<HTMLElement>('span');
-    const nextButtonSpan = nextButton.querySelector<HTMLElement>('span');
+    const previousButtonSpan = previousButton.querySelector<HTMLElement>('span') !;
+    const nextButtonSpan = nextButton.querySelector<HTMLElement>('span') !;
     spyOn(fixture.componentInstance, 'onNavigate');
 
     // prev

--- a/src/datepicker/datepicker-service.spec.ts
+++ b/src/datepicker/datepicker-service.spec.ts
@@ -33,8 +33,8 @@ describe('ngb-datepicker-service', () => {
     calendar = TestBed.inject(NgbCalendar);
     service = TestBed.inject(NgbDatepickerService);
     subscriptions = [];
-    model = undefined;
-    selectDate = null;
+    model = <any>undefined;
+    selectDate = <any>null;
     focusMove = (focusDate: NgbDate, period?: NgbPeriod, number?: number) =>
         service.focus(calendar.getNext(focusDate, period, number));
 
@@ -86,7 +86,7 @@ describe('ngb-datepicker-service', () => {
       expect(model.minDate).toBeNull();
 
       // invalid -> ignore
-      service.set({minDate: new NgbDate(-2, 0, null)});
+      service.set({minDate: new NgbDate(-2, 0, <any>null)});
       expect(model.minDate).toBeNull();
 
       expect(mock.onNext).toHaveBeenCalledTimes(2);
@@ -108,7 +108,7 @@ describe('ngb-datepicker-service', () => {
       expect(model.maxDate).toBeNull();
 
       // invalid -> ignore
-      service.set({maxDate: new NgbDate(-2, 0, null)});
+      service.set({maxDate: new NgbDate(-2, 0, <any>null)});
       expect(model.maxDate).toBeNull();
 
       expect(mock.onNext).toHaveBeenCalledTimes(2);
@@ -167,8 +167,8 @@ describe('ngb-datepicker-service', () => {
     it(`should mark dates outside 'min/maxDates' as disabled`, () => {
       // MAY 2017
       service.focus(new NgbDate(2017, 5, 1));
-      expect(model.minDate).toBeUndefined();
-      expect(model.maxDate).toBeUndefined();
+      expect(model.minDate).toBeNull();
+      expect(model.maxDate).toBeNull();
       expect(getDayCtx(0).disabled).toBe(false);  // 1 MAY
       expect(getDayCtx(5).disabled).toBe(false);  // 6 MAY
 
@@ -182,8 +182,8 @@ describe('ngb-datepicker-service', () => {
       // MAY 2017
       service.focus(new NgbDate(2017, 5, 5));
       expect(model.months.length).toBe(1);
-      expect(model.minDate).toBeUndefined();
-      expect(model.maxDate).toBeUndefined();
+      expect(model.minDate).toBeNull();
+      expect(model.maxDate).toBeNull();
 
       // MIN -> 5 MAY, 2017
       service.set({minDate: new NgbDate(2017, 5, 5)});
@@ -210,11 +210,11 @@ describe('ngb-datepicker-service', () => {
       expect(model.firstDayOfWeek).toEqual(2);
 
       // null -> ignore
-      service.set({firstDayOfWeek: null});
+      service.set({firstDayOfWeek: <any>null});
       expect(model.firstDayOfWeek).toEqual(2);
 
       // undefined -> ignore
-      service.set({firstDayOfWeek: null});
+      service.set({firstDayOfWeek: undefined});
       expect(model.firstDayOfWeek).toEqual(2);
 
       expect(mock.onNext).toHaveBeenCalledTimes(1);
@@ -275,11 +275,11 @@ describe('ngb-datepicker-service', () => {
       expect(model.displayMonths).toEqual(2);
 
       // null -> ignore
-      service.set({displayMonths: null});
+      service.set({displayMonths: <any>null});
       expect(model.displayMonths).toEqual(2);
 
       // undefined -> ignore
-      service.set({displayMonths: null});
+      service.set({displayMonths: undefined});
       expect(model.displayMonths).toEqual(2);
 
       expect(mock.onNext).toHaveBeenCalledTimes(1);
@@ -998,7 +998,7 @@ describe('ngb-datepicker-service', () => {
     it(`should ignore invalid 'focus()' values`, () => {
       service.focus(null);
       service.focus(undefined);
-      service.focus(new NgbDate(-2, 0, null));
+      service.focus(new NgbDate(-2, 0, <any>null));
 
       expect(mock.onNext).not.toHaveBeenCalled();
     });
@@ -1370,7 +1370,7 @@ describe('ngb-datepicker-service', () => {
       // off
       service.select(null);
       expect(getDayCtx(0).selected).toBeFalsy();
-      expect(getDayCtx(1).selected).toBeFalsy();
+      expect(getDayCtx(1).selected).toBeTruthy();
     });
 
     it(`should update 'disabled' flag for day template`, () => {

--- a/src/datepicker/datepicker-service.ts
+++ b/src/datepicker/datepicker-service.ts
@@ -21,14 +21,14 @@ import {
 import {filter} from 'rxjs/operators';
 import {NgbDatepickerI18n} from './datepicker-i18n';
 
-export interface DatepickerServiceInputs extends
-    Partial<Pick<DatepickerViewModel, 'dayTemplateData' | 'displayMonths' | 'disabled' | 'firstDayOfWeek' |
-                     'focusVisible' | 'markDisabled' | 'maxDate' | 'minDate' | 'navigation' | 'outsideDays'>> {}
+export interface DatepickerServiceInputs extends Partial<
+    Required<Pick<DatepickerViewModel, 'dayTemplateData' | 'displayMonths' | 'disabled' | 'firstDayOfWeek' |
+                      'focusVisible' | 'markDisabled' | 'maxDate' | 'minDate' | 'navigation' | 'outsideDays'>>> {}
 
 @Injectable()
 export class NgbDatepickerService {
   private _VALIDATORS:
-      {[K in keyof DatepickerServiceInputs]: (v: DatepickerServiceInputs[K]) => Partial<DatepickerViewModel>} = {
+      {[K in keyof DatepickerServiceInputs]: (v: DatepickerServiceInputs[K]) => Partial<DatepickerViewModel>| void} = {
         dayTemplateData: (dayTemplateData: NgbDayTemplateData) => {
           if (this._state.dayTemplateData !== dayTemplateData) {
             return {dayTemplateData};
@@ -90,17 +90,24 @@ export class NgbDatepickerService {
   private _dateSelect$ = new Subject<NgbDate>();
 
   private _state: DatepickerViewModel = {
+    dayTemplateData: null,
+    markDisabled: null,
+    maxDate: null,
+    minDate: null,
     disabled: false,
     displayMonths: 1,
+    firstDate: null,
     firstDayOfWeek: 1,
+    lastDate: null,
+    focusDate: null,
     focusVisible: false,
     months: [],
     navigation: 'select',
     outsideDays: 'visible',
     prevDisabled: false,
     nextDisabled: false,
-    selectBoxes: {years: [], months: []},
-    selectedDate: null
+    selectedDate: null,
+    selectBoxes: {years: [], months: []}
   };
 
   get model$(): Observable<DatepickerViewModel> { return this._model$.pipe(filter(model => model.months.length > 0)); }
@@ -119,8 +126,9 @@ export class NgbDatepickerService {
 
   constructor(private _calendar: NgbCalendar, private _i18n: NgbDatepickerI18n) {}
 
-  focus(date: NgbDate) {
-    if (!this._state.disabled && this._calendar.isValid(date) && isChangedDate(this._state.focusDate, date)) {
+  focus(date?: NgbDate | null) {
+    const focusedDate = this.toValidDate(date, null);
+    if (focusedDate != null && !this._state.disabled && isChangedDate(this._state.focusDate, focusedDate)) {
       this._nextState({focusDate: date});
     }
   }
@@ -131,16 +139,17 @@ export class NgbDatepickerService {
     }
   }
 
-  open(date: NgbDate) {
+  open(date?: NgbDate | null) {
     const firstDate = this.toValidDate(date, this._calendar.getToday());
-    if (!this._state.disabled && (!this._state.firstDate || isChangedMonth(this._state.firstDate, date))) {
+    if (firstDate != null && !this._state.disabled &&
+        (!this._state.firstDate || isChangedMonth(this._state.firstDate, firstDate))) {
       this._nextState({firstDate});
     }
   }
 
-  select(date: NgbDate, options: {emitEvent?: boolean} = {}) {
+  select(date?: NgbDate | null, options: {emitEvent?: boolean} = {}) {
     const selectedDate = this.toValidDate(date, null);
-    if (!this._state.disabled) {
+    if (selectedDate != null && !this._state.disabled) {
       if (isChangedDate(this._state.selectedDate, selectedDate)) {
         this._nextState({selectedDate});
       }
@@ -151,7 +160,7 @@ export class NgbDatepickerService {
     }
   }
 
-  toValidDate(date: NgbDateStruct, defaultValue?: NgbDate): NgbDate {
+  toValidDate(date?: NgbDateStruct | null, defaultValue?: NgbDate | null): NgbDate | null {
     const ngbDate = NgbDate.from(date);
     if (defaultValue === undefined) {
       defaultValue = this._calendar.getToday();
@@ -187,7 +196,8 @@ export class NgbDatepickerService {
           }
 
           // calculating tabindex
-          day.tabindex = !disabled && day.date.equals(focusDate) && focusDate.month === month.number ? 0 : -1;
+          day.tabindex =
+              !disabled && focusDate && day.date.equals(focusDate) && focusDate.month === month.number ? 0 : -1;
 
           // override context disabled
           if (disabled === true) {
@@ -245,7 +255,7 @@ export class NgbDatepickerService {
       startDate = state.focusDate;
 
       // nothing to rebuild if only focus changed and it is still visible
-      if (state.months.length !== 0 && !state.focusDate.before(state.firstDate) &&
+      if (state.months.length !== 0 && state.focusDate && !state.focusDate.before(state.firstDate) &&
           !state.focusDate.after(state.lastDate)) {
         return state;
       }
@@ -266,8 +276,8 @@ export class NgbDatepickerService {
 
       // updating months and boundary dates
       state.months = months;
-      state.firstDate = months.length > 0 ? months[0].firstDate : undefined;
-      state.lastDate = months.length > 0 ? months[months.length - 1].lastDate : undefined;
+      state.firstDate = months[0].firstDate;
+      state.lastDate = months[months.length - 1].lastDate;
 
       // reset selected date if 'markDisabled' returns true
       if ('selectedDate' in patch && !isDateSelectable(state.selectedDate, state)) {
@@ -276,8 +286,7 @@ export class NgbDatepickerService {
 
       // adjusting focus after months were built
       if ('firstDate' in patch) {
-        if (state.focusDate === undefined || state.focusDate.before(state.firstDate) ||
-            state.focusDate.after(state.lastDate)) {
+        if (!state.focusDate || state.focusDate.before(state.firstDate) || state.focusDate.after(state.lastDate)) {
           state.focusDate = startDate;
         }
       }

--- a/src/datepicker/datepicker-tools.spec.ts
+++ b/src/datepicker/datepicker-tools.spec.ts
@@ -64,7 +64,7 @@ describe(`datepicker-tools`, () => {
     });
 
     it(`should bypass invalid date values`, () => {
-      expect(checkDateInRange(undefined, undefined, undefined)).toBeUndefined();
+      expect(checkDateInRange(undefined, undefined, undefined)).toBeNull();
       expect(checkDateInRange(null, undefined, undefined)).toBeNull();
       expect(checkDateInRange(new NgbDate(-2, 0, 0), undefined, undefined)).toEqual(new NgbDate(-2, 0, 0));
     });
@@ -213,7 +213,7 @@ describe(`datepicker-tools`, () => {
   describe(`buildMonths()`, () => {
 
     it(`should generate 'displayMonths' number of months`, () => {
-      let state = { displayMonths: 1, firstDayOfWeek: 1, months: [] } as DatepickerViewModel;
+      let state = { displayMonths: 1, firstDayOfWeek: 1, months: [] as MonthViewModel[] } as DatepickerViewModel;
       let months = buildMonths(calendar, new NgbDate(2017, 5, 5), state, i18n, false);
       expect(months.length).toBe(1);
 
@@ -283,11 +283,11 @@ describe(`datepicker-tools`, () => {
     beforeEach(function() { jasmine.addMatchers(customMatchers); });
 
     it(`should reuse the same data structure (force = false)`, () => {
-      let state = { displayMonths: 1, firstDayOfWeek: 1, months: [] } as DatepickerViewModel;
+      let state = { displayMonths: 1, firstDayOfWeek: 1, months: [] as MonthViewModel[] } as DatepickerViewModel;
       let months = buildMonths(calendar, new NgbDate(2017, 5, 5), state, i18n, false);
       expect(months).toBe(state.months);
       expect(months.length).toBe(1);
-      let monthsStructure = storeMonthsDataStructure(months);
+      let monthsStructure = storeMonthsDataStructure(months) !;
 
       months = buildMonths(calendar, new NgbDate(2018, 5, 5), state, i18n, false);
       expect(months).toBe(state.months);
@@ -306,7 +306,7 @@ describe(`datepicker-tools`, () => {
       expect(months).toBe(state.months);
       expect(months.length).toBe(2);
       // the structures should be swapped:
-      monthsStructure.push(monthsStructure.shift());
+      monthsStructure.push(monthsStructure.shift() !);
       expect(storeMonthsDataStructure(months))['toHaveTheSameMonthDataStructureAs'](monthsStructure);
 
       // previous month
@@ -314,7 +314,7 @@ describe(`datepicker-tools`, () => {
       expect(months).toBe(state.months);
       expect(months.length).toBe(2);
       // the structures should be swapped (again):
-      monthsStructure.push(monthsStructure.shift());
+      monthsStructure.push(monthsStructure.shift() !);
       expect(storeMonthsDataStructure(months))['toHaveTheSameMonthDataStructureAs'](monthsStructure);
 
       state.displayMonths = 5;
@@ -354,7 +354,7 @@ describe(`datepicker-tools`, () => {
     });
 
     it(`should reuse the same data structure (force = true)`, () => {
-      let state = { displayMonths: 1, firstDayOfWeek: 1, months: [] } as DatepickerViewModel;
+      let state = { displayMonths: 1, firstDayOfWeek: 1, months: [] as MonthViewModel[] } as DatepickerViewModel;
       let months = buildMonths(calendar, new NgbDate(2017, 5, 5), state, i18n, true);
       expect(months).toBe(state.months);
       expect(months.length).toBe(1);

--- a/src/datepicker/datepicker-tools.ts
+++ b/src/datepicker/datepicker-tools.ts
@@ -1,28 +1,28 @@
 import {NgbDate} from './ngb-date';
 import {DatepickerViewModel, DayViewModel, MonthViewModel} from './datepicker-view-model';
 import {NgbCalendar} from './ngb-calendar';
-import {isDefined} from '../util/util';
 import {NgbDatepickerI18n} from './datepicker-i18n';
 
-export function isChangedDate(prev: NgbDate, next: NgbDate) {
+export function isChangedDate(prev?: NgbDate | null, next?: NgbDate | null): boolean {
   return !dateComparator(prev, next);
 }
 
-export function isChangedMonth(prev: NgbDate, next: NgbDate) {
+export function isChangedMonth(prev?: NgbDate | null, next?: NgbDate | null): boolean {
   return !prev && !next ? false : !prev || !next ? true : prev.year !== next.year || prev.month !== next.month;
 }
 
-export function dateComparator(prev: NgbDate, next: NgbDate) {
+export function dateComparator(prev?: NgbDate | null, next?: NgbDate | null): boolean {
   return (!prev && !next) || (!!prev && !!next && prev.equals(next));
 }
 
-export function checkMinBeforeMax(minDate: NgbDate, maxDate: NgbDate) {
+export function checkMinBeforeMax(minDate?: NgbDate | null, maxDate?: NgbDate | null): void {
   if (maxDate && minDate && maxDate.before(minDate)) {
     throw new Error(`'maxDate' ${maxDate} should be greater than 'minDate' ${minDate}`);
   }
 }
 
-export function checkDateInRange(date: NgbDate, minDate: NgbDate, maxDate: NgbDate): NgbDate {
+export function checkDateInRange(date?: NgbDate | null, minDate?: NgbDate | null, maxDate?: NgbDate | null): NgbDate |
+    null {
   if (date && minDate && date.before(minDate)) {
     return minDate;
   }
@@ -30,14 +30,15 @@ export function checkDateInRange(date: NgbDate, minDate: NgbDate, maxDate: NgbDa
     return maxDate;
   }
 
-  return date;
+  return date || null;
 }
 
-export function isDateSelectable(date: NgbDate, state: DatepickerViewModel) {
+export function isDateSelectable(date: NgbDate | null | undefined, state: DatepickerViewModel) {
   const {minDate, maxDate, disabled, markDisabled} = state;
   // clang-format off
   return !(
-    !isDefined(date) ||
+    date === null ||
+    date === undefined ||
     disabled ||
     (markDisabled && markDisabled(date, {year: date.year, month: date.month})) ||
     (minDate && date.before(minDate)) ||
@@ -46,7 +47,8 @@ export function isDateSelectable(date: NgbDate, state: DatepickerViewModel) {
   // clang-format on
 }
 
-export function generateSelectBoxMonths(calendar: NgbCalendar, date: NgbDate, minDate: NgbDate, maxDate: NgbDate) {
+export function generateSelectBoxMonths(
+    calendar: NgbCalendar, date: NgbDate, minDate: NgbDate | null, maxDate: NgbDate | null) {
   if (!date) {
     return [];
   }
@@ -66,7 +68,7 @@ export function generateSelectBoxMonths(calendar: NgbCalendar, date: NgbDate, mi
   return months;
 }
 
-export function generateSelectBoxYears(date: NgbDate, minDate: NgbDate, maxDate: NgbDate) {
+export function generateSelectBoxYears(date: NgbDate, minDate: NgbDate | null, maxDate: NgbDate | null) {
   if (!date) {
     return [];
   }
@@ -83,15 +85,15 @@ export function generateSelectBoxYears(date: NgbDate, minDate: NgbDate, maxDate:
   return numbers;
 }
 
-export function nextMonthDisabled(calendar: NgbCalendar, date: NgbDate, maxDate: NgbDate) {
+export function nextMonthDisabled(calendar: NgbCalendar, date: NgbDate, maxDate: NgbDate | null) {
   const nextDate = Object.assign(calendar.getNext(date, 'm'), {day: 1});
-  return maxDate && nextDate.after(maxDate);
+  return maxDate != null && nextDate.after(maxDate);
 }
 
-export function prevMonthDisabled(calendar: NgbCalendar, date: NgbDate, minDate: NgbDate) {
+export function prevMonthDisabled(calendar: NgbCalendar, date: NgbDate, minDate: NgbDate | null) {
   const prevDate = Object.assign(calendar.getPrev(date, 'm'), {day: 1});
-  return minDate && (prevDate.year === minDate.year && prevDate.month < minDate.month ||
-                     prevDate.year < minDate.year && minDate.month === 1);
+  return minDate != null && (prevDate.year === minDate.year && prevDate.month < minDate.month ||
+                             prevDate.year < minDate.year && minDate.month === 1);
 }
 
 export function buildMonths(
@@ -104,7 +106,7 @@ export function buildMonths(
   // generate new first dates, nullify or reuse months
   const firstDates = Array.from({length: displayMonths}, (_, i) => {
     const firstDate = Object.assign(calendar.getNext(date, 'm', i), {day: 1});
-    months[i] = null;
+    months[i] = <any>null;
 
     if (!force) {
       const reusedIndex = monthsToReuse.findIndex(month => month.firstDate.equals(firstDate));
@@ -133,8 +135,8 @@ export function buildMonth(
   const {dayTemplateData, minDate, maxDate, firstDayOfWeek, markDisabled, outsideDays} = state;
   const calendarToday = calendar.getToday();
 
-  month.firstDate = null;
-  month.lastDate = null;
+  month.firstDate = <any>null;
+  month.lastDate = <any>null;
   month.number = date.month;
   month.year = date.year;
   month.weeks = month.weeks || [];

--- a/src/datepicker/datepicker-view-model.ts
+++ b/src/datepicker/datepicker-view-model.ts
@@ -2,8 +2,8 @@ import {NgbDate} from './ngb-date';
 import {NgbDateStruct} from './ngb-date-struct';
 import {DayTemplateContext} from './datepicker-day-template-context';
 
-export type NgbMarkDisabled = (date: NgbDateStruct, current: {year: number, month: number}) => boolean;
-export type NgbDayTemplateData = (date: NgbDateStruct, current: {year: number, month: number}) => any;
+export type NgbMarkDisabled = (date: NgbDateStruct, current?: {year: number, month: number}) => boolean;
+export type NgbDayTemplateData = (date: NgbDateStruct, current?: {year: number, month: number}) => any;
 
 export type DayViewModel = {
   date: NgbDate,
@@ -30,17 +30,17 @@ export type MonthViewModel = {
 
 // clang-format off
 export type DatepickerViewModel = {
-  dayTemplateData?: NgbDayTemplateData,
+  dayTemplateData: NgbDayTemplateData | null,
   disabled: boolean,
   displayMonths: number,
-  firstDate?: NgbDate,
+  firstDate: NgbDate | null,
   firstDayOfWeek: number,
-  focusDate?: NgbDate,
+  focusDate: NgbDate | null,
   focusVisible: boolean,
-  lastDate?: NgbDate,
-  markDisabled?: NgbMarkDisabled,
-  maxDate?: NgbDate,
-  minDate?: NgbDate,
+  lastDate: NgbDate | null,
+  markDisabled: NgbMarkDisabled | null,
+  maxDate: NgbDate | null,
+  minDate: NgbDate | null,
   months: MonthViewModel[],
   navigation: 'select' | 'arrows' | 'none',
   outsideDays: 'visible' | 'collapsed' | 'hidden',
@@ -50,7 +50,7 @@ export type DatepickerViewModel = {
     years: number[],
     months: number[]
   },
-  selectedDate: NgbDate
+  selectedDate: NgbDate | null
 };
 // clang-format on
 

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -58,7 +58,7 @@ function triggerKeyDown(element: DebugElement, keyCode: number, shiftKey = false
     stopPropagation: function() { this.propagationStopped = true; },
     preventDefault: function() { this.defaultPrevented = true; }
   };
-  expect(document.activeElement.classList.contains('ngb-dp-day'))
+  expect(document.activeElement !.classList.contains('ngb-dp-day'))
       .toBeTruthy('You must focus day before triggering key events');
   element.triggerEventHandler('keydown', event);
   return event;
@@ -68,7 +68,7 @@ function getMonthContainer(datepicker: DebugElement) {
   return datepicker.query(By.css('ngb-datepicker-month'));
 }
 
-function expectSelectedDate(element: DebugElement, selectedDate: NgbDate) {
+function expectSelectedDate(element: DebugElement, selectedDate: NgbDate | null) {
   // checking we have 1 day with .selected class
   const days = getSelectedDays(element);
 
@@ -77,7 +77,7 @@ function expectSelectedDate(element: DebugElement, selectedDate: NgbDate) {
 
     // checking it corresponds to our date
     const day = days[0];
-    const dayView = day.parent.query(By.directive(NgbDatepickerDayView)).componentInstance as NgbDatepickerDayView;
+    const dayView = day.parent !.query(By.directive(NgbDatepickerDayView)).componentInstance as NgbDatepickerDayView;
     expect(NgbDate.from(dayView.date)).toEqual(selectedDate);
   } else {
     expect(days.length).toBe(0);
@@ -191,12 +191,12 @@ describe('ngb-datepicker', () => {
     expect(getMonthSelect(fixture.nativeElement).value).toBe('8');
     expect(getYearSelect(fixture.nativeElement).value).toBe('2016');
 
-    fixture.componentInstance.date = null;
+    fixture.componentInstance.date = <any>null;
     fixture.detectChanges();
     expect(getMonthSelect(fixture.nativeElement).value).toBe(currentMonth);
     expect(getYearSelect(fixture.nativeElement).value).toBe(currentYear);
 
-    fixture.componentInstance.date = undefined;
+    fixture.componentInstance.date = <any>undefined;
     fixture.detectChanges();
     expect(getMonthSelect(fixture.nativeElement).value).toBe(currentMonth);
     expect(getYearSelect(fixture.nativeElement).value).toBe(currentYear);
@@ -318,12 +318,12 @@ describe('ngb-datepicker', () => {
     expectMinDate(1000, 1);
 
     // resetting
-    fixture.componentInstance.minDate = null;
+    fixture.componentInstance.minDate = <any>null;
     fixture.detectChanges();
     expectMinDate(1000, 1);
 
     // resetting
-    fixture.componentInstance.minDate = undefined;
+    fixture.componentInstance.minDate = <any>undefined;
     fixture.detectChanges();
     expectMinDate(1000, 1);
   });
@@ -357,12 +357,12 @@ describe('ngb-datepicker', () => {
     expectMaxDate(10000, 1);
 
     // resetting
-    fixture.componentInstance.maxDate = null;
+    fixture.componentInstance.maxDate = <any>null;
     fixture.detectChanges();
     expectMaxDate(10000, 1);
 
     // resetting
-    fixture.componentInstance.maxDate = undefined;
+    fixture.componentInstance.maxDate = <any>undefined;
     fixture.detectChanges();
     expectMaxDate(10000, 1);
   });
@@ -1234,8 +1234,8 @@ describe('ngb-datepicker', () => {
 
     it('should provide an defensive copy of minDate', () => {
       mv.onKeyDown(<KeyboardEvent>{});
-      expect(mockState.firstDate).toEqual(NgbDate.from({year: 2016, month: 8, day: 1}));
-      expect(mockState.lastDate).toEqual(NgbDate.from({year: 2016, month: 8, day: 31}));
+      expect(mockState.firstDate).toEqual(NgbDate.from({year: 2016, month: 8, day: 1}) !);
+      expect(mockState.lastDate).toEqual(NgbDate.from({year: 2016, month: 8, day: 31}) !);
       expect(mockState.minDate).toEqual(NgbDate.from({year: 2010, month: 1, day: 1}));
       expect(mockState.maxDate).toEqual(NgbDate.from({year: 2020, month: 12, day: 31}));
       Object.assign(mockState, {minDate: undefined});
@@ -1245,8 +1245,8 @@ describe('ngb-datepicker', () => {
 
     it('should provide an defensive copy of maxDate', () => {
       mv.onKeyDown(<KeyboardEvent>{});
-      expect(mockState.firstDate).toEqual(NgbDate.from({year: 2016, month: 8, day: 1}));
-      expect(mockState.lastDate).toEqual(NgbDate.from({year: 2016, month: 8, day: 31}));
+      expect(mockState.firstDate).toEqual(NgbDate.from({year: 2016, month: 8, day: 1}) !);
+      expect(mockState.lastDate).toEqual(NgbDate.from({year: 2016, month: 8, day: 31}) !);
       expect(mockState.minDate).toEqual(NgbDate.from({year: 2010, month: 1, day: 1}));
       expect(mockState.maxDate).toEqual(NgbDate.from({year: 2020, month: 12, day: 31}));
       Object.assign(mockState, {maxDate: undefined});
@@ -1256,8 +1256,8 @@ describe('ngb-datepicker', () => {
 
     it('should provide an defensive copy of firstDate', () => {
       mv.onKeyDown(<KeyboardEvent>{});
-      expect(mockState.firstDate).toEqual(NgbDate.from({year: 2016, month: 8, day: 1}));
-      expect(mockState.lastDate).toEqual(NgbDate.from({year: 2016, month: 8, day: 31}));
+      expect(mockState.firstDate).toEqual(NgbDate.from({year: 2016, month: 8, day: 1}) !);
+      expect(mockState.lastDate).toEqual(NgbDate.from({year: 2016, month: 8, day: 31}) !);
       expect(mockState.minDate).toEqual(NgbDate.from({year: 2010, month: 1, day: 1}));
       expect(mockState.maxDate).toEqual(NgbDate.from({year: 2020, month: 12, day: 31}));
       Object.assign(mockState, {firstDate: undefined});
@@ -1267,8 +1267,8 @@ describe('ngb-datepicker', () => {
 
     it('should provide an defensive copy of lastDate', () => {
       mv.onKeyDown(<KeyboardEvent>{});
-      expect(mockState.firstDate).toEqual(NgbDate.from({year: 2016, month: 8, day: 1}));
-      expect(mockState.lastDate).toEqual(NgbDate.from({year: 2016, month: 8, day: 31}));
+      expect(mockState.firstDate).toEqual(NgbDate.from({year: 2016, month: 8, day: 1}) !);
+      expect(mockState.lastDate).toEqual(NgbDate.from({year: 2016, month: 8, day: 31}) !);
       expect(mockState.minDate).toEqual(NgbDate.from({year: 2010, month: 1, day: 1}));
       expect(mockState.maxDate).toEqual(NgbDate.from({year: 2020, month: 12, day: 31}));
       Object.assign(mockState, {lastDate: undefined});
@@ -1278,7 +1278,7 @@ describe('ngb-datepicker', () => {
 
     it('should provide an defensive copy of focusedDate', () => {
       mv.onKeyDown(<KeyboardEvent>{});
-      expect(mockState.focusedDate).toEqual(NgbDate.from({year: 2016, month: 8, day: 1}));
+      expect(mockState.focusedDate).toEqual(NgbDate.from({year: 2016, month: 8, day: 1}) !);
       Object.assign(mockState, {focusedDate: undefined});
       mv.onKeyDown(<KeyboardEvent>{});
       expect(dp.model.focusDate).toEqual(NgbDate.from({year: 2016, month: 8, day: 1}));
@@ -1306,7 +1306,7 @@ class TestComponent {
   model;
   showWeekdays = true;
   dayTemplateData = () => '!';
-  markDisabled = (date: NgbDateStruct) => { return NgbDate.from(date).equals(new NgbDate(2016, 8, 22)); };
+  markDisabled = (date: NgbDateStruct) => { return NgbDate.from(date) !.equals(new NgbDate(2016, 8, 22)); };
   onNavigate = () => {};
   onDateSelect = () => {};
   getDate = () => ({year: 2016, month: 8});

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -46,7 +46,7 @@ export interface NgbDatepickerNavigateEvent {
   /**
    * The currently displayed month.
    */
-  current: {year: number, month: number};
+  current: {year: number, month: number} | null;
 
   /**
    * The month we're navigating to.
@@ -72,12 +72,12 @@ export interface NgbDatepickerState {
   /**
    * The earliest date that can be displayed or selected
    */
-  readonly minDate: NgbDate;
+  readonly minDate: NgbDate | null;
 
   /**
    * The latest date that can be displayed or selected
    */
-  readonly maxDate: NgbDate;
+  readonly maxDate: NgbDate | null;
 
   /**
    * The first visible date of currently displayed months
@@ -146,7 +146,7 @@ export class NgbDatepickerContent {
 
     <div class="ngb-dp-header">
       <ngb-datepicker-navigation *ngIf="navigation !== 'none'"
-        [date]="model.firstDate"
+        [date]="model.firstDate!"
         [months]="model.months"
         [disabled]="model.disabled"
         [showSelect]="model.navigation === 'select'"
@@ -178,7 +178,7 @@ export class NgbDatepicker implements OnDestroy,
   @ViewChild('content', {static: true}) private _contentEl: ElementRef<HTMLElement>;
   @ContentChild(NgbDatepickerContent, {static: true}) contentTemplate: NgbDatepickerContent;
 
-  private _controlValue: NgbDate;
+  private _controlValue: NgbDate | null = null;
   private _destroyed$ = new Subject<void>();
   private _publicState: NgbDatepickerState = <any>{};
 
@@ -199,7 +199,7 @@ export class NgbDatepicker implements OnDestroy,
    *
    * @since 3.3.0
    */
-  @Input() dayTemplateData: (date: NgbDate, current: {year: number, month: number}) => any;
+  @Input() dayTemplateData: (date: NgbDate, current?: {year: number, month: number}) => any;
 
   /**
    * The number of months to display.
@@ -227,7 +227,7 @@ export class NgbDatepicker implements OnDestroy,
    *
    * `current` is the month that is currently displayed by the datepicker.
    */
-  @Input() markDisabled: (date: NgbDate, current: {year: number, month: number}) => boolean;
+  @Input() markDisabled: (date: NgbDate, current?: {year: number, month: number}) => boolean;
 
   /**
    * The latest date that can be displayed or selected.
@@ -323,16 +323,16 @@ export class NgbDatepicker implements OnDestroy,
     _service.dateSelect$.pipe(takeUntil(this._destroyed$)).subscribe(date => { this.dateSelect.emit(date); });
 
     _service.model$.pipe(takeUntil(this._destroyed$)).subscribe(model => {
-      const newDate = model.firstDate;
+      const newDate = model.firstDate !;
       const oldDate = this.model ? this.model.firstDate : null;
 
       // update public state
       this._publicState = {
         maxDate: model.maxDate,
         minDate: model.minDate,
-        firstDate: model.firstDate,
-        lastDate: model.lastDate,
-        focusedDate: model.focusDate,
+        firstDate: model.firstDate !,
+        lastDate: model.lastDate !,
+        focusedDate: model.focusDate !,
         months: model.months.map(viewModel => viewModel.firstDate)
       };
 
@@ -391,7 +391,7 @@ export class NgbDatepicker implements OnDestroy,
   /**
    *  Focuses on given date.
    */
-  focusDate(date: NgbDateStruct): void { this._service.focus(NgbDate.from(date)); }
+  focusDate(date?: NgbDateStruct | null): void { this._service.focus(NgbDate.from(date)); }
 
   /**
    *  Selects focused date.
@@ -482,10 +482,10 @@ export class NgbDatepicker implements OnDestroy,
   onNavigateEvent(event: NavigationEvent) {
     switch (event) {
       case NavigationEvent.PREV:
-        this._service.open(this._calendar.getPrev(this.model.firstDate, 'm', 1));
+        this._service.open(this._calendar.getPrev(this.model.firstDate !, 'm', 1));
         break;
       case NavigationEvent.NEXT:
-        this._service.open(this._calendar.getNext(this.model.firstDate, 'm', 1));
+        this._service.open(this._calendar.getNext(this.model.firstDate !, 'm', 1));
         break;
     }
   }

--- a/src/datepicker/hebrew/datepicker-i18n-hebrew.spec.ts
+++ b/src/datepicker/hebrew/datepicker-i18n-hebrew.spec.ts
@@ -12,48 +12,48 @@ describe('datepicker-i18n-hebrew', () => {
   });
 
   it('should return abbreviated month name', () => {
-    expect(i18n.getMonthShortName(0, 5778)).toBe(undefined);
+    expect(i18n.getMonthShortName(0, 5778)).toBe('');
     expect(i18n.getMonthShortName(1, 5778)).toBe('תשרי');
     expect(i18n.getMonthShortName(6, 5778)).toBe('אדר');
     expect(i18n.getMonthShortName(7, 5778)).toBe('ניסן');
     expect(i18n.getMonthShortName(12, 5778)).toBe('אלול');
-    expect(i18n.getMonthShortName(13, 5778)).toBe(undefined);
+    expect(i18n.getMonthShortName(13, 5778)).toBe('');
   });
 
   it('should return abbreviated month name (leap year)', () => {
-    expect(i18n.getMonthShortName(0, 5779)).toBe(undefined);
+    expect(i18n.getMonthShortName(0, 5779)).toBe('');
     expect(i18n.getMonthShortName(1, 5779)).toBe('תשרי');
     expect(i18n.getMonthShortName(6, 5779)).toBe('אדר א׳');
     expect(i18n.getMonthShortName(7, 5779)).toBe('אדר ב׳');
     expect(i18n.getMonthShortName(12, 5779)).toBe('אב');
     expect(i18n.getMonthShortName(13, 5779)).toBe('אלול');
-    expect(i18n.getMonthShortName(14, 5779)).toBe(undefined);
+    expect(i18n.getMonthShortName(14, 5779)).toBe('');
   });
 
   it('should return wide month name', () => {
-    expect(i18n.getMonthFullName(0, 5778)).toBe(undefined);
+    expect(i18n.getMonthFullName(0, 5778)).toBe('');
     expect(i18n.getMonthFullName(1, 5778)).toBe('תשרי');
     expect(i18n.getMonthFullName(6, 5778)).toBe('אדר');
     expect(i18n.getMonthFullName(7, 5778)).toBe('ניסן');
     expect(i18n.getMonthFullName(12, 5778)).toBe('אלול');
-    expect(i18n.getMonthFullName(13, 5778)).toBe(undefined);
+    expect(i18n.getMonthFullName(13, 5778)).toBe('');
   });
 
   it('should return wide month name (leap year)', () => {
-    expect(i18n.getMonthFullName(0, 5779)).toBe(undefined);
+    expect(i18n.getMonthFullName(0, 5779)).toBe('');
     expect(i18n.getMonthFullName(1, 5779)).toBe('תשרי');
     expect(i18n.getMonthFullName(6, 5779)).toBe('אדר א׳');
     expect(i18n.getMonthFullName(7, 5779)).toBe('אדר ב׳');
     expect(i18n.getMonthFullName(12, 5779)).toBe('אב');
     expect(i18n.getMonthFullName(13, 5779)).toBe('אלול');
-    expect(i18n.getMonthFullName(14, 5779)).toBe(undefined);
+    expect(i18n.getMonthFullName(14, 5779)).toBe('');
   });
 
   it('should return weekday name', () => {
-    expect(i18n.getWeekdayShortName(0)).toBe(undefined);
+    expect(i18n.getWeekdayShortName(0)).toBe('');
     expect(i18n.getWeekdayShortName(1)).toBe('שני');
     expect(i18n.getWeekdayShortName(7)).toBe('ראשון');
-    expect(i18n.getWeekdayShortName(8)).toBe(undefined);
+    expect(i18n.getWeekdayShortName(8)).toBe('');
   });
 
   it('should generate aria label for a date',

--- a/src/datepicker/hebrew/datepicker-i18n-hebrew.ts
+++ b/src/datepicker/hebrew/datepicker-i18n-hebrew.ts
@@ -17,10 +17,10 @@ export class NgbDatepickerI18nHebrew extends NgbDatepickerI18n {
   getMonthShortName(month: number, year?: number): string { return this.getMonthFullName(month, year); }
 
   getMonthFullName(month: number, year?: number): string {
-    return isHebrewLeapYear(year) ? MONTHS_LEAP[month - 1] : MONTHS[month - 1];
+    return isHebrewLeapYear(year) ? MONTHS_LEAP[month - 1] || '' : MONTHS[month - 1] || '';
   }
 
-  getWeekdayShortName(weekday: number): string { return WEEKDAYS[weekday - 1]; }
+  getWeekdayShortName(weekday: number): string { return WEEKDAYS[weekday - 1] || ''; }
 
   getDayAriaLabel(date: NgbDateStruct): string {
     return `${hebrewNumerals(date.day)} ${this.getMonthFullName(date.month, date.year)} ${hebrewNumerals(date.year)}`;

--- a/src/datepicker/hebrew/hebrew.ts
+++ b/src/datepicker/hebrew/hebrew.ts
@@ -53,9 +53,12 @@ function getDaysInHebrewYear(year: number): number {
   return numberOfFirstDayInYear(year + 1) - numberOfFirstDayInYear(year);
 }
 
-export function isHebrewLeapYear(year: number): boolean {
-  let b = (year * 12 + 17) % 19;
-  return b >= ((b < 0) ? -7 : 12);
+export function isHebrewLeapYear(year?: number): boolean {
+  if (year != null) {
+    let b = (year * 12 + 17) % 19;
+    return b >= ((b < 0) ? -7 : 12);
+  }
+  return false;
 }
 
 /**
@@ -259,7 +262,7 @@ export function hebrewNumerals(numerals: number): string {
   ];
   const geresh = '\u05f3', gershaim = '\u05f4';
   let mem = 0;
-  let result = [];
+  let result: string[] = [];
   let step = 0;
   while (numerals > 0) {
     let m = numerals % 10;

--- a/src/datepicker/hebrew/ngb-calendar-hebrew.ts
+++ b/src/datepicker/hebrew/ngb-calendar-hebrew.ts
@@ -29,11 +29,15 @@ export class NgbCalendarHebrew extends NgbCalendar {
 
   getWeeksPerMonth() { return 6; }
 
-  isValid(date: NgbDate): boolean {
-    let b = date && isNumber(date.year) && isNumber(date.month) && isNumber(date.day);
-    b = b && date.month > 0 && date.month <= (isHebrewLeapYear(date.year) ? 13 : 12);
-    b = b && date.day > 0 && date.day <= getDaysInHebrewMonth(date.month, date.year);
-    return b && !isNaN(toGregorian(date).getTime());
+  isValid(date?: NgbDate | null): boolean {
+    if (date != null) {
+      let b = isNumber(date.year) && isNumber(date.month) && isNumber(date.day);
+      b = b && date.month > 0 && date.month <= (isHebrewLeapYear(date.year) ? 13 : 12);
+      b = b && date.day > 0 && date.day <= getDaysInHebrewMonth(date.month, date.year);
+      return b && !isNaN(toGregorian(date).getTime());
+    }
+
+    return false;
   }
 
   getNext(date: NgbDate, period: NgbPeriod = 'd', number = 1) {

--- a/src/datepicker/hijri/ngb-calendar-hijri.ts
+++ b/src/datepicker/hijri/ngb-calendar-hijri.ts
@@ -76,8 +76,8 @@ export abstract class NgbCalendarHijri extends NgbCalendar {
   getToday(): NgbDate { return this.fromGregorian(new Date()); }
 
 
-  isValid(date: NgbDate): boolean {
-    return date && isNumber(date.year) && isNumber(date.month) && isNumber(date.day) &&
+  isValid(date?: NgbDate | null): boolean {
+    return date != null && isNumber(date.year) && isNumber(date.month) && isNumber(date.day) &&
         !isNaN(this.toGregorian(date).getTime());
   }
 

--- a/src/datepicker/hijri/ngb-calendar-islamic-umalqura.ts
+++ b/src/datepicker/hijri/ngb-calendar-islamic-umalqura.ts
@@ -179,6 +179,7 @@ export class NgbCalendarIslamicUmalqura extends NgbCalendarIslamicCivil {
           daysDiff = daysDiff - numOfDays;
         }
       }
+      return null as any;
     } else {
       return super.fromGregorian(gDate);
     }

--- a/src/datepicker/jalali/ngb-calendar-persian.ts
+++ b/src/datepicker/jalali/ngb-calendar-persian.ts
@@ -59,8 +59,8 @@ export class NgbCalendarPersian extends NgbCalendar {
 
   getToday(): NgbDate { return fromGregorian(new Date()); }
 
-  isValid(date: NgbDate): boolean {
-    return date && isInteger(date.year) && isInteger(date.month) && isInteger(date.day) &&
+  isValid(date?: NgbDate | null): boolean {
+    return date != null && isInteger(date.year) && isInteger(date.month) && isInteger(date.day) &&
         !isNaN(toGregorian(date).getTime());
   }
 }

--- a/src/datepicker/ngb-calendar.spec.ts
+++ b/src/datepicker/ngb-calendar.spec.ts
@@ -82,11 +82,11 @@ describe('ngb-calendar-gregorian', () => {
 
   it('should properly recognize invalid javascript date', () => {
     expect(calendar.isValid(null)).toBeFalsy();
-    expect(calendar.isValid(undefined)).toBeFalsy();
+    expect(calendar.isValid(<any>undefined)).toBeFalsy();
     expect(calendar.isValid(<any>NaN)).toBeFalsy();
     expect(calendar.isValid(<any>new Date())).toBeFalsy();
-    expect(calendar.isValid(new NgbDate(null, null, null))).toBeFalsy();
-    expect(calendar.isValid(new NgbDate(undefined, undefined, undefined))).toBeFalsy();
+    expect(calendar.isValid(new NgbDate(<any>null, <any>null, <any>null))).toBeFalsy();
+    expect(calendar.isValid(new NgbDate(<any>undefined, <any>undefined, <any>undefined))).toBeFalsy();
     expect(calendar.isValid(new NgbDate(NaN, NaN, NaN))).toBeFalsy();
     expect(calendar.isValid(new NgbDate(<any>'2017', <any>'03', <any>'10'))).toBeFalsy();
   });

--- a/src/datepicker/ngb-calendar.ts
+++ b/src/datepicker/ngb-calendar.ts
@@ -85,7 +85,7 @@ export abstract class NgbCalendar {
   /**
    * Checks if a date is valid in the current calendar.
    */
-  abstract isValid(date: NgbDate): boolean;
+  abstract isValid(date?: NgbDate | null): boolean;
 }
 
 @Injectable()
@@ -158,7 +158,7 @@ export class NgbCalendarGregorian extends NgbCalendar {
 
   getToday(): NgbDate { return fromJSDate(new Date()); }
 
-  isValid(date: NgbDate): boolean {
+  isValid(date?: NgbDate | null): boolean {
     if (!date || !isInteger(date.year) || !isInteger(date.month) || !isInteger(date.day)) {
       return false;
     }

--- a/src/datepicker/ngb-date-parser-formatter.spec.ts
+++ b/src/datepicker/ngb-date-parser-formatter.spec.ts
@@ -8,8 +8,8 @@ describe('ngb-date parsing and formatting', () => {
   describe('parsing', () => {
 
     it('should parse null undefined and empty string as null', () => {
-      expect(pf.parse(null)).toBeNull();
-      expect(pf.parse(undefined)).toBeNull();
+      expect(pf.parse(<any>null)).toBeNull();
+      expect(pf.parse(<any>undefined)).toBeNull();
       expect(pf.parse('')).toBeNull();
       expect(pf.parse('   ')).toBeNull();
     });
@@ -23,14 +23,14 @@ describe('ngb-date parsing and formatting', () => {
     });
 
     it('should do its best parsing incomplete dates',
-       () => { expect(pf.parse('2011-5')).toEqual({year: 2011, month: 5, day: null}); });
+       () => { expect(pf.parse('2011-5')).toEqual(<any>{year: 2011, month: 5, day: null}); });
   });
 
   describe('formatting', () => {
 
     it('should format null and undefined as an empty string', () => {
       expect(pf.format(null)).toBe('');
-      expect(pf.format(undefined)).toBe('');
+      expect(pf.format(<any>undefined)).toBe('');
     });
 
     it('should format a valid date', () => { expect(pf.format({year: 2016, month: 10, day: 15})).toBe('2016-10-15'); });
@@ -39,8 +39,8 @@ describe('ngb-date parsing and formatting', () => {
        () => { expect(pf.format({year: 2016, month: 10, day: 5})).toBe('2016-10-05'); });
 
     it('should try its best with invalid dates', () => {
-      expect(pf.format({year: 2016, month: NaN, day: undefined})).toBe('2016--');
-      expect(pf.format({year: 2016, month: null, day: 0})).toBe('2016--00');
+      expect(pf.format(<any>{year: 2016, month: NaN, day: undefined})).toBe('2016--');
+      expect(pf.format(<any>{year: 2016, month: null, day: 0})).toBe('2016--00');
     });
   });
 

--- a/src/datepicker/ngb-date-parser-formatter.ts
+++ b/src/datepicker/ngb-date-parser-formatter.ts
@@ -29,7 +29,7 @@ export abstract class NgbDateParserFormatter {
    * Implementations should try their best to provide a result, even
    * partial. They must return `null` if the value can't be parsed.
    */
-  abstract parse(value: string): NgbDateStruct;
+  abstract parse(value: string): NgbDateStruct | null;
 
   /**
    * Formats the given `NgbDateStruct` to a `string`.
@@ -37,18 +37,18 @@ export abstract class NgbDateParserFormatter {
    * Implementations should return an empty string if the given date is `null`,
    * and try their best to provide a partial result if the given date is incomplete or invalid.
    */
-  abstract format(date: NgbDateStruct): string;
+  abstract format(date: NgbDateStruct | null): string;
 }
 
 @Injectable()
 export class NgbDateISOParserFormatter extends NgbDateParserFormatter {
-  parse(value: string): NgbDateStruct {
-    if (value) {
+  parse(value: string): NgbDateStruct | null {
+    if (value != null) {
       const dateParts = value.trim().split('-');
       if (dateParts.length === 1 && isNumber(dateParts[0])) {
-        return {year: toInteger(dateParts[0]), month: null, day: null};
+        return {year: toInteger(dateParts[0]), month: <any>null, day: <any>null};
       } else if (dateParts.length === 2 && isNumber(dateParts[0]) && isNumber(dateParts[1])) {
-        return {year: toInteger(dateParts[0]), month: toInteger(dateParts[1]), day: null};
+        return {year: toInteger(dateParts[0]), month: toInteger(dateParts[1]), day: <any>null};
       } else if (dateParts.length === 3 && isNumber(dateParts[0]) && isNumber(dateParts[1]) && isNumber(dateParts[2])) {
         return {year: toInteger(dateParts[0]), month: toInteger(dateParts[1]), day: toInteger(dateParts[2])};
       }
@@ -56,7 +56,7 @@ export class NgbDateISOParserFormatter extends NgbDateParserFormatter {
     return null;
   }
 
-  format(date: NgbDateStruct): string {
+  format(date: NgbDateStruct | null): string {
     return date ?
         `${date.year}-${isNumber(date.month) ? padNumber(date.month) : ''}-${isNumber(date.day) ? padNumber(date.day) : ''}` :
         '';

--- a/src/datepicker/ngb-date.spec.ts
+++ b/src/datepicker/ngb-date.spec.ts
@@ -8,9 +8,12 @@ describe('ngb-date', () => {
        () => { expect(NgbDate.from({year: 2010, month: 10, day: 2})).toEqual(new NgbDate(2010, 10, 2)); });
 
     it('should work with non-numeric values', () => {
-      expect(NgbDate.from({year: null, month: null, day: null})).toEqual(new NgbDate(null, null, null));
-      expect(NgbDate.from({year: undefined, month: undefined, day: undefined})).toEqual(new NgbDate(null, null, null));
-      expect(NgbDate.from({year: <any>'2010', month: <any>'10', day: <any>'2'})).toEqual(new NgbDate(null, null, null));
+      expect(NgbDate.from(<any>{year: null, month: null, day: null}))
+          .toEqual(new NgbDate(<any>null, <any>null, <any>null));
+      expect(NgbDate.from(<any>{year: undefined, month: undefined, day: undefined}))
+          .toEqual(new NgbDate(<any>null, <any>null, <any>null));
+      expect(NgbDate.from({year: <any>'2010', month: <any>'10', day: <any>'2'}))
+          .toEqual(new NgbDate(<any>null, <any>null, <any>null));
     });
 
     it('should return the same NgbDate object', () => {

--- a/src/datepicker/ngb-date.ts
+++ b/src/datepicker/ngb-date.ts
@@ -39,7 +39,7 @@ export class NgbDate implements NgbDateStruct {
    *
    * If the `date` is already of `NgbDate` type, the method will return the same object.
    */
-  static from(date: NgbDateStruct): NgbDate {
+  static from(date?: NgbDateStruct | null): NgbDate | null {
     if (date instanceof NgbDate) {
       return date;
     }
@@ -47,22 +47,22 @@ export class NgbDate implements NgbDateStruct {
   }
 
   constructor(year: number, month: number, day: number) {
-    this.year = isInteger(year) ? year : null;
-    this.month = isInteger(month) ? month : null;
-    this.day = isInteger(day) ? day : null;
+    this.year = isInteger(year) ? year : <any>null;
+    this.month = isInteger(month) ? month : <any>null;
+    this.day = isInteger(day) ? day : <any>null;
   }
 
   /**
    * Checks if the current date is equal to another date.
    */
-  equals(other: NgbDateStruct): boolean {
-    return other && this.year === other.year && this.month === other.month && this.day === other.day;
+  equals(other?: NgbDateStruct | null): boolean {
+    return other != null && this.year === other.year && this.month === other.month && this.day === other.day;
   }
 
   /**
    * Checks if the current date is before another date.
    */
-  before(other: NgbDateStruct): boolean {
+  before(other?: NgbDateStruct | null): boolean {
     if (!other) {
       return false;
     }
@@ -81,7 +81,7 @@ export class NgbDate implements NgbDateStruct {
   /**
    * Checks if the current date is after another date.
    */
-  after(other: NgbDateStruct): boolean {
+  after(other?: NgbDateStruct | null): boolean {
     if (!other) {
       return false;
     }

--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -330,8 +330,8 @@ describe('ngb-dropdown-toggle', () => {
     const dropdown = fixture.debugElement.query(By.directive(NgbDropdown)).injector.get(NgbDropdown);
     dropdown.open();
     fixture.detectChanges();
-    const dropdownElement = document.querySelector('div[ngbDropdownMenu]');
-    const parentContainer = dropdownElement.parentNode;
+    const dropdownElement = document.querySelector('div[ngbDropdownMenu]') !;
+    const parentContainer = dropdownElement.parentNode !;
     expect(parentContainer).toHaveCssClass('dropdown');
     expect(parentContainer.parentNode).toBe(document.body, 'The dropdown should be attached to the body');
 
@@ -481,8 +481,7 @@ describe('ngb-dropdown-toggle', () => {
 @Component({selector: 'test-cmp', template: ''})
 class TestComponent {
   isOpen = false;
-  stateChanges = [];
-  items = [];
+  stateChanges: boolean[] = [];
 
   recordStateChange($event) {
     this.stateChanges.push($event);

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -71,7 +71,7 @@ export class NgbDropdownItem {
   }
 })
 export class NgbDropdownMenu {
-  placement: Placement = 'bottom';
+  placement: Placement | null = 'bottom';
   isOpen = false;
 
   @ContentChildren(NgbDropdownItem) menuItems: QueryList<NgbDropdownItem>;
@@ -137,7 +137,7 @@ export class NgbDropdown implements AfterContentInit, OnDestroy {
 
   private _closed$ = new Subject<void>();
   private _zoneSubscription: Subscription;
-  private _bodyContainer: HTMLElement;
+  private _bodyContainer: HTMLElement | null = null;
 
   @ContentChild(NgbDropdownMenu, {static: false}) private _menu: NgbDropdownMenu;
   @ContentChild(NgbDropdownMenu, {read: ElementRef, static: false}) private _menuElement: ElementRef;
@@ -294,14 +294,12 @@ export class NgbDropdown implements AfterContentInit, OnDestroy {
     const itemElements = this._getMenuElements();
 
     let position = -1;
-    let isEventFromItems = false;
-    let itemElement: HTMLElement = null;
+    let itemElement: HTMLElement | null = null;
     const isEventFromToggle = this._isEventFromToggle(event);
 
     if (!isEventFromToggle && itemElements.length) {
       itemElements.forEach((item, index) => {
         if (item.contains(event.target as HTMLElement)) {
-          isEventFromItems = true;
           itemElement = item;
         }
         if (item === this._document.activeElement) {
@@ -312,7 +310,7 @@ export class NgbDropdown implements AfterContentInit, OnDestroy {
 
     // closing on Enter / Space
     if (key === Key.Space || key === Key.Enter) {
-      if (isEventFromItems && (this.autoClose === true || this.autoClose === 'inside')) {
+      if (itemElement && (this.autoClose === true || this.autoClose === 'inside')) {
         // Item is either a button or a link, so click will be triggered by the browser on Enter or Space.
         // So we have to register a one-time click handler that will fire after any user defined click handlers
         // to close the dropdown
@@ -322,7 +320,7 @@ export class NgbDropdown implements AfterContentInit, OnDestroy {
     }
 
     // opening / navigating
-    if (isEventFromToggle || isEventFromItems) {
+    if (isEventFromToggle || itemElement) {
       this.open();
 
       if (itemElements.length) {
@@ -414,7 +412,7 @@ export class NgbDropdown implements AfterContentInit, OnDestroy {
     }
   }
 
-  private _applyPlacementClasses(placement?: Placement) {
+  private _applyPlacementClasses(placement?: Placement | null) {
     const menu = this._menu;
     if (menu) {
       if (!placement) {

--- a/src/modal/modal-ref.ts
+++ b/src/modal/modal-ref.ts
@@ -120,8 +120,8 @@ export class NgbModalRef {
       this._contentRef.viewRef.destroy();
     }
 
-    this._windowCmptRef = null;
-    this._backdropCmptRef = null;
-    this._contentRef = null;
+    this._windowCmptRef = <any>null;
+    this._backdropCmptRef = <any>null;
+    this._contentRef = <any>null;
   }
 }

--- a/src/modal/modal-stack.ts
+++ b/src/modal/modal-stack.ts
@@ -24,7 +24,7 @@ import {NgbModalWindow} from './modal-window';
 @Injectable({providedIn: 'root'})
 export class NgbModalStack {
   private _activeWindowCmptHasChanged = new Subject();
-  private _ariaHiddenValues: Map<Element, string> = new Map();
+  private _ariaHiddenValues: Map<Element, string | null> = new Map();
   private _backdropAttributes = ['backdropClass'];
   private _modalRefs: NgbModalRef[] = [];
   private _windowAttributes =
@@ -67,8 +67,8 @@ export class NgbModalStack {
     const contentRef =
         this._getContentRef(moduleCFR, options.injector || contentInjector, content, activeModal, options);
 
-    let backdropCmptRef: ComponentRef<NgbModalBackdrop> =
-        options.backdrop !== false ? this._attachBackdrop(moduleCFR, containerEl) : null;
+    let backdropCmptRef: ComponentRef<NgbModalBackdrop>| undefined =
+        options.backdrop !== false ? this._attachBackdrop(moduleCFR, containerEl) : undefined;
     let windowCmptRef: ComponentRef<NgbModalWindow> = this._attachWindowComponent(moduleCFR, containerEl, contentRef);
     let ngbModalRef: NgbModalRef = new NgbModalRef(windowCmptRef, contentRef, backdropCmptRef, options.beforeDismiss);
 

--- a/src/modal/modal-window.ts
+++ b/src/modal/modal-window.ts
@@ -41,7 +41,7 @@ import {ModalDismissReasons} from './modal-dismiss-reasons';
 export class NgbModalWindow implements OnInit,
     AfterViewInit, OnDestroy {
   private _closed$ = new Subject<void>();
-  private _elWithFocus: Element;  // element that is focused prior to modal opening
+  private _elWithFocus: Element | null = null;  // element that is focused prior to modal opening
 
   @ViewChild('dialog', {static: true}) private _dialogEl: ElementRef<HTMLElement>;
 

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -687,9 +687,9 @@ describe('ngb-modal', () => {
            const modalInstance = a11yFixture.componentInstance.open();
            a11yFixture.detectChanges();
 
-           const modal = document.querySelector('ngb-modal-window');
-           const backdrop = document.querySelector('ngb-modal-backdrop');
-           const application = document.querySelector('div[ng-version]');
+           const modal = document.querySelector('ngb-modal-window') !;
+           const backdrop = document.querySelector('ngb-modal-backdrop') !;
+           const application = document.querySelector('div[ng-version]') !;
            let ariaHidden = document.querySelectorAll('[aria-hidden]');
 
            expect(ariaHidden.length).toBeGreaterThan(2);  // 2 exist in the DOM initially
@@ -713,11 +713,11 @@ describe('ngb-modal', () => {
            const modalInstance = a11yFixture.componentInstance.open({container: '#container'});
            a11yFixture.detectChanges();
 
-           const modal = document.querySelector('ngb-modal-window');
-           const backdrop = document.querySelector('ngb-modal-backdrop');
-           const application = document.querySelector('div[ng-version]');
-           const ariaRestoreTrue = document.querySelector('.to-restore-true');
-           const ariaRestoreFalse = document.querySelector('.to-restore-false');
+           const modal = document.querySelector('ngb-modal-window') !;
+           const backdrop = document.querySelector('ngb-modal-backdrop') !;
+           const application = document.querySelector('div[ng-version]') !;
+           const ariaRestoreTrue = document.querySelector('.to-restore-true') !;
+           const ariaRestoreFalse = document.querySelector('.to-restore-false') !;
 
            expect(document.body.hasAttribute('aria-hidden')).toBe(false);
            expect(application.hasAttribute('aria-hidden')).toBe(false);

--- a/src/nav/nav-outlet.ts
+++ b/src/nav/nav-outlet.ts
@@ -18,7 +18,7 @@ import {NgbNav} from './nav';
                [class.active]="item.active"
                [attr.role]="paneRole ? paneRole : nav.roles ? 'tabpanel' : undefined"
                [attr.aria-labelledby]="item.domId">
-              <ng-template [ngTemplateOutlet]="item.contentTpl?.templateRef"
+              <ng-template [ngTemplateOutlet]="item.contentTpl?.templateRef || null"
                            [ngTemplateOutletContext]="{$implicit: item.active}"></ng-template>
           </div>
       </ng-template>

--- a/src/nav/nav.spec.ts
+++ b/src/nav/nav.spec.ts
@@ -68,7 +68,7 @@ describe('nav', () => {
   beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbNavModule]}); });
 
   it('should initialize inputs with default values', inject([NgbNavConfig], config => {
-       const nav = new NgbNav('tablist', config, null);
+       const nav = new NgbNav('tablist', config, <any>null);
        expect(nav.destroyOnHide).toBe(config.destroyOnHide);
        expect(nav.roles).toBe(config.roles);
      }));

--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -41,8 +41,8 @@ function expectPages(nativeEl: HTMLElement, pagesDef: string[], ellipsis = '...'
       expect(pages[i]).not.toHaveCssClass('active');
       expect(pages[i]).toHaveCssClass('disabled');
       expect(pages[i].getAttribute('aria-current')).toBeNull();
-      expect(pages[i].querySelector('a').getAttribute('tabindex')).toEqual('-1');
-      expect(pages[i].querySelector('a').hasAttribute('aria-disabled')).toBeTruthy();
+      expect(pages[i].querySelector('a') !.getAttribute('tabindex')).toEqual('-1');
+      expect(pages[i].querySelector('a') !.hasAttribute('aria-disabled')).toBeTruthy();
     }
   }
 }
@@ -55,8 +55,8 @@ function getList(nativeEl: HTMLElement) {
   return <HTMLUListElement>nativeEl.querySelector('ul');
 }
 
-function normalizeText(txt: string): string {
-  return txt.trim().replace(/\s+/g, ' ');
+function normalizeText(txt: string | null): string {
+  return txt != null ? txt.trim().replace(/\s+/g, ' ') : '';
 }
 
 function expectSameValues(pagination: NgbPagination, config: NgbPaginationConfig) {
@@ -84,49 +84,49 @@ describe('ngb-pagination', () => {
 
     it('should calculate and update no of pages (default page size)', () => {
       pagination.collectionSize = 100;
-      pagination.ngOnChanges(null);
+      pagination.ngOnChanges(<any>null);
       expect(pagination.pages.length).toEqual(10);
 
       pagination.collectionSize = 200;
-      pagination.ngOnChanges(null);
+      pagination.ngOnChanges(<any>null);
       expect(pagination.pages.length).toEqual(20);
     });
 
     it('should calculate and update no of pages (custom page size)', () => {
       pagination.collectionSize = 100;
       pagination.pageSize = 20;
-      pagination.ngOnChanges(null);
+      pagination.ngOnChanges(<any>null);
       expect(pagination.pages.length).toEqual(5);
 
       pagination.collectionSize = 200;
-      pagination.ngOnChanges(null);
+      pagination.ngOnChanges(<any>null);
       expect(pagination.pages.length).toEqual(10);
 
       pagination.pageSize = 10;
-      pagination.ngOnChanges(null);
+      pagination.ngOnChanges(<any>null);
       expect(pagination.pages.length).toEqual(20);
     });
 
     it('should allow setting a page within a valid range (default page size)', () => {
       pagination.collectionSize = 100;
       pagination.page = 2;
-      pagination.ngOnChanges(null);
+      pagination.ngOnChanges(<any>null);
       expect(pagination.page).toEqual(2);
     });
 
     it('should auto-correct page no if outside of valid range (default page size)', () => {
       pagination.collectionSize = 100;
       pagination.page = 100;
-      pagination.ngOnChanges(null);
+      pagination.ngOnChanges(<any>null);
       expect(pagination.page).toEqual(10);
 
       pagination.page = -100;
-      pagination.ngOnChanges(null);
+      pagination.ngOnChanges(<any>null);
       expect(pagination.page).toEqual(1);
 
       pagination.page = 5;
       pagination.collectionSize = 10;
-      pagination.ngOnChanges(null);
+      pagination.ngOnChanges(<any>null);
       expect(pagination.page).toEqual(1);
     });
 
@@ -134,7 +134,7 @@ describe('ngb-pagination', () => {
       pagination.collectionSize = 100;
       pagination.pageSize = 20;
       pagination.page = 2;
-      pagination.ngOnChanges(null);
+      pagination.ngOnChanges(<any>null);
       expect(pagination.page).toEqual(2);
     });
 
@@ -537,7 +537,7 @@ describe('ngb-pagination', () => {
       fixture.detectChanges();
       expectPages(fixture.nativeElement, ['-«', '+1', '2', '3', '4', '5', '»']);
 
-      fixture.componentInstance.maxSize = null;
+      fixture.componentInstance.maxSize = <any>null;
       fixture.detectChanges();
       expectPages(fixture.nativeElement, ['-«', '+1', '2', '3', '4', '5', '»']);
     });
@@ -554,7 +554,7 @@ describe('ngb-pagination', () => {
       fixture.detectChanges();
       expectPages(fixture.nativeElement, ['-«', '-»']);
 
-      fixture.componentInstance.collectionSize = null;
+      fixture.componentInstance.collectionSize = <any>null;
       fixture.detectChanges();
       expectPages(fixture.nativeElement, ['-«', '-»']);
     });
@@ -571,7 +571,7 @@ describe('ngb-pagination', () => {
       fixture.detectChanges();
       expectPages(fixture.nativeElement, ['-«', '-»']);
 
-      fixture.componentInstance.pageSize = null;
+      fixture.componentInstance.pageSize = <any>null;
       fixture.detectChanges();
       expectPages(fixture.nativeElement, ['-«', '-»']);
     });
@@ -591,7 +591,7 @@ describe('ngb-pagination', () => {
       fixture.componentInstance.page = NaN;
       expectPages(fixture.nativeElement, ['«', '1', '+2', '-»']);
 
-      fixture.componentInstance.page = null;
+      fixture.componentInstance.page = <any>null;
       expectPages(fixture.nativeElement, ['«', '1', '+2', '-»']);
     });
 
@@ -714,7 +714,7 @@ describe('ngb-pagination', () => {
       fixture.detectChanges();
       const firstPage = getLink(fixture.nativeElement, 2);
       expect(firstPage.parentElement).toHaveCssClass('disabled');
-      expect(firstPage.textContent.trim()).toBe('d1');
+      expect(firstPage.textContent !.trim()).toBe('d1');
     });
   });
 

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -36,7 +36,7 @@ describe('ngb-popover-window', () => {
     // Cleaning elements, because of a TestBed issue with the id attribute
     Array.from(document.body.children).map((element: HTMLElement) => {
       if (element.tagName.toLocaleLowerCase() === 'div') {
-        element.parentNode.removeChild(element);
+        element.parentNode !.removeChild(element);
       }
     });
   });

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -160,7 +160,7 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
 
   private _ngbPopoverWindowId = `ngb-popover-${nextId++}`;
   private _popupService: PopupService<NgbPopoverWindow>;
-  private _windowRef: ComponentRef<NgbPopoverWindow>;
+  private _windowRef: ComponentRef<NgbPopoverWindow>| null = null;
   private _unregisterListenersFn;
   private _zoneSubscription: any;
   private _isDisabled(): boolean {
@@ -278,7 +278,7 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
 
   ngOnChanges({ngbPopover, popoverTitle, disablePopover, popoverClass}: SimpleChanges) {
     if (popoverClass && this.isOpen()) {
-      this._windowRef.instance.popoverClass = popoverClass.currentValue;
+      this._windowRef !.instance.popoverClass = popoverClass.currentValue;
     }
     // close popover if title and content become empty, or disablePopover set to true
     if ((ngbPopover || popoverTitle || disablePopover) && this._isDisabled()) {

--- a/src/progressbar/progressbar.spec.ts
+++ b/src/progressbar/progressbar.spec.ts
@@ -19,7 +19,7 @@ function getBarHeight(nativeEl): string {
 }
 
 function getBarValue(nativeEl): number {
-  return parseInt(getProgressbar(nativeEl).getAttribute('aria-valuenow'), 10);
+  return parseInt(getProgressbar(nativeEl).getAttribute('aria-valuenow') !, 10);
 }
 
 function getProgressbar(nativeEl: Element): HTMLElement {
@@ -60,14 +60,14 @@ describe('ngb-progressbar', () => {
     });
 
     it('should calculate the percentage (custom max size of null)', () => {
-      progressCmp.max = null;
+      progressCmp.max = <any>null;
 
       progressCmp.value = 25;
       expect(progressCmp.getPercentValue()).toBe(25);
     });
 
     it('should calculate the percentage (custom max size of undefined)', () => {
-      progressCmp.max = undefined;
+      progressCmp.max = <any>undefined;
 
       progressCmp.value = 25;
       expect(progressCmp.getPercentValue()).toBe(25);

--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -38,12 +38,12 @@ function getDbgStar(element, num: number) {
 
 function getState(element: DebugElement | HTMLElement) {
   const stars = getStars(element instanceof DebugElement ? element.nativeElement : element);
-  return stars.map(star => star.textContent.trim() === String.fromCharCode(9733));
+  return stars.map(star => star.textContent !.trim() === String.fromCharCode(9733));
 }
 
 function getStateText(compiled) {
   const stars = getStars(compiled);
-  return stars.map(star => star.textContent.trim());
+  return stars.map(star => star.textContent !.trim());
 }
 
 describe('ngb-rating', () => {
@@ -54,7 +54,7 @@ describe('ngb-rating', () => {
 
   it('should initialize inputs with default values', () => {
     const defaultConfig = new NgbRatingConfig();
-    const rating = new NgbRating(new NgbRatingConfig(), null);
+    const rating = new NgbRating(new NgbRatingConfig(), <any>null);
     expect(rating.max).toBe(defaultConfig.max);
     expect(rating.readonly).toBe(defaultConfig.readonly);
   });
@@ -672,7 +672,7 @@ describe('ngb-rating', () => {
          fixture.detectChanges();
          tick();
          expect(getState(element.nativeElement)).toEqual([true, true, true, true, false]);
-         expect(fixture.componentInstance.form.get('rating').value).toBe(4);
+         expect(fixture.componentInstance.form.get('rating') !.value).toBe(4);
          expect(element.nativeElement).toHaveCssClass('ng-valid');
        }));
 
@@ -686,11 +686,11 @@ describe('ngb-rating', () => {
          const element = fixture.debugElement.query(By.directive(NgbRating));
 
          expect(getState(element.nativeElement)).toEqual([false, false, false, false, false]);
-         expect(fixture.componentInstance.form.get('rating').disabled).toBeFalsy();
+         expect(fixture.componentInstance.form.get('rating') !.disabled).toBeFalsy();
 
-         fixture.componentInstance.form.get('rating').disable();
+         fixture.componentInstance.form.get('rating') !.disable();
          fixture.detectChanges();
-         expect(fixture.componentInstance.form.get('rating').disabled).toBeTruthy();
+         expect(fixture.componentInstance.form.get('rating') !.disabled).toBeTruthy();
 
          getStar(element.nativeElement, 3).click();
          fixture.detectChanges();

--- a/src/tabset/tabset.spec.ts
+++ b/src/tabset/tabset.spec.ts
@@ -4,7 +4,7 @@ import {createGenericTestComponent} from '../test/common';
 
 import {Component} from '@angular/core';
 
-import {NgbTabsetModule} from './tabset.module';
+import {NgbTabChangeEvent, NgbTabsetModule} from './tabset.module';
 import {NgbTabsetConfig} from './tabset-config';
 import {NgbTabset} from './tabset';
 
@@ -188,8 +188,8 @@ describe('ngb-tabset', () => {
     fixture.detectChanges();
 
     const titles = getTabTitles(fixture.nativeElement);
-    const parentTitle = titles[0].textContent.trim();
-    const childTitle = titles[1].textContent.trim();
+    const parentTitle = titles[0].textContent !.trim();
+    const childTitle = titles[1].textContent !.trim();
 
     expect(parentTitle).toContain('parent');
     expect(parentTitle).not.toContain('child');
@@ -536,7 +536,7 @@ describe('ngb-tabset', () => {
 
     const button = getButton(fixture.nativeElement);
 
-    let changeEvent = null;
+    let changeEvent: NgbTabChangeEvent | null = null;
     fixture.componentInstance.changeCallback = (event) => {
       changeEvent = event;
       event.preventDefault();
@@ -545,7 +545,7 @@ describe('ngb-tabset', () => {
     // Select the second tab -> selection will be canceled
     (<HTMLElement>button[1]).click();
     fixture.detectChanges();
-    expect(changeEvent).toEqual(jasmine.objectContaining({activeId: 'first', nextId: 'second'}));
+    expect(changeEvent !).toEqual(jasmine.objectContaining({activeId: 'first', nextId: 'second'}));
     expectTabs(fixture.nativeElement, [true, false]);
   });
 

--- a/src/tabset/tabset.ts
+++ b/src/tabset/tabset.ts
@@ -117,7 +117,7 @@ export interface NgbTabChangeEvent {
           href (click)="select(tab.id); $event.preventDefault()" role="tab" [attr.tabindex]="(tab.disabled ? '-1': undefined)"
           [attr.aria-controls]="(!destroyOnHide || tab.id === activeId ? tab.id + '-panel' : null)"
           [attr.aria-selected]="tab.id === activeId" [attr.aria-disabled]="tab.disabled">
-          {{tab.title}}<ng-template [ngTemplateOutlet]="tab.titleTpl?.templateRef"></ng-template>
+          {{tab.title}}<ng-template [ngTemplateOutlet]="tab.titleTpl?.templateRef || null"></ng-template>
         </a>
       </li>
     </ul>
@@ -128,7 +128,7 @@ export interface NgbTabChangeEvent {
           *ngIf="!destroyOnHide || tab.id === activeId"
           role="tabpanel"
           [attr.aria-labelledby]="tab.id" id="{{tab.id}}-panel">
-          <ng-template [ngTemplateOutlet]="tab.contentTpl?.templateRef"></ng-template>
+          <ng-template [ngTemplateOutlet]="tab.contentTpl?.templateRef || null"></ng-template>
         </div>
       </ng-template>
     </div>
@@ -216,11 +216,11 @@ export class NgbTabset implements AfterContentChecked {
   ngAfterContentChecked() {
     // auto-correct activeId that might have been set incorrectly as input
     let activeTab = this._getTabById(this.activeId);
-    this.activeId = activeTab ? activeTab.id : (this.tabs.length ? this.tabs.first.id : null);
+    this.activeId = activeTab ? activeTab.id : (this.tabs.length ? this.tabs.first.id : <any>null);
   }
 
   private _getTabById(id: string): NgbTab {
     let tabsWithId: NgbTab[] = this.tabs.filter(tab => tab.id === id);
-    return tabsWithId.length ? tabsWithId[0] : null;
+    return tabsWithId.length ? tabsWithId[0] : <any>null;
   }
 }

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -17,8 +17,6 @@ export function createGenericTestComponent<T>(
 export type Browser = 'ie9' | 'ie10' | 'ie11' | 'ie' | 'edge' | 'chrome' | 'safari' | 'firefox';
 
 export function getBrowser(ua = window.navigator.userAgent) {
-  let browser = 'unknown';
-
   // IE < 11
   const msie = ua.indexOf('MSIE ');
   if (msie > 0) {
@@ -51,9 +49,7 @@ export function getBrowser(ua = window.navigator.userAgent) {
     return 'firefox';
   }
 
-  if (browser === 'unknown') {
-    throw new Error('Browser detection failed for: ' + ua);
-  }
+  throw new Error('Browser detection failed for: ' + ua);
 }
 
 export function isBrowser(browsers: Browser | Browser[], ua = window.navigator.userAgent) {

--- a/src/test/typeahead/common.ts
+++ b/src/test/typeahead/common.ts
@@ -1,8 +1,8 @@
 import {DebugElement} from '@angular/core';
 import {By} from '@angular/platform-browser';
 
-function normalizeText(txt: string): string {
-  return txt.trim().replace(/\s+/g, ' ');
+function normalizeText(txt: string | null): string {
+  return txt != null ? txt.trim().replace(/\s+/g, ' ') : '';
 }
 
 export function getWindowLinks(element: DebugElement): DebugElement[] {

--- a/src/timepicker/ngb-time-adapter.spec.ts
+++ b/src/timepicker/ngb-time-adapter.spec.ts
@@ -9,7 +9,7 @@ describe('ngb-time model adapter', () => {
 
     it('should convert invalid and incomplete values to null', () => {
       expect(adapter.fromModel(null)).toBeNull();
-      expect(adapter.fromModel(undefined)).toBeNull();
+      expect(adapter.fromModel(<any>undefined)).toBeNull();
       expect(adapter.fromModel(<any>'')).toBeNull();
       expect(adapter.fromModel(<any>'s')).toBeNull();
       expect(adapter.fromModel(<any>2)).toBeNull();
@@ -20,8 +20,9 @@ describe('ngb-time model adapter', () => {
 
     it('should convert valid time', () => {
       expect(adapter.fromModel({hour: 19, minute: 5, second: 1})).toEqual({hour: 19, minute: 5, second: 1});
-      expect(adapter.fromModel(<any>{hour: 19, minute: 5})).toEqual({hour: 19, minute: 5, second: null});
-      expect(adapter.fromModel(<any>{hour: 19, minute: 5, second: null})).toEqual({hour: 19, minute: 5, second: null});
+      expect(adapter.fromModel(<any>{hour: 19, minute: 5})).toEqual(<any>{hour: 19, minute: 5, second: null});
+      expect(adapter.fromModel(<any>{hour: 19, minute: 5, second: null}))
+          .toEqual(<any>{hour: 19, minute: 5, second: null});
     });
   });
 
@@ -29,7 +30,7 @@ describe('ngb-time model adapter', () => {
 
     it('should convert invalid and incomplete values to null', () => {
       expect(adapter.toModel(null)).toBeNull();
-      expect(adapter.toModel(undefined)).toBeNull();
+      expect(adapter.toModel(<any>undefined)).toBeNull();
       expect(adapter.toModel(<any>'')).toBeNull();
       expect(adapter.toModel(<any>'s')).toBeNull();
       expect(adapter.toModel(<any>2)).toBeNull();
@@ -40,8 +41,9 @@ describe('ngb-time model adapter', () => {
 
     it('should convert a valid time', () => {
       expect(adapter.toModel({hour: 19, minute: 5, second: 1})).toEqual({hour: 19, minute: 5, second: 1});
-      expect(adapter.toModel(<any>{hour: 19, minute: 5})).toEqual({hour: 19, minute: 5, second: null});
-      expect(adapter.toModel(<any>{hour: 19, minute: 5, second: null})).toEqual({hour: 19, minute: 5, second: null});
+      expect(adapter.toModel(<any>{hour: 19, minute: 5})).toEqual(<any>{hour: 19, minute: 5, second: null});
+      expect(adapter.toModel(<any>{hour: 19, minute: 5, second: null}))
+          .toEqual(<any>{hour: 19, minute: 5, second: null});
     });
   });
 

--- a/src/timepicker/ngb-time-adapter.ts
+++ b/src/timepicker/ngb-time-adapter.ts
@@ -24,12 +24,12 @@ export abstract class NgbTimeAdapter<T> {
   /**
    * Converts a user-model time of type `T` to an `NgbTimeStruct` for internal use.
    */
-  abstract fromModel(value: T): NgbTimeStruct;
+  abstract fromModel(value: T | null): NgbTimeStruct | null;
 
   /**
    * Converts an internal `NgbTimeStruct` time to a user-model time of type `T`.
    */
-  abstract toModel(time: NgbTimeStruct): T;
+  abstract toModel(time: NgbTimeStruct | null): T | null;
 }
 
 @Injectable()
@@ -37,18 +37,18 @@ export class NgbTimeStructAdapter extends NgbTimeAdapter<NgbTimeStruct> {
   /**
    * Converts a NgbTimeStruct value into NgbTimeStruct value
    */
-  fromModel(time: NgbTimeStruct): NgbTimeStruct {
+  fromModel(time: NgbTimeStruct | null): NgbTimeStruct | null {
     return (time && isInteger(time.hour) && isInteger(time.minute)) ?
-        {hour: time.hour, minute: time.minute, second: isInteger(time.second) ? time.second : null} :
+        {hour: time.hour, minute: time.minute, second: isInteger(time.second) ? time.second : <any>null} :
         null;
   }
 
   /**
    * Converts a NgbTimeStruct value into NgbTimeStruct value
    */
-  toModel(time: NgbTimeStruct): NgbTimeStruct {
+  toModel(time: NgbTimeStruct | null): NgbTimeStruct | null {
     return (time && isInteger(time.hour) && isInteger(time.minute)) ?
-        {hour: time.hour, minute: time.minute, second: isInteger(time.second) ? time.second : null} :
+        {hour: time.hour, minute: time.minute, second: isInteger(time.second) ? time.second : <any>null} :
         null;
   }
 }

--- a/src/timepicker/ngb-time.spec.ts
+++ b/src/timepicker/ngb-time.spec.ts
@@ -210,11 +210,11 @@ describe('NgbTime', () => {
 
   it('should have a validity flag', () => {
     expect(new NgbTime(11, 0, 30).isValid()).toBeTruthy();
-    expect(new NgbTime(null, 0, 30).isValid()).toBeFalsy();
-    expect(new NgbTime(11, null, 30).isValid()).toBeFalsy();
-    expect(new NgbTime(11, 0, null).isValid()).toBeFalsy();
-    expect(new NgbTime(null, 0, null).isValid()).toBeFalsy();
-    expect(new NgbTime(null, null, null).isValid()).toBeFalsy();
+    expect(new NgbTime(<any>null, 0, 30).isValid()).toBeFalsy();
+    expect(new NgbTime(11, <any>null, 30).isValid()).toBeFalsy();
+    expect(new NgbTime(11, 0, <any>null).isValid()).toBeFalsy();
+    expect(new NgbTime(<any>null, 0, <any>null).isValid()).toBeFalsy();
+    expect(new NgbTime(<any>null, <any>null, <any>null).isValid()).toBeFalsy();
   });
 
   it('should have a validity flag with optional seconds checking',

--- a/src/timepicker/timepicker.spec.ts
+++ b/src/timepicker/timepicker.spec.ts
@@ -35,7 +35,7 @@ function getFieldsetElement(element: HTMLElement): HTMLFieldSetElement {
 }
 
 function getMeridianButton(nativeEl: HTMLElement) {
-  return nativeEl.querySelector('button.btn-outline-primary');
+  return nativeEl.querySelector('button.btn-outline-primary') !;
 }
 
 function createChangeEvent(value: string) {
@@ -45,7 +45,7 @@ function createChangeEvent(value: string) {
 function expectToDisplayTime(el: HTMLElement, time: string) {
   const inputs = getInputs(el);
   const timeParts = time.split(':');
-  let timeInInputs = [];
+  let timeInInputs: string[] = [];
 
   expect(inputs.length).toBe(timeParts.length);
 
@@ -91,7 +91,8 @@ describe('ngb-timepicker', () => {
   describe('initialization', () => {
     it('should initialize inputs with provided config', () => {
       const defaultConfig = new NgbTimepickerConfig();
-      const timepicker = new NgbTimepicker(new NgbTimepickerConfig(), new NgbTimeStructAdapter(), null, new TestI18n());
+      const timepicker =
+          new NgbTimepicker(new NgbTimepickerConfig(), new NgbTimeStructAdapter(), <any>null, new TestI18n());
       expectSameValues(timepicker, defaultConfig);
     });
   });
@@ -1280,12 +1281,16 @@ describe('ngb-timepicker', () => {
              .then(() => {
                const buttons = getButtons(fixture.nativeElement);
 
-               expect((<HTMLButtonElement>buttons[0]).querySelector('.sr-only').textContent).toBe('Increment hours');
-               expect((<HTMLButtonElement>buttons[1]).querySelector('.sr-only').textContent).toBe('Decrement hours');
-               expect((<HTMLButtonElement>buttons[2]).querySelector('.sr-only').textContent).toBe('Increment minutes');
-               expect((<HTMLButtonElement>buttons[3]).querySelector('.sr-only').textContent).toBe('Decrement minutes');
-               expect((<HTMLButtonElement>buttons[4]).querySelector('.sr-only').textContent).toBe('Increment seconds');
-               expect((<HTMLButtonElement>buttons[5]).querySelector('.sr-only').textContent).toBe('Decrement seconds');
+               expect((<HTMLButtonElement>buttons[0]).querySelector('.sr-only') !.textContent).toBe('Increment hours');
+               expect((<HTMLButtonElement>buttons[1]).querySelector('.sr-only') !.textContent).toBe('Decrement hours');
+               expect((<HTMLButtonElement>buttons[2]).querySelector('.sr-only') !.textContent)
+                   .toBe('Increment minutes');
+               expect((<HTMLButtonElement>buttons[3]).querySelector('.sr-only') !.textContent)
+                   .toBe('Decrement minutes');
+               expect((<HTMLButtonElement>buttons[4]).querySelector('.sr-only') !.textContent)
+                   .toBe('Increment seconds');
+               expect((<HTMLButtonElement>buttons[5]).querySelector('.sr-only') !.textContent)
+                   .toBe('Decrement seconds');
              });
        }));
 
@@ -1670,7 +1675,7 @@ class TestComponentOnPush {
 
 @Injectable()
 class StringTimeAdapter extends NgbTimeAdapter<string> {
-  fromModel(value: string): NgbTimeStruct {
+  fromModel(value: string): NgbTimeStruct | null {
     if (!value) {
       return null;
     }
@@ -1678,7 +1683,7 @@ class StringTimeAdapter extends NgbTimeAdapter<string> {
     return {hour: parseInt(split[0], 10), minute: parseInt(split[1], 10), second: parseInt(split[2], 10)};
   }
 
-  toModel(time: NgbTimeStruct): string {
+  toModel(time: NgbTimeStruct): string | null {
     if (!time) {
       return null;
     }

--- a/src/timepicker/timepicker.ts
+++ b/src/timepicker/timepicker.ts
@@ -104,7 +104,8 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
           <button type="button" class="btn btn-outline-primary" [class.btn-sm]="isSmallSize" [class.btn-lg]="isLargeSize"
             [disabled]="disabled" [class.disabled]="disabled"
                   (click)="toggleMeridian()">
-            <ng-container *ngIf="model?.hour >= 12; else am" i18n="@@ngb.timepicker.PM">{{ i18n.getAfternoonPeriod() }}</ng-container>
+            <ng-container *ngIf="model && model.hour >= 12; else am"
+                          i18n="@@ngb.timepicker.PM">{{ i18n.getAfternoonPeriod() }}</ng-container>
             <ng-template #am i18n="@@ngb.timepicker.AM">{{ i18n.getMorningPeriod() }}</ng-template>
           </button>
         </div>
@@ -255,7 +256,7 @@ export class NgbTimepicker implements ControlValueAccessor,
 
   formatInput(input: HTMLInputElement) { input.value = input.value.replace(FILTER_REGEX, ''); }
 
-  formatHour(value: number) {
+  formatHour(value?: number) {
     if (isNumber(value)) {
       if (this.meridian) {
         return padNumber(value % 12 === 0 ? 12 : value % 12);
@@ -267,7 +268,7 @@ export class NgbTimepicker implements ControlValueAccessor,
     }
   }
 
-  formatMinSec(value: number) { return padNumber(value); }
+  formatMinSec(value?: number) { return padNumber(isNumber(value) ? value : NaN); }
 
   get isSmallSize(): boolean { return this.size === 'small'; }
 

--- a/src/tooltip/tooltip.spec.ts
+++ b/src/tooltip/tooltip.spec.ts
@@ -29,7 +29,7 @@ describe('ngb-tooltip-window', () => {
     // Cleaning elements, because of a TestBed issue with the id attribute
     Array.from(document.body.children).map((element: HTMLElement) => {
       if (element.tagName.toLocaleLowerCase() === 'div') {
-        element.parentNode.removeChild(element);
+        element.parentNode !.removeChild(element);
       }
     });
   });
@@ -645,7 +645,7 @@ describe('ngb-tooltip', () => {
 
 @Component({selector: 'test-cmpt', template: ``})
 export class TestComponent {
-  name = 'World';
+  name: string | null = 'World';
   show = true;
   tooltipClass = 'my-tooltip-class';
 

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -136,7 +136,7 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
   private _ngbTooltip: string | TemplateRef<any>;
   private _ngbTooltipWindowId = `ngb-tooltip-${nextId++}`;
   private _popupService: PopupService<NgbTooltipWindow>;
-  private _windowRef: ComponentRef<NgbTooltipWindow>;
+  private _windowRef: ComponentRef<NgbTooltipWindow>| null = null;
   private _unregisterListenersFn;
   private _zoneSubscription: any;
 
@@ -259,7 +259,7 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 
   ngOnChanges({tooltipClass}: SimpleChanges) {
     if (tooltipClass && this.isOpen()) {
-      this._windowRef.instance.tooltipClass = tooltipClass.currentValue;
+      this._windowRef !.instance.tooltipClass = tooltipClass.currentValue;
     }
   }
 

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -15,7 +15,6 @@
     ]
   },
   "angularCompilerOptions": {
-    "strictTemplates": true,
     "skipTemplateCodegen": true,
     "strictMetadataEmit": true,
     "fullTemplateTypeCheck": true

--- a/src/typeahead/highlight.ts
+++ b/src/typeahead/highlight.ts
@@ -32,7 +32,7 @@ export class NgbHighlight implements OnChanges {
    * If the `term` is found inside this text, it will be highlighted.
    * If the `term` contains array then all the items from it will be highlighted inside the text.
    */
-  @Input() result: string;
+  @Input() result?: string | null;
 
   /**
    * The term or array of terms to be highlighted.

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -82,12 +82,12 @@ let nextWindowId = 0;
 export class NgbTypeahead implements ControlValueAccessor,
     OnInit, OnDestroy {
   private _popupService: PopupService<NgbTypeaheadWindow>;
-  private _subscription: Subscription;
+  private _subscription: Subscription | null = null;
   private _closed$ = new Subject();
-  private _inputValueBackup: string;
+  private _inputValueBackup: string | null = null;
   private _valueChanges: Observable<string>;
   private _resubscribeTypeahead: BehaviorSubject<any>;
-  private _windowRef: ComponentRef<NgbTypeaheadWindow>;
+  private _windowRef: ComponentRef<NgbTypeaheadWindow>| null = null;
   private _zoneSubscription: any;
 
   /**
@@ -182,7 +182,7 @@ export class NgbTypeahead implements ControlValueAccessor,
    */
   @Output() selectItem = new EventEmitter<NgbTypeaheadSelectItemEvent>();
 
-  activeDescendant: string;
+  activeDescendant: string | null = null;
   popupId = `ngb-typeahead-${nextWindowId++}`;
 
   private _onTouched = () => {};
@@ -210,7 +210,7 @@ export class NgbTypeahead implements ControlValueAccessor,
     this._zoneSubscription = ngZone.onStable.subscribe(() => {
       if (this.isPopupOpen()) {
         positionElements(
-            this._elementRef.nativeElement, this._windowRef.location.nativeElement, this.placement,
+            this._elementRef.nativeElement, this._windowRef !.location.nativeElement, this.placement,
             this.container === 'body');
       }
     });
@@ -280,17 +280,17 @@ export class NgbTypeahead implements ControlValueAccessor,
     switch (event.which) {
       case Key.ArrowDown:
         event.preventDefault();
-        this._windowRef.instance.next();
+        this._windowRef !.instance.next();
         this._showHint();
         break;
       case Key.ArrowUp:
         event.preventDefault();
-        this._windowRef.instance.prev();
+        this._windowRef !.instance.prev();
         this._showHint();
         break;
       case Key.Enter:
       case Key.Tab:
-        const result = this._windowRef.instance.getActive();
+        const result = this._windowRef !.instance.getActive();
         if (isDefined(result)) {
           event.preventDefault();
           event.stopPropagation();
@@ -310,7 +310,7 @@ export class NgbTypeahead implements ControlValueAccessor,
       this._windowRef.instance.activeChangeEvent.subscribe((activeId: string) => this.activeDescendant = activeId);
 
       if (this.container === 'body') {
-        window.document.querySelector(this.container).appendChild(this._windowRef.location.nativeElement);
+        this._document.querySelector(this.container).appendChild(this._windowRef.location.nativeElement);
       }
 
       this._changeDetector.markForCheck();
@@ -325,7 +325,7 @@ export class NgbTypeahead implements ControlValueAccessor,
     this._closed$.next();
     this._popupService.close();
     this._windowRef = null;
-    this.activeDescendant = undefined;
+    this.activeDescendant = null;
   }
 
   private _selectResult(result: any) {
@@ -345,7 +345,7 @@ export class NgbTypeahead implements ControlValueAccessor,
   }
 
   private _showHint() {
-    if (this.showHint && this._windowRef.instance.hasActive() && this._inputValueBackup != null) {
+    if (this.showHint && this._windowRef?.instance.hasActive() && this._inputValueBackup != null) {
       const userInputLowerCase = this._inputValueBackup.toLowerCase();
       const formattedVal = this._formatItemForInput(this._windowRef.instance.getActive());
 
@@ -373,21 +373,21 @@ export class NgbTypeahead implements ControlValueAccessor,
         this._closePopup();
       } else {
         this._openPopup();
-        this._windowRef.instance.focusFirst = this.focusFirst;
-        this._windowRef.instance.results = results;
-        this._windowRef.instance.term = this._elementRef.nativeElement.value;
+        this._windowRef !.instance.focusFirst = this.focusFirst;
+        this._windowRef !.instance.results = results;
+        this._windowRef !.instance.term = this._elementRef.nativeElement.value;
         if (this.resultFormatter) {
-          this._windowRef.instance.formatter = this.resultFormatter;
+          this._windowRef !.instance.formatter = this.resultFormatter;
         }
         if (this.resultTemplate) {
-          this._windowRef.instance.resultTemplate = this.resultTemplate;
+          this._windowRef !.instance.resultTemplate = this.resultTemplate;
         }
-        this._windowRef.instance.resetActive();
+        this._windowRef !.instance.resetActive();
 
         // The observable stream we are subscribing to might have async steps
         // and if a component containing typeahead is using the OnPush strategy
         // the change detection turn wouldn't be invoked automatically.
-        this._windowRef.changeDetectorRef.detectChanges();
+        this._windowRef !.changeDetectorRef.detectChanges();
 
         this._showHint();
       }

--- a/src/util/accessibility/live.spec.ts
+++ b/src/util/accessibility/live.spec.ts
@@ -5,8 +5,8 @@ import {Live, ARIA_LIVE_DELAY} from './live';
 
 
 
-function getLiveElement(): Element | null {
-  return document.body.querySelector('#ngb-live');
+function getLiveElement(): HTMLElement {
+  return document.body.querySelector('#ngb-live') !as HTMLElement;
 }
 
 

--- a/src/util/accessibility/live.ts
+++ b/src/util/accessibility/live.ts
@@ -40,7 +40,8 @@ export class Live implements OnDestroy {
   ngOnDestroy() {
     const element = getLiveElement(this._document);
     if (element) {
-      element.parentElement.removeChild(element);
+      // if exists, it will always be attached to the <body>
+      element.parentElement !.removeChild(element);
     }
   }
 
@@ -48,12 +49,14 @@ export class Live implements OnDestroy {
     const element = getLiveElement(this._document, true);
     const delay = this._delay;
 
-    element.textContent = '';
-    const setText = () => element.textContent = message;
-    if (delay === null) {
-      setText();
-    } else {
-      setTimeout(setText, delay);
+    if (element != null) {
+      element.textContent = '';
+      const setText = () => element.textContent = message;
+      if (delay === null) {
+        setText();
+      } else {
+        setTimeout(setText, delay);
+      }
     }
   }
 }

--- a/src/util/popup.ts
+++ b/src/util/popup.ts
@@ -14,8 +14,8 @@ export class ContentRef {
 }
 
 export class PopupService<T> {
-  private _windowRef: ComponentRef<T>;
-  private _contentRef: ContentRef;
+  private _windowRef: ComponentRef<T>| null = null;
+  private _contentRef: ContentRef | null = null;
 
   constructor(
       private _type: any, private _injector: Injector, private _viewContainerRef: ViewContainerRef,
@@ -38,7 +38,7 @@ export class PopupService<T> {
       this._viewContainerRef.remove(this._viewContainerRef.indexOf(this._windowRef.hostView));
       this._windowRef = null;
 
-      if (this._contentRef.viewRef) {
+      if (this._contentRef?.viewRef) {
         this._applicationRef.detachView(this._contentRef.viewRef);
         this._contentRef.viewRef.destroy();
         this._contentRef = null;
@@ -46,7 +46,7 @@ export class PopupService<T> {
     }
   }
 
-  private _getContentRef(content: string | TemplateRef<any>, context?: any): ContentRef {
+  private _getContentRef(content?: string | TemplateRef<any>, context?: any): ContentRef {
     if (!content) {
       return new ContentRef([]);
     } else if (content instanceof TemplateRef) {

--- a/src/util/positioning.ts
+++ b/src/util/positioning.ts
@@ -174,7 +174,8 @@ export const positionService = new Positioning();
  * */
 export function positionElements(
     hostElement: HTMLElement, targetElement: HTMLElement, placement: string | Placement | PlacementArray,
-    appendToBody?: boolean, baseClass?: string): Placement {
+    appendToBody?: boolean, baseClass?: string): Placement |
+    null {
   let placementVals: Array<Placement> =
       Array.isArray(placement) ? placement : placement.split(placementSeparator) as Array<Placement>;
 
@@ -186,7 +187,7 @@ export function positionElements(
   const classList = targetElement.classList;
   const addClassesToTarget = (targetPlacement: Placement): Array<string> => {
     const[primary, secondary] = targetPlacement.split('-');
-    const classes = [];
+    const classes: string[] = [];
     if (baseClass) {
       classes.push(`${baseClass}-${primary}`);
       if (secondary) {
@@ -222,7 +223,7 @@ export function positionElements(
   style.left = '0';
   style['will-change'] = 'transform';
 
-  let testPlacement: Placement;
+  let testPlacement: Placement | null = null;
   let isInViewport = false;
   for (testPlacement of placementVals) {
     let addedClasses = addClassesToTarget(testPlacement);

--- a/src/util/triggers.spec.ts
+++ b/src/util/triggers.spec.ts
@@ -69,8 +69,8 @@ describe('triggers', () => {
     });
 
     it('should ignore empty inputs', () => {
-      expect(parseTriggers(null).length).toBe(0);
-      expect(parseTriggers(undefined).length).toBe(0);
+      expect(parseTriggers(<any>null).length).toBe(0);
+      expect(parseTriggers(<any>undefined).length).toBe(0);
       expect(parseTriggers('').length).toBe(0);
     });
 
@@ -92,7 +92,7 @@ describe('triggers', () => {
     let subject$: Subject<boolean>;
     let delayed$: Observable<boolean>;
     let open: boolean;
-    let subscription: Subscription;
+    let subscription: Subscription | null = null;
     let spy: jasmine.Spy;
 
     beforeEach(() => {

--- a/src/util/triggers.ts
+++ b/src/util/triggers.ts
@@ -1,5 +1,6 @@
 import {Observable, merge} from 'rxjs';
 import {share, filter, delay, map} from 'rxjs/operators';
+import {Renderer2} from '@angular/core';
 
 export class Trigger {
   constructor(public open: string, public close?: string) {
@@ -41,9 +42,10 @@ export function parseTriggers(triggers: string, aliases = DEFAULT_ALIASES): Trig
   return parsedTriggers;
 }
 
-export function observeTriggers(renderer: any, nativeElement: any, triggers: Trigger[], isOpenedFn: () => boolean) {
+export function observeTriggers(
+    renderer: Renderer2, nativeElement: HTMLElement, triggers: Trigger[], isOpenedFn: () => boolean) {
   return new Observable<boolean>(subscriber => {
-    const listeners = [];
+    const listeners: Function[] = [];
     const openFn = () => subscriber.next(true);
     const closeFn = () => subscriber.next(false);
     const toggleFn = () => subscriber.next(!isOpenedFn());
@@ -54,7 +56,7 @@ export function observeTriggers(renderer: any, nativeElement: any, triggers: Tri
       } else {
         listeners.push(
             renderer.listen(nativeElement, trigger.open, openFn),
-            renderer.listen(nativeElement, trigger.close, closeFn));
+            renderer.listen(nativeElement, trigger.close !, closeFn));
       }
     });
 
@@ -66,7 +68,7 @@ const delayOrNoop = <T>(time: number) => time > 0 ? delay<T>(time) : (a: Observa
 
 export function triggerDelay(openDelay: number, closeDelay: number, isOpenedFn: () => boolean) {
   return (input$: Observable<boolean>) => {
-    let pending = null;
+    let pending: {open: boolean} | null = null;
     const filteredInput$ = input$.pipe(
         map(open => ({open})), filter(event => {
           const currentlyOpen = isOpenedFn();
@@ -96,8 +98,8 @@ export function triggerDelay(openDelay: number, closeDelay: number, isOpenedFn: 
 }
 
 export function listenToTriggers(
-    renderer: any, nativeElement: any, triggers: string, isOpenedFn: () => boolean, openFn, closeFn, openDelay = 0,
-    closeDelay = 0) {
+    renderer: Renderer2, nativeElement: HTMLElement, triggers: string, isOpenedFn: () => boolean, openFn: Function,
+    closeFn: Function, openDelay = 0, closeDelay = 0) {
   const parsedTriggers = parseTriggers(triggers);
 
   if (parsedTriggers.length === 1 && parsedTriggers[0].isManual()) {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -66,7 +66,7 @@ if (typeof Element !== 'undefined' && !Element.prototype.closest) {
   };
 }
 
-export function closest(element: HTMLElement, selector): HTMLElement {
+export function closest(element: HTMLElement, selector): HTMLElement | null {
   if (!selector) {
     return null;
   }

--- a/ssr-app/server.ts
+++ b/ssr-app/server.ts
@@ -14,7 +14,7 @@ export function app() {
   const distFolder = join(process.cwd(), 'ssr-app/dist/browser');
 
   // Our Universal express-engine (found @ https://github.com/angular/universal/tree/master/modules/express-engine)
-  server.engine('html', ngExpressEngine({
+  server.engine('html', <any>ngExpressEngine({
     bootstrap: AppServerModule,
   }));
 

--- a/ssr-app/src/app/components/progress.component.ts
+++ b/ssr-app/src/app/components/progress.component.ts
@@ -3,7 +3,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'progress-component',
   template: `
-    <ngb-progressbar showValue="true" type="success" [value]="50"></ngb-progressbar>
+    <ngb-progressbar [showValue]="true" type="success" [value]="50"></ngb-progressbar>
   `
 })
 export class ProgressComponent {

--- a/ssr-app/src/app/components/rating.component.ts
+++ b/ssr-app/src/app/components/rating.component.ts
@@ -26,7 +26,7 @@ import { Component } from '@angular/core';
       </span>
     </ng-template>
 
-    <ngb-rating [(rate)]="currentRate" [starTemplate]="t" [readonly]="true" max="5"></ngb-rating>
+    <ngb-rating [(rate)]="currentRate" [starTemplate]="t" [readonly]="true" [max]="5"></ngb-rating>
   `
 })
 export class RatingComponent {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "module": "esnext",
     "moduleResolution": "node",
     "importHelpers": true,
+    "strictNullChecks": true,
     "target": "es2015",
     "typeRoots": [
       "node_modules/@types"
@@ -19,5 +20,10 @@
       "es2018",
       "dom"
     ]
+  },
+  "angularCompilerOptions": {
+    "strictTemplates": true,
+    "fullTemplateTypeCheck": true,
+    "strictInjectionParameters": true
   }
 }


### PR DESCRIPTION
This PR enables `strictNullChecks` for all applications. Works together with `strictTemplates`

Split in multiple commits to simplify navigation. Let's focus on the library code first when reviewing.

### Main library changes
- account for possibility of internal implementation methods and fields returning `null`
- account for specific APIs of standard methods like `parseInt()`, `Array.indexOf()`, `ViewContainerRef.indexOf()`, `QueryList.first`, etc. Null/types handling might be specific for them.
- add `!` in places where we're 100% sure, example:

```ts
// popover.ts
private _windowRef: ComponentRef<NgbPopoverWindow>| null = null;

if (this.isOpen() && ... ) {
  this._windowRef !.instance.class = ...
}
```

- make **some** of the public APIs accept `method(t: T | null | undefined)` instead of `method(t: T)` for convenience, ex, when working with dates:

```ts
class NgbDate {
  equals(date?: NgbDate | null);
}

class NgbCalendar {
  isValid(date?: NgbDate | null);
}

```

- use `<any>null` in places where a variable can't be null, but we still want to nullify the reference when destroying:

```ts
// modal-ref.ts
this._backdropCmptRef = <any>null;
```

- pass `null` and not `undefined` to `[ngTemplateOutlet]`

```html
// nav.ts
[ngTemplateOutlet]="item.contentTpl?.templateRef || null
```

- **Timepicker**: for backward compatibility `NgbTimeStruct` might contain `null` for hours, minutes and seconds despite `NgbTimeStruct` using only `number`s for type definition
- **Datepciker**: for backward compatibility `NgbDateStruct/NgbDate` might contain `null` for years, months and days despite `NgbDateStruct/NgbDate` using only `number`s for type definition


### Unit test changes
- use `<any>null` when constructing manually and don't care about DI
- use `<any>...` casting in places where boundary values like `''` and 'undefined' are tested
- use `textContent!`, `querySelector()!`, `parentElement!`, etc


### Other changes

Demo, e2e and ssr app changes are just to compile with `strictNullChecks` correctly

cc @pkozlowski-opensource 