### PR TITLE
feat(accordion): add animations

### DIFF
--- a/src/accordion/accordion-config.spec.ts
+++ b/src/accordion/accordion-config.spec.ts
@@ -1,8 +1,9 @@
+import {NgbConfig} from '../ngb-config';
 import {NgbAccordionConfig} from './accordion-config';
 
 describe('ngb-accordion-config', () => {
   it('should have sensible default values', () => {
-    const config = new NgbAccordionConfig();
+    const config = new NgbAccordionConfig(new NgbConfig());
 
     expect(config.closeOthers).toBe(false);
     expect(config.type).toBeUndefined();

--- a/src/accordion/accordion-config.ts
+++ b/src/accordion/accordion-config.ts
@@ -1,4 +1,5 @@
 import {Injectable} from '@angular/core';
+import {NgbConfig} from '../ngb-config';
 
 /**
  * A configuration service for the [NgbAccordion](#/components/accordion/api#NgbAccordion) component.
@@ -8,6 +9,9 @@ import {Injectable} from '@angular/core';
  */
 @Injectable({providedIn: 'root'})
 export class NgbAccordionConfig {
+  animation: boolean;
   closeOthers = false;
   type: string;
+
+  constructor(ngbConfig: NgbConfig) { this.animation = ngbConfig.animation; }
 }


### PR DESCRIPTION
Cherry picked from #2817, with some changes.

The key points are:

- Animations are managed one panel at a time, in the original code, a loop was done on all panels to guess if an animation is required, for each panel. The code is simpler this way, and aligned with ngbTransition API,
- ngbCollapseChange event  have been added. It follows the collapse widget, to discuss if the name/API must be changed,
- A little change in ngbTransition has been required, to provide the context when animations are deactivated,
- Tests have been done the same way the collpase widget,
- Some `detectChanges` have been added in the previous tests, because of the `changeDetector.detectChanges()` required in `_runTransition`,
- Only one commit in this PR, as there are only a few impacted files.