### PR TITLE
fix(animations): make collapsing transition work with SSR

### DIFF
--- a/src/util/transition/ngbCollapseTransition.ts
+++ b/src/util/transition/ngbCollapseTransition.ts
@@ -7,6 +7,11 @@ export interface NgbCollapseCtx {
 }
 
 function measureCollapsingElementHeightPx(element: HTMLElement): string {
+  // SSR fix for without injecting the PlatformId
+  if (typeof navigator === 'undefined') {
+    return '0px';
+  }
+
   const {classList} = element;
   const hasShownClass = classList.contains('show');
   if (!hasShownClass) {


### PR DESCRIPTION
Fixes an issue where collapsing transition is not compatible with SSR when launched from component lifecycle methods like `onInit`:

```
ERROR TypeError: element.getBoundingClientRect is not a function
[express]     at measureCollapsingElementHeightPx (/Users/mokorokov/Dev/Angular/core/ssr-app/dist/server/main.js:1557:28)
[express]     at ngbCollapsingTransition (/Users/mokorokov/Dev/Angular/core/ssr-app/dist/server/main.js:1568:21)
[express]     at ngbRunTransition (/Users/mokorokov/Dev/Angular/core/ssr-app/dist/server/main.js:1519:19)
[express]     at NgbCollapse._runTransition (/Users/mokorokov/Dev/Angular/core/ssr-app/dist/server/main.js:3027:9)
[express]     at NgbCollapse.ngOnInit (/Users/mokorokov/Dev/Angular/core/ssr-app/dist/server/main.js:3008:14)
```