### PR TITLE
demo: better display of the right menu when the scrollbar is displayed

### DIFF
--- a/demo/src/app/shared/component-wrapper/component-wrapper.component.html
+++ b/demo/src/app/shared/component-wrapper/component-wrapper.component.html
@@ -20,7 +20,7 @@
       <ngbd-side-nav
         id="doc-nav"
         [ngbCollapse]="sidebarCollapsed"
-        class="d-lg-block my-3 collapse sidebar"
+        class="d-lg-block py-3 collapse sidebar"
       ></ngbd-side-nav>
     </div>
 

--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -49,7 +49,8 @@ header.navbar {
 .sidebar {
   position: sticky;
   top: 1rem;
-  max-height: 100vh;
+  max-height: calc(100vh - 4rem);
+  margin-right: -1rem;
   overflow-x: hidden;
   overflow-y: auto;
 }


### PR DESCRIPTION
The issue came form the dimensions of the right menu, not well aligned with other elements. 
The main problem was the bottom of the scrollbar, which was out of the viewport.