### PR TITLE
Schematics installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,74 +44,23 @@ The supported versions are:
 
 ## Installation
 
-### Angular
+We strongly recommend using [Angular CLI](https://cli.angular.io) for setting up a new project. If you have an Angular &ge; 9 CLI project, you could simply use our schematics to add ng-bootstrap library to it. 
 
- We strongly recommend using [Angular CLI](https://cli.angular.io) for setting up a new project.
-
-If you're using Angular &ge; 9.0.0 and ng-bootstrap &ge; 6.0.0, you have to install the `@angular/localize` polyfill
+Just run the following:
 
 ```shell
-ng add @angular/localize
+ng add @ng-bootstrap/ng-bootstrap
 ```
 
-See more details in
-[the official documentation](https://angular.io/guide/i18n#setting-up-localization-with-the-angular-cli).
-
-### Bootstrap (CSS only)
-
-You also need to add Bootstrap CSS to your application using your preferred way (see [Bootstrap instructions](https://getbootstrap.com/docs/4.4/getting-started/download/))
-
-For example you could install Bootstrap from npm
+It will install ng-bootstrap for the default application specified in your `angular.json`.
+If you have multiple projects and you want to target a specific application, you could specify the `--project` option:
 
 ```shell
-npm install bootstrap
+ng add @ng-bootstrap/ng-bootstrap --project myProject
 ```
 
-and add Bootstrap CSS or SCSS to your project
-
-```css
-/* update your 'styles.css' with */
-@import '~bootstrap/dist/css/bootstrap.css';
-
-/* or your 'styles.scss' with */
-@import "~bootstrap/scss/bootstrap";
-```
-
-Please note that you need only CSS and **should not** add other JavaScript dependencies like `bootstrap.js`, `jQuery` or `popper.js` as ng-bootstrap's goal is to completely replace them.
-
-### ng-bootstrap
-
-Installing from npm is simply doing
-```shell
-npm install @ng-bootstrap/ng-bootstrap
-```
-Once installed you need to import our main module:
-```js
-import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
-
-@NgModule({
-  ...
-  imports: [NgbModule, ...],
-  ...
-})
-export class YourAppModule {
-}
-```
-
-Alternatively you could only import modules with components you need, ex. pagination and alert.
-The resulting bundle will be smaller in this case.
-
-```js
-import {NgbPaginationModule, NgbAlertModule} from '@ng-bootstrap/ng-bootstrap';
-
-@NgModule({
-  ...
-  imports: [NgbPaginationModule, NgbAlertModule, ...],
-  ...
-})
-export class YourAppModule {
-}
-```
+If you prefer not to use schematics and install everything manually, please refer to the 
+[manual installation instructions](https://ng-bootstrap.github.io/#/getting-started#installation) on our website. 
 
 ## Supported browsers
 

--- a/demo/src/app/pages/getting-started/getting-started.component.html
+++ b/demo/src/app/pages/getting-started/getting-started.component.html
@@ -52,67 +52,129 @@
 
   <ngbd-page-header title="Installation" fragment="installation" class="mb-3"></ngbd-page-header>
 
-  <h4>Angular</h4>
-
   <p>
     We strongly recommend using
     <a href="https://cli.angular.io/" target="_blank">Angular CLI</a> for setting up a new project.
+    If you have an Angular &ge; 9 CLI project, you could simply use our schematics to add ng-bootstrap library to it.
   </p>
 
   <p>
-    If you're using Angular &ge; 9.0.0 and ng-bootstrap &ge; 6.0.0, you have to install the <code>@angular/localize</code> polyfill
+    Just run the following:
   </p>
 
-  <ngbd-code [snippet]="polyfillInstall"></ngbd-code>
+  <ngbd-code [snippet]="schematics"></ngbd-code>
 
   <p>
-    See more details in
-    <a href="https://angular.io/guide/i18n#setting-up-localization-with-the-angular-cli" target="_blank">the official documentation</a>.
+    It will install ng-bootstrap for the default application specified in your <code>angular.json</code>.
+    If you have multiple projects and you want to target a specific application,
+    you could specify the <code>--project</code> option
   </p>
 
-  <h4>Bootstrap (CSS only)</h4>
+  <ngbd-code [snippet]="schematicsProject"></ngbd-code>
+
+  <br>
+
+  <h4>Manual installation</h4>
 
   <p>
-    You also need to add Bootstrap CSS to your application using your preferred way (see
-    <a href="https://getbootstrap.com/docs/4.4/getting-started/download/" target="_blank">Bootstrap instructions</a>).
+    If you prefer not to use schematics or want to add ng-bootstrap to an older project, you'll need to do the following:
+  </p>
+
+  <ul>
+    <li>Add <code>bootstrap</code> and <code>@ng-bootstrap/ng-bootstrap</code> dependencies from npm</li>
+    <li>Install the <code>@angular/localize</code> polyfill</li>
+    <li>Add bootstrap CSS/SCSS to your project (no javascript is required)</li>
+    <li>Import <code>NgbModule</code> or any other component module like <code>NgbPaginationModule</code> in your application</li>
+  </ul>
+
+  <p>
+    <a href (click)="instructionsCollapsed = !instructionsCollapsed; $event.preventDefault()"
+       [attr.aria-expanded]="!instructionsCollapsed" aria-controls="detailed-instructions">
+      Click here to {{ instructionsCollapsed ? 'show' : 'hide' }} detailed instructions
+    </a>
+  </p>
+
+  <div id="detailed=instructions" [ngbCollapse]="instructionsCollapsed">
+    <div class="card">
+      <div class="card-body">
+        <h5>Bootstrap (CSS only)</h5>
+
+        <p>
+          You need to add Bootstrap CSS to your application using your preferred way (see
+          <a href="https://getbootstrap.com/docs/4.4/getting-started/download/" target="_blank">Bootstrap instructions</a>).
+        </p>
+
+        <p>
+          For example you could install Bootstrap from npm
+        </p>
+
+        <ngbd-code [snippet]="bootstrapInstall"></ngbd-code>
+
+        <p>
+          and add Bootstrap CSS or SCSS to your project.
+        </p>
+
+        <p>
+          In case you're using CSS, you just need to add Bootstrap styles to your <code>angular.json</code> configuration:
+        </p>
+
+        <ngbd-code [snippet]="bootstrapCssAngularJson"></ngbd-code>
+
+        <p>
+          In case you're using SCSS, please add this to your <code>styles.scss</code> directly:
+        </p>
+
+        <ngbd-code [snippet]="bootstrapCss"></ngbd-code>
+
+        <ngb-alert type="warning" [dismissible]="false" class="mt-3">
+          <p class="font-weight-bold" style="font-size: 1.1rem">
+            Should I add Bootstrap JavaScript files to my project?
+          </p>
+
+          <p>No, adding <code>bootstrap.js</code> or <code>bootstrap.min.js</code> is not necessary.</p>
+
+          The goal of ng-bootstrap is to <i>completely replace</i> JavaScript implementation for components.
+          Nor should you include other dependencies like jQuery or popper.js.
+          It is not necessary and might interfere with ng-bootstrap code.
+        </ngb-alert>
+
+        <h5>@angular/localize polyfill</h5>
+
+        <p>
+          If you're using Angular &ge; 9.0.0 and ng-bootstrap &ge; 6.0.0,
+          you also have to install the <code>@angular/localize</code> polyfill:
+        </p>
+
+        <ngbd-code [snippet]="polyfillInstall"></ngbd-code>
+
+        <p>
+          See more details in
+          <a href="https://angular.io/guide/i18n#setting-up-localization-with-the-angular-cli" target="_blank">the official documentation</a>.
+        </p>
+
+        <h5>ng-bootstrap</h5>
+
+        <p>Installing the library itself from npm is simply doing</p>
+
+        <ngbd-code [snippet]="codeInstall"></ngbd-code>
+
+        <p>Once installed you need to import our main module and you're good to go</p>
+
+        <ngbd-code [snippet]="codeRoot"></ngbd-code>
+      </div>
+    </div>
+  </div>
+
+  <ngbd-page-header title="Alternative imports" fragment="imports"></ngbd-page-header>
+
+  <p>
+    Instead of importing the whole library with <code>NgbModule</code>,
+    you could only import modules with components you need, ex. pagination and alert.
   </p>
 
   <p>
-    For example you could install Bootstrap from npm
+    The resulting bundle will be smaller in this case.
   </p>
-
-  <ngbd-code [snippet]="bootstrapInstall"></ngbd-code>
-
-  <p>
-    and add Bootstrap CSS or SCSS to your project
-  </p>
-
-  <ngbd-code [snippet]="bootstrapCss"></ngbd-code>
-
-  <ngb-alert type="warning" [dismissible]="false" class="mt-3">
-    <p class="font-weight-bold" style="font-size: 1.1rem">
-      Should I add Bootstrap JavaScript files to my project?
-    </p>
-
-    <p>No, adding <code>bootstrap.js</code> or <code>bootstrap.min.js</code> is not necessary.</p>
-
-    The goal of ng-bootstrap is to <i>completely replace</i> JavaScript implementation for components.
-    Nor should you include other dependencies like jQuery or popper.js.
-    It is not necessary and might interfere with ng-bootstrap code.
-  </ngb-alert>
-
-  <h4>ng-bootstrap</h4>
-
-  <p>Installing from npm is simply doing</p>
-
-  <ngbd-code [snippet]="codeInstall"></ngbd-code>
-
-  <p>Once installed you need to import our main module and you're good to go</p>
-
-  <ngbd-code [snippet]="codeRoot"></ngbd-code>
-
-  <p>Alternatively you could only import modules with components you need, ex. pagination and alert.
-    The resulting bundle will be smaller in this case.</p>
 
   <ngbd-code [snippet]="codeOther"></ngbd-code>
 

--- a/demo/src/app/pages/getting-started/getting-started.component.ts
+++ b/demo/src/app/pages/getting-started/getting-started.component.ts
@@ -1,19 +1,43 @@
-import {Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {Snippet} from '../../shared/code/snippet';
 
 @Component({
-  templateUrl: './getting-started.component.html'
+  templateUrl: './getting-started.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class GettingStartedPage {
 
+  instructionsCollapsed = true;
+
+  schematics = Snippet({
+    lang: 'bash',
+    code: `ng add @ng-bootstrap/ng-bootstrap`,
+  });
+
+  schematicsProject = Snippet({
+    lang: 'bash',
+    code: `ng add @ng-bootstrap/ng-bootstrap --project myProject`,
+  });
+
   bootstrapCss = Snippet({
     lang: 'css',
-    code: `
-      /* update your 'styles.css' with */
-      @import '~bootstrap/dist/css/bootstrap.css';
+    code: `@import "~bootstrap/scss/bootstrap";`,
+  });
 
-      /* or your 'styles.scss' with */
-      @import "~bootstrap/scss/bootstrap";
+  bootstrapCssAngularJson = Snippet({
+    lang: 'typescript',
+    code: `
+      "yourApp": {
+        "architect": {
+          "build": {
+            "options": {
+              "styles": [
+                "node_modules/bootstrap/dist/css/bootstrap.min.css"
+              ]
+            }
+          }
+        }
+      }
     `,
   });
 
@@ -38,9 +62,7 @@ export class GettingStartedPage {
       import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 
       @NgModule({
-        ...
-        imports: [NgbModule, ...],
-        ...
+        imports: [NgbModule],
       })
       export class YourAppModule {
       }
@@ -53,9 +75,7 @@ export class GettingStartedPage {
       import {NgbPaginationModule, NgbAlertModule} from '@ng-bootstrap/ng-bootstrap';
 
       @NgModule({
-        ...
-        imports: [NgbPaginationModule, NgbAlertModule, ...],
-        ...
+        imports: [NgbPaginationModule, NgbAlertModule],
       })
       export class YourAppModule {
       }


### PR DESCRIPTION
Updated installation instructions that use schematics by default:

<img width="1081" alt="Screen Shot 2020-04-17 at 12 45 43" src="https://user-images.githubusercontent.com/8074436/79561280-60cb8380-80a9-11ea-95d9-0da091a41988.png">

Collapsed section looks like this.

<details>
  <summary>Click to see the screenshot</summary>

![Screen Shot 2020-04-17 at 12 47 59](https://user-images.githubusercontent.com/8074436/79561505-be5fd000-80a9-11ea-9678-c49e140121ee.png)


</details>

There is also a new section called "Alternative Imports". Previously part of installation, now it should be visible, event if detailed instructions are collapsed

<img width="1029" alt="Screen Shot 2020-04-17 at 12 49 52" src="https://user-images.githubusercontent.com/8074436/79561644-f8c96d00-80a9-11ea-9f1c-82f129e7af21.png">


P.S. yes, the commit message, should be `docs:`, not `schematics:`