### PR TITLE
fix(dropdown): support closest for HTMLDocument (#3783)

### DIFF
--- a/src/util/util.spec.ts
+++ b/src/util/util.spec.ts
@@ -1,6 +1,38 @@
-import {toInteger, toString, getValueInRange, isInteger, isString, hasClassName} from './util';
+import {toInteger, toString, getValueInRange, isInteger, isString, hasClassName, closest} from './util';
 
 describe('util', () => {
+
+  describe('closest', () => {
+    describe('when no selector is provided', () => {
+
+      it('should return null', () => {
+        const element = document.createElement('div');
+
+        expect(closest(element)).toBeNull();
+      });
+
+    });
+
+    describe('when selector is provided', () => {
+
+      it('should return the closest element', () => {
+        const element = document.body;
+
+        expect(closest(element, 'html')).toEqual(document.documentElement);
+      });
+
+    });
+
+    describe('when HTMLDocument is provided', () => {
+
+      it('should return null if selector is not matching document', () => {
+        const element = document.documentElement;
+
+        expect(closest(element, 'body')).toBeNull();
+      });
+
+    });
+  });
 
   describe('toInteger', () => {
 

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -66,8 +66,21 @@ if (typeof Element !== 'undefined' && !Element.prototype.closest) {
   };
 }
 
-export function closest(element: HTMLElement, selector): HTMLElement | null {
+export function closest(element: HTMLElement, selector?: string): HTMLElement | null {
   if (!selector) {
+    return null;
+  }
+
+  /*
+   * In certain browsers (e.g. Edge 44.18362.449.0) HTMLDocument does
+   * not support `Element.prototype.closest`. To emulate the correct behaviour
+   * we return null when the method is missing.
+   *
+   * Note that in evergreen browsers `closest(document.documentElement, 'html')`
+   * will return the document element whilst in Edge null will be returned. This
+   * compromise was deemed good enough.
+   */
+  if (typeof element.closest === 'undefined') {
     return null;
   }
 


### PR DESCRIPTION
## Support closest for HTMLDocument

When autoclosing a dropdown by clicking the scrollbar, an error would be
thrown in Edge 44.18362.449.0. This was due to the HTMLDocument not
supporting `Element.prototype.closest`.

By emulating `Element.prototype.closest` for this specific node, this
commit circumvents the issue.