### PR TITLE
fix(demo): remove cursor, add tabindex on navbar dropdown toggles

### DIFF
--- a/demo/src/app/components/dropdown/demos/navbar/dropdown-navbar.html
+++ b/demo/src/app/components/dropdown/demos/navbar/dropdown-navbar.html
@@ -33,7 +33,7 @@
   <div class="navbar-collapse" [class.collapse]="collapsed" id="navbarContent">
     <ul class="navbar-nav ml-auto">
       <li class="nav-item" ngbDropdown>
-        <a class="nav-link" style="cursor: pointer" ngbDropdownToggle id="navbarDropdown1" role="button">
+        <a class="nav-link" tabindex="0" ngbDropdownToggle id="navbarDropdown1" role="button">
           Static
         </a>
         <div ngbDropdownMenu aria-labelledby="navbarDropdown1" class="dropdown-menu">
@@ -44,7 +44,7 @@
       </li>
 
       <li class="nav-item" ngbDropdown>
-        <a class="nav-link" style="cursor: pointer" ngbDropdownToggle id="navbarDropdown2" role="button">
+        <a class="nav-link" tabindex="0" ngbDropdownToggle id="navbarDropdown2" role="button">
           Static right
         </a>
         <div ngbDropdownMenu aria-labelledby="navbarDropdown2" class="dropdown-menu dropdown-menu-right">
@@ -55,7 +55,7 @@
       </li>
 
       <li class="nav-item" ngbDropdown display="dynamic" placement="bottom-right">
-        <a class="nav-link" style="cursor: pointer" ngbDropdownToggle id="navbarDropdown3" role="button">
+        <a class="nav-link" tabindex="0" ngbDropdownToggle id="navbarDropdown3" role="button">
           Dynamic
         </a>
         <div ngbDropdownMenu aria-labelledby="navbarDropdown3" class="dropdown-menu">

--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -43,7 +43,6 @@ header.navbar {
   margin-left: -15px;
   margin-right: -15px;
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-  cursor: pointer;
 }
 
 .sidebar {


### PR DESCRIPTION
Bootstrap automatically sets the cursor to pointer when the element has role button.
But links without href are not tabbable by default, which makes them keyboard-inaccessible if tabindex is not set

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
