### PR TITLE
demo: showing title fragment navigation links when focused

### DIFF
--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -254,6 +254,10 @@ a.title-fragment {
   }
 }
 
+a.title-fragment:focus {
+  opacity: 1;
+}
+
 div.component-demo {
   margin-bottom: 3rem;
   h2 {


### PR DESCRIPTION
Whenever navigating with keyboard [Tab] on any demo page title fragment links were focusable but only shown when title is hovered.
Leading to a confusing behaviour where focused element was vanishing and re-appearing.

They will now be visible also as soon as they get the focus.