### PR TITLE
Tooltip animations

### DIFF
--- a/src/test/test-styles.css
+++ b/src/test/test-styles.css
@@ -9,6 +9,10 @@
   transition: opacity 0.01s linear !important;
 }
 
+.tooltip.show {
+  opacity: 1 !important;
+}
+
 .collapsing {
   transition: height 0.01s ease !important;
 }

--- a/src/tooltip/tooltip-config.spec.ts
+++ b/src/tooltip/tooltip-config.spec.ts
@@ -1,9 +1,13 @@
 import {NgbTooltipConfig} from './tooltip-config';
 
+import {NgbConfig} from '../ngb-config';
+
 describe('ngb-tooltip-config', () => {
   it('should have sensible default values', () => {
-    const config = new NgbTooltipConfig();
+    const ngbConfig = new NgbConfig();
+    const config = new NgbTooltipConfig(ngbConfig);
 
+    expect(config.animation).toBe(ngbConfig.animation);
     expect(config.autoClose).toBe(true);
     expect(config.placement).toBe('auto');
     expect(config.triggers).toBe('hover focus');

--- a/src/tooltip/tooltip-config.ts
+++ b/src/tooltip/tooltip-config.ts
@@ -1,5 +1,6 @@
 import {Injectable} from '@angular/core';
 import {PlacementArray} from '../util/positioning';
+import {NgbConfig} from '../ngb-config';
 
 /**
  * A configuration service for the [`NgbTooltip`](#/components/tooltip/api#NgbTooltip) component.
@@ -9,6 +10,7 @@ import {PlacementArray} from '../util/positioning';
  */
 @Injectable({providedIn: 'root'})
 export class NgbTooltipConfig {
+  animation: boolean;
   autoClose: boolean | 'inside' | 'outside' = true;
   placement: PlacementArray = 'auto';
   triggers = 'hover focus';
@@ -17,4 +19,6 @@ export class NgbTooltipConfig {
   tooltipClass: string;
   openDelay = 0;
   closeDelay = 0;
+
+  constructor(ngbConfig: NgbConfig) { this.animation = ngbConfig.animation; }
 }

--- a/src/tooltip/tooltip.spec.ts
+++ b/src/tooltip/tooltip.spec.ts
@@ -15,6 +15,7 @@ import {
 import {NgbTooltipModule} from './tooltip.module';
 import {NgbTooltipWindow, NgbTooltip} from './tooltip';
 import {NgbTooltipConfig} from './tooltip-config';
+import {NgbConfig} from '../ngb-config';
 
 const createTestComponent =
     (html: string) => <ComponentFixture<TestComponent>>createGenericTestComponent(html, TestComponent);
@@ -604,7 +605,7 @@ describe('ngb-tooltip', () => {
   });
 
   describe('Custom config as provider', () => {
-    let config = new NgbTooltipConfig();
+    let config = new NgbTooltipConfig(new NgbConfig());
     config.placement = 'bottom';
     config.triggers = 'click';
     config.container = 'body';


### PR DESCRIPTION
Same as popover in #3792, but for the tooltip

Again this is cherry-picked and fixed/adapted from #2817.

The popover API is the same as before:

<div ngbPopover="Look at me!" (shown)="..." (hidden)="..."></div>
(shown) and (hidden) emit synchronously as before in case of reduced motion or no animations

Will open the same thing for the tooltip once this is merged