### PR TITLE
Alert animations

### DIFF
--- a/demo/src/app/components/alert/demos/closeable/alert-closeable.html
+++ b/demo/src/app/components/alert/demos/closeable/alert-closeable.html
@@ -1,5 +1,5 @@
 <p *ngFor="let alert of alerts">
-  <ngb-alert [type]="alert.type" (close)="close(alert)">{{ alert.message }}</ngb-alert>
+  <ngb-alert [type]="alert.type" (closed)="close(alert)">{{ alert.message }}</ngb-alert>
 </p>
 <p>
   <button type="button" class="btn btn-primary" (click)="reset()">Reset</button>

--- a/demo/src/app/components/alert/demos/selfclosing/alert-selfclosing.html
+++ b/demo/src/app/components/alert/demos/selfclosing/alert-selfclosing.html
@@ -1,7 +1,7 @@
 <p>
   Static self-closing alert that disappears after 20 seconds (refresh the page if it has already disappeared)
 </p>
-<ngb-alert #staticAlert *ngIf="!staticAlertClosed" (close)="staticAlertClosed = true">Check out our awesome new
+<ngb-alert #staticAlert *ngIf="!staticAlertClosed" (closed)="staticAlertClosed = true">Check out our awesome new
   features!</ngb-alert>
 
 <hr />
@@ -9,7 +9,7 @@
 <p>
   Show a self-closing success message that disappears after 5 seconds.
 </p>
-<ngb-alert #selfClosingAlert *ngIf="successMessage" type="success" (close)="successMessage = ''">{{ successMessage }}
+<ngb-alert #selfClosingAlert *ngIf="successMessage" type="success" (closed)="successMessage = ''">{{ successMessage }}
 </ngb-alert>
 <p>
   <button class="btn btn-primary" (click)="changeSuccessMessage()">Change message</button>

--- a/demo/src/app/components/alert/demos/selfclosing/alert-selfclosing.html
+++ b/demo/src/app/components/alert/demos/selfclosing/alert-selfclosing.html
@@ -1,14 +1,16 @@
 <p>
   Static self-closing alert that disappears after 20 seconds (refresh the page if it has already disappeared)
 </p>
-<ngb-alert *ngIf="!staticAlertClosed" (close)="staticAlertClosed = true">Check out our awesome new features!</ngb-alert>
+<ngb-alert #staticAlert *ngIf="!staticAlertClosed" (close)="staticAlertClosed = true">Check out our awesome new
+  features!</ngb-alert>
 
-<hr/>
+<hr />
 
 <p>
   Show a self-closing success message that disappears after 5 seconds.
 </p>
-<ngb-alert *ngIf="successMessage" type="success" (close)="successMessage = ''">{{ successMessage }}</ngb-alert>
+<ngb-alert #selfClosingAlert *ngIf="successMessage" type="success" (close)="successMessage = ''">{{ successMessage }}
+</ngb-alert>
 <p>
   <button class="btn btn-primary" (click)="changeSuccessMessage()">Change message</button>
 </p>

--- a/demo/src/app/components/alert/demos/selfclosing/alert-selfclosing.ts
+++ b/demo/src/app/components/alert/demos/selfclosing/alert-selfclosing.ts
@@ -1,27 +1,28 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, OnInit, ViewChild} from '@angular/core';
 import {Subject} from 'rxjs';
 import {debounceTime} from 'rxjs/operators';
+import {NgbAlert} from '@ng-bootstrap/ng-bootstrap';
 
-@Component({
-  selector: 'ngbd-alert-selfclosing',
-  templateUrl: './alert-selfclosing.html'
-})
+@Component({selector: 'ngbd-alert-selfclosing', templateUrl: './alert-selfclosing.html'})
 export class NgbdAlertSelfclosing implements OnInit {
   private _success = new Subject<string>();
 
   staticAlertClosed = false;
   successMessage = '';
 
+  @ViewChild('staticAlert', {static: false}) staticAlert: NgbAlert;
+  @ViewChild('selfClosingAlert', {static: false}) selfClosingAlert: NgbAlert;
+
   ngOnInit(): void {
-    setTimeout(() => this.staticAlertClosed = true, 20000);
+    setTimeout(() => this.staticAlert.close(), 20000);
 
     this._success.subscribe(message => this.successMessage = message);
-    this._success.pipe(
-      debounceTime(5000)
-    ).subscribe(() => this.successMessage = '');
+    this._success.pipe(debounceTime(5000)).subscribe(() => {
+      if (this.selfClosingAlert) {
+        this.selfClosingAlert.close();
+      }
+    });
   }
 
-  public changeSuccessMessage() {
-    this._success.next(`${new Date()} - Message successfully changed.`);
-  }
+  public changeSuccessMessage() { this._success.next(`${new Date()} - Message successfully changed.`); }
 }

--- a/src/alert/alert-config.spec.ts
+++ b/src/alert/alert-config.spec.ts
@@ -1,8 +1,9 @@
 import {NgbAlertConfig} from './alert-config';
+import {NgbConfig} from '../ngb-config';
 
 describe('ngb-alert-config', () => {
   it('should have sensible default values', () => {
-    const config = new NgbAlertConfig();
+    const config = new NgbAlertConfig(new NgbConfig());
 
     expect(config.dismissible).toBe(true);
     expect(config.type).toBe('warning');

--- a/src/alert/alert-config.ts
+++ b/src/alert/alert-config.ts
@@ -1,4 +1,5 @@
 import {Injectable} from '@angular/core';
+import {NgbConfig} from '../ngb-config';
 
 /**
  * A configuration service for the [NgbAlert](#/components/alert/api#NgbAlert) component.
@@ -8,6 +9,9 @@ import {Injectable} from '@angular/core';
  */
 @Injectable({providedIn: 'root'})
 export class NgbAlertConfig {
+  animation: boolean;
   dismissible = true;
   type = 'warning';
+
+  constructor(ngbConfig: NgbConfig) { this.animation = ngbConfig.animation; }
 }

--- a/src/alert/alert.spec.ts
+++ b/src/alert/alert.spec.ts
@@ -7,6 +7,8 @@ import {NgbAlertModule} from './alert.module';
 import {NgbAlert} from './alert';
 import {NgbAlertConfig} from './alert-config';
 
+import {NgbConfig} from '../ngb-config';
+
 const createTestComponent = (html: string) =>
     createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
@@ -27,7 +29,7 @@ describe('ngb-alert', () => {
   beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbAlertModule]}); });
 
   it('should initialize inputs with default values', () => {
-    const defaultConfig = new NgbAlertConfig();
+    const defaultConfig = new NgbAlertConfig(new NgbConfig());
     const alertCmp = TestBed.createComponent(NgbAlert).componentInstance;
     expect(alertCmp.dismissible).toBe(defaultConfig.dismissible);
     expect(alertCmp.type).toBe(defaultConfig.type);
@@ -142,7 +144,7 @@ describe('ngb-alert', () => {
   });
 
   describe('Custom config as provider', () => {
-    let config = new NgbAlertConfig();
+    let config = new NgbAlertConfig(new NgbConfig());
     config.dismissible = false;
     config.type = 'success';
 

--- a/src/alert/alert.spec.ts
+++ b/src/alert/alert.spec.ts
@@ -1,5 +1,7 @@
+import createSpy = jasmine.createSpy;
 import {async, ComponentFixture, inject, TestBed} from '@angular/core/testing';
 import {isBrowserVisible, createGenericTestComponent} from '../test/common';
+import {By} from '@angular/platform-browser';
 
 import {Component} from '@angular/core';
 
@@ -101,7 +103,7 @@ describe('ngb-alert', () => {
 
   it('should fire an event after closing a dismissible alert', () => {
     const fixture =
-        createTestComponent('<ngb-alert [dismissible]="true" (close)="closed = true">Watch out!</ngb-alert>');
+        createTestComponent('<ngb-alert [dismissible]="true" (closed)="closed = true">Watch out!</ngb-alert>');
     const alertEl = getAlertElement(fixture.nativeElement);
     const buttonEl = getCloseButton(alertEl);
 
@@ -110,6 +112,23 @@ describe('ngb-alert', () => {
     expect(alertEl).toHaveCssClass('show');
     expect(alertEl).toHaveCssClass('fade');
     expect(fixture.componentInstance.closed).toBe(true);
+  });
+
+  it('should fire an event after closing a dismissible alert imperatively', () => {
+    const fixture =
+        createTestComponent('<ngb-alert [dismissible]="true" (closed)="closed = true">Watch out!</ngb-alert>');
+    const alertEl = getAlertElement(fixture.nativeElement);
+    const alert = fixture.debugElement.query(By.directive(NgbAlert)).injector.get(NgbAlert);
+
+    const closedSpy = createSpy();
+    expect(fixture.componentInstance.closed).toBe(false);
+    alert.close().subscribe(closedSpy);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.closed).toBe(true);
+    expect(closedSpy).toHaveBeenCalledTimes(1);
+    expect(alertEl).toHaveCssClass('show');
+    expect(alertEl).toHaveCssClass('fade');
   });
 
   it('should project the content given into the component', () => {

--- a/src/alert/alert.ts
+++ b/src/alert/alert.ts
@@ -12,6 +12,8 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 
+import {Observable} from 'rxjs';
+
 import {NgbAlertConfig} from './alert-config';
 import {ngbRunTransition} from '../util/transition/ngbTransition';
 import {ngbAlertFadingTransition} from '../util/transition/ngbFadingTransition';
@@ -23,6 +25,7 @@ import {ngbAlertFadingTransition} from '../util/transition/ngbFadingTransition';
  */
 @Component({
   selector: 'ngb-alert',
+  exportAs: 'ngbAlert',
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   host: {'role': 'alert', 'class': 'alert show fade', '[class.alert-dismissible]': 'dismissible'},
@@ -64,7 +67,7 @@ export class NgbAlert implements OnInit,
   /**
    * An event emitted when the close button is clicked. It has no payload and only relevant for dismissible alerts.
    */
-  @Output('close') closeEvent = new EventEmitter<void>();
+  @Output() closed = new EventEmitter<void>();
 
 
   constructor(config: NgbAlertConfig, private _renderer: Renderer2, private _element: ElementRef) {
@@ -73,11 +76,20 @@ export class NgbAlert implements OnInit,
     this.animation = config.animation;
   }
 
-  close() {
-    ngbRunTransition(this._element.nativeElement, ngbAlertFadingTransition, {
-      animation: this.animation,
-      runningTransition: 'continue'
-    }).subscribe(() => this.closeEvent.emit());
+  /**
+   * Triggers alert closing programmatically (same as clicking on the close button (×)).
+   *
+   * The returned observable will emit and be completed once the closing transition has finished.
+   * If the animations are turned off this happens synchronously.
+   *
+   * Alternatively you could listen or subscribe to the `(closed)` output
+   */
+  close(): Observable<void> {
+    const transition = ngbRunTransition(
+        this._element.nativeElement, ngbAlertFadingTransition,
+        {animation: this.animation, runningTransition: 'continue'});
+    transition.subscribe(() => this.closed.emit());
+    return transition;
   }
 
   ngOnChanges(changes: SimpleChanges) {

--- a/src/environment.test.ts
+++ b/src/environment.test.ts
@@ -1,3 +1,4 @@
 export const environment = {
   animation: false,
+  transitionTimerDelayMs: 500,
 };

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,3 +1,4 @@
 export const environment = {
   animation: true,
+  transitionTimerDelayMs: 5,
 };

--- a/src/karma.conf.js
+++ b/src/karma.conf.js
@@ -6,7 +6,7 @@ const browsers = process.env.TRAVIS ? ['ChromeHeadlessNoSandbox'] : ['ChromeNoEx
 module.exports = function (config) {
   config.set({
     basePath: '',
-    files: ['../node_modules/bootstrap/dist/css/bootstrap.min.css'],
+    files: ['../node_modules/bootstrap/dist/css/bootstrap.min.css', '../src/test/test-styles.css'],
     frameworks: ['jasmine', '@angular-devkit/build-angular'],
     plugins: [
       require('karma-jasmine'),

--- a/src/karma.sauce.conf.js
+++ b/src/karma.sauce.conf.js
@@ -54,7 +54,7 @@ const BROWSERS = {
 module.exports = function (config) {
   config.set({
     basePath: '',
-    files: ['../node_modules/bootstrap/dist/css/bootstrap.min.css'],
+    files: ['../node_modules/bootstrap/dist/css/bootstrap.min.css', '../src/test/test-styles.css'],
     frameworks: ['jasmine', '@angular-devkit/build-angular'],
     plugins: [
       require('karma-jasmine'),

--- a/src/test/common.ts
+++ b/src/test/common.ts
@@ -63,6 +63,14 @@ export function isBrowser(browsers: Browser | Browser[], ua = window.navigator.u
   }
 }
 
+export function isBrowserVisible(suiteName: string) {
+  if (document.hidden) {
+    console.warn(`${suiteName} tests were skipped because browser tab running these tests is hidden or inactive`);
+    return false;
+  }
+  return true;
+}
+
 export function createKeyEvent(key: Key, options: {type: 'keyup' | 'keydown'} = {
   type: 'keyup'
 }) {

--- a/src/test/ngb-config-animation.ts
+++ b/src/test/ngb-config-animation.ts
@@ -1,0 +1,7 @@
+import {Injectable} from '@angular/core';
+import {NgbConfig} from '../ngb-config';
+
+@Injectable()
+export class NgbConfigAnimation extends NgbConfig {
+  animation = true;
+}

--- a/src/test/test-styles.css
+++ b/src/test/test-styles.css
@@ -1,3 +1,22 @@
+/*
+  Overriding some of the Bootstrap transition styles for testing purposes.
+
+  Adding `!important` will disable bootstrap's prefer-reduced-motion support and always run transitions regardless
+  of the host OS setting. We can simulate reduced motion support with the `.ngb-reduce-motion` class.
+ */
+
+.fade {
+  transition: opacity 0.01s linear !important;
+}
+
+.ngb-reduce-motion .fade {
+  transition: none !important;
+}
+
+/*
+  Styles used for internal testing
+ */
+
 .ngb-test-transition {
   height: 100px;
   width: 100px;

--- a/src/test/test-styles.css
+++ b/src/test/test-styles.css
@@ -1,0 +1,17 @@
+.ngb-test-transition {
+  height: 100px;
+  width: 100px;
+  background-color: red;
+}
+
+.ngb-test-none {
+  transition: none 0.01s linear;
+}
+
+.ngb-test-fade {
+  transition: opacity 0.01s linear;
+}
+
+.ngb-test-fade:not(.ngb-test-show) {
+  opacity: 0;
+}

--- a/src/util/transition/ngbFadingTransition.ts
+++ b/src/util/transition/ngbFadingTransition.ts
@@ -1,3 +1,5 @@
-export const ngbAlertFadingTransition = ({classList}: HTMLElement): void => {
+import {NgbTransitionStartFn} from './ngbTransition';
+
+export const ngbAlertFadingTransition: NgbTransitionStartFn = ({classList}: HTMLElement) => {
   classList.remove('show');
 };

--- a/src/util/transition/ngbFadingTransition.ts
+++ b/src/util/transition/ngbFadingTransition.ts
@@ -1,0 +1,3 @@
+export const ngbAlertFadingTransition = ({classList}: HTMLElement): void => {
+  classList.remove('show');
+};

--- a/src/util/transition/ngbTransition.spec.ts
+++ b/src/util/transition/ngbTransition.spec.ts
@@ -1,0 +1,160 @@
+import {ngbRunTransition} from './ngbTransition';
+import createSpy = jasmine.createSpy;
+import {Component, ElementRef, ViewChild} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {isBrowserVisible} from '../../test/common';
+
+/**
+ * This is sometimes necessary only for IE when it fails to recalculate styles synchronously
+ * after the 'transitionend' event was fired. To remove when not supporting IE anymore.
+ */
+function getComputedStyleAsync(element: HTMLElement, style: keyof CSSStyleDeclaration) {
+  return new Promise<string>(resolve => setTimeout(() => resolve(window.getComputedStyle(element)[style])));
+}
+
+function fadeFn({classList}: HTMLElement) {
+  classList.remove('ngb-test-show');
+}
+
+if (isBrowserVisible('ngbRunTransition')) {
+  describe('ngbRunTransition', () => {
+
+    let component: ComponentFixture<TestComponent>;
+    let element: HTMLElement;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({declarations: [TestComponent]});
+
+      component = TestBed.createComponent(TestComponent);
+      component.detectChanges();
+      element = component.componentInstance.element.nativeElement;
+      spyOn(component.componentInstance, 'onTransitionEnd');
+    });
+
+    it(`should run specified transition on an element`, (done) => {
+      element.classList.add('ngb-test-fade');
+
+      const nextSpy = createSpy();
+      const errorSpy = createSpy();
+
+      ngbRunTransition(element, fadeFn, {animation: true, runningTransition: 'continue'})
+          .subscribe(nextSpy, errorSpy, async() => {
+            expect(component.componentInstance.onTransitionEnd).toHaveBeenCalledTimes(1);
+            expect(nextSpy).toHaveBeenCalledWith(undefined);
+            expect(element.classList.contains('ngb-test-show')).toBe(false);
+            expect(errorSpy).not.toHaveBeenCalled();
+            expect(await getComputedStyleAsync(element, 'opacity')).toBe('0');
+            done();
+          });
+
+      expect(window.getComputedStyle(element).opacity).toBe('1');
+    });
+
+    it(`should emit 'undefined' and complete synchronously with 'animation: false'`, () => {
+      element.classList.add('ngb-test-fade');
+      expect(window.getComputedStyle(element).opacity).toBe('1');
+
+      const nextSpy = createSpy();
+      const errorSpy = createSpy();
+      const completeSpy = createSpy();
+
+      ngbRunTransition(element, fadeFn, {animation: false, runningTransition: 'continue'})
+          .subscribe(nextSpy, errorSpy, completeSpy);
+
+      expect(element.classList.contains('ngb-test-show')).toBe(true);
+      expect(window.getComputedStyle(element).opacity).toBe('1');
+      expect(component.componentInstance.onTransitionEnd).not.toHaveBeenCalled();
+      expect(nextSpy).toHaveBeenCalledWith(undefined);
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(completeSpy).toHaveBeenCalled();
+    });
+
+    it(`should emit 'undefined' and complete synchronously if transition is 'none'`, () => {
+      element.classList.add('ngb-test-none');
+      expect(window.getComputedStyle(element).opacity).toBe('1');
+
+      const nextSpy = createSpy();
+      const errorSpy = createSpy();
+      const completeSpy = createSpy();
+
+      ngbRunTransition(element, fadeFn, {animation: true, runningTransition: 'continue'})
+          .subscribe(nextSpy, errorSpy, completeSpy);
+
+      expect(element.classList.contains('ngb-test-show')).toBe(false);
+      expect(window.getComputedStyle(element).opacity).toBe('1');
+      expect(component.componentInstance.onTransitionEnd).not.toHaveBeenCalled();
+      expect(nextSpy).toHaveBeenCalledWith(undefined);
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(completeSpy).toHaveBeenCalled();
+    });
+
+    it(`should complete new transition if one is already running with 'runningTransition: continue'`, (done) => {
+      element.classList.add('ngb-test-fade');
+
+      // first
+      const nextSpy1 = createSpy();
+      const errorSpy1 = createSpy();
+
+      ngbRunTransition(element, fadeFn, {animation: true, runningTransition: 'continue'})
+          .subscribe(nextSpy1, errorSpy1, async() => {
+            expect(component.componentInstance.onTransitionEnd).toHaveBeenCalledTimes(1);
+            expect(nextSpy1).toHaveBeenCalledWith(undefined);
+            expect(element.classList.contains('ngb-test-show')).toBe(false);
+            expect(errorSpy1).not.toHaveBeenCalled();
+            expect(await getComputedStyleAsync(element, 'opacity')).toBe('0');
+            done();
+          });
+
+      expect(window.getComputedStyle(element).opacity).toBe('1');
+
+      // second
+      const nextSpy2 = createSpy();
+      const errorSpy2 = createSpy();
+      const completeSpy2 = createSpy();
+
+      ngbRunTransition(element, fadeFn, {animation: true, runningTransition: 'continue'})
+          .subscribe(nextSpy2, errorSpy2, completeSpy2);
+
+      // first transition is on-going
+      expect(nextSpy1).not.toHaveBeenCalled();
+      expect(window.getComputedStyle(element).opacity).toBe('1');
+
+      // second transition was completed and no value was emitted
+      expect(nextSpy2).not.toHaveBeenCalled();
+      expect(errorSpy2).not.toHaveBeenCalled();
+      expect(completeSpy2).toHaveBeenCalled();
+    });
+
+    it(`should complete and release the DOM element even if transition end is not fired`, (done) => {
+      element.classList.add('ngb-test-fade');
+
+      const nextSpy = createSpy();
+      const errorSpy = createSpy();
+
+      ngbRunTransition(element, fadeFn, {animation: true, runningTransition: 'continue'})
+          .subscribe(nextSpy, errorSpy, async() => {
+            expect(component.componentInstance.onTransitionEnd).not.toHaveBeenCalled();  // <-- finished with timer
+            expect(nextSpy).toHaveBeenCalledWith(undefined);
+            expect(errorSpy).not.toHaveBeenCalled();
+            expect(element.classList.contains('ngb-test-show')).toBe(false);
+            const opacity = await getComputedStyleAsync(element, 'opacity');
+            expect(['1', '']).toContain(opacity !);  // <-- detached from DOM, different values in different browsers
+            done();
+          });
+
+      // detaching transitioning element from DOM
+      expect(window.getComputedStyle(element).opacity).toBe('1');
+      element.parentElement !.removeChild(element);
+    });
+  });
+}
+
+@Component({
+  template: `
+      <div #element class="ngb-test-transition ngb-test-show" (transitionend)="onTransitionEnd()"></div>`
+})
+class TestComponent {
+  @ViewChild('element') element: ElementRef;
+
+  onTransitionEnd = () => {};
+}

--- a/src/util/transition/ngbTransition.ts
+++ b/src/util/transition/ngbTransition.ts
@@ -1,0 +1,65 @@
+import {EMPTY, fromEvent, Observable, of, race, Subject, timer} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
+import {getTransitionDurationMs} from './util';
+import {environment} from '../../environment';
+
+export type NgbTransitionStartFn = (element: HTMLElement) => void;
+
+export interface NgbTransitionOptions {
+  animation: boolean;
+  runningTransition: 'continue' | 'stop';
+}
+
+const {transitionTimerDelayMs} = environment;
+const runningTransitions = new Map<HTMLElement, Subject<any>>();
+
+export const ngbRunTransition =
+    (element: HTMLElement, startFn: NgbTransitionStartFn, options: NgbTransitionOptions): Observable<undefined> => {
+
+      // If animations are disabled, we have to emit a value and complete the observable
+      if (!options.animation) {
+        return of(undefined);
+      }
+
+      // Checking if there are already running transitions on the given element.
+      const runningTransition$ = runningTransitions.get(element);
+      if (runningTransition$) {
+        // If there is one running and we want for it to continue to run, we have to cancel the current one.
+        // We're not emitting any values, but simply completing the observable (EMPTY).
+        if (options.runningTransition === 'continue') {
+          return EMPTY;
+        }
+      }
+
+      // If 'prefer-reduced-motion' is enabled, the 'transition' will be set to 'none'.
+      // In this case we have to call the start function, but can finish immediately by emitting a value
+      // and completing the observable.
+      const {transitionProperty} = window.getComputedStyle(element);
+      if (transitionProperty === 'none') {
+        startFn(element);
+        return of(undefined);
+      }
+
+      // Starting a new transition
+      const transition$ = new Subject<any>();
+      runningTransitions.set(element, transition$);
+
+      const transitionDurationMs = getTransitionDurationMs(element);
+
+      startFn(element);
+
+      // We have to both listen for the 'transitionend' event and have a 'just-in-case' timer,
+      // because 'transitionend' event might not be fired in some browsers, if the transitioning
+      // element becomes invisible (ex. when scrolling, making browser tab inactive, etc.). The timer
+      // guarantees, that we'll release the DOM element and complete 'ngbRunTransition'.
+      const transitionEnd$ = fromEvent(element, 'transitionend').pipe(takeUntil(transition$));
+      const timer$ = timer(transitionDurationMs + transitionTimerDelayMs).pipe(takeUntil(transition$));
+
+      race(timer$, transitionEnd$).subscribe(() => {
+        runningTransitions.delete(element);
+        transition$.next();
+        transition$.complete();
+      });
+
+      return transition$.asObservable();
+    };

--- a/src/util/transition/util.spec.ts
+++ b/src/util/transition/util.spec.ts
@@ -1,0 +1,49 @@
+import {getTransitionDurationMs} from './util';
+
+function fromString(html: string): HTMLElement {
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  const firstChild = div.firstChild as HTMLElement;
+  document.body.appendChild(firstChild);
+  return firstChild;
+}
+
+describe('transition utils', () => {
+
+  describe('getTransitionDurationMs', () => {
+
+    let element: HTMLElement;
+
+    afterEach(() => document.body.removeChild(element));
+
+    it('should return 0 if there is no transition explicitly set', () => {
+      element = fromString(`<div></div>`);
+      expect(getTransitionDurationMs(element)).toBe(0);
+    });
+
+    it('should return correct transition duration from the element (seconds)', () => {
+      element = fromString(`<div style="transition: opacity 0.01s linear"></div>`);
+      expect(getTransitionDurationMs(element)).toBe(10);
+    });
+
+    it('should return correct transition duration from the element (milliseconds)', () => {
+      element = fromString(`<div style="transition: opacity 10ms linear"></div>`);
+      expect(getTransitionDurationMs(element)).toBe(10);
+    });
+
+    it('should return correct transition duration wih delay', () => {
+      element = fromString(`<div style="transition: opacity 0.01s linear 0.02s"></div>`);
+      expect(getTransitionDurationMs(element)).toBe(30);
+    });
+
+    it('should return correct transition duration wih delay (separate declaration)', () => {
+      element = fromString(`<div style="transition-delay: 0.02s; transition-duration: 0.01s"></div>`);
+      expect(getTransitionDurationMs(element)).toBe(30);
+    });
+
+    it('should return the duration of the first one in case of multiple transitions', () => {
+      element = fromString(`<div style="transition: opacity 0.01s, color 0.02s"></div>`);
+      expect(getTransitionDurationMs(element)).toBe(10);
+    });
+  });
+});

--- a/src/util/transition/util.ts
+++ b/src/util/transition/util.ts
@@ -1,0 +1,7 @@
+export function getTransitionDurationMs(element: HTMLElement) {
+  const {transitionDelay, transitionDuration} = window.getComputedStyle(element);
+  const transitionDelaySec = parseFloat(transitionDelay);
+  const transitionDurationSec = parseFloat(transitionDuration);
+
+  return (transitionDelaySec + transitionDurationSec) * 1000;
+}


### PR DESCRIPTION
This is completely based on cherry-picked #2817. It contains extracted alert animations and initial version of the `ngbRunTransition`

What is does on top in 3 separate commits is:
- refactors `ngbRunTransition` leaving only what is necessary for alert
- adds unit tests for `ngbRunTransition` with full coverage
- adds unit tests for alert animations with full coverage

Alert animations API at the moment is:

```html
<ngb-alert #a #ngIf="closed" (close)="closed = true"></ngb-alert>
<button (click)="a.close()">Close</button>
```

Unclear points for me are:
- [ ] Is the public API ok?
- [x] ~~don't like this name → `running: 'continue' | 'restart';`~~
- [x] ~~unsure about the `runningTransitions` API, maybe too much generalisation? Maybe leave the boolean flag in the component itself. Also see next point.~~
- [x] ~~memory leaks with abrupt transition termination (ex. removed DOM before transition finishes)~~

cc @fbasso, @benouat 

P.S. Coverage:

![Screen Shot 2020-05-04 at 11 01 32](https://user-images.githubusercontent.com/8074436/80950709-acdf2d80-8df6-11ea-80ed-c74732f78d4b.png)
