### PR TITLE
feat(typeahead): popup-height to fix issue #3810

### DIFF
--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -43,6 +43,10 @@ function getNativeInput(element: HTMLElement): HTMLInputElement {
   return <HTMLInputElement>element.querySelector('input');
 }
 
+function getNativePopup(element: HTMLElement): HTMLDivElement {
+  return <HTMLInputElement>element.querySelector('.dropdown-menu');
+}
+
 function changeInput(element: any, value: string) {
   const input = getNativeInput(element);
   input.value = value;
@@ -313,6 +317,17 @@ describe('ngb-typeahead', () => {
       changeInput(compiled, 'o');
       fixture.detectChanges();
       expectWindowResults(compiled, ['+ONE', 'ONE MORE']);
+    });
+
+    it('should set max-height to component', () => {
+      const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="find" [dropdownMaxHeight]=100/>`);
+      const compiled = fixture.nativeElement;
+      changeInput(compiled, 'o');
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        expect(getNativePopup(compiled).style.maxHeight).toEqual('100px');
+        expect(getNativePopup(compiled).style.overflowY).toEqual('auto');
+      });
     });
 
     it('should not mark first result as active when focusFirst is false', () => {

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -176,6 +176,11 @@ export class NgbTypeahead implements ControlValueAccessor,
   @Input() placement: PlacementArray = 'bottom-left';
 
   /**
+   * The maximum height of the dropdown in pixels, when set overflow-y will be set to auto
+   */
+  @Input() dropdownMaxHeight: number;
+
+  /**
    * An event emitted right before an item is selected from the result list.
    *
    * Event payload is of type [`NgbTypeaheadSelectItemEvent`](#/components/typeahead/api#NgbTypeaheadSelectItemEvent).
@@ -307,6 +312,10 @@ export class NgbTypeahead implements ControlValueAccessor,
       this._inputValueBackup = this._elementRef.nativeElement.value;
       const {windowRef} = this._popupService.open();
       this._windowRef = windowRef;
+      if (this.dropdownMaxHeight > 0) {
+        this._windowRef.location.nativeElement.style['max-height'] = `${this.dropdownMaxHeight}px`;
+        this._windowRef.location.nativeElement.style['overflow-y'] = 'auto';
+      }
       this._windowRef.instance.id = this.popupId;
       this._windowRef.instance.selectEvent.subscribe((result: any) => this._selectResultClosePopup(result));
       this._windowRef.instance.activeChangeEvent.subscribe((activeId: string) => this.activeDescendant = activeId);


### PR DESCRIPTION
Add property to set popup's height to fix issues like issue [#3810](https://github.com/ng-bootstrap/ng-bootstrap/issues/3810)

User can specify a certain height in pixels and a scroll will appear, preventing the popup height from being over the page's size.

Before submitting a pull request, please make sure you have at least performed the following:

 - [X] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [X] built and tested the changes locally.
 - [X] added/updated any applicable tests.
 - [X] added/updated any applicable API documentation.
 - [X] added/updated any applicable demos.
