### PR TITLE
Modal animations

### DIFF
--- a/e2e-app/src/app/app.component.ts
+++ b/e2e-app/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import {Component} from '@angular/core';
+import {NgbConfig} from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
   selector: 'app-root',
@@ -13,4 +14,5 @@ import {Component} from '@angular/core';
   `
 })
 export class AppComponent {
+  constructor(ngbConfig: NgbConfig) { ngbConfig.animation = false; }
 }

--- a/src/modal/modal-backdrop.spec.ts
+++ b/src/modal/modal-backdrop.spec.ts
@@ -11,5 +11,16 @@ describe('ngb-modal-backdrop', () => {
 
     fixture.detectChanges();
     expect(fixture.nativeElement).toHaveCssClass('modal-backdrop');
+    expect(fixture.nativeElement).toHaveCssClass('show');
+    expect(fixture.nativeElement).not.toHaveCssClass('fade');
+  });
+
+  it('should render correct CSS classes for animations', () => {
+    const fixture = TestBed.createComponent(NgbModalBackdrop);
+    fixture.componentInstance.animation = true;
+
+    fixture.detectChanges();
+    expect(fixture.nativeElement).toHaveCssClass('show');
+    expect(fixture.nativeElement).toHaveCssClass('fade');
   });
 });

--- a/src/modal/modal-backdrop.ts
+++ b/src/modal/modal-backdrop.ts
@@ -1,12 +1,38 @@
-import {Component, Input, ViewEncapsulation} from '@angular/core';
+import {Component, ElementRef, Input, NgZone, OnInit, ViewEncapsulation} from '@angular/core';
+
+import {Observable} from 'rxjs';
+import {take} from 'rxjs/operators';
+
+import {ngbRunTransition} from '../util/transition/ngbTransition';
 
 @Component({
   selector: 'ngb-modal-backdrop',
   encapsulation: ViewEncapsulation.None,
   template: '',
-  host:
-      {'[class]': '"modal-backdrop fade show" + (backdropClass ? " " + backdropClass : "")', 'style': 'z-index: 1050'}
+  host: {
+    '[class]': '"modal-backdrop" + (backdropClass ? " " + backdropClass : "")',
+    '[class.show]': '!animation',
+    '[class.fade]': 'animation',
+    'style': 'z-index: 1050'
+  }
 })
-export class NgbModalBackdrop {
+export class NgbModalBackdrop implements OnInit {
+  @Input() animation: boolean;
   @Input() backdropClass: string;
+
+  constructor(private _el: ElementRef<HTMLElement>, private _zone: NgZone) {}
+
+  ngOnInit() {
+    this._zone.onStable.asObservable().pipe(take(1)).subscribe(() => {
+      ngbRunTransition(
+          this._el.nativeElement, ({classList}) => classList.add('show'),
+          {animation: this.animation, runningTransition: 'continue'});
+    });
+  }
+
+  hide(): Observable<void> {
+    return ngbRunTransition(
+        this._el.nativeElement, ({classList}) => classList.remove('show'),
+        {animation: this.animation, runningTransition: 'stop'});
+  }
 }

--- a/src/modal/modal-config.spec.ts
+++ b/src/modal/modal-config.spec.ts
@@ -1,11 +1,15 @@
 import {inject} from '@angular/core/testing';
 
 import {NgbModalConfig} from './modal-config';
+import {NgbConfig} from '../ngb-config';
 
 describe('NgbModalConfig', () => {
 
-  it('should have sensible default values', inject([NgbModalConfig], (config: NgbModalConfig) => {
+  it('should have sensible default values',
+     inject([NgbModalConfig, NgbConfig], (config: NgbModalConfig, ngbConfig: NgbConfig) => {
 
+       expect(config.animation).toBe(ngbConfig.animation);
+       expect(config.ariaLabelledBy).toBeUndefined();
        expect(config.ariaLabelledBy).toBeUndefined();
        expect(config.ariaDescribedBy).toBeUndefined();
        expect(config.backdrop).toBe(true);

--- a/src/modal/modal-config.ts
+++ b/src/modal/modal-config.ts
@@ -1,9 +1,15 @@
 import {Injectable, Injector} from '@angular/core';
+import {NgbConfig} from '../ngb-config';
 
 /**
  * Options available when opening new modal windows with `NgbModal.open()` method.
  */
 export interface NgbModalOptions {
+  /**
+   * If `true`, modal opening and closing will be animated.
+   */
+  animation?: boolean;
+
   /**
    * `aria-labelledby` attribute value to set on the modal window.
    *
@@ -17,7 +23,6 @@ export interface NgbModalOptions {
    * @since 6.1.0
    */
   ariaDescribedBy?: string;
-
 
   /**
    * If `true`, the backdrop element will be created for a given modal.
@@ -104,6 +109,7 @@ export interface NgbModalOptions {
 */
 @Injectable({providedIn: 'root'})
 export class NgbModalConfig implements Required<NgbModalOptions> {
+  animation: boolean;
   ariaLabelledBy: string;
   ariaDescribedBy: string;
   backdrop: boolean | 'static' = true;
@@ -116,4 +122,6 @@ export class NgbModalConfig implements Required<NgbModalOptions> {
   size: 'sm' | 'lg' | 'xl' | string;
   windowClass: string;
   backdropClass: string;
+
+  constructor(ngbConfig: NgbConfig) { this.animation = ngbConfig.animation; }
 }

--- a/src/modal/modal-stack.ts
+++ b/src/modal/modal-stack.ts
@@ -25,10 +25,12 @@ import {NgbModalWindow} from './modal-window';
 export class NgbModalStack {
   private _activeWindowCmptHasChanged = new Subject();
   private _ariaHiddenValues: Map<Element, string | null> = new Map();
-  private _backdropAttributes = ['backdropClass'];
+  private _backdropAttributes = ['animation', 'backdropClass'];
   private _modalRefs: NgbModalRef[] = [];
-  private _windowAttributes =
-      ['ariaLabelledBy', 'ariaDescribedBy', 'backdrop', 'centered', 'keyboard', 'scrollable', 'size', 'windowClass'];
+  private _windowAttributes = [
+    'animation', 'ariaLabelledBy', 'ariaDescribedBy', 'backdrop', 'centered', 'keyboard', 'scrollable', 'size',
+    'windowClass'
+  ];
   private _windowCmpts: ComponentRef<NgbModalWindow>[] = [];
 
   constructor(

--- a/src/modal/modal-window.ts
+++ b/src/modal/modal-window.ts
@@ -13,17 +13,20 @@ import {
   ViewChild,
   ViewEncapsulation
 } from '@angular/core';
-import {fromEvent, Subject} from 'rxjs';
+
+import {fromEvent, Observable, Subject, zip} from 'rxjs';
 import {filter, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 
 import {getFocusableBoundaryElements} from '../util/focus-trap';
 import {Key} from '../util/key';
 import {ModalDismissReasons} from './modal-dismiss-reasons';
+import {ngbRunTransition, NgbTransitionOptions} from '../util/transition/ngbTransition';
 
 @Component({
   selector: 'ngb-modal-window',
   host: {
-    '[class]': '"modal fade show d-block" + (windowClass ? " " + windowClass : "")',
+    '[class]': '"modal d-block" + (windowClass ? " " + windowClass : "")',
+    '[class.fade]': 'animation',
     'role': 'dialog',
     'tabindex': '-1',
     '[attr.aria-modal]': 'true',
@@ -46,6 +49,7 @@ export class NgbModalWindow implements OnInit,
 
   @ViewChild('dialog', {static: true}) private _dialogEl: ElementRef<HTMLElement>;
 
+  @Input() animation: boolean;
   @Input() ariaLabelledBy: string;
   @Input() ariaDescribedBy: string;
   @Input() backdrop: boolean | string = true;
@@ -57,6 +61,9 @@ export class NgbModalWindow implements OnInit,
 
   @Output('dismiss') dismissEvent = new EventEmitter();
 
+  shown = new Subject<void>();
+  hidden = new Subject<void>();
+
   constructor(
       @Inject(DOCUMENT) private _document: any, private _elRef: ElementRef<HTMLElement>, private _zone: NgZone) {}
 
@@ -64,10 +71,48 @@ export class NgbModalWindow implements OnInit,
 
   ngOnInit() { this._elWithFocus = this._document.activeElement; }
 
-  ngAfterViewInit() {
+  ngAfterViewInit() { this._show(); }
+
+  ngOnDestroy() { this._disableEventHandling(); }
+
+  hide(): Observable<any> {
+    const {nativeElement} = this._elRef;
+    const context: NgbTransitionOptions<any> = {animation: this.animation, runningTransition: 'stop'};
+
+    const windowTransition$ = ngbRunTransition(nativeElement, () => nativeElement.classList.remove('show'), context);
+    const dialogTransition$ = ngbRunTransition(this._dialogEl.nativeElement, () => {}, context);
+
+    const transitions$ = zip(windowTransition$, dialogTransition$);
+    transitions$.subscribe(() => {
+      this.hidden.next();
+      this.hidden.complete();
+    });
+
+    this._disableEventHandling();
+    this._restoreFocus();
+
+    return transitions$;
+  }
+
+  private _show() {
+    const {nativeElement} = this._elRef;
+    const context: NgbTransitionOptions<any> = {animation: this.animation, runningTransition: 'continue'};
+
+    const windowTransition$ = ngbRunTransition(nativeElement, () => nativeElement.classList.add('show'), context);
+    const dialogTransition$ = ngbRunTransition(this._dialogEl.nativeElement, () => {}, context);
+
+    zip(windowTransition$, dialogTransition$).subscribe(() => {
+      this.shown.next();
+      this.shown.complete();
+    });
+
+    this._enableEventHandling();
+    this._setFocus();
+  }
+
+  private _enableEventHandling() {
     const {nativeElement} = this._elRef;
     this._zone.runOutsideAngular(() => {
-
       fromEvent<KeyboardEvent>(nativeElement, 'keydown')
           .pipe(
               takeUntil(this._closed$),
@@ -100,7 +145,12 @@ export class NgbModalWindow implements OnInit,
         preventClose = false;
       });
     });
+  }
 
+  private _disableEventHandling() { this._closed$.next(); }
+
+  private _setFocus() {
+    const {nativeElement} = this._elRef;
     if (!nativeElement.contains(document.activeElement)) {
       const autoFocusable = nativeElement.querySelector(`[ngbAutofocus]`) as HTMLElement;
       const firstFocusable = getFocusableBoundaryElements(nativeElement)[0];
@@ -110,7 +160,7 @@ export class NgbModalWindow implements OnInit,
     }
   }
 
-  ngOnDestroy() {
+  private _restoreFocus() {
     const body = this._document.body;
     const elWithFocus = this._elWithFocus;
 
@@ -124,7 +174,5 @@ export class NgbModalWindow implements OnInit,
       setTimeout(() => elementToFocus.focus());
       this._elWithFocus = null;
     });
-
-    this._closed$.next();
   }
 }

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -3,6 +3,10 @@ import {Component, Injectable, Injector, NgModule, OnDestroy, ViewChild} from '@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {NgbModalConfig} from './modal-config';
 import {NgbActiveModal, NgbModal, NgbModalModule, NgbModalRef} from './modal.module';
+import {isBrowser, isBrowserVisible} from '../test/common';
+import {NgbConfig} from '..';
+import {NgbConfigAnimation} from '../test/ngb-config-animation';
+import createSpy = jasmine.createSpy;
 
 const NOOP = () => {};
 
@@ -103,6 +107,10 @@ describe('ngb-modal', () => {
         const modalInstance = fixture.componentInstance.open('foo');
         fixture.detectChanges();
         expect(fixture.nativeElement).toHaveModal('foo');
+
+        const modalEl = document.querySelector('ngb-modal-window') as HTMLElement;
+        expect(modalEl).not.toHaveClass('fade');
+        expect(modalEl).toHaveClass('show');
 
         modalInstance.close('some result');
         fixture.detectChanges();
@@ -207,6 +215,32 @@ describe('ngb-modal', () => {
         expect(fixture.nativeElement).not.toHaveModal();
       });
 
+      it(`should emit 'closed' on close`, () => {
+        const closedSpy = createSpy();
+        fixture.componentInstance.openTplClose().closed.subscribe(closedSpy);
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveModal();
+
+        (<HTMLElement>document.querySelector('button#close')).click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveModal();
+
+        expect(closedSpy).toHaveBeenCalledWith('myResult');
+      });
+
+      it(`should emit 'dismissed' on dismissal`, () => {
+        const dismissSpy = createSpy();
+        fixture.componentInstance.openTplDismiss().dismissed.subscribe(dismissSpy);
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveModal();
+
+        (<HTMLElement>document.querySelector('button#dismiss')).click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveModal();
+
+        expect(dismissSpy).toHaveBeenCalledWith('myReason');
+      });
+
       it('should resolve result promise on close', () => {
         let resolvedResult;
         fixture.componentInstance.openTplClose().result.then((result) => resolvedResult = result);
@@ -231,6 +265,22 @@ describe('ngb-modal', () => {
         expect(fixture.nativeElement).not.toHaveModal();
 
         fixture.whenStable().then(() => { expect(rejectReason).toBe('myReason'); });
+      });
+
+      it(`should emit 'shown' and 'hidden' events`, () => {
+        const shownSpy = createSpy();
+        const hiddenSpy = createSpy();
+        const modalRef = fixture.componentInstance.openTplClose();
+        modalRef.shown.subscribe(shownSpy);
+        modalRef.hidden.subscribe(hiddenSpy);
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveModal();
+        expect(shownSpy).toHaveBeenCalledWith(undefined);
+
+        (<HTMLElement>document.querySelector('button#close')).click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveModal();
+        expect(hiddenSpy).toHaveBeenCalledWith(undefined);
       });
 
       it('should add / remove "modal-open" class to body when modal is open', async(() => {
@@ -839,6 +889,73 @@ describe('ngb-modal', () => {
       fixture.detectChanges();
     });
   });
+
+  if (isBrowserVisible('ngb-modal animations')) {
+    describe('ngb-modal animations', () => {
+
+      @Component({
+        template: `
+          <ng-template #content let-close="close" let-dismiss="dismiss">
+            <button class="btn btn-primary" id="close" (click)="close('myResult')">Close me</button>
+          </ng-template>
+        `
+      })
+      class TestAnimationComponent {
+        @ViewChild('content', {static: true}) content;
+
+        constructor(private modalService: NgbModal) {}
+
+        open() { return this.modalService.open(this.content); }
+      }
+
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          declarations: [TestAnimationComponent],
+          imports: [NgbModalModule],
+          providers: [{provide: NgbConfig, useClass: NgbConfigAnimation}]
+        });
+      });
+
+      afterEach(() => document.body.classList.remove('ngb-reduce-motion'));
+
+      [true, false].forEach(reduceMotion => {
+
+        it(`should run fade transition when opening/closing modal (force-reduced-motion = ${reduceMotion})`, (done) => {
+          if (reduceMotion) {
+            document.body.classList.add('ngb-reduce-motion');
+          }
+          const component = TestBed.createComponent(TestAnimationComponent);
+          component.detectChanges();
+
+          const modalRef = component.componentInstance.open();
+          let modalEl: HTMLElement | null = null;
+
+          modalRef.shown.subscribe(() => {
+            modalEl = document.querySelector('ngb-modal-window') as HTMLElement;
+            const closeButton = document.querySelector('button#close') as HTMLButtonElement;
+
+            expect(window.getComputedStyle(modalEl).opacity).toBe('1');
+            expect(modalEl).toHaveClass('fade');
+            expect(modalEl).toHaveClass('show');
+            closeButton.click();
+          });
+
+          modalRef.hidden.subscribe(() => {
+            modalEl = document.querySelector('ngb-modal-window');
+            expect(modalEl).toBeNull();
+            done();
+          });
+
+          component.detectChanges();
+          modalEl = document.querySelector('ngb-modal-window');
+          // if reducedMotion is true, modal would be opened and closed already at this point
+          if (modalEl && !isBrowser('ie')) {
+            expect(window.getComputedStyle(modalEl).opacity).toBe('0');
+          }
+        });
+      });
+    });
+  }
 });
 
 

--- a/src/test/test-styles.css
+++ b/src/test/test-styles.css
@@ -13,7 +13,13 @@
   transition: height 0.01s ease !important;
 }
 
-.ngb-reduce-motion .fade, .ngb-reduce-motion .collapsing {
+.modal.fade .modal-dialog {
+  transition: -webkit-transform 0.01s ease-out !important;
+  transition: transform 0.01s ease-out !important;
+  transition: transform 0.01s ease-out,-webkit-transform 0.01s ease-out !important;
+}
+
+.ngb-reduce-motion .fade, .ngb-reduce-motion .collapsing, .ngb-reduce-motion .modal.fade .modal-dialog {
   transition: none !important;
 }
 

--- a/src/test/test-styles.css
+++ b/src/test/test-styles.css
@@ -56,3 +56,13 @@
 .ngb-test-after {
   opacity: 0;
 }
+
+.ngb-test-hide-outer {
+  opacity: 0 !important;
+  transition: opacity 0.1s linear;
+}
+
+.ngb-test-hide-inner {
+  opacity: 0 !important;
+  transition: opacity 0.01s linear;
+}


### PR DESCRIPTION
Again this is inspired by #2817, not cherry-picked though, because there were several issues with the implementation.

This PR has 3 commits:
- fix for nested `transitionend` events in `ngbRunTransition` with tests
- disabling of animations for e2e tests
- modal animations implementation

### Modal animations

Key implementation points are:
- fade in animation starts on `modal.open()` and is reversible.
- fade out animation starts when modal is closed/dismissed and is not reversible.
- modal is focused at the same time as fade in animation starts
- focus is restored and all modal key/mouse event handling is disabled as soon as fade out animation starts
- had to refactor `modal-window.ts` quite a lot... :/
- a new API to notify when animation is finished

```ts
const modalRef = modal.open(content);

modalRef.opened.subscribe(() => { ... });
modalRef.closed.subscribe(() => { ... });
```

![Screen Shot 2020-05-27 at 23 23 19](https://user-images.githubusercontent.com/8074436/83073765-448c1080-a071-11ea-8b49-79dfd4c88f26.png)
