### PR TITLE
Update Angular and Bootstrap versions in the docs for 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The supported versions are:
 | 4.x.x        | 7.0.0   | 4.0.0         |
 | 5.x.x        | 8.0.0   | 4.3.1         |
 | 6.x.x        | 9.0.0   | 4.4.1         |
+| 7.x.x        | 10.0.0  | 4.5.0         |
 
 ## Installation
 
@@ -64,7 +65,7 @@ If you prefer not to use schematics and install everything manually, please refe
 
 ## Supported browsers
 
-We support the same browsers and versions supported by both Bootstrap 4 and Angular, whichever is _more_ restrictive. See [Angular browser support](https://angular.io/guide/browser-support) and [Bootstrap browser support](https://getbootstrap.com/docs/4.4/getting-started/browsers-devices/#supported-browsers) for more details.
+We support the same browsers and versions supported by both Bootstrap 4 and Angular, whichever is _more_ restrictive. See [Angular browser support](https://angular.io/guide/browser-support) and [Bootstrap browser support](https://getbootstrap.com/docs/4.5/getting-started/browsers-devices/#supported-browsers) for more details.
 
 Out code is automatically tested on all supported browsers.
 

--- a/demo/src/app/components/toast/overview/toast-overview.component.html
+++ b/demo/src/app/components/toast/overview/toast-overview.component.html
@@ -88,7 +88,8 @@
       <svg:svg ngbdIcon="lightbulb" fill="currentColor" />
     </div>
     <div>
-      Note the accessibility attributes <code>aria-live="polite"</code> &amp; <code>aria-atomic="true"</code>. They are <strong>mandatory</strong> in order to be compliant with screen readers technology. More information available on <a href="https://getbootstrap.com/docs/4.3/components/toasts/#accessibility" target="_blank" rel="noopener noreferrer">Bootstrap documentation</a>.
+      Note the accessibility attributes <code>aria-live="polite"</code> &amp; <code>aria-atomic="true"</code>. They are <strong>mandatory</strong> in order to be compliant with screen readers technology.
+      More information available on <a href="https://getbootstrap.com/docs/{{ bsVersion }}/components/toasts/#accessibility" target="_blank" rel="noopener noreferrer">Bootstrap documentation</a>.
     </div>
   </ngb-alert>
 

--- a/demo/src/app/components/toast/overview/toast-overview.component.ts
+++ b/demo/src/app/components/toast/overview/toast-overview.component.ts
@@ -3,6 +3,7 @@ import {Component} from '@angular/core';
 import {Snippet} from '../../../shared/code/snippet';
 import {NgbdDemoList} from '../../shared';
 import {NgbdOverview} from '../../shared/overview';
+import {versions} from '../../../../environments/versions';
 
 
 
@@ -12,6 +13,9 @@ import {NgbdOverview} from '../../shared/overview';
   host: {'[class.overview]': 'true'}
 })
 export class NgbdToastOverviewComponent {
+
+  bsVersion = versions.bootstrap;
+
   TOAST_INLINE_BASIC = Snippet({
     lang: 'html',
     code: `

--- a/demo/src/app/components/toast/toast.module.ts
+++ b/demo/src/app/components/toast/toast.module.ts
@@ -16,6 +16,7 @@ import {NgbdToastInlineModule} from './demos/inline/toast-inline.module';
 import {NgbdToastPreventAutohide} from './demos/prevent-autohide/toast-prevent-autohide';
 import {NgbdToastPreventAutohideModule} from './demos/prevent-autohide/toast-prevent-autohide.module';
 import {NgbdToastOverviewComponent} from './overview/toast-overview.component';
+import {versions} from '../../../environments/versions';
 
 const OVERVIEW = {
   'inline-usage': 'Declarative usage',
@@ -92,12 +93,14 @@ const DEMOS = {
   }
 };
 
+const bsVersion = versions.bootstrap;
+
 export const ROUTES = [
   {path: '', pathMatch: 'full', redirectTo: 'overview'}, {
     path: '',
     component: ComponentWrapper,
     data: {
-      bootstrap: 'https://getbootstrap.com/docs/4.4/components/toasts/'
+      bootstrap: `https://getbootstrap.com/docs/${bsVersion}/components/toasts/`
     },
     children: [
       {path: 'overview', component: NgbdToastOverviewComponent}, {path: 'examples', component: NgbdExamplesPage},

--- a/demo/src/app/pages/getting-started/getting-started.component.html
+++ b/demo/src/app/pages/getting-started/getting-started.component.html
@@ -101,7 +101,7 @@
 
         <p>
           You need to add Bootstrap CSS to your application using your preferred way (see
-          <a href="https://getbootstrap.com/docs/4.4/getting-started/download/" target="_blank">Bootstrap instructions</a>).
+          <a href="https://getbootstrap.com/docs/{{ bsVersion }}/getting-started/download/" target="_blank">Bootstrap instructions</a>).
         </p>
 
         <p>
@@ -182,7 +182,7 @@
 
   <p>We strive to support the same browsers and versions as supported by both Bootstrap and Angular, whichever is more restrictive. Check browser support notes for
     <a href="https://angular.io/guide/browser-support" target="_blank">Angular</a> and
-    <a href="https://getbootstrap.com/docs/4.4/getting-started/browsers-devices/" target="_blank">Bootstrap</a>.
+    <a href="https://getbootstrap.com/docs/{{ bsVersion }}/getting-started/browsers-devices/" target="_blank">Bootstrap</a>.
   </p>
 
   <p>Our code is automatically tested on all supported browsers.</p>

--- a/demo/src/app/pages/getting-started/getting-started.component.html
+++ b/demo/src/app/pages/getting-started/getting-started.component.html
@@ -47,6 +47,11 @@
         <td>9.0.0</td>
         <td>4.4.1</td>
       </tr>
+      <tr>
+        <th scope="row">7.x.x</th>
+        <td>10.0.0</td>
+        <td>4.5.0</td>
+      </tr>
     </tbody>
   </table>
 

--- a/demo/src/app/pages/getting-started/getting-started.component.ts
+++ b/demo/src/app/pages/getting-started/getting-started.component.ts
@@ -1,5 +1,6 @@
 import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {Snippet} from '../../shared/code/snippet';
+import {versions} from '../../../environments/versions';
 
 @Component({
   templateUrl: './getting-started.component.html',
@@ -8,6 +9,7 @@ import {Snippet} from '../../shared/code/snippet';
 export class GettingStartedPage {
 
   instructionsCollapsed = true;
+  bsVersion = versions.bootstrap;
 
   schematics = Snippet({
     lang: 'bash',


### PR DESCRIPTION
Contains two commits:
- first one fixes places in the documentation where Bootstrap version was hardcoded
- second bumps Angular to 10 and Bootstrap to 4.5 in the docs