### PR TITLE
demo(modal): improve explanations on entryComponents

### DIFF
--- a/demo/src/app/components/modal/demos/component/modal-component.html
+++ b/demo/src/app/components/modal/demos/component/modal-component.html
@@ -1,4 +1,5 @@
-<p>You can pass an existing component as content of the modal window. In this case remember to add content component
-as an <code>entryComponents</code> section of your <code>NgModule</code>.</p>
+<p>You can pass an existing component as content of the modal window. In this case, if you're still using Angular 8 or older, remember to add the content component
+in the <code>entryComponents</code> section of your <code>NgModule</code>. For Angular 9 or newer, it's not needed anymore.
+</p>
 
 <button class="btn btn-lg btn-outline-primary" (click)="open()">Launch demo modal</button>

--- a/demo/src/app/components/modal/demos/component/modal-component.module.ts
+++ b/demo/src/app/components/modal/demos/component/modal-component.module.ts
@@ -8,7 +8,7 @@ import { NgbdModalComponent, NgbdModalContent } from './modal-component';
   imports: [BrowserModule, NgbModule],
   declarations: [NgbdModalComponent, NgbdModalContent],
   exports: [NgbdModalComponent],
-  bootstrap: [NgbdModalComponent],
-  entryComponents: [NgbdModalContent]
+  bootstrap: [NgbdModalComponent]
+  // entryComponents: [NgbdModalContent] // this line would be needed in Angular 8 or older
 })
 export class NgbdModalComponentModule {}


### PR DESCRIPTION
entryComponents is not needed anymore since Angular 9.

fix #3722

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
