### PR TITLE
fix(animations): pass transition context with animation disabled

### DIFF
--- a/src/util/transition/ngbTransition.spec.ts
+++ b/src/util/transition/ngbTransition.spec.ts
@@ -1,4 +1,4 @@
-import {ngbRunTransition} from './ngbTransition';
+import {ngbRunTransition, NgbTransitionStartFn} from './ngbTransition';
 import createSpy = jasmine.createSpy;
 import {Component, ElementRef, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -260,6 +260,23 @@ if (isBrowserVisible('ngbRunTransition')) {
       expect(contextSpy).toHaveBeenCalledWith({text: 'two', counter: 2});
 
       expect(window.getComputedStyle(element).opacity).toBe('1');
+    });
+
+    it(`should pass context with 'animation: false'`, () => {
+      const startFn: NgbTransitionStartFn<{flag: number}> = (_, context) => { expect(context.flag).toBe(42); };
+
+      const nextSpy = createSpy();
+      const errorSpy = createSpy();
+      const completeSpy = createSpy();
+      const startFnSpy = createSpy('startFn', startFn).and.callThrough();
+
+      ngbRunTransition(element, startFnSpy, {animation: false, runningTransition: 'continue', context: {flag: 42}})
+          .subscribe(nextSpy, errorSpy, completeSpy);
+
+      expect(nextSpy).toHaveBeenCalledWith(undefined);
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(completeSpy).toHaveBeenCalled();
+      expect(startFnSpy).toHaveBeenCalled();
     });
 
     it(`should complete and release the DOM element even if transition end is not fired`, (done) => {

--- a/src/util/transition/ngbTransition.ts
+++ b/src/util/transition/ngbTransition.ts
@@ -26,12 +26,6 @@ export const ngbRunTransition =
     <T>(element: HTMLElement, startFn: NgbTransitionStartFn<T>, options: NgbTransitionOptions<T>):
         Observable<undefined> => {
 
-          // If animations are disabled, we have to emit a value and complete the observable
-          if (!options.animation) {
-            (startFn(element, null !) || noopFn)();
-            return of(undefined);
-          }
-
           // Getting initial context from options
           let context = options.context || <T>{};
 
@@ -51,6 +45,12 @@ export const ngbRunTransition =
                 context = Object.assign(running.context, context);
                 runningTransitions.delete(element);
             }
+          }
+
+          // If animations are disabled, we have to emit a value and complete the observable
+          if (!options.animation) {
+            (startFn(element, context) || noopFn)();
+            return of(undefined);
           }
 
           // If 'prefer-reduced-motion' is enabled, the 'transition' will be set to 'none'.


### PR DESCRIPTION
Fixes an issue when the context was not passed across two transitions when `animation = false` (see test for the example)