### PR TITLE
feat(modal): add scale animation when static backdrop is clicked

### DIFF
--- a/src/modal/modal-window.ts
+++ b/src/modal/modal-window.ts
@@ -32,6 +32,7 @@ import {ngbRunTransition, NgbTransitionOptions} from '../util/transition/ngbTran
     '[attr.aria-modal]': 'true',
     '[attr.aria-labelledby]': 'ariaLabelledBy',
     '[attr.aria-describedby]': 'ariaDescribedBy',
+    '(click)': 'bump($event)'
   },
   template: `
     <div #dialog [class]="'modal-dialog' + (size ? ' modal-' + size : '') + (centered ? ' modal-dialog-centered' : '') +
@@ -92,6 +93,19 @@ export class NgbModalWindow implements OnInit,
     this._restoreFocus();
 
     return transitions$;
+  }
+
+  bump(event: Event) {
+    const nativeElement = this._elRef.nativeElement;
+    // the animation must only happen if the backdrop is static
+    // and if the click is not inside the modal
+    if (event.target === nativeElement && this.backdrop === 'static') {
+      ngbRunTransition(nativeElement, ({classList}) => {
+        classList.add('modal-static');
+        return () => classList.remove('modal-static');
+      }, {animation: this.animation, runningTransition: 'continue'});
+      event.stopPropagation();
+    }
   }
 
   private _show() {

--- a/src/modal/modal-window.ts
+++ b/src/modal/modal-window.ts
@@ -125,8 +125,9 @@ export class NgbModalWindow implements OnInit,
                   this._zone.run(() => this.dismiss(ModalDismissReasons.ESC));
                 }
               });
+            } else if (this.backdrop === 'static') {
+              this._bumpBackdrop();
             }
-            this._bumpIfStaticBackdrop();
           });
 
       // We're listening to 'mousedown' and 'mouseup' to prevent modal from closing when pressing the mouse
@@ -144,12 +145,12 @@ export class NgbModalWindow implements OnInit,
       // 2. closing was prevented by mousedown/up handlers
       // 3. clicking on scrollbar when the viewport is too small and modal doesn't fit (click is not triggered at all)
       fromEvent<MouseEvent>(nativeElement, 'click').pipe(takeUntil(this._closed$)).subscribe(({target}) => {
-        if (this.backdrop === true && nativeElement === target && !preventClose) {
-          this._zone.run(() => this.dismiss(ModalDismissReasons.BACKDROP_CLICK));
-        }
-
         if (nativeElement === target) {
-          this._bumpIfStaticBackdrop();
+          if (this.backdrop === 'static') {
+            this._bumpBackdrop();
+          } else if (this.backdrop === true && !preventClose) {
+            this._zone.run(() => this.dismiss(ModalDismissReasons.BACKDROP_CLICK));
+          }
         }
 
         preventClose = false;
@@ -186,7 +187,7 @@ export class NgbModalWindow implements OnInit,
     });
   }
 
-  private _bumpIfStaticBackdrop() {
+  private _bumpBackdrop() {
     if (this.backdrop === 'static') {
       ngbRunTransition(this._elRef.nativeElement, ({classList}) => {
         classList.add('modal-static');

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -907,7 +907,9 @@ describe('ngb-modal', () => {
 
         constructor(private modalService: NgbModal) {}
 
-        open(backdrop: boolean | 'static' = true) { return this.modalService.open(this.content, {backdrop}); }
+        open(backdrop: boolean | 'static' = true, keyboard = true) {
+          return this.modalService.open(this.content, {backdrop, keyboard});
+        }
       }
 
       beforeEach(() => {
@@ -1035,7 +1037,9 @@ describe('ngb-modal', () => {
         const component = TestBed.createComponent(TestAnimationComponent);
         component.detectChanges();
 
-        const modalRef = component.componentInstance.open('static');
+        // currently, to keep backward compatibility, the modal is closed on escape if keyboard is true,
+        // even if backdrop is static. This will be fixed in the future.
+        const modalRef = component.componentInstance.open('static', false);
         let modalEl: HTMLElement | null = null;
 
         modalRef.shown.subscribe(() => {


### PR DESCRIPTION
fix #3768

Note: this is my first PR on animations, and I don't really master everything. 
There are 3 points that I'm not sure about in the submitted code:

- should I pass 'continue' or 'stop'. I chose 'continue', and it seems to behave correctly, and the same way as the native bootstrap modal, but maybe I'm missing something
- in the unit tests, I don't know how to test that the `modal-static` class disappears at the end of the transition: nothing is emitted when that happens, and I didn't want to introduce an output only useful for tests. (see TODO in the test)
- I'm not sure exactly what the `reduceMotion` flag is supposed to do. I have noticed that the `modal-static` is not added when `reduceMotion` is true, and I guess it's a feature, but I'm not sure. (see TODO in the test)

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.
