### PR TITLE
Update popover-triggers.html

### DIFF
--- a/demo/src/app/components/popover/demos/triggers/popover-triggers.html
+++ b/demo/src/app/components/popover/demos/triggers/popover-triggers.html
@@ -1,5 +1,5 @@
 <p>
-  You can easily override open and close triggers by specifying event names (separated by <code>:</code>) in the <code>triggers</code> property.
+  You can easily override open and close triggers by specifying event names (separated by <code>:</code>) in the <code>triggers</code> property. You may pass multiple triggers; separate them with a space.
 </p>
 
 <button type="button" class="btn btn-outline-secondary" ngbPopover="You see, I show up on hover!" triggers="mouseenter:mouseleave" popoverTitle="Pop title">


### PR DESCRIPTION
Clarify documentation regarding passing multiple triggers. [1]

I got confused by the documentation by thinking that ":" was a replacement for the space separator, and had to look at the source code to understand how triggers are parsed. Perhaps this will save someone else time.

[1] https://getbootstrap.com/docs/4.5/components/popovers/#options