### PR TITLE
demo: removed unnecessary semver dep

### DIFF
--- a/demo/src/environments/versions.ts
+++ b/demo/src/environments/versions.ts
@@ -1,9 +1,7 @@
-import {major, minor} from 'semver';
-
 let bootstrap: string = require('../../../package.json').devDependencies['bootstrap'];
 // extracts only the minor version from package.json
 // ex. "bootstrap": "4.0.1" -> "4.0"
-bootstrap = `${major(bootstrap)}.${minor(bootstrap)}`;
+bootstrap = bootstrap.split('.').slice(0, 2).join('.');
 
 const ngBootstrap = require('../../../package.json').version;
 

--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "protractor": "~5.4.3",
     "rimraf": "^3.0.2",
     "rxjs": "~6.5.4",
-    "semver": "7.2.1",
     "ts-loader": "^6.0.1",
     "ts-node": "~8.3.0",
     "ts-node-dev": "^1.0.0-pre.42",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9160,11 +9160,6 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@7.2.1:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.2.1.tgz#d997aa36bdbb00b501ae4ac4c7d17e9f7a587ae5"
-  integrity sha512-aHhm1pD02jXXkyIpq25qBZjr3CQgg8KST8uX0OWXch3xE6jw+1bfbWnCjzMwojsTquroUmKFHNzU6x26mEiRxw==
-
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"


### PR DESCRIPTION
Internet Explorer ES5 build was broken because of the introduction of `semver` dependency.
It was wrongly bundled as ESM inside the ES5 bundle which was obviously causing IE to crash.

I move back to string manipulation, but did not revert the commit, to actually take into consideration any eventual Bootstrap rc usage.

Previously, we were using (broken with alpha/beta/rc pattern)
```typescript
bootstrap = bootstrap.substr(0, bootstrap.lastIndexOf('.'));
```

Now I used
```typescript
bootstrap = bootstrap.split('.').slice(0, 2).join('.');
```

Fixes #3751 