### PR TITLE
docs: update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Please check all components we have in action at https://ng-bootstrap.github.io
 ## Dependencies
 
 The only two dependencies are [Angular](https://angular.io) and [Bootstrap 4](https://getbootstrap.com) CSS.
-Here is the list of minimal required versions:
+The supported versions are:
 
 | ng-bootstrap | Angular | Bootstrap CSS |
 | ------------ | ------- | ------------- |
@@ -44,21 +44,46 @@ Here is the list of minimal required versions:
 
 ## Installation
 
-You need to have an Angular project with the supported Angular version. We strongly recommend using [Angular CLI](https://cli.angular.io) for this.
+### Angular
 
-You also need to add Bootstrap 4 CSS to your application by using your preferred way (it really depends on the setup you're using). Ex. for Angular CLI you can [get Bootstrap from npm](https://www.npmjs.com/package/bootstrap) and update your `angular.json` with something like:
+ We strongly recommend using [Angular CLI](https://cli.angular.io) for setting up a new project.
 
-```json
-"styles": [
-  "node_modules/bootstrap/dist/css/bootstrap.min.css"
-]
+If you're using Angular &ge; 9.0.0 and ng-bootstrap &ge; 6.0.0, you have to install the `@angular/localize` polyfill
+
+```shell
+ng add @angular/localize
+```
+
+See more details in
+[the official documentation](https://angular.io/guide/i18n#setting-up-localization-with-the-angular-cli).
+
+### Bootstrap (CSS only)
+
+You also need to add Bootstrap CSS to your application using your preferred way (see [Bootstrap instructions](https://getbootstrap.com/docs/4.4/getting-started/download/))
+
+For example you could install Bootstrap from npm
+
+```shell
+npm install bootstrap
+```
+
+and add Bootstrap CSS or SCSS to your project
+
+```css
+/* update your 'styles.css' with */
+@import '~bootstrap/dist/css/bootstrap.css';
+
+/* or your 'styles.scss' with */
+@import "~bootstrap/scss/bootstrap";
 ```
 
 Please note that you need only CSS and **should not** add other JavaScript dependencies like `bootstrap.js`, `jQuery` or `popper.js` as ng-bootstrap's goal is to completely replace them.
 
-After installing the above dependencies, install `ng-bootstrap` via:
+### ng-bootstrap
+
+Installing from npm is simply doing
 ```shell
-npm install --save @ng-bootstrap/ng-bootstrap
+npm install @ng-bootstrap/ng-bootstrap
 ```
 Once installed you need to import our main module:
 ```js
@@ -88,24 +113,11 @@ export class YourAppModule {
 }
 ```
 
-If you're using Angular >= 9.0.0 and ng-bootstrap >= 6.0.0, you might also need to install the `@angular/localize`polyfill via
- 
-```shell
-ng add @angular/localize
-```
- See more details in
-[the official documentation](https://angular.io/guide/i18n#setting-up-localization-with-the-angular-cli).
-
-
 ## Supported browsers
 
-We support the same browsers and versions supported by both Bootstrap 4 and Angular, whichever is _more_ restrictive. See [Angular browser support](https://angular.io/guide/browser-support) and [Bootstrap browser support](https://getbootstrap.com/docs/4.4/getting-started/browsers-devices/#supported-browsers) for more details, but on the high-level it should be something like:
+We support the same browsers and versions supported by both Bootstrap 4 and Angular, whichever is _more_ restrictive. See [Angular browser support](https://angular.io/guide/browser-support) and [Bootstrap browser support](https://getbootstrap.com/docs/4.4/getting-started/browsers-devices/#supported-browsers) for more details.
 
-* Chrome (45+)
-* Firefox (40+)
-* IE (10+)
-* Edge (20+)
-* Safari (7+)
+Out code is automatically tested on all supported browsers.
 
 
 ## Getting help

--- a/demo/src/app/pages/getting-started/getting-started.component.html
+++ b/demo/src/app/pages/getting-started/getting-started.component.html
@@ -3,13 +3,9 @@
   <ngbd-page-header title="Dependencies" fragment="dependencies" class="mt-0"></ngbd-page-header>
 
   <p>
-    This repository contains a set of native Angular directives based on Bootstrap's markup and CSS.
-    As a result no dependency on jQuery or Bootstrap's JavaScript is required.
-  </p>
-
-  <p>
-    Here is a list of minimal required versions of <a href="https://angular.io" target="_blank">Angular</a>
-    and <a href="https://getbootstrap.com" target="_blank">Bootstrap</a> CSS for ng-bootstrap:
+    The only two required dependencies are <a href="https://angular.io" target="_blank">Angular</a> and
+    <a href="https://getbootstrap.com" target="_blank">Bootstrap</a> CSS.
+    The supported versions are:
   </p>
 
   <table class="table" style="width: auto">
@@ -54,33 +50,64 @@
     </tbody>
   </table>
 
+  <ngbd-page-header title="Installation" fragment="installation" class="mb-3"></ngbd-page-header>
+
+  <h4>Angular</h4>
+
   <p>
-    If you're using Angular &ge; 9.0.0 and ng-bootstrap &ge; 6.0.0, you might also need to install the <code>@angular/localize</code>
-    polyfill with <code>ng add @angular/localize</code>. See more details in
+    We strongly recommend using
+    <a href="https://cli.angular.io/" target="_blank">Angular CLI</a> for setting up a new project.
+  </p>
+
+  <p>
+    If you're using Angular &ge; 9.0.0 and ng-bootstrap &ge; 6.0.0, you have to install the <code>@angular/localize</code> polyfill
+  </p>
+
+  <ngbd-code [snippet]="polyfillInstall"></ngbd-code>
+
+  <p>
+    See more details in
     <a href="https://angular.io/guide/i18n#setting-up-localization-with-the-angular-cli" target="_blank">the official documentation</a>.
   </p>
 
-  <ngb-alert type="warning" [dismissible]="false">
-    <p>Should I add <b>bootstrap.js</b> or <b>bootstrap.min.js</b> to my project?</p>
+  <h4>Bootstrap (CSS only)</h4>
 
-    No, the goal of ng-bootstrap is to <i>completely replace</i> JavaScript implementation for components. Nor should you include other dependencies like jQuery or popper.js. It is not necessary and might interfere with ng-bootstrap code.
+  <p>
+    You also need to add Bootstrap CSS to your application using your preferred way (see
+    <a href="https://getbootstrap.com/docs/4.4/getting-started/download/" target="_blank">Bootstrap instructions</a>).
+  </p>
+
+  <p>
+    For example you could install Bootstrap from npm
+  </p>
+
+  <ngbd-code [snippet]="bootstrapInstall"></ngbd-code>
+
+  <p>
+    and add Bootstrap CSS or SCSS to your project
+  </p>
+
+  <ngbd-code [snippet]="bootstrapCss"></ngbd-code>
+
+  <ngb-alert type="warning" [dismissible]="false" class="mt-3">
+    <p class="font-weight-bold" style="font-size: 1.1rem">
+      Should I add Bootstrap JavaScript files to my project?
+    </p>
+
+    <p>No, adding <code>bootstrap.js</code> or <code>bootstrap.min.js</code> is not necessary.</p>
+
+    The goal of ng-bootstrap is to <i>completely replace</i> JavaScript implementation for components.
+    Nor should you include other dependencies like jQuery or popper.js.
+    It is not necessary and might interfere with ng-bootstrap code.
   </ngb-alert>
 
-  <ngbd-page-header title="Supported Browsers" fragment="browsers"></ngbd-page-header>
+  <h4>ng-bootstrap</h4>
 
-  <p>We strive to support the same browsers and versions as supported by both Bootstrap 4 and Angular, whichever is more restrictive. Check browser support notes for
-    <a href="https://angular.io/guide/browser-support" target="_blank">Angular</a> and
-    <a href="https://getbootstrap.com/docs/4.4/getting-started/browsers-devices/" target="_blank">Bootstrap</a>.
-  </p>
-  <p>Our code is automatically tested on all the supported browsers.</p>
-
-  <ngbd-page-header title="Installation" fragment="installation"></ngbd-page-header>
-
-  <p>After installing the above dependencies, install <code>ng-bootstrap</code> via:</p>
+  <p>Installing from npm is simply doing</p>
 
   <ngbd-code [snippet]="codeInstall"></ngbd-code>
 
-  <p>Once installed you need to import our main module.</p>
+  <p>Once installed you need to import our main module and you're good to go</p>
 
   <ngbd-code [snippet]="codeRoot"></ngbd-code>
 
@@ -89,10 +116,19 @@
 
   <ngbd-code [snippet]="codeOther"></ngbd-code>
 
+  <ngbd-page-header title="Supported Browsers" fragment="browsers"></ngbd-page-header>
+
+  <p>We strive to support the same browsers and versions as supported by both Bootstrap and Angular, whichever is more restrictive. Check browser support notes for
+    <a href="https://angular.io/guide/browser-support" target="_blank">Angular</a> and
+    <a href="https://getbootstrap.com/docs/4.4/getting-started/browsers-devices/" target="_blank">Bootstrap</a>.
+  </p>
+
+  <p>Our code is automatically tested on all supported browsers.</p>
+
   <ngbd-page-header title="Internationalization" fragment="i18n"></ngbd-page-header>
 
   <ngb-alert type="warning" [dismissible]="false">
-    We're using standard Angular i18n in ng-bootstrap templates. Since Angular 9 (and ng-bootstrap 6) you might have to
+    We're using standard Angular i18n in ng-bootstrap templates. Since Angular 9 (and ng-bootstrap 6) you have to
     add the additional <code>@angular/localize</code> polyfill to your CLI project. See more details in
     <a href="https://angular.io/guide/i18n#setting-up-localization-with-the-angular-cli" target="_blank">the official documentation</a>.
   </ngb-alert>

--- a/demo/src/app/pages/getting-started/getting-started.component.ts
+++ b/demo/src/app/pages/getting-started/getting-started.component.ts
@@ -5,9 +5,31 @@ import {Snippet} from '../../shared/code/snippet';
   templateUrl: './getting-started.component.html'
 })
 export class GettingStartedPage {
+
+  bootstrapCss = Snippet({
+    lang: 'css',
+    code: `
+      /* update your 'styles.css' with */
+      @import '~bootstrap/dist/css/bootstrap.css';
+
+      /* or your 'styles.scss' with */
+      @import "~bootstrap/scss/bootstrap";
+    `,
+  });
+
+  bootstrapInstall = Snippet({
+    lang: 'bash',
+    code: `npm install bootstrap`,
+  });
+
   codeInstall = Snippet({
     lang: 'bash',
-    code: `npm install --save @ng-bootstrap/ng-bootstrap`,
+    code: `npm install @ng-bootstrap/ng-bootstrap`,
+  });
+
+  polyfillInstall = Snippet({
+    lang: 'bash',
+    code: `ng add @angular/localize`,
   });
 
   codeRoot = Snippet({


### PR DESCRIPTION
As more people are unclear what to do with CSS, here is another update to installation instructions. Based on  https://github.com/ng-bootstrap/ng-bootstrap/issues/2203#issuecomment-450644888

<details>
  <summary>Click to see the screenshot</summary>


![Screen Shot 2020-04-03 at 14 59 47](https://user-images.githubusercontent.com/8074436/78363444-0962e900-75bc-11ea-9355-0fbe39e68f02.png)

</details>

But we'd better release updated schematics.