### PR TITLE
feat(carousel): add animations

### DIFF
--- a/src/carousel/carousel-config.spec.ts
+++ b/src/carousel/carousel-config.spec.ts
@@ -1,8 +1,9 @@
 import {NgbCarouselConfig} from './carousel-config';
+import {NgbConfig} from '../ngb-config';
 
 describe('ngb-carousel-config', () => {
   it('should have sensible default values', () => {
-    const config = new NgbCarouselConfig();
+    const config = new NgbCarouselConfig(new NgbConfig());
 
     expect(config.interval).toBe(5000);
     expect(config.keyboard).toBe(true);

--- a/src/carousel/carousel-config.ts
+++ b/src/carousel/carousel-config.ts
@@ -1,4 +1,5 @@
 import {Injectable} from '@angular/core';
+import {NgbConfig} from '../ngb-config';
 
 /**
  * A configuration service for the [NgbCarousel](#/components/carousel/api#NgbCarousel) component.
@@ -8,6 +9,7 @@ import {Injectable} from '@angular/core';
  */
 @Injectable({providedIn: 'root'})
 export class NgbCarouselConfig {
+  animation: boolean;
   interval = 5000;
   wrap = true;
   keyboard = true;
@@ -15,4 +17,6 @@ export class NgbCarouselConfig {
   pauseOnFocus = true;
   showNavigationArrows = true;
   showNavigationIndicators = true;
+
+  constructor(ngbConfig: NgbConfig) { this.animation = ngbConfig.animation; }
 }

--- a/src/carousel/carousel-transition.ts
+++ b/src/carousel/carousel-transition.ts
@@ -1,0 +1,63 @@
+import {NgbTransitionStartFn} from '../util/transition/ngbTransition';
+import {reflow} from '../util/util';
+
+/**
+ * Defines the carousel slide transition direction.
+ */
+export enum NgbSlideEventDirection {
+  LEFT = 'left',
+  RIGHT = 'right'
+}
+
+export interface NgbCarouselCtx { direction: 'left' | 'right'; }
+
+const isAnimated = ({classList}) => {
+  return classList.contains('carousel-item-left') || classList.contains('carousel-item-right');
+};
+
+const removeDirectionClasses = ({classList}) => {
+  classList.remove('carousel-item-left');
+  classList.remove('carousel-item-right');
+};
+
+const removeClasses = ({classList}) => {
+  removeDirectionClasses({classList});
+  classList.remove('carousel-item-prev');
+  classList.remove('carousel-item-next');
+};
+
+export const ngbCarouselTransitionIn: NgbTransitionStartFn<NgbCarouselCtx> =
+    (element: HTMLElement, {direction}: NgbCarouselCtx) => {
+      const {classList} = element;
+      if (isAnimated(element)) {
+        // Revert the transition
+        removeDirectionClasses(element);
+      } else {
+        // For the 'in' transition, a 'pre-class' is applied to the element to ensure its visibility
+        classList.add('carousel-item-' + (direction === NgbSlideEventDirection.LEFT ? 'next' : 'prev'));
+        reflow(element);
+        classList.add('carousel-item-' + direction);
+      }
+
+      return () => {
+        removeClasses(element);
+        classList.add('active');
+      };
+    };
+
+export const ngbCarouselTransitionOut: NgbTransitionStartFn<NgbCarouselCtx> =
+    (element: HTMLElement, {direction}: NgbCarouselCtx) => {
+      const {classList} = element;
+      //  direction is left or right, depending on the way the slide goes out.
+      if (isAnimated(element)) {
+        // Revert the transition
+        removeDirectionClasses(element);
+      } else {
+        classList.add('carousel-item-' + direction);
+      }
+
+      return () => {
+        removeClasses(element);
+        classList.remove('active');
+      };
+    };

--- a/src/carousel/carousel.module.ts
+++ b/src/carousel/carousel.module.ts
@@ -3,7 +3,8 @@ import {CommonModule} from '@angular/common';
 
 import {NGB_CAROUSEL_DIRECTIVES} from './carousel';
 
-export {NgbCarousel, NgbSlide, NgbSlideEvent, NgbSlideEventDirection, NgbSlideEventSource} from './carousel';
+export {NgbCarousel, NgbSlide, NgbSlideEvent, NgbSlideEventSource} from './carousel';
+export {NgbSlideEventDirection} from './carousel-transition';
 export {NgbCarouselConfig} from './carousel-config';
 
 @NgModule({declarations: NGB_CAROUSEL_DIRECTIVES, exports: NGB_CAROUSEL_DIRECTIVES, imports: [CommonModule]})

--- a/src/test/test-styles.css
+++ b/src/test/test-styles.css
@@ -23,7 +23,16 @@
   transition: transform 0.01s ease-out,-webkit-transform 0.01s ease-out !important;
 }
 
-.ngb-reduce-motion .fade, .ngb-reduce-motion .collapsing, .ngb-reduce-motion .modal.fade .modal-dialog {
+.carousel-item {
+  transition: -webkit-transform 0.01s ease-out !important;
+  transition: transform 0.01s ease-out !important;
+  transition: transform 0.01s ease-out,-webkit-transform 0.01s ease-out !important;
+}
+
+.ngb-reduce-motion .fade,
+.ngb-reduce-motion .collapsing,
+.ngb-reduce-motion .modal.fade .modal-dialog,
+.ngb-reduce-motion .carousel-item {
   transition: none !important;
 }
 


### PR DESCRIPTION
Cherry-picked form #2817, then simplified and adapted to be aligned with recent widget development.

To be noticed:

- The `slid` event has been added (when the transition finish),
- The revert can be done only if the previous slide is selected.