### PR TITLE
docs(modal): false positive A11y warning

### DIFF
--- a/src/modal/modal.ts
+++ b/src/modal/modal.ts
@@ -23,6 +23,10 @@ export class NgbModal {
    * then instances of those components can be injected with an instance of the `NgbActiveModal` class. You can then
    * use `NgbActiveModal` methods to close / dismiss modals from "inside" of your component.
    *
+   * The modal implementation adds `aria-hidden="true"` to parent DOM elements while keeping focus trapped inside
+   * the modal. This leads to false positive warnings from A11y tools, e.g. "aria-hidden elements do not contain
+   * focusable elements" from [axe](https://dequeuniversity.com/rules/axe/3.2/aria-hidden-focus).
+   *
    * Also see the [`NgbModalOptions`](#/components/modal/api#NgbModalOptions) for the list of supported options.
    */
   open(content: any, options: NgbModalOptions = {}): NgbModalRef {


### PR DESCRIPTION
- describes false positive A11y warning related to `aria-hidden="true"` and focus trap

Closes #3319

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [ ] built and tested the changes locally.
 - [ ] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.
