### PR TITLE
Sticky popovers and tooltips

### DIFF
--- a/demo/src/app/components/popover/demos/triggers/popover-triggers.html
+++ b/demo/src/app/components/popover/demos/triggers/popover-triggers.html
@@ -16,6 +16,20 @@
 
 <hr>
 <p>
+  Note that <code>mouseleave</code> close trigger will not close the popover when mouse cursor is over it.  Similarly, the <code>focusout</code> trigger will not close the popover when it is focused.  Use the buttons below to see it in action.
+</p>
+
+<button type="button" class="btn btn-outline-secondary mr-2" ngbPopover="Try to select and copy this text.  The popover is still open." triggers="mouseenter:mouseleave" popoverTitle="Pop title">
+  Hover over me!
+</button>
+
+<ng-template #popLink>Click the link to <a href="https://ng-bootstrap.github.io/" target="_blank">ng-bootstrap homepage</a>.  The popover is still open.</ng-template>
+<button type="button" class="btn btn-outline-secondary mr-2" [ngbPopover]="popLink" triggers="focusin:focusout" popoverTitle="Pop title">
+  Focus me!
+</button>
+
+<hr>
+<p>
   Alternatively you can take full manual control over popover opening / closing events.
 </p>
 

--- a/demo/src/app/components/popover/demos/triggers/popover-triggers.html
+++ b/demo/src/app/components/popover/demos/triggers/popover-triggers.html
@@ -16,17 +16,23 @@
 
 <hr>
 <p>
-  Note that <code>mouseleave</code> close trigger will not close the popover when mouse cursor is over it.  Similarly, the <code>focusout</code> trigger will not close the popover when it is focused.  Use the buttons below to see it in action.
+  Note that <code>mouseleave</code> close trigger will not close the popover when mouse cursor is over it.
+  Similarly, the <code>focusout</code> trigger will not close the popover when it is focused.
+  Use the buttons below to see it in action.
 </p>
 
-<button type="button" class="btn btn-outline-secondary mr-2" ngbPopover="Try to select and copy this text.  The popover is still open." triggers="mouseenter:mouseleave" popoverTitle="Pop title">
+<button type="button" class="btn btn-outline-secondary mr-2" ngbPopover="Try to select and copy this text.  The popover is still open." triggers="mouseenter:mouseleave" autoClose="outside" popoverTitle="Pop title">
   Hover over me!
 </button>
 
 <ng-template #popLink>Click the link to <a href="https://ng-bootstrap.github.io/" target="_blank">ng-bootstrap homepage</a>.  The popover is still open.</ng-template>
-<button type="button" class="btn btn-outline-secondary mr-2" [ngbPopover]="popLink" triggers="focusin:focusout" popoverTitle="Pop title">
+<button type="button" class="btn btn-outline-secondary mr-2" [ngbPopover]="popLink" triggers="focusin:focusout" autoClose="outside" popoverTitle="Pop title">
   Focus me!
 </button>
+
+<p class="mt-2">
+  <small><strong>NB</strong>: These buttons use <code>autoClose="outside"</code> to enable clicks inside the popoever.</small>
+</p>
 
 <hr>
 <p>

--- a/demo/src/app/components/popover/demos/triggers/popover-triggers.html
+++ b/demo/src/app/components/popover/demos/triggers/popover-triggers.html
@@ -2,8 +2,16 @@
   You can easily override open and close triggers by specifying event names (separated by <code>:</code>) in the <code>triggers</code> property.
 </p>
 
-<button type="button" class="btn btn-outline-secondary" ngbPopover="You see, I show up on hover!" triggers="mouseenter:mouseleave" popoverTitle="Pop title">
+<p>
+  Two common options are <code>mouseenter:mouseleave</code> (alias <code>hover</code>) and <code>focusin:focusout</code> (alias <code>focus</code>).
+</p>
+
+<button type="button" class="btn btn-outline-secondary mr-2" ngbPopover="You see, I show up on hover!" triggers="mouseenter:mouseleave" popoverTitle="Pop title">
   Hover over me!
+</button>
+
+<button type="button" class="btn btn-outline-secondary mr-2" ngbPopover="You see, I show up on focus!" triggers="focusin:focusout" popoverTitle="Pop title">
+  Focus me!
 </button>
 
 <hr>

--- a/demo/src/app/components/tooltip/demos/triggers/tooltip-triggers.html
+++ b/demo/src/app/components/tooltip/demos/triggers/tooltip-triggers.html
@@ -2,9 +2,37 @@
   You can easily override open and close triggers by specifying event names (separated by <code>:</code>) in the <code>triggers</code> property.
 </p>
 
-<button type="button" class="btn btn-outline-secondary" ngbTooltip="You see, I show up on click!" triggers="click:blur">
+<button type="button" class="btn btn-outline-secondary mr-2" ngbTooltip="You see, I show up on click!" triggers="click:blur">
   Click me!
 </button>
+
+<button type="button" class="btn btn-outline-secondary mr-2" ngbTooltip="You see, I show up on hover!" triggers="mouseenter:mouseleave">
+  Hover over me!
+</button>
+
+<button type="button" class="btn btn-outline-secondary mr-2" ngbTooltip="You see, I show up on focus!" triggers="focusin:focusout">
+  Focus me!
+</button>
+
+<hr>
+<p>
+  Note that <code>mouseleave</code> close trigger will not close the tooltip when mouse cursor is over it.
+  Similarly, the <code>focusout</code> trigger will not close the tooltip when it is focused.
+  Use the buttons below to see it in action.
+</p>
+
+<button type="button" class="btn btn-outline-secondary mr-2" ngbTooltip="Try to select and copy this text.  The tooltip is still open." triggers="mouseenter:mouseleave" autoClose="outside">
+  Hover over me!
+</button>
+
+<ng-template #popLink>Click the link to <a href="https://ng-bootstrap.github.io/" target="_blank">ng-bootstrap homepage</a>.  The tooltip is still open.</ng-template>
+<button type="button" class="btn btn-outline-secondary mr-2" [ngbTooltip]="popLink" triggers="focusin:focusout" autoClose="outside">
+  Focus me!
+</button>
+
+<p class="mt-2">
+  <small><strong>NB</strong>: These buttons use <code>autoClose="outside"</code> to enable clicks inside the tooltip.</small>
+</p>
 
 <hr>
 <p>

--- a/src/popover/popover-config.ts
+++ b/src/popover/popover-config.ts
@@ -17,4 +17,6 @@ export class NgbPopoverConfig {
   popoverClass: string;
   openDelay = 0;
   closeDelay = 0;
+  focusoutCloseDelay = 10;
+  mouseleaveCloseDelay = 100;
 }

--- a/src/popover/popover.scss
+++ b/src/popover/popover.scss
@@ -35,4 +35,8 @@ ngb-popover-window {
     top: auto;
     bottom: 0.7em;
   }
+
+  &:focus {
+    outline: none;
+  }
 }

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
+import {TestBed, ComponentFixture, inject, fakeAsync, tick} from '@angular/core/testing';
 import {createGenericTestComponent, triggerEvent} from '../test/common';
 
 import {By} from '@angular/platform-browser';
@@ -662,6 +662,58 @@ describe('ngb-popover', () => {
       fixture.detectChanges();
       expect(getWindow(fixture.nativeElement)).toBeNull();
     });
+  });
+
+  describe('stays open when hovered or focused', () => {
+    beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbPopoverModule]}); });
+
+    it('stays open when hovered with mouseleave close trigger', fakeAsync(() => {
+         const fixture = createTestComponent(`<div ngbPopover="Great tip!" triggers="mouseenter:mouseleave"></div>`);
+         const directive = fixture.debugElement.query(By.directive(NgbPopover));
+
+         triggerEvent(directive, 'mouseenter');
+         fixture.detectChanges();
+         expect(getWindow(fixture.nativeElement)).not.toBeNull();
+
+         triggerEvent(directive, 'mouseleave');
+         triggerEvent(getWindow(fixture.nativeElement), 'mouseenter');
+         fixture.detectChanges();
+         expect(getWindow(fixture.nativeElement)).not.toBeNull();
+
+         triggerEvent(getWindow(fixture.nativeElement), 'mouseleave');
+         triggerEvent(directive, 'mouseenter');
+         fixture.detectChanges();
+         expect(getWindow(fixture.nativeElement)).not.toBeNull();
+
+         triggerEvent(directive, 'mouseleave');
+         fixture.detectChanges();
+         tick(200);  // Artificially wait for some 200ms
+         expect(getWindow(fixture.nativeElement)).toBeNull();
+       }));
+
+    it('stays open when focused with focusout close trigger', fakeAsync(() => {
+         const fixture = createTestComponent(`<div ngbPopover="Great tip!" triggers="focusin:focusout"></div>`);
+         const directive = fixture.debugElement.query(By.directive(NgbPopover));
+
+         triggerEvent(directive, 'focusin');
+         fixture.detectChanges();
+         expect(getWindow(fixture.nativeElement)).not.toBeNull();
+
+         triggerEvent(directive, 'focusout');
+         triggerEvent(getWindow(fixture.nativeElement), 'focusin');
+         fixture.detectChanges();
+         expect(getWindow(fixture.nativeElement)).not.toBeNull();
+
+         triggerEvent(getWindow(fixture.nativeElement), 'focusout');
+         triggerEvent(directive, 'focusin');
+         fixture.detectChanges();
+         expect(getWindow(fixture.nativeElement)).not.toBeNull();
+
+         triggerEvent(directive, 'focusout');
+         fixture.detectChanges();
+         tick(200);  // Artificially wait for some 200ms
+         expect(getWindow(fixture.nativeElement)).toBeNull();
+       }));
   });
 
   describe('Custom config', () => {

--- a/src/tooltip/tooltip-config.ts
+++ b/src/tooltip/tooltip-config.ts
@@ -17,4 +17,6 @@ export class NgbTooltipConfig {
   tooltipClass: string;
   openDelay = 0;
   closeDelay = 0;
+  focusoutCloseDelay = 10;
+  mouseleaveCloseDelay = 100;
 }

--- a/src/tooltip/tooltip.scss
+++ b/src/tooltip/tooltip.scss
@@ -33,4 +33,8 @@ ngb-tooltip-window {
     top: auto;
     bottom: 0.4rem;
   }
+
+  &:focus {
+    outline: none;
+  }
 }

--- a/src/tooltip/tooltip.spec.ts
+++ b/src/tooltip/tooltip.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed, ComponentFixture, inject} from '@angular/core/testing';
+import {TestBed, ComponentFixture, inject, fakeAsync, tick} from '@angular/core/testing';
 import {createGenericTestComponent, triggerEvent} from '../test/common';
 
 import {By} from '@angular/platform-browser';
@@ -67,97 +67,102 @@ describe('ngb-tooltip', () => {
 
   describe('basic functionality', () => {
 
-    it('should open and close a tooltip - default settings and content as string', () => {
-      const fixture = createTestComponent(`<div ngbTooltip="Great tip!" style="margin-top: 100px;"></div>`);
-      const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+    it('should open and close a tooltip - default settings and content as string', fakeAsync(() => {
+         const fixture = createTestComponent(`<div ngbTooltip="Great tip!" style="margin-top: 100px;"></div>`);
+         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-      triggerEvent(directive, 'mouseenter');
-      fixture.detectChanges();
-      const windowEl = getWindow(fixture.nativeElement);
-      const id = windowEl.getAttribute('id');
+         triggerEvent(directive, 'mouseenter');
+         fixture.detectChanges();
+         const windowEl = getWindow(fixture.nativeElement);
+         const id = windowEl.getAttribute('id');
 
-      expect(windowEl).toHaveCssClass('tooltip');
-      expect(windowEl).toHaveCssClass('bs-tooltip-top');
-      expect(windowEl.textContent.trim()).toBe('Great tip!');
-      expect(windowEl.getAttribute('role')).toBe('tooltip');
-      expect(windowEl.parentNode).toBe(fixture.nativeElement);
-      expect(directive.nativeElement.getAttribute('aria-describedby')).toBe(id);
+         expect(windowEl).toHaveCssClass('tooltip');
+         expect(windowEl).toHaveCssClass('bs-tooltip-top');
+         expect(windowEl.textContent.trim()).toBe('Great tip!');
+         expect(windowEl.getAttribute('role')).toBe('tooltip');
+         expect(windowEl.parentNode).toBe(fixture.nativeElement);
+         expect(directive.nativeElement.getAttribute('aria-describedby')).toBe(id);
 
-      triggerEvent(directive, 'mouseleave');
-      fixture.detectChanges();
-      expect(getWindow(fixture.nativeElement)).toBeNull();
-      expect(directive.nativeElement.getAttribute('aria-describedby')).toBeNull();
-    });
+         triggerEvent(directive, 'mouseleave');
+         fixture.detectChanges();
+         tick(200);  // Artificially wait for some 200ms
+         expect(getWindow(fixture.nativeElement)).toBeNull();
+         expect(directive.nativeElement.getAttribute('aria-describedby')).toBeNull();
+       }));
 
-    it('should open and close a tooltip - default settings and content from a template', () => {
-      const fixture = createTestComponent(`
+    it('should open and close a tooltip - default settings and content from a template', fakeAsync(() => {
+         const fixture = createTestComponent(`
         <ng-template #t>Hello, {{name}}!</ng-template><div [ngbTooltip]="t" style="margin-top: 100px;"></div>`);
-      const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-      triggerEvent(directive, 'mouseenter');
-      fixture.detectChanges();
-      const windowEl = getWindow(fixture.nativeElement);
-      const id = windowEl.getAttribute('id');
+         triggerEvent(directive, 'mouseenter');
+         fixture.detectChanges();
+         const windowEl = getWindow(fixture.nativeElement);
+         const id = windowEl.getAttribute('id');
 
-      expect(windowEl).toHaveCssClass('tooltip');
-      expect(windowEl).toHaveCssClass('bs-tooltip-top');
-      expect(windowEl.textContent.trim()).toBe('Hello, World!');
-      expect(windowEl.getAttribute('role')).toBe('tooltip');
-      expect(windowEl.parentNode).toBe(fixture.nativeElement);
-      expect(directive.nativeElement.getAttribute('aria-describedby')).toBe(id);
+         expect(windowEl).toHaveCssClass('tooltip');
+         expect(windowEl).toHaveCssClass('bs-tooltip-top');
+         expect(windowEl.textContent.trim()).toBe('Hello, World!');
+         expect(windowEl.getAttribute('role')).toBe('tooltip');
+         expect(windowEl.parentNode).toBe(fixture.nativeElement);
+         expect(directive.nativeElement.getAttribute('aria-describedby')).toBe(id);
 
-      triggerEvent(directive, 'mouseleave');
-      fixture.detectChanges();
-      expect(getWindow(fixture.nativeElement)).toBeNull();
-      expect(directive.nativeElement.getAttribute('aria-describedby')).toBeNull();
-    });
+         triggerEvent(directive, 'mouseleave');
+         fixture.detectChanges();
+         tick(200);  // Artificially wait for some 200ms
+         expect(getWindow(fixture.nativeElement)).toBeNull();
+         expect(directive.nativeElement.getAttribute('aria-describedby')).toBeNull();
+       }));
 
-    it('should open and close a tooltip - default settings, content from a template and context supplied', () => {
-      const fixture = createTestComponent(`
+    it('should open and close a tooltip - default settings, content from a template and context supplied',
+       fakeAsync(() => {
+         const fixture = createTestComponent(`
         <ng-template #t let-name="name">Hello, {{name}}!</ng-template><div [ngbTooltip]="t" style="margin-top: 100px;"></div>`);
-      const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-      directive.context.tooltip.open({name: 'John'});
-      fixture.detectChanges();
-      const windowEl = getWindow(fixture.nativeElement);
-      const id = windowEl.getAttribute('id');
+         directive.context.tooltip.open({name: 'John'});
+         fixture.detectChanges();
+         const windowEl = getWindow(fixture.nativeElement);
+         const id = windowEl.getAttribute('id');
 
-      expect(windowEl).toHaveCssClass('tooltip');
-      expect(windowEl).toHaveCssClass('bs-tooltip-top');
-      expect(windowEl.textContent.trim()).toBe('Hello, John!');
-      expect(windowEl.getAttribute('role')).toBe('tooltip');
-      expect(windowEl.parentNode).toBe(fixture.nativeElement);
-      expect(directive.nativeElement.getAttribute('aria-describedby')).toBe(id);
+         expect(windowEl).toHaveCssClass('tooltip');
+         expect(windowEl).toHaveCssClass('bs-tooltip-top');
+         expect(windowEl.textContent.trim()).toBe('Hello, John!');
+         expect(windowEl.getAttribute('role')).toBe('tooltip');
+         expect(windowEl.parentNode).toBe(fixture.nativeElement);
+         expect(directive.nativeElement.getAttribute('aria-describedby')).toBe(id);
 
-      triggerEvent(directive, 'mouseleave');
-      fixture.detectChanges();
-      expect(getWindow(fixture.nativeElement)).toBeNull();
-      expect(directive.nativeElement.getAttribute('aria-describedby')).toBeNull();
-    });
+         triggerEvent(directive, 'mouseleave');
+         fixture.detectChanges();
+         tick(200);  // Artificially wait for some 200ms
+         expect(getWindow(fixture.nativeElement)).toBeNull();
+         expect(directive.nativeElement.getAttribute('aria-describedby')).toBeNull();
+       }));
 
-    it('should open and close a tooltip - default settings and custom class', () => {
-      const fixture = createTestComponent(`
+    it('should open and close a tooltip - default settings and custom class', fakeAsync(() => {
+         const fixture = createTestComponent(`
         <div ngbTooltip="Great tip!" tooltipClass="my-custom-class" style="margin-top: 100px;"></div>`);
-      const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-      triggerEvent(directive, 'mouseenter');
-      fixture.detectChanges();
-      const windowEl = getWindow(fixture.nativeElement);
-      const id = windowEl.getAttribute('id');
+         triggerEvent(directive, 'mouseenter');
+         fixture.detectChanges();
+         const windowEl = getWindow(fixture.nativeElement);
+         const id = windowEl.getAttribute('id');
 
-      expect(windowEl).toHaveCssClass('tooltip');
-      expect(windowEl).toHaveCssClass('bs-tooltip-top');
-      expect(windowEl).toHaveCssClass('my-custom-class');
-      expect(windowEl.textContent.trim()).toBe('Great tip!');
-      expect(windowEl.getAttribute('role')).toBe('tooltip');
-      expect(windowEl.parentNode).toBe(fixture.nativeElement);
-      expect(directive.nativeElement.getAttribute('aria-describedby')).toBe(id);
+         expect(windowEl).toHaveCssClass('tooltip');
+         expect(windowEl).toHaveCssClass('bs-tooltip-top');
+         expect(windowEl).toHaveCssClass('my-custom-class');
+         expect(windowEl.textContent.trim()).toBe('Great tip!');
+         expect(windowEl.getAttribute('role')).toBe('tooltip');
+         expect(windowEl.parentNode).toBe(fixture.nativeElement);
+         expect(directive.nativeElement.getAttribute('aria-describedby')).toBe(id);
 
-      triggerEvent(directive, 'mouseleave');
-      fixture.detectChanges();
-      expect(getWindow(fixture.nativeElement)).toBeNull();
-      expect(directive.nativeElement.getAttribute('aria-describedby')).toBeNull();
-    });
+         triggerEvent(directive, 'mouseleave');
+         fixture.detectChanges();
+         tick(200);  // Artificially wait for some 200ms
+         expect(getWindow(fixture.nativeElement)).toBeNull();
+         expect(directive.nativeElement.getAttribute('aria-describedby')).toBeNull();
+       }));
 
     it('should propagate tooltipClass changes to the window', () => {
       const fixture = createTestComponent(`<div ngbTooltip="Great tip!" [tooltipClass]="tooltipClass"></div>`);
@@ -209,22 +214,23 @@ describe('ngb-tooltip', () => {
       expect(windowEl).toBeNull();
     });
 
-    it('should allow re-opening previously closed tooltips', () => {
-      const fixture = createTestComponent(`<div ngbTooltip="Great tip!"></div>`);
-      const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+    it('should allow re-opening previously closed tooltips', fakeAsync(() => {
+         const fixture = createTestComponent(`<div ngbTooltip="Great tip!"></div>`);
+         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-      triggerEvent(directive, 'mouseenter');
-      fixture.detectChanges();
-      expect(getWindow(fixture.nativeElement)).not.toBeNull();
+         triggerEvent(directive, 'mouseenter');
+         fixture.detectChanges();
+         expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
-      triggerEvent(directive, 'mouseleave');
-      fixture.detectChanges();
-      expect(getWindow(fixture.nativeElement)).toBeNull();
+         triggerEvent(directive, 'mouseleave');
+         fixture.detectChanges();
+         tick(200);  // Artificially wait for some 200ms
+         expect(getWindow(fixture.nativeElement)).toBeNull();
 
-      triggerEvent(directive, 'mouseenter');
-      fixture.detectChanges();
-      expect(getWindow(fixture.nativeElement)).not.toBeNull();
-    });
+         triggerEvent(directive, 'mouseenter');
+         fixture.detectChanges();
+         expect(getWindow(fixture.nativeElement)).not.toBeNull();
+       }));
 
     it('should not leave dangling tooltips in the DOM', () => {
       const fixture = createTestComponent(`<ng-template [ngIf]="show"><div ngbTooltip="Great tip!"></div></ng-template>`);
@@ -354,18 +360,19 @@ describe('ngb-tooltip', () => {
 
     describe('triggers', () => {
 
-      it('should support focus triggers', () => {
-        const fixture = createTestComponent(`<div ngbTooltip="Great tip!"></div>`);
-        const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+      it('should support focus triggers', fakeAsync(() => {
+           const fixture = createTestComponent(`<div ngbTooltip="Great tip!"></div>`);
+           const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
-        triggerEvent(directive, 'focusin');
-        fixture.detectChanges();
-        expect(getWindow(fixture.nativeElement)).not.toBeNull();
+           triggerEvent(directive, 'focusin');
+           fixture.detectChanges();
+           expect(getWindow(fixture.nativeElement)).not.toBeNull();
 
-        triggerEvent(directive, 'focusout');
-        fixture.detectChanges();
-        expect(getWindow(fixture.nativeElement)).toBeNull();
-      });
+           triggerEvent(directive, 'focusout');
+           fixture.detectChanges();
+           tick(200);  // Artificially wait for some 200ms
+           expect(getWindow(fixture.nativeElement)).toBeNull();
+         }));
 
       it('should support toggle triggers', () => {
         const fixture = createTestComponent(`<div ngbTooltip="Great tip!" triggers="click"></div>`);
@@ -475,6 +482,58 @@ describe('ngb-tooltip', () => {
         expect(getWindow(fixture.nativeElement)).toBeNull();
       });
     });
+  });
+
+  describe('stays open when hovered or focused', () => {
+    beforeEach(() => { TestBed.configureTestingModule({declarations: [TestComponent], imports: [NgbTooltipModule]}); });
+
+    it('stays open when hovered with mouseleave close trigger', fakeAsync(() => {
+         const fixture = createTestComponent(`<div ngbTooltip="Great tip!" triggers="mouseenter:mouseleave"></div>`);
+         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+
+         triggerEvent(directive, 'mouseenter');
+         fixture.detectChanges();
+         expect(getWindow(fixture.nativeElement)).not.toBeNull();
+
+         triggerEvent(directive, 'mouseleave');
+         triggerEvent(getWindow(fixture.nativeElement), 'mouseenter');
+         fixture.detectChanges();
+         expect(getWindow(fixture.nativeElement)).not.toBeNull();
+
+         triggerEvent(getWindow(fixture.nativeElement), 'mouseleave');
+         triggerEvent(directive, 'mouseenter');
+         fixture.detectChanges();
+         expect(getWindow(fixture.nativeElement)).not.toBeNull();
+
+         triggerEvent(directive, 'mouseleave');
+         fixture.detectChanges();
+         tick(200);  // Artificially wait for some 200ms
+         expect(getWindow(fixture.nativeElement)).toBeNull();
+       }));
+
+    it('stays open when focused with focusout close trigger', fakeAsync(() => {
+         const fixture = createTestComponent(`<div ngbTooltip="Great tip!" triggers="focusin:focusout"></div>`);
+         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+
+         triggerEvent(directive, 'focusin');
+         fixture.detectChanges();
+         expect(getWindow(fixture.nativeElement)).not.toBeNull();
+
+         triggerEvent(directive, 'focusout');
+         triggerEvent(getWindow(fixture.nativeElement), 'focusin');
+         fixture.detectChanges();
+         expect(getWindow(fixture.nativeElement)).not.toBeNull();
+
+         triggerEvent(getWindow(fixture.nativeElement), 'focusout');
+         triggerEvent(directive, 'focusin');
+         fixture.detectChanges();
+         expect(getWindow(fixture.nativeElement)).not.toBeNull();
+
+         triggerEvent(directive, 'focusout');
+         fixture.detectChanges();
+         tick(200);  // Artificially wait for some 200ms
+         expect(getWindow(fixture.nativeElement)).toBeNull();
+       }));
   });
 
   describe('container', () => {

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -25,7 +25,7 @@ import {
 } from '@angular/core';
 import {DOCUMENT} from '@angular/common';
 import {Subject, Subscription} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
+import {switchMap, filter} from 'rxjs/operators';
 
 import {parseTriggers, observeTriggers, triggerDelay} from '../util/triggers';
 import {ngbAutoClose} from '../util/autoclose';
@@ -230,7 +230,7 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 
       // Subscribe to trigger events on the popover
       this._subscriptions.add(
-          this._windowRef.instance.inited.pipe(switchMap(nativeElement => this.observeEvents(nativeElement)))
+          this._windowRef.instance.inited.pipe(switchMap(nativeElement => this.observeEvents(nativeElement, true)))
               .subscribe(this._triggerEvents$$));
 
       this._renderer.setAttribute(this._elementRef.nativeElement, 'aria-describedby', this._ngbTooltipWindowId);
@@ -294,7 +294,7 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 
   ngOnInit() {
     // Subscribe to trigger events
-    this._subscriptions.add(this.observeEvents(this._elementRef.nativeElement).subscribe(this._triggerEvents$$));
+    this._subscriptions.add(this.observeEvents(this._elementRef.nativeElement, false).subscribe(this._triggerEvents$$));
 
     // React to trigger events by opening and closing the popover
     this._subscriptions.add(
@@ -318,8 +318,11 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
     this._subscriptions.unsubscribe();
   }
 
-  private observeEvents(nativeElement: HTMLElement) {
+  private observeEvents(nativeElement: HTMLElement, isPopover: boolean) {
     const parsedTriggers = parseTriggers(this.triggers);
-    return observeTriggers(this._renderer, nativeElement, parsedTriggers, this.isOpen.bind(this));
+    return observeTriggers(this._renderer, nativeElement, parsedTriggers, this.isOpen.bind(this))
+        .pipe(
+            // Do not handle popover clicks here because it is the realm of [autoClose]
+            isPopover ? filter(event => event.type !== 'click') : observable => observable);
   }
 }

--- a/src/util/triggers.spec.ts
+++ b/src/util/triggers.spec.ts
@@ -1,6 +1,6 @@
 import {fakeAsync, tick} from '@angular/core/testing';
 import {Subject, Subscription, Observable} from 'rxjs';
-import {parseTriggers, triggerDelay} from './triggers';
+import {parseTriggers, triggerDelay, TriggerEvent} from './triggers';
 
 describe('triggers', () => {
 
@@ -89,7 +89,7 @@ describe('triggers', () => {
   });
 
   describe('triggerDelay', () => {
-    let subject$: Subject<boolean>;
+    let subject$: Subject<TriggerEvent>;
     let delayed$: Observable<boolean>;
     let open: boolean;
     let subscription: Subscription | null = null;
@@ -98,7 +98,7 @@ describe('triggers', () => {
     beforeEach(() => {
       subject$ = new Subject();
       spy = jasmine.createSpy('listener', (newValue) => open = newValue).and.callThrough();
-      delayed$ = subject$.asObservable().pipe(triggerDelay(5000, 1000, () => open));
+      delayed$ = subject$.asObservable().pipe(triggerDelay(5000, 1000, 0, 0, () => open));
       subscription = delayed$.subscribe(spy);
     });
 
@@ -111,7 +111,7 @@ describe('triggers', () => {
 
     it('delays open', fakeAsync(() => {
          open = false;
-         subject$.next(true);
+         subject$.next({type: 'click', open: true});
          tick(4999);
          expect(spy).not.toHaveBeenCalled();
          tick(2);
@@ -122,7 +122,7 @@ describe('triggers', () => {
 
     it('cancels open if it is already done through another way', fakeAsync(() => {
          open = false;
-         subject$.next(true);
+         subject$.next({type: 'click', open: true});
          tick(4999);
          expect(spy).not.toHaveBeenCalled();
          open = true;
@@ -134,7 +134,7 @@ describe('triggers', () => {
 
     it('delays close', fakeAsync(() => {
          open = true;
-         subject$.next(false);
+         subject$.next({type: 'click', open: false});
          tick(999);
          expect(spy).not.toHaveBeenCalled();
          tick(2);
@@ -145,7 +145,7 @@ describe('triggers', () => {
 
     it('cancels close if it is already done through another way', fakeAsync(() => {
          open = true;
-         subject$.next(false);
+         subject$.next({type: 'click', open: false});
          tick(999);
          expect(spy).not.toHaveBeenCalled();
          open = false;
@@ -157,11 +157,11 @@ describe('triggers', () => {
 
     it('ignores extra open during openDelay', fakeAsync(() => {
          open = false;
-         subject$.next(true);
+         subject$.next({type: 'click', open: true});
          tick(200);
-         subject$.next(true);
+         subject$.next({type: 'click', open: true});
          tick(100);
-         subject$.next(true);
+         subject$.next({type: 'click', open: true});
          tick(200);
          tick(4499);
          expect(spy).not.toHaveBeenCalled();
@@ -173,11 +173,11 @@ describe('triggers', () => {
 
     it('ignores extra close during closeDelay', fakeAsync(() => {
          open = true;
-         subject$.next(false);
+         subject$.next({type: 'click', open: false});
          tick(200);
-         subject$.next(false);
+         subject$.next({type: 'click', open: false});
          tick(100);
-         subject$.next(false);
+         subject$.next({type: 'click', open: false});
          tick(200);
          tick(499);
          expect(spy).not.toHaveBeenCalled();
@@ -189,28 +189,28 @@ describe('triggers', () => {
 
     it('cancels open when receiving close during openDelay', fakeAsync(() => {
          open = false;
-         subject$.next(true);
+         subject$.next({type: 'click', open: true});
          tick(4999);
-         subject$.next(false);
+         subject$.next({type: 'click', open: false});
          tick(100000);
          expect(spy).not.toHaveBeenCalled();
        }));
 
     it('cancels close when receiving open during closeDelay', fakeAsync(() => {
          open = true;
-         subject$.next(false);
+         subject$.next({type: 'click', open: false});
          tick(999);
-         subject$.next(true);
+         subject$.next({type: 'click', open: true});
          tick(100000);
          expect(spy).not.toHaveBeenCalled();
        }));
 
     it('closes during openDelay if opened through another way', fakeAsync(() => {
          open = false;
-         subject$.next(true);
+         subject$.next({type: 'click', open: true});
          tick(4999);
          open = true;
-         subject$.next(false);
+         subject$.next({type: 'click', open: false});
          tick(999);
          expect(spy).not.toHaveBeenCalled();
          tick(2);
@@ -221,10 +221,10 @@ describe('triggers', () => {
 
     it('opens during closeDelay if closed through another way', fakeAsync(() => {
          open = true;
-         subject$.next(false);
+         subject$.next({type: 'click', open: false});
          tick(999);
          open = false;
-         subject$.next(true);
+         subject$.next({type: 'click', open: true});
          tick(4999);
          expect(spy).not.toHaveBeenCalled();
          tick(2);


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.

---

This PR attempts to solve the problem described in https://github.com/ng-bootstrap/ng-bootstrap/issues/2169,

# Motivation

In our project we have popovers with information that users might like to copy, and also popovers with links for users to click. I consider these scenarios fairly basic and common, but ngbPopover doesn't really support them because it closes as soon as the user moves the mouse out of the element the popover is bound to (I will call it _the target element_ from here on).

Here are some "solutions" we considered:
  - Force our users to make a click to open the popup
  - Confugure `[closeDelay]` large enough for users to be able to click a link before the popup closes
  - Use code snippets from https://github.com/ng-bootstrap/ng-bootstrap/issues/2169.

None of these are acceptable.

# Proposal

The _basic idea_ is to listen to trigger events both on the target element AND the popover element. To illustrate, in case of `triggers="mouseenter:mouseleave"` the popover will close on `mouseleave` UNLESS `mouseenter` was triggered when the user moved the cursor from the target element to the popover.

Of course, the cursor isn't moved instantaneously, so some delay is required. You can find it in the new `NgbPopoverConfig.mouseleaveCloseDelay` field and `NgbPopover.mouseleaveCloseDelay` input. I chose 100 ms as the default, but you are welcome to suggest any other positive number. I will tell you more, there is a similar field and a similar input for `focusout` as well.

You might argue that this approach is wrong and these events shouldn't be treated as special citizens. Maybe they shouldn't, but although I am open to suggestions regarding design and refactoring I would prefer to keep the code dumb and not over-complicate things until the basic idea is approved and my approach reviewed and tested. (Also I must note here that events will need to be handled differently anyway because they require different delays: mouse movement does not happen instantly while clicks and focus changes do.)

Among the enhancements themselves this PR includes:
1. A couple of new unit tests which appropriately fail without the enhancements
2. A couple of new buttons on the popover demo page so that the updated behavior can be seen in action.
3. Similar enhancements, unit tests and demos for ngbTooltip

There are some technical details I would like to point out:
1. In order to detect focus events, a popover needs to be focusable (have `tabIndex`)
2. "Click" triggers are excluded from the general rule: in contrast to other trigger events, clicks are not listened to on the popover element. This is because clicks outside the target element are already nicely handled by `autoClose`.

_Update_: fixed some typos.