### PR TITLE
Toast animations

### DIFF
--- a/demo/src/app/components/toast/demos/closeable/toast-closeable.html
+++ b/demo/src/app/components/toast/demos/closeable/toast-closeable.html
@@ -1,5 +1,4 @@
-<ngb-toast *ngIf="show" header="Click my close icon →" [autohide]="false"
-  (hide)="close()">
+<ngb-toast *ngIf="show" header="Click my close icon →" [autohide]="false" (hidden)="close()">
   If you close me, I will automatically re-appear after a few seconds.
 </ngb-toast>
 <p *ngIf="!show">I'll be back!</p>

--- a/demo/src/app/components/toast/demos/closeable/toast-closeable.ts
+++ b/demo/src/app/components/toast/demos/closeable/toast-closeable.ts
@@ -7,6 +7,6 @@ export class NgbdToastCloseable {
 
   close() {
     this.show = false;
-    setTimeout(() => this.show = true, 5000);
+    setTimeout(() => this.show = true, 3000);
   }
 }

--- a/demo/src/app/components/toast/demos/custom-header/toast-custom-header.html
+++ b/demo/src/app/components/toast/demos/custom-header/toast-custom-header.html
@@ -1,8 +1,10 @@
-<ngb-toast>
+<ngb-toast *ngIf="show" [autohide]="false" (hidden)="show=false">
   <ng-template ngbToastHeader>
-    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"><path d="M16.896 10l-4.896-8-4.896 8-7.104-4 3 11v5h18v-5l3-11-7.104 4zm-11.896 10v-2h14v2h-14zm14.2-4h-14.4l-1.612-5.909 4.615 2.598 4.197-6.857 4.197 6.857 4.615-2.598-1.612 5.909z"/></svg>
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24">
+      <path
+        d="M16.896 10l-4.896-8-4.896 8-7.104-4 3 11v5h18v-5l3-11-7.104 4zm-11.896 10v-2h14v2h-14zm14.2-4h-14.4l-1.612-5.909 4.615 2.598 4.197-6.857 4.197 6.857 4.615-2.598-1.612 5.909z" />
+    </svg>
     <strong class="mx-1">Fancy</strong>header here
   </ng-template>
   Hello, I am toast. Have you noticed my header has been generated from a Template?
 </ngb-toast>
-<ngb-alert type="secondary" [dismissible]="false">Clicking on the close icon won't do anything in this example.</ngb-alert>

--- a/demo/src/app/components/toast/demos/custom-header/toast-custom-header.ts
+++ b/demo/src/app/components/toast/demos/custom-header/toast-custom-header.ts
@@ -1,4 +1,6 @@
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
-@Component({ selector: 'ngbd-toast-customheader', templateUrl: './toast-custom-header.html' })
-export class NgbdToastCustomHeader {}
+@Component({selector: 'ngbd-toast-customheader', templateUrl: './toast-custom-header.html'})
+export class NgbdToastCustomHeader {
+  show = true;
+}

--- a/demo/src/app/components/toast/demos/howto-global/toasts-container.component.ts
+++ b/demo/src/app/components/toast/demos/howto-global/toasts-container.component.ts
@@ -11,7 +11,7 @@ import {ToastService} from './toast-service';
       [class]="toast.classname"
       [autohide]="true"
       [delay]="toast.delay || 5000"
-      (hide)="toastService.remove(toast)"
+      (hidden)="toastService.remove(toast)"
     >
       <ng-template [ngIf]="isTemplate(toast)" [ngIfElse]="text">
         <ng-template [ngTemplateOutlet]="toast.textOrTpl"></ng-template>

--- a/demo/src/app/components/toast/demos/inline/toast-inline.html
+++ b/demo/src/app/components/toast/demos/inline/toast-inline.html
@@ -1,10 +1,9 @@
 <h6>Body only</h6>
-<ngb-toast>
+<ngb-toast [autohide]="false">
   I am a simple static toast.
 </ngb-toast>
 
 <h6>With a text header</h6>
-<ngb-toast header="Hello" [autohide]="false">
+<ngb-toast *ngIf="show" header="Hello" [autohide]="false" (hidden)="show=false">
   I am a simple static toast with a header.
 </ngb-toast>
-<ngb-alert type="secondary" [dismissible]="false">Clicking on the close icon won't do anything in this example.</ngb-alert>

--- a/demo/src/app/components/toast/demos/inline/toast-inline.ts
+++ b/demo/src/app/components/toast/demos/inline/toast-inline.ts
@@ -1,4 +1,6 @@
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
-@Component({ selector: 'ngbd-toast-inline', templateUrl: './toast-inline.html' })
-export class NgbdToastInline {}
+@Component({selector: 'ngbd-toast-inline', templateUrl: './toast-inline.html'})
+export class NgbdToastInline {
+  show = true;
+}

--- a/src/alert/alert.spec.ts
+++ b/src/alert/alert.spec.ts
@@ -109,7 +109,7 @@ describe('ngb-alert', () => {
 
     expect(fixture.componentInstance.closed).toBe(false);
     buttonEl.click();
-    expect(alertEl).toHaveCssClass('show');
+    expect(alertEl).not.toHaveCssClass('show');
     expect(alertEl).toHaveCssClass('fade');
     expect(fixture.componentInstance.closed).toBe(true);
   });
@@ -127,7 +127,7 @@ describe('ngb-alert', () => {
 
     expect(fixture.componentInstance.closed).toBe(true);
     expect(closedSpy).toHaveBeenCalledTimes(1);
-    expect(alertEl).toHaveCssClass('show');
+    expect(alertEl).not.toHaveCssClass('show');
     expect(alertEl).toHaveCssClass('fade');
   });
 

--- a/src/toast/toast-config.spec.ts
+++ b/src/toast/toast-config.spec.ts
@@ -1,8 +1,9 @@
 import {NgbToastConfig} from './toast-config';
+import {NgbConfig} from '../ngb-config';
 
 describe('NgbToastConfig', () => {
   it('should have sensible default values', () => {
-    const config = new NgbToastConfig();
+    const config = new NgbToastConfig(new NgbConfig());
 
     expect(config.delay).toBe(500);
     expect(config.autohide).toBe(true);

--- a/src/toast/toast-config.ts
+++ b/src/toast/toast-config.ts
@@ -1,4 +1,5 @@
 import {Injectable} from '@angular/core';
+import {NgbConfig} from '../ngb-config';
 
 /**
  * Interface used to type all toast config options. See `NgbToastConfig`.
@@ -36,7 +37,10 @@ export interface NgbToastOptions {
  */
 @Injectable({providedIn: 'root'})
 export class NgbToastConfig implements NgbToastOptions {
+  animation: boolean;
   autohide = true;
   delay = 500;
   ariaLive: 'polite' | 'alert' = 'polite';
+
+  constructor(ngbConfig: NgbConfig) { this.animation = ngbConfig.animation; }
 }

--- a/src/toast/toast.scss
+++ b/src/toast/toast.scss
@@ -7,6 +7,8 @@
 }
 
 ngb-toast {
+  display: block;
+
   .toast-header .close {
     margin-left: auto;
     margin-bottom: 0.25rem;

--- a/src/toast/toast.spec.ts
+++ b/src/toast/toast.spec.ts
@@ -1,21 +1,21 @@
 import {Component} from '@angular/core';
-import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 
-import {createGenericTestComponent} from '../test/common';
+import {createGenericTestComponent, isBrowserVisible} from '../test/common';
 import {NgbToastModule} from './toast.module';
+
+import {NgbConfig} from '../ngb-config';
+import {NgbConfigAnimation} from '../test/ngb-config-animation';
 
 const createTestComponent = (html: string) =>
     createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
 
-const getElementWithSelector = (fixture: ComponentFixture<TestComponent>, className) =>
-    fixture.nativeElement.querySelector(className);
+const getElementWithSelector = (element: HTMLElement, className) => element.querySelector(className);
 
-const getToastElement = (fixture: ComponentFixture<TestComponent>): Element =>
-    getElementWithSelector(fixture, 'ngb-toast');
-const getToastHeaderElement = (fixture: ComponentFixture<TestComponent>): Element =>
-    getElementWithSelector(fixture, 'ngb-toast .toast-header');
-const getToastBodyElement = (fixture: ComponentFixture<TestComponent>): Element =>
-    getElementWithSelector(fixture, 'ngb-toast .toast-body');
+const getToastElement = (element: HTMLElement): Element => getElementWithSelector(element, 'ngb-toast');
+const getToastHeaderElement = (element: HTMLElement): Element =>
+    getElementWithSelector(element, 'ngb-toast .toast-header');
+const getToastBodyElement = (element: HTMLElement): Element => getElementWithSelector(element, 'ngb-toast .toast-body');
 
 describe('ngb-toast', () => {
 
@@ -30,12 +30,13 @@ describe('ngb-toast', () => {
     it('should have default classnames', () => {
       const fixture = createTestComponent(`<ngb-toast header="header">body</ngb-toast>`);
       // Below getter are using Bootstrap classnames
-      const toast = getToastElement(fixture);
-      const header = getToastHeaderElement(fixture);
-      const body = getToastBodyElement(fixture);
+      const toast = getToastElement(fixture.nativeElement);
+      const header = getToastHeaderElement(fixture.nativeElement);
+      const body = getToastBodyElement(fixture.nativeElement);
 
       expect(toast).toBeDefined();
       expect(toast).toHaveCssClass('toast');
+      expect(toast).not.toHaveCssClass('fade');
       expect(toast).toHaveCssClass('show');
       expect(header).toBeDefined();
       expect(body).toBeDefined();
@@ -43,13 +44,13 @@ describe('ngb-toast', () => {
 
     it('should not generate a header element when header input is not specified', () => {
       const fixture = createTestComponent(`<ngb-toast>body</ngb-toast>`);
-      const toastHeader = getToastHeaderElement(fixture);
+      const toastHeader = getToastHeaderElement(fixture.nativeElement);
       expect(toastHeader).toBeNull();
     });
 
     it('should contain a close button when header is specified', () => {
       const fixture = createTestComponent(`<ngb-toast header="header">body</ngb-toast>`);
-      const toastHeader = getToastHeaderElement(fixture);
+      const toastHeader = getToastHeaderElement(fixture.nativeElement);
       expect(toastHeader.querySelector('button.close')).toBeDefined();
     });
 
@@ -58,15 +59,15 @@ describe('ngb-toast', () => {
         <ng-template ngbToastHeader>{{header}}</ng-template>
         body
       </ngb-toast>`);
-      const toastHeader = getToastHeaderElement(fixture);
+      const toastHeader = getToastHeaderElement(fixture.nativeElement);
       expect(toastHeader.querySelector('button.close')).toBeDefined();
     });
 
     it('should emit hide output when close is clicked', () => {
       const fixture =
-          createTestComponent(`<ngb-toast header="header" [autohide]="false" (hide)="hide()">body</ngb-toast>`);
+          createTestComponent(`<ngb-toast header="header" [autohide]="false" (hidden)="hide()">body</ngb-toast>`);
 
-      const toast = getToastElement(fixture);
+      const toast = getToastElement(fixture.nativeElement);
       const closeButton = toast.querySelector('button.close') as HTMLElement;
       closeButton.click();
       fixture.detectChanges();
@@ -74,7 +75,7 @@ describe('ngb-toast', () => {
     });
 
     it('should emit hide output after default delay (500ms)', fakeAsync(() => {
-         const fixture = createTestComponent(`<ngb-toast header="header" (hide)="hide()">body</ngb-toast>`);
+         const fixture = createTestComponent(`<ngb-toast header="header" (hidden)="hide()">body</ngb-toast>`);
          tick(499);
          fixture.detectChanges();
          expect(fixture.componentInstance.hide).not.toHaveBeenCalled();
@@ -85,7 +86,7 @@ describe('ngb-toast', () => {
 
     it('should emit hide output after a custom delay in ms', fakeAsync(() => {
          const fixture =
-             createTestComponent(`<ngb-toast header="header" [delay]="10000" (hide)="hide()">body</ngb-toast>`);
+             createTestComponent(`<ngb-toast header="header" [delay]="10000" (hidden)="hide()">body</ngb-toast>`);
          tick(9999);
          fixture.detectChanges();
          expect(fixture.componentInstance.hide).not.toHaveBeenCalled();
@@ -96,7 +97,7 @@ describe('ngb-toast', () => {
 
     it('should emit hide only one time regardless of autohide toggling', fakeAsync(() => {
          const fixture =
-             createTestComponent(`<ngb-toast header="header" [autohide]="autohide" (hide)="hide()">body</ngb-toast>`);
+             createTestComponent(`<ngb-toast header="header" [autohide]="autohide" (hidden)="hide()">body</ngb-toast>`);
          tick(250);
          fixture.componentInstance.autohide = false;
          fixture.detectChanges();
@@ -111,6 +112,83 @@ describe('ngb-toast', () => {
        }));
   });
 });
+
+if (isBrowserVisible('ngb-toast animations')) {
+  describe('ngb-toast animations', () => {
+
+    @Component({
+      template: `
+        <ngb-toast header="Hello" [autohide]="false" (shown)="onShown()" (hidden)="onHidden()">Cool!</ngb-toast>`,
+      host: {'[class.ngb-reduce-motion]': 'reduceMotion'}
+    })
+    class TestAnimationComponent {
+      reduceMotion = true;
+      onShown = () => {};
+      onHidden = () => {};
+    }
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        declarations: [TestAnimationComponent],
+        imports: [NgbToastModule],
+        providers: [{provide: NgbConfig, useClass: NgbConfigAnimation}]
+      });
+    });
+
+    [true, false].forEach(reduceMotion => {
+
+      it(`should run the transition when creating a toast (force-reduced-motion = ${reduceMotion})`, async(() => {
+           const fixture = TestBed.createComponent(TestAnimationComponent);
+           fixture.componentInstance.reduceMotion = reduceMotion;
+           fixture.detectChanges();
+
+           const toastEl = getToastElement(fixture.nativeElement);
+
+           spyOn(fixture.componentInstance, 'onShown').and.callFake(() => {
+             expect(window.getComputedStyle(toastEl).opacity).toBe('1');
+             expect(toastEl).not.toHaveCssClass('showing');
+             expect(toastEl).toHaveCssClass('show');
+             expect(toastEl).toHaveCssClass('fade');
+           });
+
+           expect(toastEl).toHaveCssClass('fade');
+           if (reduceMotion) {
+             expect(window.getComputedStyle(toastEl).opacity).toBe('1');
+             expect(toastEl).toHaveCssClass('show');
+           } else {
+             expect(window.getComputedStyle(toastEl).opacity).toBe('0');
+             expect(toastEl).not.toHaveCssClass('show');
+             expect(toastEl).toHaveCssClass('showing');
+           }
+         }));
+
+      it(`should run the transition when closing a toast (force-reduced-motion = ${reduceMotion})`, async(() => {
+           const fixture = TestBed.createComponent(TestAnimationComponent);
+           fixture.componentInstance.reduceMotion = reduceMotion;
+           fixture.detectChanges();
+
+           const toastEl = getToastElement(fixture.nativeElement);
+           const buttonEl = fixture.nativeElement.querySelector('button');
+
+           spyOn(fixture.componentInstance, 'onShown').and.callFake(() => {
+             expect(window.getComputedStyle(toastEl).opacity).toBe('1');
+             expect(toastEl).toHaveCssClass('show');
+             expect(toastEl).toHaveCssClass('fade');
+
+             buttonEl.click();
+           });
+
+           spyOn(fixture.componentInstance, 'onHidden').and.callFake(() => {
+             expect(window.getComputedStyle(toastEl).opacity).toBe('0');
+             expect(toastEl).not.toHaveCssClass('show');
+             expect(toastEl).toHaveCssClass('fade');
+             expect(toastEl).toHaveCssClass('hide');
+           });
+         }));
+    });
+  });
+}
+
 
 
 @Component({selector: 'test-cmp', template: ''})

--- a/src/toast/toast.ts
+++ b/src/toast/toast.ts
@@ -15,10 +15,12 @@ import {
   NgZone,
 } from '@angular/core';
 
+import {Observable} from 'rxjs';
+import {take} from 'rxjs/operators';
+
 import {NgbToastConfig} from './toast-config';
 import {ngbRunTransition} from '../util/transition/ngbTransition';
 import {ngbToastFadeInTransition, ngbToastFadeOutTransition} from '../util/transition/ngbFadingTransition';
-import {take} from 'rxjs/operators';
 
 
 /**
@@ -102,18 +104,19 @@ export class NgbToast implements AfterContentInit,
   @ContentChild(NgbToastHeader, {read: TemplateRef, static: true}) contentHeaderTpl: TemplateRef<any>| null = null;
 
   /**
-   * An event fired when the toast fade in animation
+   * An event fired after the animation triggered by calling `.show()` method has finished.
    */
   @Output() shown = new EventEmitter<void>();
 
   /**
-   * An event fired immediately when toast's `hide()` method has been called.
+   * An event fired after the animation triggered by calling `.hide()` method has finished.
+   *
    * It can only occur in 2 different scenarios:
    * - `autohide` timeout fires
    * - user clicks on a closing cross (&times)
    *
-   * Additionally this output is purely informative. The toast won't disappear. It's up to the user to take care of
-   * that.
+   * Additionally this output is purely informative. The toast won't be removed from DOM automatically, it's up
+   * to the user to take care of that.
    */
   @Output() hidden = new EventEmitter<void>();
 
@@ -150,7 +153,7 @@ export class NgbToast implements AfterContentInit,
    *
    * Alternatively you could listen or subscribe to the `(hidden)` output
    */
-  hide() {
+  hide(): Observable<void> {
     this._clearTimeout();
     const transition = ngbRunTransition(
         this._element.nativeElement, ngbToastFadeOutTransition, {animation: this.animation, runningTransition: 'stop'});
@@ -166,7 +169,7 @@ export class NgbToast implements AfterContentInit,
    *
    * Alternatively you could listen or subscribe to the `(shown)` output
    */
-  show() {
+  show(): Observable<void> {
     const transition = ngbRunTransition(this._element.nativeElement, ngbToastFadeInTransition, {
       animation: this.animation,
       runningTransition: 'continue',

--- a/src/util/transition/ngbFadingTransition.ts
+++ b/src/util/transition/ngbFadingTransition.ts
@@ -3,3 +3,19 @@ import {NgbTransitionStartFn} from './ngbTransition';
 export const ngbAlertFadingTransition: NgbTransitionStartFn = ({classList}: HTMLElement) => {
   classList.remove('show');
 };
+
+export const ngbToastFadeInTransition: NgbTransitionStartFn = ({classList}: HTMLElement) => {
+  classList.remove('hide');
+  classList.add('showing');
+
+  return () => {
+    classList.remove('showing');
+    classList.add('show');
+  };
+};
+
+export const ngbToastFadeOutTransition: NgbTransitionStartFn = ({classList}: HTMLElement) => {
+  classList.remove('show');
+
+  return () => { classList.add('hide'); };
+};

--- a/src/util/transition/ngbTransition.spec.ts
+++ b/src/util/transition/ngbTransition.spec.ts
@@ -63,7 +63,7 @@ if (isBrowserVisible('ngbRunTransition')) {
       ngbRunTransition(element, fadeFn, {animation: false, runningTransition: 'continue'})
           .subscribe(nextSpy, errorSpy, completeSpy);
 
-      expect(element.classList.contains('ngb-test-show')).toBe(true);
+      expect(element.classList.contains('ngb-test-show')).toBe(false);
       expect(window.getComputedStyle(element).opacity).toBe('1');
       expect(component.componentInstance.onTransitionEnd).not.toHaveBeenCalled();
       expect(nextSpy).toHaveBeenCalledWith(undefined);

--- a/src/util/transition/ngbTransition.ts
+++ b/src/util/transition/ngbTransition.ts
@@ -28,6 +28,7 @@ export const ngbRunTransition =
 
           // If animations are disabled, we have to emit a value and complete the observable
           if (!options.animation) {
+            (startFn(element, null !) || noopFn)();
             return of(undefined);
           }
 


### PR DESCRIPTION
Inspired by #2817, not cherry-picked because the toast animations are finally quite different compared to the alert.

This PR has 3 commits:
- toast animations implementation
- fix some test, due to a change on ngbTransition (the startFn function and its optional callback are now run even if animation = false)
- The changes in the demo examples

### Toast animations

The toast animations are defined as follow:

- The `fade` class exists only when the animations are defined,
- When visible, the toast contains the class `show`,
- When not visible, the toast contains the class `hide` (if, for any reason, the developer choose to keep the toast in the dom),
- When closing, the `show` class is removed to start the transition, then the `hide` class is added once finished,
- When opening, the `hide` class is removed, the `showing` class is added. Then the `showing` class is replaced the the `show` class,
- `show` (new api) and `hide` return the transition observer (to be able to implement code after the animations without the events),
- New events are available: `shown` and `hidden` (`hide`is deprecated, to stick with the official Bootstrap api).