### PR TITLE
Collapse animations

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -6,6 +6,7 @@ const angularTypes = require('@commitlint/config-angular-type-enum').value();
 */
 const scopes = [
   'schematics',
+  'animations',
   ...fs.readdirSync("./src", {withFileTypes: true})
     .filter(d => d.isDirectory())
     .filter(d => !["test", "util"].includes(d.name))

--- a/demo/src/app/components/collapse/demos/basic/collapse-basic.html
+++ b/demo/src/app/components/collapse/demos/basic/collapse-basic.html
@@ -1,10 +1,10 @@
 <p>
-  <button type="button" class="btn btn-outline-primary" (click)="isCollapsed = !isCollapsed"
-          [attr.aria-expanded]="!isCollapsed" aria-controls="collapseExample">
+  <button type="button" class="btn btn-outline-primary" (click)="collapse.toggle()" [attr.aria-expanded]="!isCollapsed"
+    aria-controls="collapseExample">
     Toggle
   </button>
 </p>
-<div id="collapseExample" [ngbCollapse]="isCollapsed">
+<div #collapse="ngbCollapse" [(ngbCollapse)]="isCollapsed">
   <div class="card">
     <div class="card-body">
       You can collapse this card by clicking Toggle

--- a/src/collapse/collapse.spec.ts
+++ b/src/collapse/collapse.spec.ts
@@ -1,9 +1,11 @@
-import {ComponentFixture, TestBed} from '@angular/core/testing';
-import {createGenericTestComponent} from '../test/common';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import {createGenericTestComponent, isBrowserVisible} from '../test/common';
 
 import {Component} from '@angular/core';
 
 import {NgbCollapseModule} from './collapse.module';
+import {NgbConfig} from '../ngb-config';
+import {NgbConfigAnimation} from '../test/ngb-config-animation';
 
 const createTestComponent = (html: string) =>
     createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
@@ -68,6 +70,114 @@ describe('ngb-collapse', () => {
     expect(collapseEl).toHaveCssClass('show');
   });
 });
+
+if (isBrowserVisible('ngb-collapse animations')) {
+  describe('ngb-collapse animations', () => {
+
+    @Component({
+      template: `
+        <button (click)="c.toggle()">Collapse!</button>
+        <div [(ngbCollapse)]="collapsed" #c="ngbCollapse" (ngbCollapseChange)="onCollapse()"></div>
+      `,
+      host: {'[class.ngb-reduce-motion]': 'reduceMotion'}
+    })
+    class TestAnimationComponent {
+      collapsed = false;
+      reduceMotion = true;
+      onCollapse = () => {};
+    }
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        declarations: [TestAnimationComponent],
+        imports: [NgbCollapseModule],
+        providers: [{provide: NgbConfig, useClass: NgbConfigAnimation}]
+      });
+    });
+
+    [true, false].forEach(reduceMotion => {
+
+      it(`should run collapsing transition (force-reduced-motion = ${reduceMotion})`, async(() => {
+           const fixture = TestBed.createComponent(TestAnimationComponent);
+           fixture.componentInstance.reduceMotion = reduceMotion;
+           fixture.detectChanges();
+
+           const buttonEl = fixture.nativeElement.querySelector('button');
+           const content = getCollapsibleContent(fixture.nativeElement);
+
+           const onCollapseSpy = spyOn(fixture.componentInstance, 'onCollapse');
+
+           // First we're going to collapse, then expand
+           onCollapseSpy.and.callFake(() => {
+             if (fixture.componentInstance.collapsed) {
+               expect(content).toHaveClass('collapse');
+               expect(content).not.toHaveClass('show');
+               expect(content).not.toHaveClass('collapsing');
+
+               // Expanding
+               buttonEl.click();
+             } else {
+               expect(content).toHaveClass('collapse');
+               expect(content).toHaveClass('show');
+               expect(content).not.toHaveClass('collapsing');
+             }
+           });
+
+           expect(content).toHaveClass('collapse');
+           expect(content).toHaveClass('show');
+           expect(content).not.toHaveClass('collapsing');
+           expect(fixture.componentInstance.collapsed).toBe(false);
+
+           // Collapsing
+           buttonEl.click();
+           expect(content).not.toHaveClass('collapse');
+           expect(content).not.toHaveClass('show');
+           expect(content).toHaveClass('collapsing');
+         }));
+
+      it(`should run revert collapsing transition (force-reduced-motion = ${reduceMotion})`, async(() => {
+           const fixture = TestBed.createComponent(TestAnimationComponent);
+           fixture.componentInstance.reduceMotion = reduceMotion;
+           fixture.detectChanges();
+
+           const buttonEl = fixture.nativeElement.querySelector('button');
+           const content = getCollapsibleContent(fixture.nativeElement);
+
+           const onCollapseSpy = spyOn(fixture.componentInstance, 'onCollapse');
+
+           onCollapseSpy.and.callFake(() => {
+             expect(fixture.componentInstance.collapsed).toBe(false);
+             expect(content).toHaveClass('collapse');
+             expect(content).toHaveClass('show');
+             expect(content).not.toHaveClass('collapsing');
+           });
+
+           expect(content).toHaveClass('collapse');
+           expect(content).toHaveClass('show');
+           expect(content).not.toHaveClass('collapsing');
+           expect(fixture.componentInstance.collapsed).toBe(false);
+
+           // Collapsing
+           buttonEl.click();
+           expect(content).not.toHaveClass('collapse');
+           expect(content).not.toHaveClass('show');
+           expect(content).toHaveClass('collapsing');
+
+           // Expanding
+           buttonEl.click();
+           if (reduceMotion) {
+             expect(content).toHaveClass('collapse');
+             expect(content).toHaveClass('show');
+             expect(content).not.toHaveClass('collapsing');
+           } else {
+             expect(content).not.toHaveClass('collapse');
+             expect(content).not.toHaveClass('show');
+             expect(content).toHaveClass('collapsing');
+           }
+         }));
+    });
+  });
+}
 
 @Component({selector: 'test-cmp', template: ''})
 class TestComponent {

--- a/src/collapse/collapse.ts
+++ b/src/collapse/collapse.ts
@@ -1,4 +1,7 @@
-import {Directive, Input} from '@angular/core';
+import {Directive, Input, ElementRef, Output, EventEmitter} from '@angular/core';
+import {ngbRunTransition} from '../util/transition/ngbTransition';
+import {ngbCollapsingTransition} from '../util/transition/ngbCollapseTransition';
+import {NgbConfig} from '../ngb-config';
 
 /**
  * A directive to provide a simple way of hiding and showing elements on the page.
@@ -10,7 +13,34 @@ import {Directive, Input} from '@angular/core';
 })
 export class NgbCollapse {
   /**
+   * If `true`, collapse will be animated.
+   *
+   * Animation is triggered only when clicked on triggering element
+   * or via the `.toggle()` function
+   */
+  @Input() animation = false;
+
+  /**
    * If `true`, will collapse the element or show it otherwise.
    */
   @Input('ngbCollapse') collapsed = false;
+
+  @Output() ngbCollapseChange = new EventEmitter<boolean>();
+
+  constructor(private _element: ElementRef, ngbConfig: NgbConfig) { this.animation = ngbConfig.animation; }
+
+  /**
+   * Triggers collapsing programmatically.
+   *
+   * If there is a collapsing transition running already, it will be reversed.
+   * If the animations are turned off this happens synchronously.
+   */
+  toggle(open: boolean = this.collapsed) {
+    this.collapsed = !open;
+    ngbRunTransition(this._element.nativeElement, ngbCollapsingTransition, {
+      animation: this.animation,
+      runningTransition: 'stop',
+      context: {direction: open ? 'show' : 'hide'}
+    }).subscribe(() => this.ngbCollapseChange.next(this.collapsed));
+  }
 }

--- a/src/test/test-styles.css
+++ b/src/test/test-styles.css
@@ -9,7 +9,11 @@
   transition: opacity 0.01s linear !important;
 }
 
-.ngb-reduce-motion .fade {
+.collapsing {
+  transition: height 0.01s ease !important;
+}
+
+.ngb-reduce-motion .fade, .ngb-reduce-motion .collapsing {
   transition: none !important;
 }
 

--- a/src/test/test-styles.css
+++ b/src/test/test-styles.css
@@ -39,3 +39,16 @@
   opacity: 0;
   transition: opacity 1s linear;
 }
+
+.ngb-test-before {
+  opacity: 1;
+}
+
+.ngb-test-during {
+  opacity: 0;
+  transition: opacity 0.01s linear;
+}
+
+.ngb-test-after {
+  opacity: 0;
+}

--- a/src/test/test-styles.css
+++ b/src/test/test-styles.css
@@ -34,3 +34,8 @@
 .ngb-test-fade:not(.ngb-test-show) {
   opacity: 0;
 }
+
+.ngb-test-long-duration {
+  opacity: 0;
+  transition: opacity 1s linear;
+}

--- a/src/util/transition/ngbCollapseTransition.ts
+++ b/src/util/transition/ngbCollapseTransition.ts
@@ -1,0 +1,63 @@
+import {NgbTransitionStartFn} from './ngbTransition';
+import {reflow} from '../util';
+
+export interface NgbCollapseCtx {
+  direction: 'show' | 'hide';
+  maxHeight?: string;
+}
+
+function measureCollapsingElementHeightPx(element: HTMLElement): string {
+  const {classList} = element;
+  const hasShownClass = classList.contains('show');
+  if (!hasShownClass) {
+    classList.add('show');
+  }
+
+  element.style.height = '';
+  const height = element.getBoundingClientRect().height + 'px';
+
+  if (!hasShownClass) {
+    classList.remove('show');
+  }
+
+  return height;
+}
+
+export const ngbCollapsingTransition: NgbTransitionStartFn<NgbCollapseCtx> =
+    (element: HTMLElement, context: NgbCollapseCtx) => {
+      let {direction, maxHeight} = context;
+      const {classList} = element;
+
+      // No maxHeight -> running the transition for the first time
+      if (!maxHeight) {
+        maxHeight = measureCollapsingElementHeightPx(element);
+        context.maxHeight = maxHeight;
+
+        // Fix the height before starting the animation
+        element.style.height = direction !== 'show' ? maxHeight : '0px';
+
+        classList.remove('collapse');
+        classList.remove('collapsing');
+        classList.remove('show');
+
+        reflow(element);
+
+        // Start the animation
+        classList.add('collapsing');
+      }
+
+      // Start or revert the animation
+      element.style.height = direction === 'show' ? maxHeight : '0px';
+
+      return () => {
+        classList.remove('collapsing');
+        classList.add('collapse');
+        if (direction === 'show') {
+          classList.add('show');
+        } else {
+          classList.remove('show');
+        }
+
+        element.style.height = '';
+      };
+    };

--- a/src/util/transition/ngbTransition.spec.ts
+++ b/src/util/transition/ngbTransition.spec.ts
@@ -146,6 +146,27 @@ if (isBrowserVisible('ngbRunTransition')) {
       expect(window.getComputedStyle(element).opacity).toBe('1');
       element.parentElement !.removeChild(element);
     });
+
+    it(`should read duration after the start function was executed`, (done) => {
+      const startFn = ({classList}: HTMLElement) => classList.add('ngb-test-long-duration');
+
+      const nextSpy = createSpy();
+      const errorSpy = createSpy();
+
+      ngbRunTransition(element, startFn, {animation: true, runningTransition: 'continue'})
+          .subscribe(nextSpy, errorSpy, async() => {
+            // if duration is read before the 'startFn' is executed, it will be read as 0
+            expect(component.componentInstance.onTransitionEnd).toHaveBeenCalledTimes(1);
+            expect(nextSpy).toHaveBeenCalledWith(undefined);
+            expect(element.classList.contains('ngb-test-long-duration')).toBe(true);
+            expect(await getComputedStyleAsync(element, 'opacity')).toBe('0');
+            expect(errorSpy).not.toHaveBeenCalled();
+            done();
+          });
+
+      expect(window.getComputedStyle(element).opacity).toBe('1');
+      expect(element.classList.contains('ngb-test-long-duration')).toBe(true);
+    });
   });
 }
 

--- a/src/util/transition/ngbTransition.spec.ts
+++ b/src/util/transition/ngbTransition.spec.ts
@@ -8,11 +8,7 @@ import {isBrowser, isBrowserVisible} from '../../test/common';
  * This is sometimes necessary only for IE when it fails to recalculate styles synchronously
  * after the 'transitionend' event was fired. To remove when not supporting IE anymore.
  */
-function getComputedStyleAsync(element: HTMLElement, style: keyof CSSStyleDeclaration): Promise<string> {
-  const getStyle = () => window.getComputedStyle(element)[style];
-  return isBrowser('ie') ? new Promise<string>(resolve => setTimeout(() => resolve(getStyle()), 16)) :
-                           Promise.resolve(getStyle());
-}
+const waitForIE = () => isBrowser('ie') ? new Promise<void>(resolve => setTimeout(resolve, 100)) : Promise.resolve();
 
 function fadeFn({classList}: HTMLElement) {
   classList.remove('ngb-test-show');
@@ -45,7 +41,8 @@ if (isBrowserVisible('ngbRunTransition')) {
             expect(nextSpy).toHaveBeenCalledWith(undefined);
             expect(element.classList.contains('ngb-test-show')).toBe(false);
             expect(errorSpy).not.toHaveBeenCalled();
-            expect(await getComputedStyleAsync(element, 'opacity')).toBe('0');
+            await waitForIE();
+            expect(getComputedStyle(element).opacity).toBe('0');
             done();
           });
 
@@ -116,7 +113,8 @@ if (isBrowserVisible('ngbRunTransition')) {
             expect(errorSpy1).not.toHaveBeenCalled();
             expect(element.classList.contains('ngb-test-during')).toBe(false);
             expect(element.classList.contains('ngb-test-after')).toBe(true);
-            expect(await getComputedStyleAsync(element, 'opacity')).toBe('0');
+            await waitForIE();
+            expect(getComputedStyle(element).opacity).toBe('0');
             done();
           });
 
@@ -187,7 +185,8 @@ if (isBrowserVisible('ngbRunTransition')) {
             expect(errorSpy2).not.toHaveBeenCalled();
             expect(element.classList.contains('ngb-test-during')).toBe(false);
             expect(element.classList.contains('ngb-test-after')).toBe(true);
-            expect(await getComputedStyleAsync(element, 'opacity')).toBe('0');
+            await waitForIE();
+            expect(getComputedStyle(element).opacity).toBe('0');
             done();
           });
 
@@ -216,7 +215,8 @@ if (isBrowserVisible('ngbRunTransition')) {
 
       ngbRunTransition(element, startFn, {animation: true, runningTransition: 'continue', context: ctx})
           .subscribe(async() => {
-            expect(await getComputedStyleAsync(element, 'opacity')).toBe('0');
+            await waitForIE();
+            expect(getComputedStyle(element).opacity).toBe('0');
             expect(ctx.number).toBe(456);
             done();
           });
@@ -252,7 +252,8 @@ if (isBrowserVisible('ngbRunTransition')) {
       // second transiiton
       ngbRunTransition(element, startFn, {animation: true, runningTransition: 'stop', context: {text: 'two'}})
           .subscribe(async() => {
-            expect(await getComputedStyleAsync(element, 'opacity')).toBe('0');
+            await waitForIE();
+            expect(getComputedStyle(element).opacity).toBe('0');
             expect(contextSpy).toHaveBeenCalledTimes(3);
             expect(contextSpy).toHaveBeenCalledWith({text: 'two', counter: 999});
             done();
@@ -274,7 +275,8 @@ if (isBrowserVisible('ngbRunTransition')) {
             expect(nextSpy).toHaveBeenCalledWith(undefined);
             expect(errorSpy).not.toHaveBeenCalled();
             expect(element.classList.contains('ngb-test-show')).toBe(false);
-            const opacity = await getComputedStyleAsync(element, 'opacity');
+            await waitForIE();
+            const {opacity} = getComputedStyle(element);
             expect(['1', '']).toContain(opacity !);  // <-- detached from DOM, different values in different browsers
             done();
           });
@@ -296,7 +298,8 @@ if (isBrowserVisible('ngbRunTransition')) {
             expect(component.componentInstance.onTransitionEnd).toHaveBeenCalledTimes(1);
             expect(nextSpy).toHaveBeenCalledWith(undefined);
             expect(element.classList.contains('ngb-test-long-duration')).toBe(true);
-            expect(await getComputedStyleAsync(element, 'opacity')).toBe('0');
+            await waitForIE();
+            expect(getComputedStyle(element).opacity).toBe('0');
             expect(errorSpy).not.toHaveBeenCalled();
             done();
           });
@@ -327,7 +330,8 @@ if (isBrowserVisible('ngbRunTransition')) {
             expect(element.classList.contains('ngb-test-before')).toBe(false);
             expect(element.classList.contains('ngb-test-during')).toBe(false);
             expect(element.classList.contains('ngb-test-after')).toBe(true);
-            expect(await getComputedStyleAsync(element, 'opacity')).toBe('0');
+            await waitForIE();
+            expect(getComputedStyle(element).opacity).toBe('0');
             expect(errorSpy).not.toHaveBeenCalled();
             done();
           });

--- a/src/util/transition/ngbTransition.ts
+++ b/src/util/transition/ngbTransition.ts
@@ -44,9 +44,9 @@ export const ngbRunTransition =
       const transition$ = new Subject<any>();
       runningTransitions.set(element, transition$);
 
-      const transitionDurationMs = getTransitionDurationMs(element);
-
       startFn(element);
+
+      const transitionDurationMs = getTransitionDurationMs(element);
 
       // We have to both listen for the 'transitionend' event and have a 'just-in-case' timer,
       // because 'transitionend' event might not be fired in some browsers, if the transitioning

--- a/src/util/transition/ngbTransition.ts
+++ b/src/util/transition/ngbTransition.ts
@@ -3,74 +3,86 @@ import {endWith, takeUntil} from 'rxjs/operators';
 import {getTransitionDurationMs} from './util';
 import {environment} from '../../environment';
 
-export type NgbTransitionStartFn = (element: HTMLElement) => NgbTransitionEndFn | void;
+export type NgbTransitionStartFn<T = any> = (element: HTMLElement, context: T) => NgbTransitionEndFn | void;
 export type NgbTransitionEndFn = () => void;
 
-export interface NgbTransitionOptions {
+export interface NgbTransitionOptions<T> {
   animation: boolean;
   runningTransition: 'continue' | 'stop';
+  context?: T;
+}
+
+export interface NgbTransitionCtx<T> {
+  transition$: Subject<any>;
+  context: T;
 }
 
 const noopFn: NgbTransitionEndFn = () => {};
 
 const {transitionTimerDelayMs} = environment;
-const runningTransitions = new Map<HTMLElement, Subject<any>>();
+const runningTransitions = new Map<HTMLElement, NgbTransitionCtx<any>>();
 
 export const ngbRunTransition =
-    (element: HTMLElement, startFn: NgbTransitionStartFn, options: NgbTransitionOptions): Observable<undefined> => {
+    <T>(element: HTMLElement, startFn: NgbTransitionStartFn<T>, options: NgbTransitionOptions<T>):
+        Observable<undefined> => {
 
-      // If animations are disabled, we have to emit a value and complete the observable
-      if (!options.animation) {
-        return of(undefined);
-      }
+          // If animations are disabled, we have to emit a value and complete the observable
+          if (!options.animation) {
+            return of(undefined);
+          }
 
-      // Checking if there are already running transitions on the given element.
-      const runningTransition$ = runningTransitions.get(element);
-      if (runningTransition$) {
-        switch (options.runningTransition) {
-          // If there is one running and we want for it to 'continue' to run, we have to cancel the new one.
-          // We're not emitting any values, but simply completing the observable (EMPTY).
-          case 'continue':
-            return EMPTY;
-          // If there is one running and we want for it to 'stop', we have to complete the running one.
-          // We're simply completing the running one and not emitting any values.
-          case 'stop':
-            runningTransition$.complete();
+          // Getting initial context from options
+          let context = options.context || <T>{};
+
+          // Checking if there are already running transitions on the given element.
+          const running = runningTransitions.get(element);
+          if (running) {
+            switch (options.runningTransition) {
+              // If there is one running and we want for it to 'continue' to run, we have to cancel the new one.
+              // We're not emitting any values, but simply completing the observable (EMPTY).
+              case 'continue':
+                return EMPTY;
+              // If there is one running and we want for it to 'stop', we have to complete the running one.
+              // We're simply completing the running one and not emitting any values and merging newly provided context
+              // with the one coming from currently running transition.
+              case 'stop':
+                running.transition$.complete();
+                context = Object.assign(running.context, context);
+                runningTransitions.delete(element);
+            }
+          }
+
+          // If 'prefer-reduced-motion' is enabled, the 'transition' will be set to 'none'.
+          // In this case we have to call the start function, but can finish immediately by emitting a value,
+          // completing the observable and executing both start and end functions synchronously.
+          const {transitionProperty} = window.getComputedStyle(element);
+          if (transitionProperty === 'none') {
+            (startFn(element, context) || noopFn)();
+            return of(undefined);
+          }
+
+          // Starting a new transition
+          const transition$ = new Subject<any>();
+          const stop$ = transition$.pipe(endWith(true));
+          runningTransitions.set(element, {transition$, context});
+
+          const endFn = startFn(element, context) || noopFn;
+
+          const transitionDurationMs = getTransitionDurationMs(element);
+
+          // We have to both listen for the 'transitionend' event and have a 'just-in-case' timer,
+          // because 'transitionend' event might not be fired in some browsers, if the transitioning
+          // element becomes invisible (ex. when scrolling, making browser tab inactive, etc.). The timer
+          // guarantees, that we'll release the DOM element and complete 'ngbRunTransition'.
+          const transitionEnd$ = fromEvent(element, 'transitionend').pipe(takeUntil(stop$));
+          const timer$ = timer(transitionDurationMs + transitionTimerDelayMs).pipe(takeUntil(stop$));
+
+          race(timer$, transitionEnd$).pipe(takeUntil(stop$)).subscribe(() => {
             runningTransitions.delete(element);
-        }
-      }
+            endFn();
+            transition$.next();
+            transition$.complete();
+          });
 
-      // If 'prefer-reduced-motion' is enabled, the 'transition' will be set to 'none'.
-      // In this case we have to call the start function, but can finish immediately by emitting a value,
-      // completing the observable and executing both start and end functions synchronously.
-      const {transitionProperty} = window.getComputedStyle(element);
-      if (transitionProperty === 'none') {
-        (startFn(element) || noopFn)();
-        return of(undefined);
-      }
-
-      // Starting a new transition
-      const transition$ = new Subject<any>();
-      const stop$ = transition$.pipe(endWith(true));
-      runningTransitions.set(element, transition$);
-
-      const endFn = startFn(element) || noopFn;
-
-      const transitionDurationMs = getTransitionDurationMs(element);
-
-      // We have to both listen for the 'transitionend' event and have a 'just-in-case' timer,
-      // because 'transitionend' event might not be fired in some browsers, if the transitioning
-      // element becomes invisible (ex. when scrolling, making browser tab inactive, etc.). The timer
-      // guarantees, that we'll release the DOM element and complete 'ngbRunTransition'.
-      const transitionEnd$ = fromEvent(element, 'transitionend').pipe(takeUntil(stop$));
-      const timer$ = timer(transitionDurationMs + transitionTimerDelayMs).pipe(takeUntil(stop$));
-
-      race(timer$, transitionEnd$).pipe(takeUntil(stop$)).subscribe(() => {
-        runningTransitions.delete(element);
-        endFn();
-        transition$.next();
-        transition$.complete();
-      });
-
-      return transition$.asObservable();
-    };
+          return transition$.asObservable();
+        };

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -67,9 +67,13 @@ if (typeof Element !== 'undefined' && !Element.prototype.closest) {
 }
 
 export function closest(element: HTMLElement, selector): HTMLElement | null {
-  if (!selector) {
-    return null;
-  }
+  return selector ? element.closest(selector) : null;
+}
 
-  return element.closest(selector);
+/**
+ * Force a browser reflow
+ * @param element element where to apply the reflow
+ */
+export function reflow(element: HTMLElement) {
+  return (element || document.body).offsetHeight;
 }


### PR DESCRIPTION
Again the collapsing implementation is cherry-picked and is based on #2817.

This contains several commits (**please review in the historical order with whitespaces/lines diff turned off for simplicity**):
- a bugfix for duration calculation
- add `endFn()` along with `startFn()` for transition
- support transition reverting with `runningTransition: stop`
- introduction of transition context to store parameters and data
- finally cherry-picked collapsed implementation and tests

Changes to the original PR are:
- end function has no arguments and simply using a closure (see these tests to get the idea of how it works → https://github.com/ng-bootstrap/ng-bootstrap/pull/3727/commits/5a8bebd0d3f2244b17da51f0fcd3b32a4d6b0723#diff-ec1addfdfcf53282cbf22a4f924fad6bR206-R264)
- using a transaction context for both data and initial arguments (so no need in storing things in DOM, because we already have the element-releated context)

cc @benouat @fbasso 