### PR TITLE
demo(table): avoid re-creation of array at each change detection

### DIFF
--- a/demo/src/app/components/table/demos/pagination/table-pagination.html
+++ b/demo/src/app/components/table/demos/pagination/table-pagination.html
@@ -23,10 +23,10 @@
 </table>
 
 <div class="d-flex justify-content-between p-2">
-  <ngb-pagination [collectionSize]="collectionSize" [(page)]="page" [pageSize]="pageSize">
+  <ngb-pagination [collectionSize]="collectionSize" [(page)]="page" [pageSize]="pageSize" (pageChange)="refreshCountries()">
   </ngb-pagination>
 
-  <select class="custom-select" style="width: auto" [(ngModel)]="pageSize">
+  <select class="custom-select" style="width: auto" [(ngModel)]="pageSize" (ngModelChange)="refreshCountries()">
     <option [ngValue]="2">2 items per page</option>
     <option [ngValue]="4">4 items per page</option>
     <option [ngValue]="6">6 items per page</option>

--- a/demo/src/app/components/table/demos/pagination/table-pagination.ts
+++ b/demo/src/app/components/table/demos/pagination/table-pagination.ts
@@ -98,9 +98,14 @@ export class NgbdTablePagination {
   page = 1;
   pageSize = 4;
   collectionSize = COUNTRIES.length;
+  countries: Country[];
 
-  get countries(): Country[] {
-    return COUNTRIES
+  constructor() {
+    this.refreshCountries();
+  }
+
+  refreshCountries() {
+    this.countries = COUNTRIES
       .map((country, i) => ({id: i + 1, ...country}))
       .slice((this.page - 1) * this.pageSize, (this.page - 1) * this.pageSize + this.pageSize);
   }


### PR DESCRIPTION
The pagination example re-created the array of countries to display at each change detection, which is not only a performance problem, but also causes problems if popovers or tooltips are used inside the table for example.

fix #3675

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
