### PR TITLE
Removed tabindex=-1 so that opening the modal does not unfocus already focused inputs.

### DIFF
--- a/src/modal/modal-window.ts
+++ b/src/modal/modal-window.ts
@@ -25,7 +25,7 @@ import {ModalDismissReasons} from './modal-dismiss-reasons';
   host: {
     '[class]': '"modal fade show d-block" + (windowClass ? " " + windowClass : "")',
     'role': 'dialog',
-    'tabindex': '-1',
+    // 'tabindex': '-1',
     '[attr.aria-modal]': 'true',
     '[attr.aria-labelledby]': 'ariaLabelledBy',
     '[attr.aria-describedby]': 'ariaDescribedBy',


### PR DESCRIPTION
Removed tabindex=-1 so that opening the modal does not unfocus already focused inputs.

Before submitting a pull request, please make sure you have at least performed the following:

 - [ ] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [ ] built and tested the changes locally.
 - [ ] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.
