### PR TITLE
feat(carousel): accessibility

### DIFF
--- a/demo/src/app/components/carousel/demos/pause/carousel-pause.html
+++ b/demo/src/app/components/carousel/demos/pause/carousel-pause.html
@@ -1,4 +1,4 @@
-<ngb-carousel #carousel [interval]="1000" [pauseOnHover]="pauseOnHover" (slide)="onSlide($event)">
+<ngb-carousel #carousel [interval]="1000" [pauseOnHover]="pauseOnHover" [pauseOnFocus]="pauseOnFocus" (slide)="onSlide($event)">
   <ng-template ngbSlide *ngFor="let img of images; index as i">
     <div class="carousel-caption">
       <h3>My slide {{i + 1}} title</h3>
@@ -16,6 +16,10 @@
 <div class="form-check">
   <input type="checkbox" class="form-check-input" id="pauseOnHover" [(ngModel)]="pauseOnHover">
   <label class="form-check-label" for="pauseOnHover">Pause on hover</label>
+</div>
+<div class="form-check">
+  <input type="checkbox" class="form-check-input" id="pauseOnFocus" [(ngModel)]="pauseOnFocus">
+  <label class="form-check-label" for="pauseOnFocus">Pause on focus</label>
 </div>
 <div class="form-check">
   <input type="checkbox" class="form-check-input" id="unpauseOnArrow" [(ngModel)]="unpauseOnArrow">

--- a/demo/src/app/components/carousel/demos/pause/carousel-pause.ts
+++ b/demo/src/app/components/carousel/demos/pause/carousel-pause.ts
@@ -10,6 +10,7 @@ export class NgbdCarouselPause {
   unpauseOnArrow = false;
   pauseOnIndicator = false;
   pauseOnHover = true;
+  pauseOnFocus = true;
 
   @ViewChild('carousel', {static : true}) carousel: NgbCarousel;
 

--- a/src/carousel/carousel-config.ts
+++ b/src/carousel/carousel-config.ts
@@ -12,6 +12,7 @@ export class NgbCarouselConfig {
   wrap = true;
   keyboard = true;
   pauseOnHover = true;
+  pauseOnFocus = true;
   showNavigationArrows = true;
   showNavigationIndicators = true;
 }

--- a/src/carousel/carousel.spec.ts
+++ b/src/carousel/carousel.spec.ts
@@ -36,12 +36,13 @@ describe('ngb-carousel', () => {
 
   it('should initialize inputs with default values', () => {
     const defaultConfig = new NgbCarouselConfig();
-    const carousel = new NgbCarousel(new NgbCarouselConfig(), null, <any>null, <any>null);
+    const carousel = new NgbCarousel(new NgbCarouselConfig(), null, <any>null, <any>null, <any>null);
 
     expect(carousel.interval).toBe(defaultConfig.interval);
     expect(carousel.wrap).toBe(defaultConfig.wrap);
     expect(carousel.keyboard).toBe(defaultConfig.keyboard);
     expect(carousel.pauseOnHover).toBe(defaultConfig.pauseOnHover);
+    expect(carousel.pauseOnFocus).toBe(defaultConfig.pauseOnFocus);
     expect(carousel.showNavigationIndicators).toBe(defaultConfig.showNavigationIndicators);
     expect(carousel.showNavigationArrows).toBe(defaultConfig.showNavigationArrows);
   });
@@ -195,7 +196,7 @@ describe('ngb-carousel', () => {
 
   it('should not resume without call to cycle()', fakeAsync(() => {
        const html = `
-    <ngb-carousel #c [interval]="1000" (slide)="carouselSlideCallBack($event)">
+    <ngb-carousel #c [interval]="1000" [pauseOnFocus]="false" (slide)="carouselSlideCallBack($event)">
       <ng-template ngbSlide>foo</ng-template>
       <ng-template ngbSlide>bar</ng-template>
       <ng-template ngbSlide>third</ng-template>
@@ -667,6 +668,40 @@ describe('ngb-carousel', () => {
        discardPeriodicTasks();
      }));
 
+  it('should pause / resume slide change with time passage on focusin / focusout', fakeAsync(() => {
+       const html = `
+      <ngb-carousel>
+        <ng-template ngbSlide>foo</ng-template>
+        <ng-template ngbSlide>bar</ng-template>
+      </ngb-carousel>
+    `;
+
+       const fixture = createTestComponent(html);
+
+       const carouselDebugEl = fixture.debugElement.query(By.directive(NgbCarousel));
+
+       expectActiveSlides(fixture.nativeElement, [true, false]);
+
+       carouselDebugEl.triggerEventHandler('focusin', {});
+       fixture.detectChanges();
+       expectActiveSlides(fixture.nativeElement, [true, false]);
+
+       tick(6000);
+       fixture.detectChanges();
+       expectActiveSlides(fixture.nativeElement, [true, false]);
+
+       carouselDebugEl.triggerEventHandler('focusout', {});
+       fixture.detectChanges();
+       expectActiveSlides(fixture.nativeElement, [true, false]);
+
+       tick(6000);
+       fixture.detectChanges();
+       expectActiveSlides(fixture.nativeElement, [false, true]);
+
+       discardPeriodicTasks();
+     }));
+
+
   it('should wrap slide changes by default', fakeAsync(() => {
        const html = `
       <ngb-carousel>
@@ -795,11 +830,13 @@ describe('ngb-carousel', () => {
        const slideElms = fixture.nativeElement.querySelectorAll('.carousel-item');
        expect(slideElms.length).toBe(1);
        expect(slideElms[0].textContent).toMatch(/foo/);
+       expect(fixture.nativeElement.querySelectorAll('ol.carousel-indicators.sr-only > li').length).toBe(0);
        expect(fixture.nativeElement.querySelectorAll('ol.carousel-indicators > li').length).toBe(1);
 
        fixture.componentInstance.showNavigationIndicators = false;
        fixture.detectChanges();
-       expect(fixture.nativeElement.querySelectorAll('ol.carousel-indicators > li').length).toBe(0);
+       expect(fixture.nativeElement.querySelectorAll('ol.carousel-indicators.sr-only > li').length).toBe(1);
+       expect(fixture.nativeElement.querySelectorAll('ol.carousel-indicators > li').length).toBe(1);
 
        discardPeriodicTasks();
      }));
@@ -834,6 +871,7 @@ describe('ngb-carousel', () => {
       config.wrap = false;
       config.keyboard = false;
       config.pauseOnHover = false;
+      config.pauseOnFocus = false;
       config.showNavigationIndicators = true;
       config.showNavigationArrows = true;
     }));
@@ -847,6 +885,7 @@ describe('ngb-carousel', () => {
       expect(carousel.wrap).toBe(config.wrap);
       expect(carousel.keyboard).toBe(config.keyboard);
       expect(carousel.pauseOnHover).toBe(config.pauseOnHover);
+      expect(carousel.pauseOnFocus).toBe(config.pauseOnFocus);
       expect(carousel.showNavigationIndicators).toBe(config.showNavigationIndicators);
       expect(carousel.showNavigationArrows).toBe(config.showNavigationArrows);
     });
@@ -858,6 +897,7 @@ describe('ngb-carousel', () => {
     config.wrap = false;
     config.keyboard = false;
     config.pauseOnHover = false;
+    config.pauseOnFocus = false;
     config.showNavigationIndicators = true;
     config.showNavigationArrows = true;
 
@@ -875,6 +915,7 @@ describe('ngb-carousel', () => {
       expect(carousel.wrap).toBe(config.wrap);
       expect(carousel.keyboard).toBe(config.keyboard);
       expect(carousel.pauseOnHover).toBe(config.pauseOnHover);
+      expect(carousel.pauseOnFocus).toBe(config.pauseOnFocus);
       expect(carousel.showNavigationIndicators).toBe(config.showNavigationIndicators);
       expect(carousel.showNavigationArrows).toBe(config.showNavigationArrows);
     });

--- a/src/carousel/carousel.ts
+++ b/src/carousel/carousel.ts
@@ -6,8 +6,8 @@ import {
   Component,
   ContentChildren,
   Directive,
+  ElementRef,
   EventEmitter,
-  HostListener,
   Inject,
   Input,
   NgZone,
@@ -55,24 +55,34 @@ export class NgbSlide {
     'class': 'carousel slide',
     '[style.display]': '"block"',
     'tabIndex': '0',
-    '(keydown.arrowLeft)': 'keyboard && prev(NgbSlideEventSource.ARROW_LEFT)',
-    '(keydown.arrowRight)': 'keyboard && next(NgbSlideEventSource.ARROW_RIGHT)'
+    '(keydown.arrowLeft)': 'keyboard && arrowLeft()',
+    '(keydown.arrowRight)': 'keyboard && arrowRight()',
+    '(mouseenter)': 'mouseHover = true',
+    '(mouseleave)': 'mouseHover = false',
+    '(focusin)': 'focused = true',
+    '(focusout)': 'focused = false',
+    '[attr.aria-activedescendant]': 'activeId'
   },
   template: `
-    <ol class="carousel-indicators" *ngIf="showNavigationIndicators">
+    <ol class="carousel-indicators" [class.sr-only]="!showNavigationIndicators" role="tablist">
       <li *ngFor="let slide of slides" [id]="slide.id" [class.active]="slide.id === activeId"
-          (click)="select(slide.id, NgbSlideEventSource.INDICATOR)"></li>
+          role="tab" [attr.aria-labelledby]="slide.id + '-slide'" [attr.aria-controls]="slide.id + '-slide'"
+          [attr.aria-selected]="slide.id === activeId"
+          (click)="focus();select(slide.id, NgbSlideEventSource.INDICATOR);"></li>
     </ol>
     <div class="carousel-inner">
-      <div *ngFor="let slide of slides" class="carousel-item" [class.active]="slide.id === activeId">
+      <div *ngFor="let slide of slides; index as i; count as c" class="carousel-item" [class.active]="slide.id === activeId" [id]="slide.id + '-slide'" role="tabpanel">
+        <span class="sr-only" i18n="Currently selected slide number read by screen reader@@ngb.carousel.slide-number">
+          Slide {{i + 1}} of {{c}}
+        </span>
         <ng-template [ngTemplateOutlet]="slide.tplRef"></ng-template>
       </div>
     </div>
-    <a class="carousel-control-prev" role="button" (click)="prev(NgbSlideEventSource.ARROW_LEFT)" *ngIf="showNavigationArrows">
+    <a class="carousel-control-prev" role="button" (click)="arrowLeft()" *ngIf="showNavigationArrows">
       <span class="carousel-control-prev-icon" aria-hidden="true"></span>
       <span class="sr-only" i18n="@@ngb.carousel.previous">Previous</span>
     </a>
-    <a class="carousel-control-next" role="button" (click)="next(NgbSlideEventSource.ARROW_RIGHT)" *ngIf="showNavigationArrows">
+    <a class="carousel-control-next" role="button" (click)="arrowRight()" *ngIf="showNavigationArrows">
       <span class="carousel-control-next-icon" aria-hidden="true"></span>
       <span class="sr-only" i18n="@@ngb.carousel.next">Next</span>
     </a>
@@ -87,7 +97,9 @@ export class NgbCarousel implements AfterContentChecked,
   private _destroy$ = new Subject<void>();
   private _interval$ = new BehaviorSubject(0);
   private _mouseHover$ = new BehaviorSubject(false);
+  private _focused$ = new BehaviorSubject(false);
   private _pauseOnHover$ = new BehaviorSubject(false);
+  private _pauseOnFocus$ = new BehaviorSubject(false);
   private _pause$ = new BehaviorSubject(false);
   private _wrap$ = new BehaviorSubject(false);
 
@@ -136,6 +148,16 @@ export class NgbCarousel implements AfterContentChecked,
   get pauseOnHover() { return this._pauseOnHover$.value; }
 
   /**
+   * If `true`, will pause slide switching when the focus is inside the carousel.
+   */
+  @Input()
+  set pauseOnFocus(value: boolean) {
+    this._pauseOnFocus$.next(value);
+  }
+
+  get pauseOnFocus() { return this._pauseOnFocus$.value; }
+
+  /**
    * If `true`, 'previous' and 'next' navigation arrows will be visible on the slide.
    *
    * @since 2.2.0
@@ -156,25 +178,34 @@ export class NgbCarousel implements AfterContentChecked,
    */
   @Output() slide = new EventEmitter<NgbSlideEvent>();
 
+  set mouseHover(value: boolean) { this._mouseHover$.next(value); }
+
+  get mouseHover() { return this._mouseHover$.value; }
+
+  set focused(value: boolean) { this._focused$.next(value); }
+
+  get focused() { return this._focused$.value; }
+
   constructor(
       config: NgbCarouselConfig, @Inject(PLATFORM_ID) private _platformId, private _ngZone: NgZone,
-      private _cd: ChangeDetectorRef) {
+      private _cd: ChangeDetectorRef, private _container: ElementRef) {
     this.interval = config.interval;
     this.wrap = config.wrap;
     this.keyboard = config.keyboard;
     this.pauseOnHover = config.pauseOnHover;
+    this.pauseOnFocus = config.pauseOnFocus;
     this.showNavigationArrows = config.showNavigationArrows;
     this.showNavigationIndicators = config.showNavigationIndicators;
   }
 
-  @HostListener('mouseenter')
-  mouseEnter() {
-    this._mouseHover$.next(true);
+  arrowLeft() {
+    this.focus();
+    this.prev(NgbSlideEventSource.ARROW_LEFT);
   }
 
-  @HostListener('mouseleave')
-  mouseLeave() {
-    this._mouseHover$.next(false);
+  arrowRight() {
+    this.focus();
+    this.next(NgbSlideEventSource.ARROW_RIGHT);
   }
 
   ngAfterContentInit() {
@@ -193,10 +224,16 @@ export class NgbCarousel implements AfterContentChecked,
                                         return wrap ? slideArr.length > 1 : currentSlideIdx < slideArr.length - 1;
                                       }),
                                       distinctUntilChanged());
-        combineLatest([this._pause$, this._pauseOnHover$, this._mouseHover$, this._interval$, hasNextSlide$])
+        combineLatest([
+          this._pause$, this._pauseOnHover$, this._mouseHover$, this._pauseOnFocus$, this._focused$, this._interval$,
+          hasNextSlide$
+        ])
             .pipe(
-                map(([pause, pauseOnHover, mouseHover, interval, hasNextSlide]) =>
-                        ((pause || (pauseOnHover && mouseHover) || !hasNextSlide) ? 0 : interval)),
+                map(([pause, pauseOnHover, mouseHover, pauseOnFocus, focused, interval,
+                      hasNextSlide]: [boolean, boolean, boolean, boolean, boolean, number, boolean]) =>
+                        ((pause || (pauseOnHover && mouseHover) || (pauseOnFocus && focused) || !hasNextSlide) ?
+                             0 :
+                             interval)),
 
                 distinctUntilChanged(), switchMap(interval => interval > 0 ? timer(interval, interval) : NEVER),
                 takeUntil(this._destroy$))
@@ -244,6 +281,11 @@ export class NgbCarousel implements AfterContentChecked,
    * Restarts cycling through the slides from left to right.
    */
   cycle() { this._pause$.next(false); }
+
+  /**
+   * Set the focus on the carousel.
+   */
+  focus() { this._container.nativeElement.focus(); }
 
   private _cycleToSelected(slideIdx: string, direction: NgbSlideEventDirection, source?: NgbSlideEventSource) {
     let selectedSlide = this._getSlideById(slideIdx);


### PR DESCRIPTION
This PR adds accessibility to the carousel:
 - the carousel is now automatically paused when the focus is inside it (this can be controlled with the `pauseOnFocus` property)
 - some roles and aria attributes are added to make it easier to use the carousel with a screen reader. This mostly relies on the carousel indicators that act like tabs.

In the future, it would be nice to integrate [assistive-webdriver](https://github.com/AmadeusITGroup/Assistive-Webdriver) to execute end-to-end tests with a screen reader.

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.

Fixes #3755