### PR TITLE
feat(datepicker): improve 'restoreFocus' input

### DIFF
--- a/src/datepicker/datepicker-input-config.ts
+++ b/src/datepicker/datepicker-input-config.ts
@@ -17,5 +17,5 @@ export class NgbInputDatepickerConfig extends NgbDatepickerConfig {
   container: null | 'body';
   positionTarget: string | HTMLElement;
   placement: PlacementArray = ['bottom-left', 'bottom-right', 'top-left', 'top-right'];
-  restoreFocus: true | HTMLElement | string = true;
+  restoreFocus: boolean | HTMLElement | string = true;
 }

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -198,13 +198,14 @@ export class NgbInputDatepicker implements OnChanges,
 
   /**
    * If `true`, when closing datepicker will focus element that was focused before datepicker was opened.
+   * If `false`, when closing datepicker will not change the focus.
    *
    * Alternatively you could provide a selector or an `HTMLElement` to focus. If the element doesn't exist or invalid,
    * we'll fallback to focus document body.
    *
    * @since 5.2.0
    */
-  @Input() restoreFocus: true | string | HTMLElement;
+  @Input() restoreFocus: boolean | string | HTMLElement;
 
   /**
    * If `true`, weekdays will be displayed.
@@ -394,6 +395,11 @@ export class NgbInputDatepicker implements OnChanges,
       this._cRef = null;
       this.closed.emit();
       this._changeDetector.markForCheck();
+
+      // dont restore focus
+      if (this.restoreFocus === false) {
+        return;
+      }
 
       // restore focus
       let elementToFocus: HTMLElement | null = this._elWithFocus;


### PR DESCRIPTION
Hello,

in my angular project I need to disable the restore focus feature on the date picker, so I created this pull request.

It's a very trivial fix, I changed the datatype from "true" to "boolean" and added one if statement

Thanks
Ramon