### PR TITLE
fix(dropdown): container body keyboard navigation

### DIFF
--- a/e2e-app/src/app/dropdown/focus/dropdown-focus.e2e-spec.ts
+++ b/e2e-app/src/app/dropdown/focus/dropdown-focus.e2e-spec.ts
@@ -1,4 +1,4 @@
-import {$, ElementFinder, Key} from 'protractor';
+import {ElementFinder, Key} from 'protractor';
 import {expectFocused, sendKey, openUrl} from '../../tools.po';
 import {DropdownFocusPage} from './dropdown-focus.po';
 
@@ -106,7 +106,7 @@ describe(`Dropdown focus`, () => {
         await expectFocused(toggle, `Toggling element should be focused`);
       });
 
-      it(`should close dropdown with 'Escape' and focus nothing (item was focused)`, async() => {
+      it(`should close dropdown with 'Escape' and focus toggling element (item was focused)`, async() => {
         await page.open(dropdown);
         await expectFocused(toggle, `Toggling element should be focused`);
 
@@ -115,7 +115,7 @@ describe(`Dropdown focus`, () => {
 
         await sendKey(Key.ESCAPE);
         expect(await page.isOpened(dropdown)).toBeFalsy(`Dropdown should be closed on 'Escape' press`);
-        await expectFocused($('body'), `Nothing should be focused after dropdown is closed`);
+        await expectFocused(toggle, `Toggling element should be focused`);
       });
 
       it(`should focus dropdown first item with Tab when dropdown is opened (toggle was focused)`, async() => {

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -74,12 +74,15 @@ export class NgbDropdownItem {
   }
 })
 export class NgbDropdownMenu {
+  nativeElement: HTMLElement;
   placement: Placement | null = 'bottom';
   isOpen = false;
 
   @ContentChildren(NgbDropdownItem) menuItems: QueryList<NgbDropdownItem>;
 
-  constructor(@Inject(forwardRef(() => NgbDropdown)) public dropdown) {}
+  constructor(@Inject(forwardRef(() => NgbDropdown)) public dropdown, _elementRef: ElementRef<HTMLElement>) {
+    this.nativeElement = _elementRef.nativeElement;
+  }
 }
 
 /**
@@ -96,13 +99,10 @@ export class NgbDropdownMenu {
   host: {'class': 'dropdown-toggle', 'aria-haspopup': 'true', '[attr.aria-expanded]': 'dropdown.isOpen()'}
 })
 export class NgbDropdownAnchor {
-  anchorEl;
-
-  constructor(@Inject(forwardRef(() => NgbDropdown)) public dropdown, private _elementRef: ElementRef<HTMLElement>) {
-    this.anchorEl = _elementRef.nativeElement;
+  nativeElement: HTMLElement;
+  constructor(@Inject(forwardRef(() => NgbDropdown)) public dropdown, _elementRef: ElementRef<HTMLElement>) {
+    this.nativeElement = _elementRef.nativeElement;
   }
-
-  getNativeElement() { return this._elementRef.nativeElement; }
 }
 
 /**
@@ -144,7 +144,6 @@ export class NgbDropdown implements AfterContentInit, OnDestroy {
   private _bodyContainer: HTMLElement | null = null;
 
   @ContentChild(NgbDropdownMenu, {static: false}) private _menu: NgbDropdownMenu;
-  @ContentChild(NgbDropdownMenu, {read: ElementRef, static: false}) private _menuElement: ElementRef;
   @ContentChild(NgbDropdownAnchor, {static: false}) private _anchor: NgbDropdownAnchor;
 
   /**
@@ -251,22 +250,21 @@ export class NgbDropdown implements AfterContentInit, OnDestroy {
       this.openChange.emit(true);
       this._setCloseHandlers();
       if (this._anchor) {
-        this._anchor.getNativeElement().focus();
+        this._anchor.nativeElement.focus();
       }
     }
   }
 
   private _setCloseHandlers() {
-    const anchor = this._anchor;
     ngbAutoClose(
         this._ngZone, this._document, this.autoClose,
         (source: SOURCE) => {
           this.close();
           if (source === SOURCE.ESCAPE) {
-            this._anchor.getNativeElement().focus();
+            this._anchor.nativeElement.focus();
           }
         },
-        this._closed$, this._menu ? [this._menuElement.nativeElement] : [], anchor ? [anchor.getNativeElement()] : [],
+        this._closed$, this._menu ? [this._menu.nativeElement] : [], this._anchor ? [this._anchor.nativeElement] : [],
         '.dropdown-item,.dropdown-divider');
   }
 
@@ -334,22 +332,27 @@ export class NgbDropdown implements AfterContentInit, OnDestroy {
 
     if (key === Key.Tab) {
       if (event.target && this.isOpen() && this.autoClose) {
-        if (this._anchor.anchorEl === event.target) {
+        if (this._anchor.nativeElement === event.target) {
           if (this.container === 'body' && !event.shiftKey) {
-            this._renderer.setAttribute(this._menuElement.nativeElement, 'tabindex', '0');
-            this._menuElement.nativeElement.focus();
-            this._renderer.removeAttribute(this._menuElement.nativeElement, 'tabindex');
+            /* This case is special: user is using [Tab] from the anchor/toggle.
+               User expects the next focusable element in the dropdown menu to get focus.
+               But the menu is not a sibling to anchor/toggle, it is at the end of the body.
+               Trick is to synchronously focus the menu element, and let the [keydown.Tab] go
+               so that browser will focus the proper element (first one focusable in the menu) */
+            this._renderer.setAttribute(this._menu.nativeElement, 'tabindex', '0');
+            this._menu.nativeElement.focus();
+            this._renderer.removeAttribute(this._menu.nativeElement, 'tabindex');
           } else if (event.shiftKey) {
             this.close();
           }
           return;
         } else if (this.container === 'body') {
-          const focusableElements = [...this._menuElement.nativeElement.querySelectorAll(FOCUSABLE_ELEMENTS_SELECTOR)];
+          const focusableElements = this._menu.nativeElement.querySelectorAll(FOCUSABLE_ELEMENTS_SELECTOR);
           if (event.shiftKey && event.target === focusableElements[0]) {
-            this._anchor.anchorEl.focus();
+            this._anchor.nativeElement.focus();
             event.preventDefault();
           } else if (!event.shiftKey && event.target === focusableElements[focusableElements.length - 1]) {
-            this._anchor.getNativeElement().focus();
+            this._anchor.nativeElement.focus();
             this.close();
           }
         } else {
@@ -395,7 +398,7 @@ export class NgbDropdown implements AfterContentInit, OnDestroy {
   private _isDropup(): boolean { return this._elementRef.nativeElement.classList.contains('dropup'); }
 
   private _isEventFromToggle(event: KeyboardEvent) {
-    return this._anchor.getNativeElement().contains(event.target as HTMLElement);
+    return this._anchor.nativeElement.contains(event.target as HTMLElement);
   }
 
   private _getMenuElements(): HTMLElement[] {
@@ -410,11 +413,10 @@ export class NgbDropdown implements AfterContentInit, OnDestroy {
     const menu = this._menu;
     if (this.isOpen() && menu) {
       this._applyPlacementClasses(
-          this.display === 'dynamic' ?
-              positionElements(
-                  this._anchor.anchorEl, this._bodyContainer || this._menuElement.nativeElement, this.placement,
-                  this.container === 'body') :
-              this._getFirstPlacement(this.placement));
+          this.display === 'dynamic' ? positionElements(
+                                           this._anchor.nativeElement, this._bodyContainer || this._menu.nativeElement,
+                                           this.placement, this.container === 'body') :
+                                       this._getFirstPlacement(this.placement));
     }
   }
 
@@ -424,10 +426,9 @@ export class NgbDropdown implements AfterContentInit, OnDestroy {
 
   private _resetContainer() {
     const renderer = this._renderer;
-    const menuElement = this._menuElement;
-    if (menuElement) {
+    if (this._menu) {
       const dropdownElement = this._elementRef.nativeElement;
-      const dropdownMenuElement = menuElement.nativeElement;
+      const dropdownMenuElement = this._menu.nativeElement;
 
       renderer.appendChild(dropdownElement, dropdownMenuElement);
       renderer.removeStyle(dropdownMenuElement, 'position');
@@ -443,7 +444,7 @@ export class NgbDropdown implements AfterContentInit, OnDestroy {
     this._resetContainer();
     if (container === 'body') {
       const renderer = this._renderer;
-      const dropdownMenuElement = this._menuElement.nativeElement;
+      const dropdownMenuElement = this._menu.nativeElement;
       const bodyContainer = this._bodyContainer = this._bodyContainer || renderer.createElement('div');
 
       // Override some styles to have the positionning working

--- a/src/util/focus-trap.ts
+++ b/src/util/focus-trap.ts
@@ -6,7 +6,7 @@ import {filter, map, takeUntil, withLatestFrom} from 'rxjs/operators';
 import {Key} from './key';
 
 
-const FOCUSABLE_ELEMENTS_SELECTOR = [
+export const FOCUSABLE_ELEMENTS_SELECTOR = [
   'a[href]', 'button:not([disabled])', 'input:not([disabled]):not([type="hidden"])', 'select:not([disabled])',
   'textarea:not([disabled])', '[contenteditable]', '[tabindex]:not([tabindex="-1"])'
 ].join(', ');


### PR DESCRIPTION
This PR is a follow up PR to #3625 which introduced the ability to close the dropdown when leaving it by the last elements.
Unfortunately, it did not fix the keyboard navigation when using `container="body"` is used.

Leaving the dropdown menu from the bottom when container is set to "body" leaves the user in a broken state, where the browser window url bar gets the focus.

The PR introduces a mechanism to _catch_ the last <kbd>Tab</kbd> from the dropdown menu, and temporary set the focus back in a synchronous fashion to the dropdown anchor, hence letting the browser placing the focus on the next focusable element.

It also makes sure now that whenever the user wants to close the dropdown from the keyboard with <kbd>Esc</kbd>, the focus gets back to the dropdown toggle element.

This used to be the broken behaviour that now works
![Kapture 2020-06-29 at 11 44 04](https://user-images.githubusercontent.com/1152740/85994971-18f89f00-b9fe-11ea-848d-38fb2c7b14b3.gif)
