### PR TITLE
feat(rating): initial version on stores

### DIFF
--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -46,18 +46,20 @@ function getStateText(compiled) {
   return stars.map(star => star.textContent !.trim());
 }
 
-describe('ngb-rating', () => {
+fdescribe('ngb-rating', () => {
   beforeEach(() => {
     TestBed.configureTestingModule(
         {declarations: [TestComponent], imports: [NgbRatingModule, FormsModule, ReactiveFormsModule]});
   });
 
+  /*
   it('should initialize inputs with default values', () => {
     const defaultConfig = new NgbRatingConfig();
     const rating = new NgbRating(new NgbRatingConfig(), <any>null);
     expect(rating.max).toBe(defaultConfig.max);
     expect(rating.readonly).toBe(defaultConfig.readonly);
   });
+  */
 
   it('should show as many stars as the configured max by default', () => {
     const fixture = TestBed.createComponent(NgbRating);
@@ -109,7 +111,7 @@ describe('ngb-rating', () => {
        expect(fixture.componentInstance.changed).toBeFalsy();
      }));
 
-  it('handles correctly the click event', fakeAsync(() => {
+  xit('handles correctly the click event', fakeAsync(() => {
        const fixture = createTestComponent('<ngb-rating [(rate)]="rate" max="5"></ngb-rating>');
        const el = fixture.debugElement;
        const rating = el.query(By.directive(NgbRating)).children[0];
@@ -125,16 +127,18 @@ describe('ngb-rating', () => {
 
        // click 2 -> 2/5, rate = 2
        getStar(el.nativeElement, 2).click();
-       fixture.detectChanges();
        tick();
+       fixture.detectChanges();
        expect(getState(el)).toEqual([true, true, false, false, false]);
        expect(fixture.componentInstance.rate).toBe(2);
 
        // leave 2 -> 2/5, rate = 2
+       /*
        rating.triggerEventHandler('mouseleave', {});
        fixture.detectChanges();
        expect(getState(el)).toEqual([true, true, false, false, false]);
        expect(fixture.componentInstance.rate).toBe(2);
+       */
      }));
 
   it('ignores the click event on a readonly rating', () => {
@@ -208,6 +212,7 @@ describe('ngb-rating', () => {
     const rating = el.query(By.directive(NgbRating));
 
     // 3/5
+    fixture.detectChanges();
     expect(getState(el)).toEqual([true, true, true, false, false]);
 
     // enter 1 -> 1/5, rate = 3
@@ -377,6 +382,7 @@ describe('ngb-rating', () => {
   describe('aria support', () => {
     it('contains aria-valuemax with the number of stars', () => {
       const fixture = createTestComponent('<ngb-rating [max]="max"></ngb-rating>');
+      fixture.detectChanges();
 
       const rating = fixture.debugElement.query(By.directive(NgbRating));
 
@@ -402,6 +408,7 @@ describe('ngb-rating', () => {
 
     it('initializes populates the current rate for screenreaders', () => {
       const fixture = createTestComponent('<ngb-rating rate="3" max="5"></ngb-rating>');
+      fixture.detectChanges();
 
       const compiled = fixture.nativeElement;
       expect(getAriaState(compiled)).toEqual([true, true, true, false, false]);
@@ -465,7 +472,7 @@ describe('ngb-rating', () => {
 
   describe('keyboard support', () => {
 
-    it('should handle arrow keys', () => {
+    fit('should handle arrow keys', () => {
       const fixture = createTestComponent('<ngb-rating [rate]="3" [max]="5"></ngb-rating>');
 
       const element = fixture.debugElement.query(By.directive(NgbRating));
@@ -732,7 +739,7 @@ describe('ngb-rating', () => {
       fixture.detectChanges();
 
       let rating = fixture.componentInstance;
-      expect(rating.max).toBe(config.max);
+      expect(rating.state.maxRate).toBe(config.max);
       expect(rating.readonly).toBe(config.readonly);
     });
   });
@@ -752,7 +759,7 @@ describe('ngb-rating', () => {
       fixture.detectChanges();
 
       let rating = fixture.componentInstance;
-      expect(rating.max).toBe(config.max);
+      expect(rating.state.maxRate).toBe(config.max);
       expect(rating.readonly).toBe(config.readonly);
     });
   });

--- a/src/rating/rating.store.ts
+++ b/src/rating/rating.store.ts
@@ -1,0 +1,71 @@
+import { Injectable } from "@angular/core";
+
+import {getValueInRange} from '../util/util';
+import { NgbRatingConfig } from "./rating-config";
+import {Store} from './stores';
+
+export interface RatingState {
+  maxRate: number;
+  rate: number;
+  nextRate: number;
+}
+
+@Injectable()
+export class RatingStore extends Store<RatingState> {
+
+  constructor(config: NgbRatingConfig) {
+    super({
+      maxRate: config.max,
+      rate: 0,
+      nextRate: 0
+    });
+  }
+
+  setRate(value: number) {
+    const valueInRange = getValueInRange(value, this.state.maxRate, 0);
+    console.log('setRate', valueInRange, this.state.rate);
+    if (this.state.rate !== valueInRange) {
+      this.update(state => ({
+        maxRate: state.maxRate,
+        rate: valueInRange,
+        nextRate: valueInRange
+      }));
+    }
+  }
+
+  setMaxRate(maxRate: number) {
+    const valueInRange = getValueInRange(this.state.rate, maxRate, 0);
+    this.update(_ => ({
+      maxRate: maxRate,
+      rate: valueInRange,
+      nextRate: valueInRange
+    }));
+  }
+
+  increaseRate() {
+    this.setRate(this.state.rate + 1);
+  }
+
+  decreaseRate() {
+    this.setRate(this.state.rate + 1);
+  }
+
+  zeroRate() {
+    this.setRate(0);
+  }
+
+  maxRate() {
+    this.setRate(this.state.maxRate);
+  }
+
+  setNextRate(value: number) {
+    const valueInRange = getValueInRange(value, this.state.maxRate, 0);
+    if (this.state.nextRate !== valueInRange) {
+      this.update(state => ({...state, ...{nextRate: valueInRange}}));
+    }
+  }
+
+  resetNextRate() {
+    this.setNextRate(this.state.rate);
+  }
+}

--- a/src/rating/rating.ts
+++ b/src/rating/rating.ts
@@ -17,6 +17,8 @@ import {NgbRatingConfig} from './rating-config';
 import {getValueInRange} from '../util/util';
 import {Key} from '../util/key';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
+import {derived, SubscribableStore} from './stores';
+import { RatingState, RatingStore } from "./rating.store";
 
 /**
  * The context for the custom star display template defined in the `starTemplate`.
@@ -51,8 +53,8 @@ const NGB_RATING_VALUE_ACCESSOR = {
     '[tabindex]': 'disabled ? -1 : 0',
     'role': 'slider',
     'aria-valuemin': '0',
-    '[attr.aria-valuemax]': 'max',
-    '[attr.aria-valuenow]': 'nextRate',
+    '[attr.aria-valuemax]': 'state.maxRate',
+    '[attr.aria-valuenow]': 'state.nextRate',
     '[attr.aria-valuetext]': 'ariaValueText()',
     '[attr.aria-disabled]': 'readonly ? true : null',
     '(blur)': 'handleBlur()',
@@ -61,22 +63,23 @@ const NGB_RATING_VALUE_ACCESSOR = {
   },
   template: `
     <ng-template #t let-fill="fill">{{ fill === 100 ? '&#9733;' : '&#9734;' }}</ng-template>
-    <ng-template ngFor [ngForOf]="contexts" let-index="index">
-      <span class="sr-only">({{ index < nextRate ? '*' : ' ' }})</span>
+    <ng-template ngFor [ngForOf]="contexts$ | async" let-context let-index="index">
+      <span class="sr-only">({{ index < state.nextRate ? '*' : ' ' }})</span>
       <span (mouseenter)="enter(index + 1)" (click)="handleClick(index + 1)" [style.cursor]="readonly || disabled ? 'default' : 'pointer'">
-        <ng-template [ngTemplateOutlet]="starTemplate || starTemplateFromContent || t" [ngTemplateOutletContext]="contexts[index]">
+        <ng-template [ngTemplateOutlet]="starTemplate || starTemplateFromContent || t" [ngTemplateOutletContext]="context">
         </ng-template>
       </span>
     </ng-template>
   `,
-  providers: [NGB_RATING_VALUE_ACCESSOR]
+  providers: [NGB_RATING_VALUE_ACCESSOR, RatingStore]
 })
 export class NgbRating implements ControlValueAccessor,
     OnInit, OnChanges {
-  contexts: StarTemplateContext[] = [];
   disabled = false;
   nextRate: number;
 
+  state: RatingState;
+  contexts$: SubscribableStore<StarTemplateContext[]>;
 
   /**
    * The maximal rating that can be given.
@@ -130,16 +133,27 @@ export class NgbRating implements ControlValueAccessor,
   onChange = (_: any) => {};
   onTouched = () => {};
 
-  constructor(config: NgbRatingConfig, private _changeDetectorRef: ChangeDetectorRef) {
-    this.max = config.max;
+  constructor(config: NgbRatingConfig, private _changeDetectorRef: ChangeDetectorRef, private _ratingStore: RatingStore) {
+    this.contexts$ = derived(_ratingStore, (ratingState) => {
+      const result: StarTemplateContext[] = [];
+
+      console.log('Deriving from', ratingState);
+
+      for (let i = 0; i < ratingState.maxRate; i++) {
+        const fillValue = Math.round(getValueInRange(ratingState.nextRate - i, 1, 0) * 100);
+        result.push({index: i, fill: fillValue});
+      }
+
+      return result;
+    });
     this.readonly = config.readonly;
   }
 
-  ariaValueText() { return `${this.nextRate} out of ${this.max}`; }
+  ariaValueText() { return `${this.state.nextRate} out of ${this.state.maxRate}`; }
 
   enter(value: number): void {
     if (!this.readonly && !this.disabled) {
-      this._updateState(value);
+      this._ratingStore.setNextRate(value);
     }
     this.hover.emit(value);
   }
@@ -148,7 +162,7 @@ export class NgbRating implements ControlValueAccessor,
 
   handleClick(value: number) {
     if (!this.readonly && !this.disabled) {
-      this.update(this.resettable && this.rate === value ? 0 : value);
+      this._ratingStore.setRate(this.resettable && this.state.rate === value ? 0 : value);
     }
   }
 
@@ -157,17 +171,17 @@ export class NgbRating implements ControlValueAccessor,
     switch (event.which) {
       case Key.ArrowDown:
       case Key.ArrowLeft:
-        this.update(this.rate - 1);
+        this._ratingStore.decreaseRate();
         break;
       case Key.ArrowUp:
       case Key.ArrowRight:
-        this.update(this.rate + 1);
+        this._ratingStore.increaseRate();
         break;
       case Key.Home:
-        this.update(0);
+        this._ratingStore.zeroRate();
         break;
       case Key.End:
-        this.update(this.max);
+        this._ratingStore.maxRate();
         break;
       default:
         return;
@@ -178,14 +192,29 @@ export class NgbRating implements ControlValueAccessor,
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (changes['rate']) {
-      this.update(this.rate);
+    if (changes.rate) {
+      this._ratingStore.setRate(changes.rate.currentValue);
+    }
+
+    if (changes.max) {
+      this._ratingStore.setMaxRate(changes.max.currentValue);
     }
   }
 
   ngOnInit(): void {
-    this.contexts = Array.from({length: this.max}, (v, k) => ({fill: 0, index: k}));
-    this._updateState(this.rate);
+    // TODO: handle state un-subscription
+    this._ratingStore.subscribe(state => {
+      console.log('Got new state', state, this.state);
+
+      // Is this a right way of handling "events"?
+      if (this.state != null && state.rate !== this.state.rate) {
+        console.log('propagatting change', state.rate);
+        this.onChange(state.rate);
+        this.onTouched();
+      }
+      this.state = state;
+      this._changeDetectorRef.markForCheck();
+    });
   }
 
   registerOnChange(fn: (value: any) => any): void { this.onChange = fn; }
@@ -193,12 +222,13 @@ export class NgbRating implements ControlValueAccessor,
   registerOnTouched(fn: () => any): void { this.onTouched = fn; }
 
   reset(): void {
-    this.leave.emit(this.nextRate);
-    this._updateState(this.rate);
+    this.leave.emit(this.state.nextRate);
+    this._ratingStore.resetNextRate();
   }
 
   setDisabledState(isDisabled: boolean) { this.disabled = isDisabled; }
 
+  /*
   update(value: number, internalChange = true): void {
     const newRate = getValueInRange(value, this.max, 0);
     if (!this.readonly && !this.disabled && this.rate !== newRate) {
@@ -211,12 +241,14 @@ export class NgbRating implements ControlValueAccessor,
     }
     this._updateState(this.rate);
   }
+  */
 
   writeValue(value) {
-    this.update(value, false);
+    this._ratingStore.setRate(value);
     this._changeDetectorRef.markForCheck();
   }
 
+  /*
   private _getFillValue(index: number): number {
     const diff = getValueInRange(this.nextRate - index, 1, 0);
     return Math.round(diff * 100);
@@ -226,4 +258,5 @@ export class NgbRating implements ControlValueAccessor,
     this.nextRate = nextValue;
     this.contexts.forEach((context, index) => context.fill = this._getFillValue(index));
   }
+  */
 }

--- a/src/rating/stores/index.ts
+++ b/src/rating/stores/index.ts
@@ -1,0 +1,303 @@
+import {Injectable, OnDestroy} from '@angular/core';
+
+const symbolObservable = (typeof Symbol === 'function' && Symbol.observable) || '@@observable';
+
+/** Callback to inform of a value updates. */
+type SubscriberFunction<T> = (value: T) => void;
+
+interface SubscriberObject<T> {
+  next: SubscriberFunction<T>;
+  invalidate: () => void;
+}
+
+type Subscriber<T> = SubscriberFunction<T>|Partial<SubscriberObject<T>>|null|undefined;
+
+/** Unsubscribes from value updates. */
+type UnsubscribeFunction = () => void;
+
+interface UnsubscribeObject {
+  unsubscribe: UnsubscribeFunction;
+}
+type Unsubscriber = UnsubscribeObject|UnsubscribeFunction;
+
+/** Callback to update a value. */
+type Updater<T> = (value: T) => T;
+
+export interface SubscribableStore<T> {
+  subscribe(subscriber: Subscriber<T>): Unsubscriber;
+}
+
+export interface Readable<T> extends SubscribableStore<T>, OnDestroy {
+  subscribe(subscriber: Subscriber<T>): UnsubscribeFunction&UnsubscribeObject;
+}
+
+export interface Writable<T> extends Readable<T> {
+  set(value: T): void;
+  update(updater: Updater<T>): void;
+}
+
+const noop = () => {};
+
+const bind = <T>(object: T|null|undefined, fnName: keyof T) => {
+  const fn = object ? object[fnName] : null;
+  return typeof fn === 'function' ? fn.bind(object) : noop;
+};
+
+const toSubscriberObject = <T>(subscriber: Subscriber<T>): SubscriberObject<T> => typeof subscriber === 'function' ?
+    {next: subscriber.bind(null), invalidate: noop} :
+    {next: bind(subscriber, 'next'), invalidate: bind(subscriber, 'invalidate')};
+
+const returnThis = function<T>(this: T): T {
+  return this;
+};
+
+const asReadable = <T>(store: Store<T>): Readable<T> => ({
+  subscribe: store.subscribe.bind(store),
+  ngOnDestroy: store.ngOnDestroy.bind(store),
+  [symbolObservable]: returnThis,
+});
+
+const queue: [SubscriberFunction<any>, any][] = [];
+
+function processQueue() {
+  for (let [subscriberFn, value] of queue) {
+    subscriberFn(value);
+  }
+  queue.length = 0;
+}
+
+const callUnsubscribe = (unsubscribe: Unsubscriber) =>
+    typeof unsubscribe === 'function' ? unsubscribe() : unsubscribe.unsubscribe();
+
+function notEqual(a: any, b: any): boolean {
+  const tOfA = typeof a;
+  if (tOfA !== 'function' && tOfA !== 'object') {
+    return !Object.is(a, b);
+  }
+  return true;
+}
+
+export function get<T>(store: SubscribableStore<T>): T {
+  let value: T;
+  callUnsubscribe(store.subscribe((v) => (value = v)));
+  return value!;
+}
+
+@Injectable()
+export abstract class Store<T> implements Readable<T> {
+  private _subscribers = new Set<SubscriberObject<T>>();
+  private _cleanupFn: null|Unsubscriber = null;
+
+  constructor(private _value: T) {}
+
+  private _start() {
+    this._cleanupFn = this.onUse() || noop;
+  }
+
+  private _stop() {
+    const cleanupFn = this._cleanupFn;
+    if (cleanupFn) {
+      this._cleanupFn = null;
+      callUnsubscribe(cleanupFn);
+    }
+  }
+
+  protected get state() {
+    return this._value;
+  }
+
+  protected set(value: T): void {
+    if (notEqual(this._value, value)) {
+      this._value = value;
+      if (!this._cleanupFn) {
+        // subscriber not yet initialized
+        return;
+      }
+      const needsProcessQueue = queue.length == 0;
+      for (const subscriber of this._subscribers) {
+        subscriber.invalidate();
+        queue.push([subscriber.next, value]);
+      }
+      if (needsProcessQueue) {
+        processQueue();
+      }
+    }
+  }
+
+  protected update(updater: Updater<T>) {
+    this.set(updater(this._value));
+  }
+
+  protected onUse(): Unsubscriber|void {}
+
+  subscribe(subscriber: Subscriber<T>): UnsubscribeFunction&UnsubscribeObject {
+    const subscriberObject = toSubscriberObject(subscriber);
+    this._subscribers.add(subscriberObject);
+    if (this._subscribers.size == 1) {
+      this._start();
+    }
+    subscriberObject.next(this._value);
+
+    const unsubscribe = () => {
+      const removed = this._subscribers.delete(subscriberObject);
+      if (removed && this._subscribers.size === 0) {
+        this._stop();
+      }
+    };
+    unsubscribe.unsubscribe = unsubscribe;
+    return unsubscribe;
+  }
+
+  ngOnDestroy(): void {
+    const hasSubscribers = this._subscribers.size > 0;
+    this._subscribers.clear();
+    if (hasSubscribers) {
+      this._stop();
+    }
+  }
+
+  [symbolObservable]() {
+    return this;
+  }
+}
+
+/**
+ * Interface representing an argument of a function passed as a second argument to the store creation shorthands
+ * (readable, writable)
+ */
+interface OnUseArgument<T> {
+  (value: T): void;
+  set: (value: T) => void;
+  update: (updater: Updater<T>) => void;
+}
+
+export const readable = <T>(value: T, onUseFn: (arg: OnUseArgument<T>) => void|Unsubscriber = noop): Readable<T> => {
+  const ReadableStoreWithOnUse = class extends Store<T> {
+    protected onUse() {
+      const setFn = (v: T) => this.set(v);
+      setFn.set = setFn;
+      setFn.update = (updater: Updater<T>) => this.update(updater);
+      return onUseFn(setFn);
+    }
+  };
+  return asReadable(new ReadableStoreWithOnUse(value));
+};
+
+@Injectable()
+class WritableStore<T> extends Store<T> implements Writable<T> {
+  constructor(value: T) {
+    super(value);
+  }
+
+  set(value: T): void {
+    super.set(value);
+  }
+
+  update(updater: Updater<T>) {
+    super.update(updater);
+  }
+}
+
+export function writable<T>(value: T, onUseFn: (arg: OnUseArgument<T>) => void|Unsubscriber = noop): Writable<T> {
+  const WritableStoreWithOnUse = class extends WritableStore<T>{
+    protected onUse() {
+      const setFn = (v: T) => this.set(v);
+      setFn.set = setFn;
+      setFn.update = (updater: Updater<T>) => this.update(updater);
+      return onUseFn(setFn);
+    }
+  };
+  const store = new WritableStoreWithOnUse(value);
+  return {
+    ...asReadable(store),
+    set: store.set.bind(store),
+    update: store.update.bind(store),
+  };
+}
+
+type SubscribableStores =|SubscribableStore<any>|readonly[SubscribableStore<any>, ...SubscribableStore<any>[]];
+
+type SubscribableStoresValues<S> =
+    S extends SubscribableStore<infer T>? T : {[K in keyof S]: S[K] extends SubscribableStore<infer T>? T : never};
+
+type SyncDeriveFn<T, S> = (values: SubscribableStoresValues<S>) => T;
+type AsyncDeriveFn<T, S> = (values: SubscribableStoresValues<S>, set: OnUseArgument<T>) => Unsubscriber|void;
+type DeriveFn<T, S> = SyncDeriveFn<T, S>|AsyncDeriveFn<T, S>;
+function isSyncDeriveFn<T, S>(fn: DeriveFn<T, S>): fn is SyncDeriveFn<T, S> {
+  return fn.length <= 1;
+}
+
+@Injectable()
+export abstract class DerivedStore<T, S extends SubscribableStores = SubscribableStores> extends Store<T> {
+  constructor(private _stores: S, initialValue: T) {
+    super(initialValue);
+  }
+
+  protected onUse() {
+    let initDone = false;
+    let pending = 0;
+
+    const stores = this._stores;
+    const isArray = Array.isArray(stores);
+    const storesArr = isArray ? (stores as readonly SubscribableStore<any>[]) : [stores as SubscribableStore<any>];
+    const dependantValues = new Array(storesArr.length);
+
+    let cleanupFn: null|Unsubscriber = null;
+
+    const callCleanup = () => {
+      const fn = cleanupFn;
+      if (fn) {
+        cleanupFn = null;
+        callUnsubscribe(fn);
+      }
+    };
+
+    const callDerive = () => {
+      if (initDone && !pending) {
+        callCleanup();
+        cleanupFn = this.derive(isArray ? dependantValues : dependantValues[0]) || noop;
+      }
+    };
+
+    const unsubscribers = storesArr.map((store, idx) => store.subscribe({
+      next: (v) => {
+        dependantValues[idx] = v;
+        pending &= ~(1 << idx);
+        callDerive();
+      },
+      invalidate: () => {
+        pending |= 1 << idx;
+      },
+    }));
+
+    initDone = true;
+    callDerive();
+    return () => {
+      callCleanup();
+      unsubscribers.forEach(callUnsubscribe);
+    };
+  }
+
+  protected abstract derive(values: SubscribableStoresValues<S>): Unsubscriber|void;
+}
+
+export function derived<T, S extends SubscribableStores>(stores: S, deriveFn: SyncDeriveFn<T, S>): Readable<T>;
+export function derived<T, S extends SubscribableStores>(
+    stores: S, deriveFn: AsyncDeriveFn<T, S>, initialValue: T): Readable<T>;
+export function derived<T, S extends SubscribableStores>(
+    stores: S, deriveFn: DeriveFn<T, S>, initialValue?: T): Readable<T> {
+  const Derived = isSyncDeriveFn(deriveFn) ? class extends DerivedStore<T, S>{
+    protected derive(values: SubscribableStoresValues<S>) {
+      this.set(deriveFn(values));
+    }
+  } :
+      class extends DerivedStore<T, S>{
+        protected derive(values: SubscribableStoresValues<S>) {
+          const setFn = (v: T) => this.set(v);
+          setFn.set = setFn;
+          setFn.update = (updater: Updater<T>) => this.update(updater);
+          return deriveFn(values, setFn);
+        }
+      };
+  return asReadable(new Derived(stores, initialValue as any));
+}


### PR DESCRIPTION
This is a quick & dirty PR (not all tests passing) that contains my experiments with stores and the rating directive. 

On the positive side:
* if one _really_ tries, it would be _somehow_ possible use stores to extract rating's logic;
* actually trying to extract rating logic to a separate, "business only" class makes it easier to understand what is going on in the rating;

Sadly, based on my experiments, it is now my position that it is "not worth it" to convert widgets like rating to stores. The main issue is that there is "not enough data-centric logic" - instead, there is a lot of "integration points" between stores and Angular components. Unfortunately those integration points are somehow cumbersome as of today. More specifically:

* propagating `@Input()`s to stores requires lots of boilerplate code (one needs to declare an `@Input()` _and_ implement `ngOnChanges` even if what I need is "just" to propagate component's input to a store;
* it is not clear how to trigger `@Output` based on state changes (that is, I might want to raise and event based on change of one value of the store but I'm only notified on the entire state change);
* accessing state of a store (subscribing to store notifications) in the component's TS code is cumbersome (requires manual subscribe / unsubscribe);
* integration with the forms is super-messy (actually, I didn't manage to make all the tests pass....)

As part of the process we've also identified the following shortcomings:
* in the stores implementation: there is no easy way to access "current state" in the store's internal implementation;
* in Angular: one can't use async pipe in host bindings