### PR TITLE
Popover animations

### DIFF
--- a/src/popover/popover-config.spec.ts
+++ b/src/popover/popover-config.spec.ts
@@ -1,9 +1,12 @@
 import {NgbPopoverConfig} from './popover-config';
+import {NgbConfig} from '../ngb-config';
 
 describe('ngb-popover-config', () => {
   it('should have sensible default values', () => {
-    const config = new NgbPopoverConfig();
+    const ngbConfig = new NgbConfig();
+    const config = new NgbPopoverConfig(ngbConfig);
 
+    expect(config.animation).toBe(ngbConfig.animation);
     expect(config.autoClose).toBe(true);
     expect(config.placement).toBe('auto');
     expect(config.triggers).toBe('click');

--- a/src/popover/popover-config.ts
+++ b/src/popover/popover-config.ts
@@ -1,5 +1,6 @@
 import {Injectable} from '@angular/core';
 import {PlacementArray} from '../util/positioning';
+import {NgbConfig} from '../ngb-config';
 
 /**
  * A configuration service for the [`NgbPopover`](#/components/popover/api#NgbPopover) component.
@@ -9,6 +10,7 @@ import {PlacementArray} from '../util/positioning';
  */
 @Injectable({providedIn: 'root'})
 export class NgbPopoverConfig {
+  animation: boolean;
   autoClose: boolean | 'inside' | 'outside' = true;
   placement: PlacementArray = 'auto';
   triggers = 'click';
@@ -17,4 +19,6 @@ export class NgbPopoverConfig {
   popoverClass: string;
   openDelay = 0;
   closeDelay = 0;
+
+  constructor(ngbConfig: NgbConfig) { this.animation = ngbConfig.animation; }
 }

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -205,7 +205,8 @@ export class NgbTypeahead implements ControlValueAccessor,
     this._resubscribeTypeahead = new BehaviorSubject(null);
 
     this._popupService = new PopupService<NgbTypeaheadWindow>(
-        NgbTypeaheadWindow, injector, viewContainerRef, _renderer, componentFactoryResolver, applicationRef);
+        NgbTypeaheadWindow, injector, viewContainerRef, _renderer, this._ngZone, componentFactoryResolver,
+        applicationRef);
 
     this._zoneSubscription = ngZone.onStable.subscribe(() => {
       if (this.isPopupOpen()) {
@@ -304,7 +305,8 @@ export class NgbTypeahead implements ControlValueAccessor,
   private _openPopup() {
     if (!this.isPopupOpen()) {
       this._inputValueBackup = this._elementRef.nativeElement.value;
-      this._windowRef = this._popupService.open();
+      const {windowRef} = this._popupService.open();
+      this._windowRef = windowRef;
       this._windowRef.instance.id = this.popupId;
       this._windowRef.instance.selectEvent.subscribe((result: any) => this._selectResultClosePopup(result));
       this._windowRef.instance.activeChangeEvent.subscribe((activeId: string) => this.activeDescendant = activeId);
@@ -322,10 +324,11 @@ export class NgbTypeahead implements ControlValueAccessor,
   }
 
   private _closePopup() {
-    this._closed$.next();
-    this._popupService.close();
-    this._windowRef = null;
-    this.activeDescendant = null;
+    this._popupService.close().subscribe(() => {
+      this._closed$.next();
+      this._windowRef = null;
+      this.activeDescendant = null;
+    });
   }
 
   private _selectResult(result: any) {

--- a/src/util/popup.ts
+++ b/src/util/popup.ts
@@ -1,13 +1,19 @@
 import {
-  Injector,
-  TemplateRef,
-  ViewRef,
-  ViewContainerRef,
-  Renderer2,
-  ComponentRef,
+  ApplicationRef,
   ComponentFactoryResolver,
-  ApplicationRef
+  ComponentRef,
+  Injector,
+  NgZone,
+  Renderer2,
+  TemplateRef,
+  ViewContainerRef,
+  ViewRef
 } from '@angular/core';
+
+import {Observable, of} from 'rxjs';
+import {mergeMap, take, tap} from 'rxjs/operators';
+
+import {ngbRunTransition} from './transition/ngbTransition';
 
 export class ContentRef {
   constructor(public nodes: any[], public viewRef?: ViewRef, public componentRef?: ComponentRef<any>) {}
@@ -19,10 +25,11 @@ export class PopupService<T> {
 
   constructor(
       private _type: any, private _injector: Injector, private _viewContainerRef: ViewContainerRef,
-      private _renderer: Renderer2, private _componentFactoryResolver: ComponentFactoryResolver,
-      private _applicationRef: ApplicationRef) {}
+      private _renderer: Renderer2, private _ngZone: NgZone,
+      private _componentFactoryResolver: ComponentFactoryResolver, private _applicationRef: ApplicationRef) {}
 
-  open(content?: string | TemplateRef<any>, context?: any): ComponentRef<T> {
+  open(content?: string | TemplateRef<any>, context?: any, animation = false):
+      {windowRef: ComponentRef<T>, transition$: Observable<void>} {
     if (!this._windowRef) {
       this._contentRef = this._getContentRef(content, context);
       this._windowRef = this._viewContainerRef.createComponent(
@@ -30,20 +37,36 @@ export class PopupService<T> {
           this._injector, this._contentRef.nodes);
     }
 
-    return this._windowRef;
+    const {nativeElement} = this._windowRef.location;
+    const onStable$ = this._ngZone.onStable.asObservable().pipe(take(1));
+    const transition$ = onStable$.pipe(
+        mergeMap(
+            () => ngbRunTransition(
+                nativeElement, ({classList}) => classList.add('show'), {animation, runningTransition: 'continue'})));
+
+    return {windowRef: this._windowRef, transition$};
   }
 
-  close() {
-    if (this._windowRef) {
-      this._viewContainerRef.remove(this._viewContainerRef.indexOf(this._windowRef.hostView));
-      this._windowRef = null;
-
-      if (this._contentRef?.viewRef) {
-        this._applicationRef.detachView(this._contentRef.viewRef);
-        this._contentRef.viewRef.destroy();
-        this._contentRef = null;
-      }
+  close(animation = false): Observable<void> {
+    if (!this._windowRef) {
+      return of(undefined);
     }
+
+    return ngbRunTransition(
+               this._windowRef.location.nativeElement, ({classList}) => classList.remove('show'),
+               {animation, runningTransition: 'stop'})
+        .pipe(tap(() => {
+          if (this._windowRef) {
+            // this is required because of the container='body' option
+            this._viewContainerRef.remove(this._viewContainerRef.indexOf(this._windowRef.hostView));
+            this._windowRef = null;
+          }
+          if (this._contentRef?.viewRef) {
+            this._applicationRef.detachView(this._contentRef.viewRef);
+            this._contentRef.viewRef.destroy();
+            this._contentRef = null;
+          }
+        }));
   }
 
   private _getContentRef(content?: string | TemplateRef<any>, context?: any): ContentRef {


### PR DESCRIPTION
Again this is cherry-picked and fixed/adapted from #2817.

The popover API is the same as before:

```html
<div ngbPopover="Look at me!" (shown)="..." (hidden)="..."></div>
```

`(shown)` and `(hidden)` emit synchronously as before in case of reduced motion or no animations

Will open the same thing for the tooltip once this is merged