### PR TITLE
feat(datepicker): remove deprecated 'select' output

### DIFF
--- a/src/datepicker/datepicker-month.spec.ts
+++ b/src/datepicker/datepicker-month.spec.ts
@@ -19,7 +19,7 @@ const createTestComponent = () => createGenericTestComponent(
                   [showWeekdays]="showWeekdays"
                   [showWeekNumbers]="showWeekNumbers"
                   [outsideDays]="outsideDays"
-                  (select)="onClick($event)">
+                  (dateSelect)="onClick($event)">
     <ng-template #dt let-date="date">{{ date.day }}</ng-template>
   </ngb-datepicker>
 `,

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -299,16 +299,6 @@ export class NgbDatepicker implements OnDestroy,
    */
   @Output() dateSelect = new EventEmitter<NgbDate>();
 
-  /**
-   * An event emitted when user selects a date using keyboard or mouse.
-   *
-   * The payload of the event is currently selected `NgbDate`.
-   *
-   * @deprecated 6.0.0 Please use 'dateSelect' output instead due to collision with native
-   * 'select' event.
-   */
-  @Output() select = this.dateSelect;
-
   onChange = (_: any) => {};
   onTouched = () => {};
 


### PR DESCRIPTION
BREAKING CHANGE: datepicker `(select)` output  deprecated in 6.0.0 is now removed

Before:

```
<ngb-datepicker (select)="inDateSelect($event)"></ngb-datepicker>
```

After:

```
<ngb-datepicker (dateSelect)="inDateSelect($event)"></ngb-datepicker>
```