### PR TITLE
demo(dropdown): new container body example

### DIFF
--- a/demo/src/app/components/dropdown/demos/container/dropdown-container.html
+++ b/demo/src/app/components/dropdown/demos/container/dropdown-container.html
@@ -1,0 +1,52 @@
+<p>
+  Set the <code>container</code> property to "body" to have the dropdown menu be appended to the body instead of
+  where it belongs. This option is useful if the dropdown is defined inside an element that clips its contents (i.e.
+  <code>overflow: hidden</code>).
+</p>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th scope="col">#</th>
+      <th scope="col">Items</th>
+      <th scope="col">Actions</th>
+      <th scope="col">Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>1</td>
+      <td>
+        Item
+        <div>
+          <small class="text-muted">Both &ldquo;Actions&rdquo; table cells define an overflow hidden</small>
+        </div>
+      </td>
+      <td class="overflow-hidden">
+        <div ngbDropdown container="body">
+          <button class="btn btn-outline-primary btn-sm" ngbDropdownToggle>Actions</button>
+          <div ngbDropdownMenu>
+            <button ngbDropdownItem>Edit</button>
+            <button ngbDropdownItem>Duplicate</button>
+            <button ngbDropdownItem>Move</button>
+            <div class="dropdown-divider"></div>
+            <button ngbDropdownItem>Delete</button>
+          </div>
+        </div>
+        <small class="text-muted">Dropdown uses container "body"</small>
+      </td>
+      <td class="overflow-hidden">
+        <div ngbDropdown>
+          <button class="btn btn-outline-primary btn-sm" ngbDropdownToggle>Actions</button>
+          <div ngbDropdownMenu>
+            <button ngbDropdownItem>Edit</button>
+            <button ngbDropdownItem>Duplicate</button>
+            <button ngbDropdownItem>Move</button>
+            <div class="dropdown-divider"></div>
+            <button ngbDropdownItem>Delete</button>
+          </div>
+        </div>
+        <small class="text-muted">Default dropdown</small>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/demo/src/app/components/dropdown/demos/container/dropdown-container.module.ts
+++ b/demo/src/app/components/dropdown/demos/container/dropdown-container.module.ts
@@ -1,0 +1,14 @@
+import {NgModule} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
+
+import {NgbdDropdownContainer} from './dropdown-container';
+
+@NgModule({
+  imports: [BrowserModule, NgbModule],
+  declarations: [NgbdDropdownContainer],
+  exports: [NgbdDropdownContainer],
+  bootstrap: [NgbdDropdownContainer]
+})
+export class NgbdDropdownContainerModule {
+}

--- a/demo/src/app/components/dropdown/demos/container/dropdown-container.ts
+++ b/demo/src/app/components/dropdown/demos/container/dropdown-container.ts
@@ -1,0 +1,8 @@
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'ngbd-dropdown-container',
+  templateUrl: './dropdown-container.html',
+})
+export class NgbdDropdownContainer {
+}

--- a/demo/src/app/components/dropdown/dropdown.module.ts
+++ b/demo/src/app/components/dropdown/dropdown.module.ts
@@ -9,6 +9,8 @@ import { NgbdDropdownBasic } from './demos/basic/dropdown-basic';
 import { NgbdDropdownBasicModule } from './demos/basic/dropdown-basic.module';
 import { NgbdDropdownConfig } from './demos/config/dropdown-config';
 import { NgbdDropdownConfigModule } from './demos/config/dropdown-config.module';
+import { NgbdDropdownContainer } from './demos/container/dropdown-container';
+import { NgbdDropdownContainerModule } from './demos/container/dropdown-container.module';
 import { NgbdDropdownForm } from './demos/form/dropdown-form';
 import { NgbdDropdownFormModule } from './demos/form/dropdown-form.module';
 import { NgbdDropdownManual } from './demos/manual/dropdown-manual';
@@ -42,6 +44,12 @@ const DEMOS = {
     type: NgbdDropdownForm,
     code: require('!!raw-loader!./demos/form/dropdown-form').default,
     markup: require('!!raw-loader!./demos/form/dropdown-form.html').default
+  },
+  container: {
+    title: 'Container “body”',
+    type: NgbdDropdownContainer,
+    code: require('!!raw-loader!./demos/container/dropdown-container').default,
+    markup: require('!!raw-loader!./demos/container/dropdown-container.html').default
   },
   navbar: {
     title: 'Dynamic positioning in a navbar',
@@ -78,6 +86,7 @@ export const ROUTES = [
     NgbdComponentsSharedModule,
     NgbdDropdownBasicModule,
     NgbdDropdownConfigModule,
+    NgbdDropdownContainerModule,
     NgbdDropdownManualModule,
     NgbdDropdownSplitModule,
     NgbdDropdownFormModule,


### PR DESCRIPTION
Working on a fix for #3758, I realised we don't have any demo for that.
As we had several time by the past issues where people did not know there is this option, I quickly crafted one.

Here is the visual aspect of it:

![image](https://user-images.githubusercontent.com/1152740/84369803-af902800-abd7-11ea-8a43-389dc1819197.png)
