### PR TITLE
fix(dropdown): ngbDropdown adds vertical scrollbar ... (#3580)

### DIFF
--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -390,6 +390,7 @@ export class NgbDropdown implements AfterContentInit, OnDestroy {
       renderer.appendChild(dropdownElement, dropdownMenuElement);
       renderer.removeStyle(dropdownMenuElement, 'position');
       renderer.removeStyle(dropdownMenuElement, 'transform');
+      renderer.removeStyle(dropdownMenuElement, 'overflow');
     }
     if (this._bodyContainer) {
       renderer.removeChild(this._document.body, this._bodyContainer);

--- a/src/util/positioning.spec.ts
+++ b/src/util/positioning.spec.ts
@@ -23,7 +23,9 @@ describe('Positioning', () => {
 
   function checkPosition(el: HTMLElement, top: number, left: number) {
     const transform = el.style.transform;
+    const overflow = el.style.overflow;
     expect(transform).toBe(`translate(${left}px, ${top}px)`);
+    expect(overflow).toBe(`hidden`);
   }
 
   let element, targetElement, positioning, documentMargin, bodyMargin;

--- a/src/util/positioning.ts
+++ b/src/util/positioning.ts
@@ -147,6 +147,7 @@ export class Positioning {
     /// The translate3d/gpu acceleration render a blurry text on chrome, the next line is commented until a browser fix
     // targetElement.style.transform = `translate3d(${Math.round(leftPosition)}px, ${Math.floor(topPosition)}px, 0px)`;
     targetElement.style.transform = `translate(${Math.round(leftPosition)}px, ${Math.round(topPosition)}px)`;
+    targetElement.style.overflow = `hidden`;
 
     // Check if the targetElement is inside the viewport
     const targetElBCR = targetElement.getBoundingClientRect();


### PR DESCRIPTION
Fixes #3580 and #3640
Adds `overflow:hidden` on dropdown.
Issue affects all derrative components i.e. datepicker upon popup, tooltip, typeahead etc.

CC: @maxokorokov @benouat Please review
