### PR TITLE
test: don't use deprecated 'async' function

### DIFF
--- a/src/alert/alert.spec.ts
+++ b/src/alert/alert.spec.ts
@@ -1,5 +1,5 @@
 import createSpy = jasmine.createSpy;
-import {async, ComponentFixture, inject, TestBed} from '@angular/core/testing';
+import {ComponentFixture, inject, TestBed} from '@angular/core/testing';
 import {isBrowserVisible, createGenericTestComponent} from '../test/common';
 import {By} from '@angular/platform-browser';
 
@@ -211,25 +211,25 @@ if (isBrowserVisible('ngb-alert animations')) {
 
     [true, false].forEach(reduceMotion => {
 
-      it(`should run fade transition when closing alert (force-reduced-motion = ${reduceMotion})`, async(() => {
-           const fixture = TestBed.createComponent(TestAnimationComponent);
-           fixture.componentInstance.reduceMotion = reduceMotion;
-           fixture.detectChanges();
+      it(`should run fade transition when closing alert (force-reduced-motion = ${reduceMotion})`, () => {
+        const fixture = TestBed.createComponent(TestAnimationComponent);
+        fixture.componentInstance.reduceMotion = reduceMotion;
+        fixture.detectChanges();
 
-           const alertEl = getAlertElement(fixture.nativeElement);
-           const buttonEl = fixture.nativeElement.querySelector('button');
+        const alertEl = getAlertElement(fixture.nativeElement);
+        const buttonEl = fixture.nativeElement.querySelector('button');
 
-           spyOn(fixture.componentInstance, 'onClose').and.callFake(() => {
-             expect(window.getComputedStyle(alertEl).opacity).toBe('0');
-             expect(alertEl).not.toHaveCssClass('show');
-             expect(alertEl).toHaveCssClass('fade');
-           });
+        spyOn(fixture.componentInstance, 'onClose').and.callFake(() => {
+          expect(window.getComputedStyle(alertEl).opacity).toBe('0');
+          expect(alertEl).not.toHaveCssClass('show');
+          expect(alertEl).toHaveCssClass('fade');
+        });
 
-           expect(window.getComputedStyle(alertEl).opacity).toBe('1');
-           expect(alertEl).toHaveCssClass('show');
-           expect(alertEl).toHaveCssClass('fade');
-           buttonEl.click();
-         }));
+        expect(window.getComputedStyle(alertEl).opacity).toBe('1');
+        expect(alertEl).toHaveCssClass('show');
+        expect(alertEl).toHaveCssClass('fade');
+        buttonEl.click();
+      });
     });
   });
 }

--- a/src/buttons/radio.spec.ts
+++ b/src/buttons/radio.spec.ts
@@ -1,5 +1,5 @@
 import {ChangeDetectionStrategy, Component} from '@angular/core';
-import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {FormControl, FormGroup, FormsModule, NgModel, ReactiveFormsModule, Validators} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 
@@ -62,7 +62,7 @@ describe('ngbRadioGroup', () => {
     TestBed.overrideComponent(TestComponentOnPush, {set: {template: defaultHtml}});
   });
 
-  it('toggles radio inputs based on model changes', async(() => {
+  it('toggles radio inputs based on model changes', fakeAsync(() => {
        const fixture = TestBed.createComponent(TestComponent);
 
        let values = fixture.componentInstance.values;
@@ -76,65 +76,52 @@ describe('ngbRadioGroup', () => {
        // checking null
        fixture.componentInstance.model = null;
        fixture.detectChanges();
-       fixture.whenStable()
-           .then(() => {
-             fixture.detectChanges();
-             expectRadios(fixture.nativeElement, [0, 0]);
-
-             // checking first radio
-             fixture.componentInstance.model = values[0];
-             fixture.detectChanges();
-             return fixture.whenStable();
-           })
-           .then(() => {
-             fixture.detectChanges();
-             expectRadios(fixture.nativeElement, [1, 0]);
-
-             // checking second radio
-             fixture.componentInstance.model = values[1];
-             fixture.detectChanges();
-             return fixture.whenStable();
-           })
-           .then(() => {
-             fixture.detectChanges();
-             expectRadios(fixture.nativeElement, [0, 1]);
-
-             // checking non-matching value
-             fixture.componentInstance.model = values[3];
-             fixture.detectChanges();
-             return fixture.whenStable();
-           })
-           .then(() => {
-             fixture.detectChanges();
-             expectRadios(fixture.nativeElement, [0, 0]);
-           });
-     }));
-
-  it('updates model based on radio input clicks', async(() => {
-       const fixture = TestBed.createComponent(TestComponent);
-
+       tick();
        fixture.detectChanges();
        expectRadios(fixture.nativeElement, [0, 0]);
 
-       fixture.whenStable()
-           .then(() => {
-             // clicking first radio
-             getInput(fixture.nativeElement, 0).click();
-             fixture.detectChanges();
-             expectRadios(fixture.nativeElement, [1, 0]);
-             expect(fixture.componentInstance.model).toBe('one');
-             return fixture.whenStable();
-           })
-           .then(() => {
-             // clicking second radio
-             getInput(fixture.nativeElement, 1).click();
-             fixture.detectChanges();
-             expectRadios(fixture.nativeElement, [0, 1]);
-             expect(fixture.componentInstance.model).toBe('two');
-           });
+       // checking first radio
+       fixture.componentInstance.model = values[0];
+       fixture.detectChanges();
+       tick();
+       fixture.detectChanges();
+       expectRadios(fixture.nativeElement, [1, 0]);
+
+       // checking second radio
+       fixture.componentInstance.model = values[1];
+       fixture.detectChanges();
+       tick();
+       fixture.detectChanges();
+       expectRadios(fixture.nativeElement, [0, 1]);
+
+       // checking non-matching value
+       fixture.componentInstance.model = values[3];
+       fixture.detectChanges();
+       tick();
+       fixture.detectChanges();
+       expectRadios(fixture.nativeElement, [0, 0]);
      }));
 
-  it('can be used with objects as values', async(() => {
+  it('updates model based on radio input clicks', () => {
+    const fixture = TestBed.createComponent(TestComponent);
+
+    fixture.detectChanges();
+    expectRadios(fixture.nativeElement, [0, 0]);
+
+    // clicking first radio
+    getInput(fixture.nativeElement, 0).click();
+    fixture.detectChanges();
+    expectRadios(fixture.nativeElement, [1, 0]);
+    expect(fixture.componentInstance.model).toBe('one');
+
+    // clicking second radio
+    getInput(fixture.nativeElement, 1).click();
+    fixture.detectChanges();
+    expectRadios(fixture.nativeElement, [0, 1]);
+    expect(fixture.componentInstance.model).toBe('two');
+  });
+
+  it('can be used with objects as values', fakeAsync(() => {
        const fixture = TestBed.createComponent(TestComponent);
 
        let [one, two] = [{one: 'one'}, {two: 'two'}];
@@ -151,19 +138,18 @@ describe('ngbRadioGroup', () => {
        // checking model -> radio input
        fixture.componentInstance.model = one;
        fixture.detectChanges();
-       fixture.whenStable().then(() => {
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [1, 0]);
+       tick();
+       fixture.detectChanges();
+       expectRadios(fixture.nativeElement, [1, 0]);
 
-         // checking radio click -> model
-         getInput(fixture.nativeElement, 1).click();
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0, 1]);
-         expect(fixture.componentInstance.model).toBe(two);
-       });
+       // checking radio click -> model
+       getInput(fixture.nativeElement, 1).click();
+       fixture.detectChanges();
+       expectRadios(fixture.nativeElement, [0, 1]);
+       expect(fixture.componentInstance.model).toBe(two);
      }));
 
-  it('updates radio input values dynamically', async(() => {
+  it('updates radio input values dynamically', fakeAsync(() => {
        const fixture = TestBed.createComponent(TestComponent);
 
        let values = fixture.componentInstance.values;
@@ -171,30 +157,28 @@ describe('ngbRadioGroup', () => {
        // checking first radio
        fixture.componentInstance.model = values[0];
        fixture.detectChanges();
-       fixture.whenStable().then(() => {
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [1, 0]);
-         expect(fixture.componentInstance.model).toEqual(values[0]);
+       tick();
+       fixture.detectChanges();
+       expectRadios(fixture.nativeElement, [1, 0]);
+       expect(fixture.componentInstance.model).toEqual(values[0]);
 
-         // updating first radio value -> expecting none selected
-         let initialValue = values[0];
-         values[0] = 'ten';
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0, 0]);
-         expect(getInput(fixture.nativeElement, 0).value).toEqual('ten');
-         expect(fixture.componentInstance.model).toEqual(initialValue);
+       // updating first radio value -> expecting none selected
+       let initialValue = values[0];
+       values[0] = 'ten';
+       fixture.detectChanges();
+       expectRadios(fixture.nativeElement, [0, 0]);
+       expect(getInput(fixture.nativeElement, 0).value).toEqual('ten');
+       expect(fixture.componentInstance.model).toEqual(initialValue);
 
-         // updating values back -> expecting initial state
-         values[0] = initialValue;
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [1, 0]);
-         expect(getInput(fixture.nativeElement, 0).value).toEqual(values[0]);
-         expect(fixture.componentInstance.model).toEqual(values[0]);
-       });
+       // updating values back -> expecting initial state
+       values[0] = initialValue;
+       fixture.detectChanges();
+       expectRadios(fixture.nativeElement, [1, 0]);
+       expect(getInput(fixture.nativeElement, 0).value).toEqual(values[0]);
+       expect(fixture.componentInstance.model).toEqual(values[0]);
      }));
 
-  it('can be used with ngFor', async(() => {
-
+  it('can be used with ngFor', fakeAsync(() => {
        const forHtml = `<div [(ngModel)]="model" ngbRadioGroup>
           <label *ngFor="let v of values" ngbButtonLabel>
             <input ngbButton type="radio" name="radio" [value]="v"/> {{ v }}
@@ -208,14 +192,12 @@ describe('ngbRadioGroup', () => {
 
        fixture.componentInstance.model = values[1];
        fixture.detectChanges();
-       fixture.whenStable().then(() => {
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0, 1, 0]);
-       });
+       tick();
+       fixture.detectChanges();
+       expectRadios(fixture.nativeElement, [0, 1, 0]);
      }));
 
-  it('cleans up the model when radio inputs are added / removed', async(() => {
-
+  it('cleans up the model when radio inputs are added / removed', fakeAsync(() => {
        const ifHtml = `<div [(ngModel)]="model" ngbRadioGroup>
         <label ngbButtonLabel>
           <input ngbButton type="radio" name="radio" [value]="values[0]"/> {{ values[0] }}
@@ -244,23 +226,22 @@ describe('ngbRadioGroup', () => {
        // hiding/showing selected radio -> expecting model to unchange, but none selected
        fixture.componentInstance.model = values[1];
        fixture.detectChanges();
-       fixture.whenStable().then(() => {
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0, 1]);
+       tick();
+       fixture.detectChanges();
+       expectRadios(fixture.nativeElement, [0, 1]);
 
-         fixture.componentInstance.shown = false;
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0]);
-         expect(fixture.componentInstance.model).toEqual(values[1]);
+       fixture.componentInstance.shown = false;
+       fixture.detectChanges();
+       expectRadios(fixture.nativeElement, [0]);
+       expect(fixture.componentInstance.model).toEqual(values[1]);
 
-         fixture.componentInstance.shown = true;
-         fixture.detectChanges();
-         expectRadios(fixture.nativeElement, [0, 1]);
-         expect(fixture.componentInstance.model).toEqual(values[1]);
-       });
+       fixture.componentInstance.shown = true;
+       fixture.detectChanges();
+       expectRadios(fixture.nativeElement, [0, 1]);
+       expect(fixture.componentInstance.model).toEqual(values[1]);
      }));
 
-  it('should work with template-driven form validation', async(() => {
+  it('should work with template-driven form validation', fakeAsync(() => {
        const html = `
         <form>
           <div ngbRadioGroup [(ngModel)]="model" name="control" required>
@@ -271,17 +252,15 @@ describe('ngbRadioGroup', () => {
         </form>`;
 
        const fixture = createTestComponent(html);
+       tick();
+       fixture.detectChanges();
+       expect(getGroupElement(fixture.nativeElement)).toHaveCssClass('ng-invalid');
+       expect(getGroupElement(fixture.nativeElement)).not.toHaveCssClass('ng-valid');
 
-       fixture.whenStable().then(() => {
-         fixture.detectChanges();
-         expect(getGroupElement(fixture.nativeElement)).toHaveCssClass('ng-invalid');
-         expect(getGroupElement(fixture.nativeElement)).not.toHaveCssClass('ng-valid');
-
-         getInput(fixture.nativeElement, 0).click();
-         fixture.detectChanges();
-         expect(getGroupElement(fixture.nativeElement)).toHaveCssClass('ng-valid');
-         expect(getGroupElement(fixture.nativeElement)).not.toHaveCssClass('ng-invalid');
-       });
+       getInput(fixture.nativeElement, 0).click();
+       fixture.detectChanges();
+       expect(getGroupElement(fixture.nativeElement)).toHaveCssClass('ng-valid');
+       expect(getGroupElement(fixture.nativeElement)).not.toHaveCssClass('ng-invalid');
      }));
 
   it('should work with model-driven form validation', () => {
@@ -348,7 +327,7 @@ describe('ngbRadioGroup', () => {
     expect(getInput(fixture.nativeElement, 0).hasAttribute('disabled')).toBeTruthy();
   });
 
-  it('should disable label and input when it is disabled using template-driven forms', async(() => {
+  it('should disable label and input when it is disabled using template-driven forms', fakeAsync(() => {
        const html = `
       <form>
         <div ngbRadioGroup [(ngModel)]="model" name="control" [disabled]="disabled">
@@ -359,26 +338,21 @@ describe('ngbRadioGroup', () => {
       </form>`;
 
        const fixture = createTestComponent(html);
+       tick();
+       fixture.detectChanges();
+       expect(getLabel(fixture.nativeElement, 0)).toHaveCssClass('disabled');
+       expect(getInput(fixture.nativeElement, 0).hasAttribute('disabled')).toBeTruthy();
 
-       fixture.whenStable()
-           .then(() => {
-             fixture.detectChanges();
-             expect(getLabel(fixture.nativeElement, 0)).toHaveCssClass('disabled');
-             expect(getInput(fixture.nativeElement, 0).hasAttribute('disabled')).toBeTruthy();
-
-             fixture.componentInstance.disabled = false;
-             fixture.detectChanges();
-             return fixture.whenStable();
-           })
-           .then(() => {
-             fixture.detectChanges();
-             expect(getLabel(fixture.nativeElement, 0)).not.toHaveCssClass('disabled');
-             expect(getInput(fixture.nativeElement, 0).hasAttribute('disabled')).toBeFalsy();
-           });
+       fixture.componentInstance.disabled = false;
+       fixture.detectChanges();
+       tick();
+       fixture.detectChanges();
+       expect(getLabel(fixture.nativeElement, 0)).not.toHaveCssClass('disabled');
+       expect(getInput(fixture.nativeElement, 0).hasAttribute('disabled')).toBeFalsy();
      }));
 
-  it('should disable individual label and input using template-driven forms', async(() => {
-       const html = `
+  it('should disable individual label and input using template-driven forms', () => {
+    const html = `
       <form>
         <div ngbRadioGroup [(ngModel)]="model" name="control">
           <label ngbButtonLabel>
@@ -387,27 +361,19 @@ describe('ngbRadioGroup', () => {
         </div>
       </form>`;
 
-       const fixture = createTestComponent(html);
+    const fixture = createTestComponent(html);
+    fixture.componentInstance.disabled = true;
+    fixture.detectChanges();
+    expect(getLabel(fixture.nativeElement, 0)).toHaveCssClass('disabled');
+    expect(getInput(fixture.nativeElement, 0).hasAttribute('disabled')).toBeTruthy();
 
-       fixture.whenStable()
-           .then(() => {
-             fixture.componentInstance.disabled = true;
-             fixture.detectChanges();
-             expect(getLabel(fixture.nativeElement, 0)).toHaveCssClass('disabled');
-             expect(getInput(fixture.nativeElement, 0).hasAttribute('disabled')).toBeTruthy();
+    fixture.componentInstance.disabled = false;
+    fixture.detectChanges();
+    expect(getLabel(fixture.nativeElement, 0)).not.toHaveCssClass('disabled');
+    expect(getInput(fixture.nativeElement, 0).hasAttribute('disabled')).toBeFalsy();
+  });
 
-             fixture.componentInstance.disabled = false;
-             fixture.detectChanges();
-             return fixture.whenStable();
-           })
-           .then(() => {
-             fixture.detectChanges();
-             expect(getLabel(fixture.nativeElement, 0)).not.toHaveCssClass('disabled');
-             expect(getInput(fixture.nativeElement, 0).hasAttribute('disabled')).toBeFalsy();
-           });
-     }));
-
-  it('disable all radio buttons when group is disabled regardless of button disabled state', async(() => {
+  it('disable all radio buttons when group is disabled regardless of button disabled state', fakeAsync(() => {
        const html = `
       <form>
         <div ngbRadioGroup [(ngModel)]="model" name="control" [disabled]="groupDisabled">
@@ -418,24 +384,17 @@ describe('ngbRadioGroup', () => {
       </form>`;
 
        const fixture = createTestComponent(html);
+       expect(getLabel(fixture.nativeElement, 0)).toHaveCssClass('disabled');
+       expect(getInput(fixture.nativeElement, 0).hasAttribute('disabled')).toBeTruthy();
 
-       fixture.whenStable()
-           .then(() => {
-             expect(getLabel(fixture.nativeElement, 0)).toHaveCssClass('disabled');
-             expect(getInput(fixture.nativeElement, 0).hasAttribute('disabled')).toBeTruthy();
-
-             fixture.componentInstance.disabled = false;
-             fixture.detectChanges();
-             return fixture.whenStable();
-           })
-           .then(() => {
-             fixture.detectChanges();
-             expect(getLabel(fixture.nativeElement, 0)).toHaveCssClass('disabled');
-             expect(getInput(fixture.nativeElement, 0).hasAttribute('disabled')).toBeTruthy();
-           });
+       fixture.componentInstance.disabled = false;
+       tick();
+       fixture.detectChanges();
+       expect(getLabel(fixture.nativeElement, 0)).toHaveCssClass('disabled');
+       expect(getInput(fixture.nativeElement, 0).hasAttribute('disabled')).toBeTruthy();
      }));
 
-  it('button stays disabled when group is enabled', async(() => {
+  it('button stays disabled when group is enabled', fakeAsync(() => {
        const html = `
       <form>
         <div ngbRadioGroup [(ngModel)]="model" name="control" [disabled]="groupDisabled">
@@ -446,21 +405,14 @@ describe('ngbRadioGroup', () => {
       </form>`;
 
        const fixture = createTestComponent(html);
+       expect(getLabel(fixture.nativeElement, 0)).toHaveCssClass('disabled');
+       expect(getInput(fixture.nativeElement, 0).hasAttribute('disabled')).toBeTruthy();
 
-       fixture.whenStable()
-           .then(() => {
-             expect(getLabel(fixture.nativeElement, 0)).toHaveCssClass('disabled');
-             expect(getInput(fixture.nativeElement, 0).hasAttribute('disabled')).toBeTruthy();
-
-             fixture.componentInstance.groupDisabled = false;
-             fixture.detectChanges();
-             return fixture.whenStable();
-           })
-           .then(() => {
-             fixture.detectChanges();
-             expect(getLabel(fixture.nativeElement, 0)).toHaveCssClass('disabled');
-             expect(getInput(fixture.nativeElement, 0).hasAttribute('disabled')).toBeTruthy();
-           });
+       fixture.componentInstance.groupDisabled = false;
+       tick();
+       fixture.detectChanges();
+       expect(getLabel(fixture.nativeElement, 0)).toHaveCssClass('disabled');
+       expect(getInput(fixture.nativeElement, 0).hasAttribute('disabled')).toBeTruthy();
      }));
 
 

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed, ComponentFixture, async, inject, fakeAsync, tick} from '@angular/core/testing';
+import {TestBed, ComponentFixture, inject, fakeAsync, tick} from '@angular/core/testing';
 import {createGenericTestComponent, isBrowser} from '../test/common';
 import {getMonthSelect, getYearSelect, getNavigationLinks} from '../test/datepicker/common';
 
@@ -698,127 +698,109 @@ describe('ngb-datepicker', () => {
 
   describe('ngModel', () => {
 
-    it('should update model based on calendar clicks', async(() => {
-         const fixture = createTestComponent(
-             `<ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="model"></ngb-datepicker>`);
+    it('should update model based on calendar clicks', () => {
+      const fixture = createTestComponent(
+          `<ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="model"></ngb-datepicker>`);
 
-         const dates = getDates(fixture.nativeElement);
-         dates[0].click();  // 1 AUG 2016
-         expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 1});
+      const dates = getDates(fixture.nativeElement);
+      dates[0].click();  // 1 AUG 2016
+      expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 1});
 
-         dates[1].click();
-         expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 2});
-       }));
+      dates[1].click();
+      expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 2});
+    });
 
-    it('should not update model based on calendar clicks when disabled', async(() => {
+    it('should not update model based on calendar clicks when disabled', fakeAsync(() => {
          const fixture = createTestComponent(
              `<ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="model" [disabled]="true">
               </ngb-datepicker>`);
 
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
+         tick();
+         fixture.detectChanges();
 
-               const dates = getDates(fixture.nativeElement);
-               dates[0].click();  // 1 AUG 2016
-               expect(fixture.componentInstance.model).toBeFalsy();
+         const dates = getDates(fixture.nativeElement);
+         dates[0].click();  // 1 AUG 2016
+         expect(fixture.componentInstance.model).toBeFalsy();
 
-               dates[1].click();
-               expect(fixture.componentInstance.model).toBeFalsy();
-             });
+         dates[1].click();
+         expect(fixture.componentInstance.model).toBeFalsy();
        }));
 
-    it('select calendar date based on model updates', async(() => {
+    it('select calendar date based on model updates', fakeAsync(() => {
          const fixture = createTestComponent(
              `<ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="model"></ngb-datepicker>`);
 
          fixture.componentInstance.model = {year: 2016, month: 8, day: 1};
-
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expect(getDay(fixture.nativeElement, 0)).toHaveCssClass('bg-primary');
+         tick();
+         fixture.detectChanges();
+         expect(getDay(fixture.nativeElement, 0)).toHaveCssClass('bg-primary');
 
-               fixture.componentInstance.model = {year: 2016, month: 8, day: 2};
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expect(getDay(fixture.nativeElement, 0)).not.toHaveCssClass('bg-primary');
-               expect(getDay(fixture.nativeElement, 1)).toHaveCssClass('bg-primary');
-             });
+         fixture.componentInstance.model = {year: 2016, month: 8, day: 2};
+         fixture.detectChanges();
+         tick();
+         fixture.detectChanges();
+         expect(getDay(fixture.nativeElement, 0)).not.toHaveCssClass('bg-primary');
+         expect(getDay(fixture.nativeElement, 1)).toHaveCssClass('bg-primary');
        }));
 
-    it('should switch month when clicked on the date outside of current month', async(() => {
+    it('should switch month when clicked on the date outside of current month', fakeAsync(() => {
          const fixture = createTestComponent(
              `<ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="model"></ngb-datepicker>`);
          fixture.detectChanges();
-         fixture.whenStable().then(() => {
-
-           let dates = getDates(fixture.nativeElement);
-
-           dates[31].click();  // 1 SEP 2016
-           expect(fixture.componentInstance.model).toEqual({year: 2016, month: 9, day: 1});
-
-           // month changes to SEP
-           fixture.detectChanges();
-           expect(getDay(fixture.nativeElement, 0).innerText).toBe('29');          // 29 AUG 2016
-           expect(getDay(fixture.nativeElement, 3)).toHaveCssClass('bg-primary');  // 1 SEP still selected
-         });
-       }));
-
-    it('should switch month on prev/next navigation click', async(() => {
-         const fixture = createTestComponent(
-             `<ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="model"></ngb-datepicker>`);
-
+         tick();
          let dates = getDates(fixture.nativeElement);
-         const navigation = getNavigationLinks(fixture.nativeElement);
 
-         dates[0].click();  // 1 AUG 2016
-         expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 1});
+         dates[31].click();  // 1 SEP 2016
+         expect(fixture.componentInstance.model).toEqual({year: 2016, month: 9, day: 1});
 
-         // PREV
-         navigation[0].click();
+         // month changes to SEP
          fixture.detectChanges();
-         dates = getDates(fixture.nativeElement);
-         dates[4].click();  // 1 JUL 2016
-         expect(fixture.componentInstance.model).toEqual({year: 2016, month: 7, day: 1});
-
-         // NEXT
-         navigation[1].click();
-         fixture.detectChanges();
-         dates = getDates(fixture.nativeElement);
-         dates[0].click();  // 1 AUG 2016
-         expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 1});
+         expect(getDay(fixture.nativeElement, 0).innerText).toBe('29');          // 29 AUG 2016
+         expect(getDay(fixture.nativeElement, 3)).toHaveCssClass('bg-primary');  // 1 SEP still selected
        }));
 
-    it('should switch month using navigateTo({date})', async(() => {
-         const fixture = createTestComponent(
-             `<ngb-datepicker #dp [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="model"></ngb-datepicker>
-       <button id="btn"(click)="dp.navigateTo({year: 2015, month: 6})"></button>`);
+    it('should switch month on prev/next navigation click', () => {
+      const fixture = createTestComponent(
+          `<ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="model"></ngb-datepicker>`);
 
-         const button = fixture.nativeElement.querySelector('button#btn');
-         button.click();
+      let dates = getDates(fixture.nativeElement);
+      const navigation = getNavigationLinks(fixture.nativeElement);
 
-         fixture.detectChanges();
-         expect(getMonthSelect(fixture.nativeElement).value).toBe('6');
-         expect(getYearSelect(fixture.nativeElement).value).toBe('2015');
+      dates[0].click();  // 1 AUG 2016
+      expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 1});
 
-         const dates = getDates(fixture.nativeElement);
-         dates[0].click();  // 1 JUN 2015
-         expect(fixture.componentInstance.model).toEqual({year: 2015, month: 6, day: 1});
-       }));
+      // PREV
+      navigation[0].click();
+      fixture.detectChanges();
+      dates = getDates(fixture.nativeElement);
+      dates[4].click();  // 1 JUL 2016
+      expect(fixture.componentInstance.model).toEqual({year: 2016, month: 7, day: 1});
+
+      // NEXT
+      navigation[1].click();
+      fixture.detectChanges();
+      dates = getDates(fixture.nativeElement);
+      dates[0].click();  // 1 AUG 2016
+      expect(fixture.componentInstance.model).toEqual({year: 2016, month: 8, day: 1});
+    });
+
+    it('should switch month using navigateTo({date})', () => {
+      const fixture = createTestComponent(
+          `<ngb-datepicker #dp [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="model"></ngb-datepicker>
+       <button id="btn" (click)="dp.navigateTo({year: 2015, month: 6})"></button>`);
+
+      const button = fixture.nativeElement.querySelector('button#btn');
+      button.click();
+
+      fixture.detectChanges();
+      expect(getMonthSelect(fixture.nativeElement).value).toBe('6');
+      expect(getYearSelect(fixture.nativeElement).value).toBe('2015');
+
+      const dates = getDates(fixture.nativeElement);
+      dates[0].click();  // 1 JUN 2015
+      expect(fixture.componentInstance.model).toEqual({year: 2015, month: 6, day: 1});
+    });
 
     it('should switch to current month using navigateTo() without arguments', () => {
       const fixture = createTestComponent(
@@ -834,26 +816,21 @@ describe('ngb-datepicker', () => {
       expect(getYearSelect(fixture.nativeElement).value).toBe(`${today.getFullYear()}`);
     });
 
-    it('should support disabling all dates and navigation via the disabled attribute', async(() => {
+    it('should support disabling all dates and navigation via the disabled attribute', fakeAsync(() => {
          const fixture = createTestComponent(
              `<ngb-datepicker [(ngModel)]="model" [startDate]="date" [disabled]="true"></ngb-datepicker>`);
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               for (let index = 0; index < 31; index++) {
-                 expect(getDay(fixture.nativeElement, index)).toHaveCssClass('text-muted');
-               }
+         tick();
+         fixture.detectChanges();
+         for (let index = 0; index < 31; index++) {
+           expect(getDay(fixture.nativeElement, index)).toHaveCssClass('text-muted');
+         }
 
-               const links = getNavigationLinks(fixture.nativeElement);
-               expect(links[0].hasAttribute('disabled')).toBeTruthy();
-               expect(links[1].hasAttribute('disabled')).toBeTruthy();
-               expect(getYearSelect(fixture.nativeElement).disabled).toBeTruthy();
-               expect(getMonthSelect(fixture.nativeElement).disabled).toBeTruthy();
-             });
+         const links = getNavigationLinks(fixture.nativeElement);
+         expect(links[0].hasAttribute('disabled')).toBeTruthy();
+         expect(links[1].hasAttribute('disabled')).toBeTruthy();
+         expect(getYearSelect(fixture.nativeElement).disabled).toBeTruthy();
+         expect(getMonthSelect(fixture.nativeElement).disabled).toBeTruthy();
        }));
   });
 
@@ -1059,7 +1036,7 @@ describe('ngb-datepicker', () => {
 
   describe('forms', () => {
 
-    it('should work with template-driven form validation', async(() => {
+    it('should work with template-driven form validation', fakeAsync(() => {
          const fixture = createTestComponent(`
         <form>
           <ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="model" name="date" required>
@@ -1069,74 +1046,58 @@ describe('ngb-datepicker', () => {
 
          const compiled = fixture.nativeElement;
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expect(getDatepicker(compiled)).toHaveCssClass('ng-invalid');
-               expect(getDatepicker(compiled)).not.toHaveCssClass('ng-valid');
+         tick();
+         fixture.detectChanges();
+         expect(getDatepicker(compiled)).toHaveCssClass('ng-invalid');
+         expect(getDatepicker(compiled)).not.toHaveCssClass('ng-valid');
 
-               fixture.componentInstance.model = {year: 2016, month: 8, day: 1};
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expect(getDatepicker(compiled)).toHaveCssClass('ng-valid');
-               expect(getDatepicker(compiled)).not.toHaveCssClass('ng-invalid');
-             });
+         fixture.componentInstance.model = {year: 2016, month: 8, day: 1};
+         fixture.detectChanges();
+         tick();
+         fixture.detectChanges();
+         expect(getDatepicker(compiled)).toHaveCssClass('ng-valid');
+         expect(getDatepicker(compiled)).not.toHaveCssClass('ng-invalid');
        }));
 
-    it('should work with model-driven form validation', async(() => {
-         const html = `
+    it('should work with model-driven form validation', () => {
+      const html = `
           <form [formGroup]="form">
             <ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" formControlName="control" required></ngb-datepicker>
           </form>`;
 
-         const fixture = createTestComponent(html);
-         const compiled = fixture.nativeElement;
-         fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               const dates = getDates(fixture.nativeElement);
+      const fixture = createTestComponent(html);
+      const compiled = fixture.nativeElement;
+      fixture.detectChanges();
+      const dates = getDates(fixture.nativeElement);
 
-               expect(getDatepicker(compiled)).toHaveCssClass('ng-invalid');
-               expect(getDatepicker(compiled)).not.toHaveCssClass('ng-valid');
+      expect(getDatepicker(compiled)).toHaveCssClass('ng-invalid');
+      expect(getDatepicker(compiled)).not.toHaveCssClass('ng-valid');
 
-               dates[0].click();
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expect(getDatepicker(compiled)).toHaveCssClass('ng-valid');
-               expect(getDatepicker(compiled)).not.toHaveCssClass('ng-invalid');
-             });
-       }));
+      dates[0].click();
+      fixture.detectChanges();
+      expect(getDatepicker(compiled)).toHaveCssClass('ng-valid');
+      expect(getDatepicker(compiled)).not.toHaveCssClass('ng-invalid');
+    });
 
-    it('should be disabled with reactive forms', async(() => {
-         const html = `<form [formGroup]="disabledForm">
+    it('should be disabled with reactive forms', () => {
+      const html = `<form [formGroup]="disabledForm">
             <ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" formControlName="control">
             </ngb-datepicker>
         </form>`;
 
-         const fixture = createTestComponent(html);
-         fixture.detectChanges();
-         const dates = getDates(fixture.nativeElement);
-         dates[0].click();  // 1 AUG 2016
-         expect(fixture.componentInstance.disabledForm.controls['control'].value).toBeFalsy();
-         for (let index = 0; index < 31; index++) {
-           expect(getDay(fixture.nativeElement, index)).toHaveCssClass('text-muted');
-         }
-         expect(fixture.nativeElement.querySelector('ngb-datepicker').getAttribute('tabindex')).toBeFalsy();
-       }));
+      const fixture = createTestComponent(html);
+      fixture.detectChanges();
+      const dates = getDates(fixture.nativeElement);
+      dates[0].click();  // 1 AUG 2016
+      expect(fixture.componentInstance.disabledForm.controls['control'].value).toBeFalsy();
+      for (let index = 0; index < 31; index++) {
+        expect(getDay(fixture.nativeElement, index)).toHaveCssClass('text-muted');
+      }
+      expect(fixture.nativeElement.querySelector('ngb-datepicker').getAttribute('tabindex')).toBeFalsy();
+    });
 
     it('should not change again the value in the model on a change coming from the model (template-driven form)',
-       async(() => {
+       () => {
          const html = `<form>
              <ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" [(ngModel)]="model" name="date">
              </ngb-datepicker>
@@ -1147,32 +1108,27 @@ describe('ngb-datepicker', () => {
 
          const value = new NgbDate(2018, 7, 28);
          fixture.componentInstance.model = value;
-
          fixture.detectChanges();
-         fixture.whenStable().then(() => { expect(fixture.componentInstance.model).toBe(value); });
-       }));
+         expect(fixture.componentInstance.model).toBe(value);
+       });
 
-    it('should not change again the value in the model on a change coming from the model (reactive form)', async(() => {
-         const html = `<form [formGroup]="form">
+    it('should not change again the value in the model on a change coming from the model (reactive form)', () => {
+      const html = `<form [formGroup]="form">
              <ngb-datepicker [startDate]="date" [minDate]="minDate" [maxDate]="maxDate" formControlName="control">
              </ngb-datepicker>
            </form>`;
 
-         const fixture = createTestComponent(html);
-         fixture.detectChanges();
+      const fixture = createTestComponent(html);
 
-         const formChangeSpy = jasmine.createSpy('form change');
-         const form = fixture.componentInstance.form;
-         form.valueChanges.subscribe(formChangeSpy);
-         const controlValue = new NgbDate(2018, 7, 28);
-         form.setValue({control: controlValue});
+      const formChangeSpy = jasmine.createSpy('form change');
+      const form = fixture.componentInstance.form;
+      form.valueChanges.subscribe(formChangeSpy);
 
-         fixture.detectChanges();
-         fixture.whenStable().then(() => {
-           expect(formChangeSpy).toHaveBeenCalledTimes(1);
-           expect(form.value.control).toBe(controlValue);
-         });
-       }));
+      const controlValue = new NgbDate(2018, 7, 28);
+      form.setValue({control: controlValue});
+      expect(formChangeSpy).toHaveBeenCalledTimes(1);
+      expect(form.value.control).toBe(controlValue);
+    });
 
   });
 

--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed, ComponentFixture, inject, async, fakeAsync, tick} from '@angular/core/testing';
+import {TestBed, ComponentFixture, inject, fakeAsync, tick} from '@angular/core/testing';
 import {createGenericTestComponent} from '../test/common';
 import {Key} from '../util/key';
 
@@ -530,7 +530,7 @@ describe('ngb-rating', () => {
 
   describe('forms', () => {
 
-    it('should work with template-driven form validation', async(() => {
+    it('should work with template-driven form validation', fakeAsync(() => {
          const html = `
         <form>
           <ngb-rating [(ngModel)]="model" name="control" max="5" required></ngb-rating>
@@ -540,33 +540,27 @@ describe('ngb-rating', () => {
          const element = fixture.debugElement.query(By.directive(NgbRating));
 
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               expect(getState(element.nativeElement)).toEqual([false, false, false, false, false]);
-               expect(element.nativeElement).toHaveCssClass('ng-invalid');
-               expect(element.nativeElement).toHaveCssClass('ng-untouched');
+         tick();
+         fixture.detectChanges();
+         expect(getState(element.nativeElement)).toEqual([false, false, false, false, false]);
+         expect(element.nativeElement).toHaveCssClass('ng-invalid');
+         expect(element.nativeElement).toHaveCssClass('ng-untouched');
 
-               fixture.componentInstance.model = 1;
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               fixture.detectChanges();
-               expect(getState(element.nativeElement)).toEqual([true, false, false, false, false]);
-               expect(element.nativeElement).toHaveCssClass('ng-valid');
-               expect(element.nativeElement).toHaveCssClass('ng-untouched');
+         fixture.componentInstance.model = 1;
+         fixture.detectChanges();
+         tick();
+         fixture.detectChanges();
+         expect(getState(element.nativeElement)).toEqual([true, false, false, false, false]);
+         expect(element.nativeElement).toHaveCssClass('ng-valid');
+         expect(element.nativeElement).toHaveCssClass('ng-untouched');
 
-               fixture.componentInstance.model = 0;
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               fixture.detectChanges();
-               expect(getState(element.nativeElement)).toEqual([false, false, false, false, false]);
-               expect(element.nativeElement).toHaveCssClass('ng-valid');
-               expect(element.nativeElement).toHaveCssClass('ng-untouched');
-             });
+         fixture.componentInstance.model = 0;
+         fixture.detectChanges();
+         tick();
+         fixture.detectChanges();
+         expect(getState(element.nativeElement)).toEqual([false, false, false, false, false]);
+         expect(element.nativeElement).toHaveCssClass('ng-valid');
+         expect(element.nativeElement).toHaveCssClass('ng-untouched');
        }));
 
     it('should work with reactive form validation', () => {
@@ -595,7 +589,7 @@ describe('ngb-rating', () => {
       expect(element.nativeElement).toHaveCssClass('ng-untouched');
     });
 
-    it('should not update template driven form by clicking disabled control', async(() => {
+    it('should not update template driven form by clicking disabled control', fakeAsync(() => {
          const html = `
           <ngb-rating [(ngModel)]="model" class="control" max="5"></ngb-rating>
           <ngb-rating [(ngModel)]="model" class="control-disabled" max="5" disabled></ngb-rating>`;
@@ -604,29 +598,22 @@ describe('ngb-rating', () => {
          const element = fixture.debugElement.query(By.css('.control'));
          const disabledElement = fixture.debugElement.query(By.css('.control-disabled'));
 
+
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               getStar(element.nativeElement, 3).click();
+         tick();
+         getStar(element.nativeElement, 3).click();
+         fixture.detectChanges();
+         expect(getState(element.nativeElement)).toEqual([true, true, true, false, false]);
+         expect(getState(disabledElement.nativeElement)).toEqual([false, false, false, false, false]);
+         expect(fixture.componentInstance.model).toEqual(3);
 
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expect(getState(element.nativeElement)).toEqual([true, true, true, false, false]);
-               expect(getState(disabledElement.nativeElement)).toEqual([false, false, false, false, false]);
-               expect(fixture.componentInstance.model).toEqual(3);
-
-               getStar(disabledElement.nativeElement, 4).click();
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               fixture.detectChanges();
-               expect(getState(element.nativeElement)).toEqual([true, true, true, false, false]);
-               expect(getState(disabledElement.nativeElement)).toEqual([false, false, false, false, false]);
-               expect(fixture.componentInstance.model).toEqual(3);
-             });
+         getStar(disabledElement.nativeElement, 4).click();
+         fixture.detectChanges();
+         tick();
+         fixture.detectChanges();
+         expect(getState(element.nativeElement)).toEqual([true, true, true, false, false]);
+         expect(getState(disabledElement.nativeElement)).toEqual([false, false, false, false, false]);
+         expect(fixture.componentInstance.model).toEqual(3);
        }));
 
     it('should handle clicks and update form control', () => {

--- a/src/timepicker/timepicker.spec.ts
+++ b/src/timepicker/timepicker.spec.ts
@@ -1,4 +1,4 @@
-import {async, ComponentFixture, inject, TestBed} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
 import {createGenericTestComponent} from '../test/common';
 
 import {ChangeDetectionStrategy, Component, DebugElement, Injectable} from '@angular/core';
@@ -99,295 +99,235 @@ describe('ngb-timepicker', () => {
 
   describe('rendering based on model', () => {
 
-    it('should render hour and minute inputs', async(() => {
+    it('should render hour and minute inputs', fakeAsync(() => {
          const html = `<ngb-timepicker [ngModel]="model"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 13, minute: 30};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => { expectToDisplayTime(fixture.nativeElement, '13:30'); });
+         tick();
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '13:30');
        }));
 
-    it('should update inputs value on model change', async(() => {
+    it('should update inputs value on model change', fakeAsync(() => {
          const html = `<ngb-timepicker [ngModel]="model"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 13, minute: 30};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expectToDisplayTime(fixture.nativeElement, '13:30');
+         tick();
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '13:30');
 
-               fixture.componentInstance.model = {hour: 14, minute: 40};
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => { expectToDisplayTime(fixture.nativeElement, '14:40'); });
+         fixture.componentInstance.model = {hour: 14, minute: 40};
+         fixture.detectChanges();
+         tick();
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '14:40');
        }));
 
-    it('should render hour and minute inputs with padding', async(() => {
+    it('should render hour and minute inputs with padding', fakeAsync(() => {
          const html = `<ngb-timepicker [ngModel]="model"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 1, minute: 3};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => { expectToDisplayTime(fixture.nativeElement, '01:03'); });
+         tick();
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '01:03');
        }));
 
-    it('should render hour, minute and seconds inputs with padding', async(() => {
+    it('should render hour, minute and seconds inputs with padding', fakeAsync(() => {
          const html = `<ngb-timepicker [ngModel]="model" [seconds]="true"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 3, second: 4};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => { expectToDisplayTime(fixture.nativeElement, '10:03:04'); });
+         tick();
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:03:04');
        }));
 
-    it('should render invalid or empty hour and minute as blank string', async(() => {
+    it('should render invalid or empty hour and minute as blank string', fakeAsync(() => {
          const html = `<ngb-timepicker [ngModel]="model"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: undefined, minute: 'aaa'};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => { expectToDisplayTime(fixture.nativeElement, ':'); });
+         tick();
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, ':');
        }));
 
-    it('should render invalid or empty second as blank string', async(() => {
+    it('should render invalid or empty second as blank string', fakeAsync(() => {
          const html = `<ngb-timepicker [ngModel]="model" [seconds]="true"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 20, second: false};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => { expectToDisplayTime(fixture.nativeElement, '10:20:'); });
+         tick();
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:20:');
        }));
 
-    it('should render empty fields on null model', async(() => {
+    it('should render empty fields on null model', fakeAsync(() => {
          const html = `<ngb-timepicker [ngModel]="model" [seconds]="true"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = null;
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => { expectToDisplayTime(fixture.nativeElement, '::'); });
+         tick();
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '::');
        }));
   });
 
 
   describe('model updates in response to increment / decrement button clicks', () => {
 
-    it('should increment / decrement hours', async(() => {
+    it('should increment / decrement hours', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
+         tick();
+         fixture.detectChanges();
+         const buttons = getButtons(fixture.nativeElement);
 
-               const buttons = getButtons(fixture.nativeElement);
+         expectToDisplayTime(fixture.nativeElement, '10:30');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-               expectToDisplayTime(fixture.nativeElement, '10:30');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
-
-               (<HTMLButtonElement>buttons[0]).click();  // H+
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '11:30');
-               expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
+         (<HTMLButtonElement>buttons[0]).click();  // H+
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '11:30');
+         expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
 
 
-               (<HTMLButtonElement>buttons[1]).click();  // H-
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '10:30');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
-             });
+         (<HTMLButtonElement>buttons[1]).click();  // H-
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:30');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
        }));
 
-    it('should wrap hours', async(() => {
+    it('should wrap hours', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 23, minute: 30, second: 0};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
+         tick();
+         fixture.detectChanges();
+         const buttons = getButtons(fixture.nativeElement);
 
-               const buttons = getButtons(fixture.nativeElement);
+         expectToDisplayTime(fixture.nativeElement, '23:30');
+         expect(fixture.componentInstance.model).toEqual({hour: 23, minute: 30, second: 0});
 
-               expectToDisplayTime(fixture.nativeElement, '23:30');
-               expect(fixture.componentInstance.model).toEqual({hour: 23, minute: 30, second: 0});
+         (<HTMLButtonElement>buttons[0]).click();  // H+
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '00:30');
+         expect(fixture.componentInstance.model).toEqual({hour: 0, minute: 30, second: 0});
 
-               (<HTMLButtonElement>buttons[0]).click();  // H+
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '00:30');
-               expect(fixture.componentInstance.model).toEqual({hour: 0, minute: 30, second: 0});
-
-               (<HTMLButtonElement>buttons[1]).click();  // H-
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '23:30');
-               expect(fixture.componentInstance.model).toEqual({hour: 23, minute: 30, second: 0});
-             });
+         (<HTMLButtonElement>buttons[1]).click();  // H-
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '23:30');
+         expect(fixture.componentInstance.model).toEqual({hour: 23, minute: 30, second: 0});
        }));
 
-    it('should increment / decrement minutes', async(() => {
+    it('should increment / decrement minutes', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
+         tick();
+         fixture.detectChanges();
+         const buttons = getButtons(fixture.nativeElement);
 
-               const buttons = getButtons(fixture.nativeElement);
+         expectToDisplayTime(fixture.nativeElement, '10:30');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-               expectToDisplayTime(fixture.nativeElement, '10:30');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+         (<HTMLButtonElement>buttons[2]).click();  // M+
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:31');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 0});
 
-               (<HTMLButtonElement>buttons[2]).click();  // M+
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '10:31');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 0});
-
-               (<HTMLButtonElement>buttons[3]).click();  // M-
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '10:30');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
-             });
+         (<HTMLButtonElement>buttons[3]).click();  // M-
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:30');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
        }));
 
-    it('should wrap minutes', async(() => {
+    it('should wrap minutes', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 22, minute: 59, second: 0};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               const buttons = getButtons(fixture.nativeElement);
+         tick();
+         fixture.detectChanges();
+         const buttons = getButtons(fixture.nativeElement);
 
-               expectToDisplayTime(fixture.nativeElement, '22:59');
-               expect(fixture.componentInstance.model).toEqual({hour: 22, minute: 59, second: 0});
+         expectToDisplayTime(fixture.nativeElement, '22:59');
+         expect(fixture.componentInstance.model).toEqual({hour: 22, minute: 59, second: 0});
 
-               (<HTMLButtonElement>buttons[2]).click();  // M+
-               fixture.detectChanges();
-               expect(fixture.componentInstance.model).toEqual({hour: 23, minute: 0, second: 0});
+         (<HTMLButtonElement>buttons[2]).click();  // M+
+         fixture.detectChanges();
+         expect(fixture.componentInstance.model).toEqual({hour: 23, minute: 0, second: 0});
 
-               (<HTMLButtonElement>buttons[3]).click();  // M-
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '22:59');
-               expect(fixture.componentInstance.model).toEqual({hour: 22, minute: 59, second: 0});
-             });
+         (<HTMLButtonElement>buttons[3]).click();  // M-
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '22:59');
+         expect(fixture.componentInstance.model).toEqual({hour: 22, minute: 59, second: 0});
        }));
 
-    it('should increment / decrement seconds', async(() => {
+    it('should increment / decrement seconds', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               const buttons = getButtons(fixture.nativeElement);
+         tick();
+         fixture.detectChanges();
+         const buttons = getButtons(fixture.nativeElement);
 
-               expectToDisplayTime(fixture.nativeElement, '10:30:00');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+         expectToDisplayTime(fixture.nativeElement, '10:30:00');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-               (<HTMLButtonElement>buttons[4]).click();  // S+
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '10:30:01');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 1});
+         (<HTMLButtonElement>buttons[4]).click();  // S+
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:30:01');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 1});
 
-               (<HTMLButtonElement>buttons[5]).click();  // S-
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '10:30:00');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
-             });
+         (<HTMLButtonElement>buttons[5]).click();  // S-
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:30:00');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
        }));
 
-    it('should wrap seconds', async(() => {
+    it('should wrap seconds', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30, second: 59};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
+         tick();
+         fixture.detectChanges();
+         const buttons = getButtons(fixture.nativeElement);
 
-               const buttons = getButtons(fixture.nativeElement);
+         expectToDisplayTime(fixture.nativeElement, '10:30:59');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 59});
 
-               expectToDisplayTime(fixture.nativeElement, '10:30:59');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 59});
+         (<HTMLButtonElement>buttons[4]).click();  // S+
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:31:00');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 0});
 
-               (<HTMLButtonElement>buttons[4]).click();  // S+
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '10:31:00');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 0});
-
-               (<HTMLButtonElement>buttons[5]).click();  // S-
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '10:30:59');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 59});
-             });
+         (<HTMLButtonElement>buttons[5]).click();  // S-
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:30:59');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 59});
        }));
   });
 
@@ -397,199 +337,166 @@ describe('ngb-timepicker', () => {
       return fixture.debugElement.queryAll(By.css('input'));
     }
 
-    it('should increment / decrement hours', async(() => {
+    it('should increment / decrement hours', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expectToDisplayTime(fixture.nativeElement, '10:30');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+         tick();
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:30');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-               const hourInput = getDebugInputs(fixture)[0];
+         const hourInput = getDebugInputs(fixture)[0];
 
-               hourInput.triggerEventHandler('keydown.ArrowUp', {preventDefault: () => {}});  // H+
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '11:30');
-               expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
+         hourInput.triggerEventHandler('keydown.ArrowUp', {preventDefault: () => {}});  // H+
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '11:30');
+         expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
 
-               hourInput.triggerEventHandler('keydown.ArrowDown', {preventDefault: () => {}});  // H-
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '10:30');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
-             });
+         hourInput.triggerEventHandler('keydown.ArrowDown', {preventDefault: () => {}});  // H-
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:30');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
        }));
 
-    it('should increment / decrement minutes', async(() => {
+    it('should increment / decrement minutes', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expectToDisplayTime(fixture.nativeElement, '10:30');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+         tick();
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:30');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-               const minuteInput = getDebugInputs(fixture)[1];
+         const minuteInput = getDebugInputs(fixture)[1];
 
-               minuteInput.triggerEventHandler('keydown.ArrowUp', {preventDefault: () => {}});  // M+
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '10:31');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 0});
+         minuteInput.triggerEventHandler('keydown.ArrowUp', {preventDefault: () => {}});  // M+
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:31');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 0});
 
-               minuteInput.triggerEventHandler('keydown.ArrowDown', {preventDefault: () => {}});  // M-
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '10:30');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
-             });
+         minuteInput.triggerEventHandler('keydown.ArrowDown', {preventDefault: () => {}});  // M-
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:30');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
        }));
 
-    it('should increment / decrement seconds', async(() => {
+    it('should increment / decrement seconds', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expectToDisplayTime(fixture.nativeElement, '10:30:00');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+         tick();
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:30:00');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-               const secondInput = getDebugInputs(fixture)[2];
+         const secondInput = getDebugInputs(fixture)[2];
 
-               secondInput.triggerEventHandler('keydown.ArrowUp', {preventDefault: () => {}});  // S+
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '10:30:01');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 1});
+         secondInput.triggerEventHandler('keydown.ArrowUp', {preventDefault: () => {}});  // S+
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:30:01');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 1});
 
-               secondInput.triggerEventHandler('keydown.ArrowDown', {preventDefault: () => {}});  // S-
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '10:30:00');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
-             });
+         secondInput.triggerEventHandler('keydown.ArrowDown', {preventDefault: () => {}});  // S-
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:30:00');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
        }));
   });
 
   describe('model updates in response to input field changes', () => {
 
-    it('should update hours', async(() => {
+    it('should update hours', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
+         tick();
+         fixture.detectChanges();
+         const inputs = fixture.debugElement.queryAll(By.css('input'));
 
-               const inputs = fixture.debugElement.queryAll(By.css('input'));
+         expectToDisplayTime(fixture.nativeElement, '10:30');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-               expectToDisplayTime(fixture.nativeElement, '10:30');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+         inputs[0].triggerEventHandler('change', createChangeEvent('11'));
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '11:30');
+         expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
 
-               inputs[0].triggerEventHandler('change', createChangeEvent('11'));
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '11:30');
-               expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
+         inputs[0].triggerEventHandler('change', createChangeEvent(`${24 + 11}`));
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '11:30');
+         expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
 
-               inputs[0].triggerEventHandler('change', createChangeEvent(`${24 + 11}`));
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '11:30');
-               expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 30, second: 0});
-
-               inputs[0].triggerEventHandler('change', createChangeEvent('aa'));
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, ':30');
-               expect(fixture.componentInstance.model).toEqual(null);
-             });
+         inputs[0].triggerEventHandler('change', createChangeEvent('aa'));
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, ':30');
+         expect(fixture.componentInstance.model).toEqual(null);
        }));
 
-    it('should update minutes', async(() => {
+    it('should update minutes', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
+         tick();
+         fixture.detectChanges();
+         const inputs = fixture.debugElement.queryAll(By.css('input'));
 
-               const inputs = fixture.debugElement.queryAll(By.css('input'));
+         expectToDisplayTime(fixture.nativeElement, '10:30');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-               expectToDisplayTime(fixture.nativeElement, '10:30');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+         inputs[1].triggerEventHandler('change', createChangeEvent('40'));
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:40');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 40, second: 0});
 
-               inputs[1].triggerEventHandler('change', createChangeEvent('40'));
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '10:40');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 40, second: 0});
+         inputs[1].triggerEventHandler('change', createChangeEvent('70'));
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '11:10');
+         expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 10, second: 0});
 
-               inputs[1].triggerEventHandler('change', createChangeEvent('70'));
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '11:10');
-               expect(fixture.componentInstance.model).toEqual({hour: 11, minute: 10, second: 0});
-
-               inputs[1].triggerEventHandler('change', createChangeEvent('aa'));
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '11:');
-               expect(fixture.componentInstance.model).toEqual(null);
-             });
+         inputs[1].triggerEventHandler('change', createChangeEvent('aa'));
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '11:');
+         expect(fixture.componentInstance.model).toEqual(null);
        }));
 
-    it('should update seconds', async(() => {
+    it('should update seconds', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
+         tick();
+         fixture.detectChanges();
+         const inputs = fixture.debugElement.queryAll(By.css('input'));
 
-               const inputs = fixture.debugElement.queryAll(By.css('input'));
+         expectToDisplayTime(fixture.nativeElement, '10:30:00');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
 
-               expectToDisplayTime(fixture.nativeElement, '10:30:00');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
+         inputs[2].triggerEventHandler('change', createChangeEvent('40'));
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:30:40');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 40});
 
-               inputs[2].triggerEventHandler('change', createChangeEvent('40'));
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '10:30:40');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 40});
+         inputs[2].triggerEventHandler('change', createChangeEvent('70'));
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:31:10');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 10});
 
-               inputs[2].triggerEventHandler('change', createChangeEvent('70'));
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '10:31:10');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 31, second: 10});
-
-               inputs[2].triggerEventHandler('change', createChangeEvent('aa'));
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '10:31:');
-               expect(fixture.componentInstance.model).toEqual(null);
-             });
+         inputs[2].triggerEventHandler('change', createChangeEvent('aa'));
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:31:');
+         expect(fixture.componentInstance.model).toEqual(null);
        }));
   });
 
@@ -598,263 +505,203 @@ describe('ngb-timepicker', () => {
     beforeEach(
         () => { TestBed.configureTestingModule({providers: [{provide: NgbTimepickerI18n, useClass: TestI18n}]}); });
 
-    it('should render meridian button with proper value', async(() => {
+    it('should render meridian button with proper value', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [meridian]="true"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 13, minute: 30, second: 0};
          const meridianButton = getMeridianButton(fixture.nativeElement);
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expectToDisplayTime(fixture.nativeElement, '01:30:00');
-               expect(meridianButton.textContent).toBe('afternoon');
+         tick();
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '01:30:00');
+         expect(meridianButton.textContent).toBe('afternoon');
 
-               fixture.componentInstance.model = {hour: 1, minute: 30, second: 0};
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expectToDisplayTime(fixture.nativeElement, '01:30:00');
-               expect(meridianButton.textContent).toBe('morning');
-             });
+         fixture.componentInstance.model = {hour: 1, minute: 30, second: 0};
+         fixture.detectChanges();
+         tick();
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '01:30:00');
+         expect(meridianButton.textContent).toBe('morning');
        }));
 
-    it('should render 12 PM/AM as 12:mm and meridian button with proper value', async(() => {
+    it('should render 12 PM/AM as 12:mm and meridian button with proper value', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [meridian]="true"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 12, minute: 30, second: 0};
          const meridianButton = getMeridianButton(fixture.nativeElement);
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expectToDisplayTime(fixture.nativeElement, '12:30:00');
-               expect(meridianButton.textContent).toBe('afternoon');
+         tick();
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '12:30:00');
+         expect(meridianButton.textContent).toBe('afternoon');
 
-               fixture.componentInstance.model = {hour: 0, minute: 30, second: 0};
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expectToDisplayTime(fixture.nativeElement, '12:30:00');
-               expect(meridianButton.textContent).toBe('morning');
-             });
+         fixture.componentInstance.model = {hour: 0, minute: 30, second: 0};
+         fixture.detectChanges();
+         tick();
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '12:30:00');
+         expect(meridianButton.textContent).toBe('morning');
        }));
 
-    it('should update model on meridian click', async(() => {
+    it('should update model on meridian click', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [meridian]="true"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 13, minute: 30, second: 0};
          const meridianButton = <HTMLButtonElement>getMeridianButton(fixture.nativeElement);
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expectToDisplayTime(fixture.nativeElement, '01:30:00');
-               expect(meridianButton.textContent).toBe('afternoon');
+         tick();
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '01:30:00');
+         expect(meridianButton.textContent).toBe('afternoon');
 
-               meridianButton.click();
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expectToDisplayTime(fixture.nativeElement, '01:30:00');
-               expect(fixture.componentInstance.model).toEqual({hour: 1, minute: 30, second: 0});
-               expect(meridianButton.textContent).toBe('morning');
-             });
+         meridianButton.click();
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '01:30:00');
+         expect(fixture.componentInstance.model).toEqual({hour: 1, minute: 30, second: 0});
+         expect(meridianButton.textContent).toBe('morning');
        }));
 
 
-    it('should respect meridian when propagating model (PM)', async(() => {
+    it('should respect meridian when propagating model (PM)', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [meridian]="true"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 14, minute: 30};
          fixture.detectChanges();
+         tick();
+         fixture.detectChanges();
 
          const inputs = fixture.debugElement.queryAll(By.css('input'));
-
-         fixture.whenStable()
-             .then(() => {
-               inputs[0].triggerEventHandler('change', createChangeEvent('3'));
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => { expect(fixture.componentInstance.model).toEqual({hour: 15, minute: 30, second: 0}); });
+         inputs[0].triggerEventHandler('change', createChangeEvent('3'));
+         expect(fixture.componentInstance.model).toEqual({hour: 15, minute: 30, second: 0});
        }));
 
-    it('should respect meridian when propagating model (AM)', async(() => {
+    it('should respect meridian when propagating model (AM)', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [meridian]="true"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 9, minute: 30};
          fixture.detectChanges();
+         tick();
+         fixture.detectChanges();
 
          const inputs = fixture.debugElement.queryAll(By.css('input'));
-
-         fixture.whenStable()
-             .then(() => {
-               inputs[0].triggerEventHandler('change', createChangeEvent('10'));
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => { expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0}); });
+         inputs[0].triggerEventHandler('change', createChangeEvent('10'));
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
        }));
 
-    it('should interpret 12 as midnight (00:00) when meridian is set to AM', async(() => {
+    it('should interpret 12 as midnight (00:00) when meridian is set to AM', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [meridian]="true"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 9, minute: 0};
          fixture.detectChanges();
+         tick();
+         fixture.detectChanges();
 
          const inputs = fixture.debugElement.queryAll(By.css('input'));
-
-         fixture.whenStable()
-             .then(() => {
-               inputs[0].triggerEventHandler('change', createChangeEvent('12'));
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => { expect(fixture.componentInstance.model).toEqual({hour: 0, minute: 0, second: 0}); });
+         inputs[0].triggerEventHandler('change', createChangeEvent('12'));
+         expect(fixture.componentInstance.model).toEqual({hour: 0, minute: 0, second: 0});
        }));
 
-    it('should interpret 12 as noon (12:00) when meridian is set to PM', async(() => {
+    it('should interpret 12 as noon (12:00) when meridian is set to PM', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [meridian]="true"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 18, minute: 0};
          fixture.detectChanges();
+         tick();
+         fixture.detectChanges();
 
          const inputs = fixture.debugElement.queryAll(By.css('input'));
-
-         fixture.whenStable()
-             .then(() => {
-               inputs[0].triggerEventHandler('change', createChangeEvent('12'));
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => { expect(fixture.componentInstance.model).toEqual({hour: 12, minute: 0, second: 0}); });
+         inputs[0].triggerEventHandler('change', createChangeEvent('12'));
+         expect(fixture.componentInstance.model).toEqual({hour: 12, minute: 0, second: 0});
        }));
 
-    it('should interpret hour more than 12 as 24h value (AM)', async(() => {
+    it('should interpret hour more than 12 as 24h value (AM)', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [meridian]="true"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 7, minute: 30, second: 0};
          fixture.detectChanges();
-
-         const inputs = fixture.debugElement.queryAll(By.css('input'));
-         const meridianButton = <HTMLButtonElement>getMeridianButton(fixture.nativeElement);
-
-         fixture.whenStable()
-             .then(() => {
-               inputs[0].triggerEventHandler('change', createChangeEvent('22'));
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expectToDisplayTime(fixture.nativeElement, '10:30');
-               expect(meridianButton.textContent).toBe('afternoon');
-               expect(fixture.componentInstance.model).toEqual({hour: 22, minute: 30, second: 0});
-             });
-       }));
-
-    it('should interpret hour more than 12 as 24h value (PM)', async(() => {
-         const html = `<ngb-timepicker [(ngModel)]="model" [meridian]="true"></ngb-timepicker>`;
-
-         const fixture = createTestComponent(html);
-         fixture.componentInstance.model = {hour: 15, minute: 30, second: 0};
+         tick();
          fixture.detectChanges();
 
          const inputs = fixture.debugElement.queryAll(By.css('input'));
          const meridianButton = <HTMLButtonElement>getMeridianButton(fixture.nativeElement);
 
-         fixture.whenStable()
-             .then(() => {
-               inputs[0].triggerEventHandler('change', createChangeEvent('22'));
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expectToDisplayTime(fixture.nativeElement, '10:30');
-               expect(meridianButton.textContent).toBe('afternoon');
-               expect(fixture.componentInstance.model).toEqual({hour: 22, minute: 30, second: 0});
-             });
+         inputs[0].triggerEventHandler('change', createChangeEvent('22'));
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:30');
+         expect(meridianButton.textContent).toBe('afternoon');
+         expect(fixture.componentInstance.model).toEqual({hour: 22, minute: 30, second: 0});
        }));
 
-    it('should use remainder of division by 24 as a value in 24h format when hour > 24 (AM)', async(() => {
+    it('should interpret hour more than 12 as 24h value (PM)', fakeAsync(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model" [meridian]="true"></ngb-timepicker>`;
+
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 15, minute: 30, second: 0};
+         fixture.detectChanges();
+         tick();
+         fixture.detectChanges();
+
+         const inputs = fixture.debugElement.queryAll(By.css('input'));
+         const meridianButton = <HTMLButtonElement>getMeridianButton(fixture.nativeElement);
+
+         inputs[0].triggerEventHandler('change', createChangeEvent('22'));
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:30');
+         expect(meridianButton.textContent).toBe('afternoon');
+         expect(fixture.componentInstance.model).toEqual({hour: 22, minute: 30, second: 0});
+       }));
+
+    it('should use remainder of division by 24 as a value in 24h format when hour > 24 (AM)', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [meridian]="true"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 7, minute: 30, second: 0};
          fixture.detectChanges();
-
-         const inputs = fixture.debugElement.queryAll(By.css('input'));
-         const meridianButton = <HTMLButtonElement>getMeridianButton(fixture.nativeElement);
-
-         fixture.whenStable()
-             .then(() => {
-               inputs[0].triggerEventHandler('change', createChangeEvent(`${24 + 9}`));
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expectToDisplayTime(fixture.nativeElement, '09:30');
-               expect(meridianButton.textContent).toBe('morning');
-               expect(fixture.componentInstance.model).toEqual({hour: 9, minute: 30, second: 0});
-             });
-       }));
-
-    it('should use remainder of division by 24 as a value in 24h format when hour > 24 (PM)', async(() => {
-         const html = `<ngb-timepicker [(ngModel)]="model" [meridian]="true"></ngb-timepicker>`;
-
-         const fixture = createTestComponent(html);
-         fixture.componentInstance.model = {hour: 15, minute: 30, second: 0};
+         tick();
          fixture.detectChanges();
 
          const inputs = fixture.debugElement.queryAll(By.css('input'));
          const meridianButton = <HTMLButtonElement>getMeridianButton(fixture.nativeElement);
 
-         fixture.whenStable()
-             .then(() => {
-               inputs[0].triggerEventHandler('change', createChangeEvent(`${24 + 9}`));
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expectToDisplayTime(fixture.nativeElement, '09:30');
-               expect(meridianButton.textContent).toBe('morning');
-               expect(fixture.componentInstance.model).toEqual({hour: 9, minute: 30, second: 0});
-             });
+         inputs[0].triggerEventHandler('change', createChangeEvent(`${24 + 9}`));
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '09:30');
+         expect(meridianButton.textContent).toBe('morning');
+         expect(fixture.componentInstance.model).toEqual({hour: 9, minute: 30, second: 0});
+       }));
+
+    it('should use remainder of division by 24 as a value in 24h format when hour > 24 (PM)', fakeAsync(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model" [meridian]="true"></ngb-timepicker>`;
+
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = {hour: 15, minute: 30, second: 0};
+         fixture.detectChanges();
+         tick();
+         fixture.detectChanges();
+
+         const inputs = fixture.debugElement.queryAll(By.css('input'));
+         const meridianButton = <HTMLButtonElement>getMeridianButton(fixture.nativeElement);
+
+         inputs[0].triggerEventHandler('change', createChangeEvent(`${24 + 9}`));
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '09:30');
+         expect(meridianButton.textContent).toBe('morning');
+         expect(fixture.componentInstance.model).toEqual({hour: 9, minute: 30, second: 0});
        }));
 
   });
 
   describe('forms', () => {
 
-    it('should work with template-driven form validation', async(() => {
+    it('should work with template-driven form validation', fakeAsync(() => {
          const html = `
           <form>
             <ngb-timepicker [(ngModel)]="model" name="control" required></ngb-timepicker>
@@ -863,30 +710,20 @@ describe('ngb-timepicker', () => {
          const fixture = createTestComponent(html);
          const compiled = fixture.nativeElement;
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expect(getTimepicker(compiled)).toHaveCssClass('ng-invalid');
-               expect(getTimepicker(compiled)).not.toHaveCssClass('ng-valid');
+         tick();
+         fixture.detectChanges();
+         expect(getTimepicker(compiled)).toHaveCssClass('ng-invalid');
+         expect(getTimepicker(compiled)).not.toHaveCssClass('ng-valid');
 
-               fixture.componentInstance.model = {hour: 12, minute: 0, second: 0};
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expect(getTimepicker(compiled)).toHaveCssClass('ng-valid');
-               expect(getTimepicker(compiled)).not.toHaveCssClass('ng-invalid');
-             });
+         fixture.componentInstance.model = {hour: 12, minute: 0, second: 0};
+         fixture.detectChanges();
+         tick();
+         fixture.detectChanges();
+         expect(getTimepicker(compiled)).toHaveCssClass('ng-valid');
+         expect(getTimepicker(compiled)).not.toHaveCssClass('ng-invalid');
        }));
 
-    it('should work with template-driven form validation when meridian is true', async(() => {
+    it('should work with template-driven form validation when meridian is true', fakeAsync(() => {
          const html = `
           <form>
             <ngb-timepicker [(ngModel)]="model" name="control"></ngb-timepicker>
@@ -895,55 +732,39 @@ describe('ngb-timepicker', () => {
          const fixture = createTestComponent(html);
          const compiled = fixture.nativeElement;
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expect(getTimepicker(compiled)).toHaveCssClass('ng-valid');
-               expect(getTimepicker(compiled)).not.toHaveCssClass('ng-invalid');
+         tick();
+         fixture.detectChanges();
+         expect(getTimepicker(compiled)).toHaveCssClass('ng-valid');
+         expect(getTimepicker(compiled)).not.toHaveCssClass('ng-invalid');
 
-               fixture.componentInstance.model = {hour: 11, minute: 0, second: 0};
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expect(getTimepicker(compiled)).toHaveCssClass('ng-valid');
-               expect(getTimepicker(compiled)).not.toHaveCssClass('ng-invalid');
-             });
+         fixture.componentInstance.model = {hour: 11, minute: 0, second: 0};
+         fixture.detectChanges();
+         tick();
+         fixture.detectChanges();
+         expect(getTimepicker(compiled)).toHaveCssClass('ng-valid');
+         expect(getTimepicker(compiled)).not.toHaveCssClass('ng-invalid');
        }));
 
-    it('should work with model-driven form validation', async(() => {
-         const html = `
+    it('should work with model-driven form validation', () => {
+      const html = `
           <form [formGroup]="form">
             <ngb-timepicker formControlName="control" required></ngb-timepicker>
           </form>`;
 
-         const fixture = createTestComponent(html);
-         const compiled = fixture.nativeElement;
-         fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               const inputs = fixture.debugElement.queryAll(By.css('input'));
+      const fixture = createTestComponent(html);
+      const compiled = fixture.nativeElement;
+      fixture.detectChanges();
+      const inputs = fixture.debugElement.queryAll(By.css('input'));
 
-               expect(getTimepicker(compiled)).toHaveCssClass('ng-invalid');
-               expect(getTimepicker(compiled)).not.toHaveCssClass('ng-valid');
+      expect(getTimepicker(compiled)).toHaveCssClass('ng-invalid');
+      expect(getTimepicker(compiled)).not.toHaveCssClass('ng-valid');
 
-               inputs[0].triggerEventHandler('change', createChangeEvent('12'));
-               inputs[1].triggerEventHandler('change', createChangeEvent('15'));
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expect(getTimepicker(compiled)).toHaveCssClass('ng-valid');
-               expect(getTimepicker(compiled)).not.toHaveCssClass('ng-invalid');
-             });
-       }));
+      inputs[0].triggerEventHandler('change', createChangeEvent('12'));
+      inputs[1].triggerEventHandler('change', createChangeEvent('15'));
+      fixture.detectChanges();
+      expect(getTimepicker(compiled)).toHaveCssClass('ng-valid');
+      expect(getTimepicker(compiled)).not.toHaveCssClass('ng-invalid');
+    });
 
     it('should propagate model changes only if valid - no seconds', () => {
       const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
@@ -973,7 +794,7 @@ describe('ngb-timepicker', () => {
       expect(fixture.componentInstance.model).toBeNull();
     });
 
-    it('should not submit form when spinners clicked', async(() => {
+    it('should not submit form when spinners clicked', fakeAsync(() => {
          const html = `<form (ngSubmit)="onSubmit()">
            <ngb-timepicker name="control" [(ngModel)]="model"></ngb-timepicker>
            </form>`;
@@ -984,157 +805,134 @@ describe('ngb-timepicker', () => {
          const button = buttons[0] as HTMLButtonElement;
 
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               button.click();
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => { expect(fixture.componentInstance.submitted).toBeFalsy(); });
+         tick();
+         fixture.detectChanges();
+
+         button.click();
+         fixture.detectChanges();
+         expect(fixture.componentInstance.submitted).toBeFalsy();
        }));
   });
 
   describe('disabled', () => {
 
-    it('should not change the value on button click, when it is disabled', async(() => {
+    it('should not change the value on button click, when it is disabled', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [disabled]="disabled"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 13, minute: 30, second: 0};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
+         tick();
+         fixture.detectChanges();
+         const buttons = getButtons(fixture.nativeElement);
 
-               const buttons = getButtons(fixture.nativeElement);
+         expectToDisplayTime(fixture.nativeElement, '13:30:00');
+         expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-               expectToDisplayTime(fixture.nativeElement, '13:30:00');
-               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+         (<HTMLButtonElement>buttons[0]).click();  // H+
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '13:30:00');
+         expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-               (<HTMLButtonElement>buttons[0]).click();  // H+
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '13:30:00');
-               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+         (<HTMLButtonElement>buttons[1]).click();  // H-
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '13:30:00');
+         expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-               (<HTMLButtonElement>buttons[1]).click();  // H-
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '13:30:00');
-               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+         (<HTMLButtonElement>buttons[2]).click();  // M+
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '13:30:00');
+         expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-               (<HTMLButtonElement>buttons[2]).click();  // M+
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '13:30:00');
-               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+         (<HTMLButtonElement>buttons[3]).click();  // M-
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '13:30:00');
+         expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-               (<HTMLButtonElement>buttons[3]).click();  // M-
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '13:30:00');
-               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+         (<HTMLButtonElement>buttons[4]).click();  // S+
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '13:30:00');
+         expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-               (<HTMLButtonElement>buttons[4]).click();  // S+
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '13:30:00');
-               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
-
-               (<HTMLButtonElement>buttons[5]).click();  // S-
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '13:30:00');
-               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
-             });
+         (<HTMLButtonElement>buttons[5]).click();  // S-
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '13:30:00');
+         expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
        }));
 
-    it('should have disabled class, when it is disabled', async(() => {
+    it('should have disabled class, when it is disabled', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [disabled]="disabled"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               let fieldset = getFieldsetElement(fixture.nativeElement);
-               expect(fieldset.hasAttribute('disabled')).toBeTruthy();
-
-               fixture.componentInstance.disabled = false;
-               fixture.detectChanges();
-               fixture.whenStable().then(() => {
-                 fixture.detectChanges();
-                 fieldset = getFieldsetElement(fixture.nativeElement);
-                 expect(fieldset.hasAttribute('disabled')).toBeFalsy();
-               });
-             });
-       }));
-
-    it('should have disabled attribute when it is disabled using reactive forms', async(() => {
-         const html = `<form [formGroup]="disabledForm"><ngb-timepicker formControlName="control"></ngb-timepicker></form>`;
-
-         const fixture = createTestComponent(html);
+         tick();
          fixture.detectChanges();
          let fieldset = getFieldsetElement(fixture.nativeElement);
          expect(fieldset.hasAttribute('disabled')).toBeTruthy();
+
+         fixture.componentInstance.disabled = false;
+         fixture.detectChanges();
+         tick();
+         fixture.detectChanges();
+         fieldset = getFieldsetElement(fixture.nativeElement);
+         expect(fieldset.hasAttribute('disabled')).toBeFalsy();
        }));
+
+    it('should have disabled attribute when it is disabled using reactive forms', () => {
+      const html = `<form [formGroup]="disabledForm"><ngb-timepicker formControlName="control"></ngb-timepicker></form>`;
+
+      const fixture = createTestComponent(html);
+      fixture.detectChanges();
+      let fieldset = getFieldsetElement(fixture.nativeElement);
+      expect(fieldset.hasAttribute('disabled')).toBeTruthy();
+    });
   });
 
   describe('readonly', () => {
 
-    it('should change the value on button click, when it is readonly', async(() => {
+    it('should change the value on button click, when it is readonly', fakeAsync(() => {
          const html =
              `<ngb-timepicker [(ngModel)]="model" [seconds]="true" [readonlyInputs]="readonly"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 13, minute: 30, second: 0};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
+         tick();
+         fixture.detectChanges();
+         const buttons = getButtons(fixture.nativeElement);
 
-               const buttons = getButtons(fixture.nativeElement);
+         expectToDisplayTime(fixture.nativeElement, '13:30:00');
+         expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-               expectToDisplayTime(fixture.nativeElement, '13:30:00');
-               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+         (<HTMLButtonElement>buttons[0]).click();  // H+
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '14:30:00');
+         expect(fixture.componentInstance.model).toEqual({hour: 14, minute: 30, second: 0});
 
-               (<HTMLButtonElement>buttons[0]).click();  // H+
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '14:30:00');
-               expect(fixture.componentInstance.model).toEqual({hour: 14, minute: 30, second: 0});
+         (<HTMLButtonElement>buttons[1]).click();  // H-
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '13:30:00');
+         expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-               (<HTMLButtonElement>buttons[1]).click();  // H-
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '13:30:00');
-               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+         (<HTMLButtonElement>buttons[2]).click();  // M+
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '13:31:00');
+         expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 31, second: 0});
 
-               (<HTMLButtonElement>buttons[2]).click();  // M+
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '13:31:00');
-               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 31, second: 0});
+         (<HTMLButtonElement>buttons[3]).click();  // M-
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '13:30:00');
+         expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
 
-               (<HTMLButtonElement>buttons[3]).click();  // M-
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '13:30:00');
-               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
+         (<HTMLButtonElement>buttons[4]).click();  // S+
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '13:30:01');
+         expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 1});
 
-               (<HTMLButtonElement>buttons[4]).click();  // S+
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '13:30:01');
-               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 1});
-
-               (<HTMLButtonElement>buttons[5]).click();  // S-
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '13:30:00');
-               expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
-             });
+         (<HTMLButtonElement>buttons[5]).click();  // S-
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '13:30:00');
+         expect(fixture.componentInstance.model).toEqual({hour: 13, minute: 30, second: 0});
        }));
 
     it('should not change value on input change, when it is readonly', () => {
@@ -1267,51 +1065,37 @@ describe('ngb-timepicker', () => {
 
   describe('accessibility', () => {
 
-    it('should have text for screen readers on buttons', async(() => {
+    it('should have text for screen readers on buttons', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               const buttons = getButtons(fixture.nativeElement);
+         tick();
+         fixture.detectChanges();
+         const buttons = getButtons(fixture.nativeElement);
 
-               expect((<HTMLButtonElement>buttons[0]).querySelector('.sr-only') !.textContent).toBe('Increment hours');
-               expect((<HTMLButtonElement>buttons[1]).querySelector('.sr-only') !.textContent).toBe('Decrement hours');
-               expect((<HTMLButtonElement>buttons[2]).querySelector('.sr-only') !.textContent)
-                   .toBe('Increment minutes');
-               expect((<HTMLButtonElement>buttons[3]).querySelector('.sr-only') !.textContent)
-                   .toBe('Decrement minutes');
-               expect((<HTMLButtonElement>buttons[4]).querySelector('.sr-only') !.textContent)
-                   .toBe('Increment seconds');
-               expect((<HTMLButtonElement>buttons[5]).querySelector('.sr-only') !.textContent)
-                   .toBe('Decrement seconds');
-             });
+         expect((<HTMLButtonElement>buttons[0]).querySelector('.sr-only') !.textContent).toBe('Increment hours');
+         expect((<HTMLButtonElement>buttons[1]).querySelector('.sr-only') !.textContent).toBe('Decrement hours');
+         expect((<HTMLButtonElement>buttons[2]).querySelector('.sr-only') !.textContent).toBe('Increment minutes');
+         expect((<HTMLButtonElement>buttons[3]).querySelector('.sr-only') !.textContent).toBe('Decrement minutes');
+         expect((<HTMLButtonElement>buttons[4]).querySelector('.sr-only') !.textContent).toBe('Increment seconds');
+         expect((<HTMLButtonElement>buttons[5]).querySelector('.sr-only') !.textContent).toBe('Decrement seconds');
        }));
 
-    it('should have aria-label for inputs', async(() => {
+    it('should have aria-label for inputs', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="true"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               const inputs = getInputs(fixture.nativeElement);
+         tick();
+         fixture.detectChanges();
+         const inputs = getInputs(fixture.nativeElement);
 
-               expect(inputs[0].getAttribute('aria-label')).toBe('Hours');
-               expect(inputs[1].getAttribute('aria-label')).toBe('Minutes');
-               expect(inputs[2].getAttribute('aria-label')).toBe('Seconds');
-             });
+         expect(inputs[0].getAttribute('aria-label')).toBe('Hours');
+         expect(inputs[1].getAttribute('aria-label')).toBe('Minutes');
+         expect(inputs[2].getAttribute('aria-label')).toBe('Seconds');
        }));
   });
 
@@ -1327,16 +1111,14 @@ describe('ngb-timepicker', () => {
           {imports: [NgbTimepickerModule], providers: [{provide: NgbTimepickerConfig, useValue: config}]});
     });
 
-    it('should increment / decrement hours by 6', async(async() => {
+    it('should increment / decrement hours by 6', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [hourStep]="6"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
          fixture.detectChanges();
-         await fixture.whenStable();
-
+         tick();
          fixture.detectChanges();
-         await fixture.whenStable();
          const buttons = getButtons(fixture.nativeElement);
 
          expectToDisplayTime(fixture.nativeElement, '10:30:00');
@@ -1353,15 +1135,14 @@ describe('ngb-timepicker', () => {
          expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
        }));
 
-    it('should increment / decrement hours to default value if step set to undefined', async(async() => {
+    it('should increment / decrement hours to default value if step set to undefined', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [hourStep]="undefined"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
          fixture.detectChanges();
-         await fixture.whenStable();
+         tick();
          fixture.detectChanges();
-         await fixture.whenStable();
 
          const buttons = getButtons(fixture.nativeElement);
 
@@ -1379,16 +1160,15 @@ describe('ngb-timepicker', () => {
          expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
        }));
 
-    it('should increment / decrement minutes by 7', async(async() => {
+    it('should increment / decrement minutes by 7', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [minuteStep]="7"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
          fixture.detectChanges();
-         await fixture.whenStable();
-
+         tick();
          fixture.detectChanges();
-         await fixture.whenStable();
+
          const buttons = getButtons(fixture.nativeElement);
 
          expectToDisplayTime(fixture.nativeElement, '10:30:00');
@@ -1405,16 +1185,14 @@ describe('ngb-timepicker', () => {
          expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
        }));
 
-    it('should increment / decrement minutes to default value if step set to undefined', async(async() => {
+    it('should increment / decrement minutes to default value if step set to undefined', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [minuteStep]="undefined"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
          fixture.detectChanges();
-         await fixture.whenStable();
-
+         tick();
          fixture.detectChanges();
-         await fixture.whenStable();
 
          const buttons = getButtons(fixture.nativeElement);
 
@@ -1432,16 +1210,15 @@ describe('ngb-timepicker', () => {
          expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
        }));
 
-    it('should increment / decrement seconds by 8', async(async() => {
+    it('should increment / decrement seconds by 8', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [secondStep]="8"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
          fixture.detectChanges();
-         await fixture.whenStable();
-
+         tick();
          fixture.detectChanges();
-         await fixture.whenStable();
+
          const buttons = getButtons(fixture.nativeElement);
 
          expectToDisplayTime(fixture.nativeElement, '10:30:00');
@@ -1458,15 +1235,15 @@ describe('ngb-timepicker', () => {
          expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
        }));
 
-    it('should increment / decrement seconds to default value if step set to undefined', async(async() => {
+    it('should increment / decrement seconds to default value if step set to undefined', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [secondStep]="undefined"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30, second: 0};
          fixture.detectChanges();
-         await fixture.whenStable();
+         tick();
          fixture.detectChanges();
-         await fixture.whenStable();
+
          const buttons = getButtons(fixture.nativeElement);
 
          expectToDisplayTime(fixture.nativeElement, '10:30:00');
@@ -1485,91 +1262,68 @@ describe('ngb-timepicker', () => {
   });
 
   describe('Seconds handling', () => {
-    it('should propagate seconds to 0 in model if seconds not shown and no second in initial model', async(() => {
+    it('should propagate seconds to 0 in model if seconds not shown and no second in initial model', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="false"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               const inputs = fixture.debugElement.queryAll(By.css('input'));
+         tick();
+         fixture.detectChanges();
+         const inputs = fixture.debugElement.queryAll(By.css('input'));
 
-               inputs[1].triggerEventHandler('change', createChangeEvent('40'));
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '10:40');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 40, second: 0});
-             });
+         inputs[1].triggerEventHandler('change', createChangeEvent('40'));
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:40');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 40, second: 0});
        }));
 
-    it('should propagate second as 0 in model if seconds not shown and null initial model', async(() => {
+    it('should propagate second as 0 in model if seconds not shown and null initial model', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="false"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               const inputs = fixture.debugElement.queryAll(By.css('input'));
+         tick();
+         fixture.detectChanges();
+         const inputs = fixture.debugElement.queryAll(By.css('input'));
 
-               inputs[0].triggerEventHandler('change', createChangeEvent('10'));
-               inputs[1].triggerEventHandler('change', createChangeEvent('40'));
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '10:40');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 40, second: 0});
-             });
+         inputs[0].triggerEventHandler('change', createChangeEvent('10'));
+         inputs[1].triggerEventHandler('change', createChangeEvent('40'));
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:40');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 40, second: 0});
        }));
 
-    it('should leave second as is in model if seconds not shown and second present in initial model', async(() => {
+    it('should leave second as is in model if seconds not shown and second present in initial model', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="false"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30, second: 30};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               const inputs = fixture.debugElement.queryAll(By.css('input'));
+         tick();
+         fixture.detectChanges();
+         const inputs = fixture.debugElement.queryAll(By.css('input'));
 
-               inputs[1].triggerEventHandler('change', createChangeEvent('40'));
-               fixture.detectChanges();
-               expectToDisplayTime(fixture.nativeElement, '10:40');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 40, second: 30});
-             });
+         inputs[1].triggerEventHandler('change', createChangeEvent('40'));
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:40');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 40, second: 30});
        }));
 
-    it('should reset the second to 0 if invalid when seconds are hidden', async(() => {
+    it('should reset the second to 0 if invalid when seconds are hidden', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model" [seconds]="showSeconds"></ngb-timepicker>`;
 
          const fixture = createTestComponent(html);
          fixture.componentInstance.model = {hour: 10, minute: 30, second: null};
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expectToDisplayTime(fixture.nativeElement, '10:30:');
+         tick();
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:30:');
 
-               fixture.componentInstance.showSeconds = false;
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expectToDisplayTime(fixture.nativeElement, '10:30');
-               expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
-             });
+         fixture.componentInstance.showSeconds = false;
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '10:30');
+         expect(fixture.componentInstance.model).toEqual({hour: 10, minute: 30, second: 0});
        }));
   });
 
@@ -1583,71 +1337,57 @@ describe('ngb-timepicker', () => {
       });
     });
 
-    it('should display the right time when model is a string parsed by a custom time adapter', async(() => {
+    it('should display the right time when model is a string parsed by a custom time adapter', fakeAsync(() => {
          const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
          const fixture = createTestComponent(html);
 
          fixture.componentInstance.model = null;
          fixture.detectChanges();
-
+         tick();
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => { expectToDisplayTime(fixture.nativeElement, ':'); })
-             .then(() => {
-               fixture.componentInstance.model = '09:25:00';
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => { expectToDisplayTime(fixture.nativeElement, '09:25'); });
+         expectToDisplayTime(fixture.nativeElement, ':');
+
+         fixture.componentInstance.model = '09:25:00';
+         fixture.detectChanges();
+         tick();
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '09:25');
        }));
 
-    it('should write the entered value as a string formatted by a custom time adapter', () => {
-      const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
+    it('should write the entered value as a string formatted by a custom time adapter', fakeAsync(() => {
+         const html = `<ngb-timepicker [(ngModel)]="model"></ngb-timepicker>`;
 
-      const fixture = createTestComponent(html);
-      fixture.componentInstance.model = null;
-      fixture.detectChanges();
-      fixture.whenStable()
-          .then(() => {
-            fixture.detectChanges();
-            return fixture.whenStable();
-          })
-          .then(() => {
+         const fixture = createTestComponent(html);
+         fixture.componentInstance.model = null;
+         fixture.detectChanges();
+         tick();
+         fixture.detectChanges();
 
-            const inputs = fixture.debugElement.queryAll(By.css('input'));
-            inputs[0].triggerEventHandler('change', createChangeEvent('11'));
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '11:');
-            expect(fixture.componentInstance.model).toBeNull();
+         const inputs = fixture.debugElement.queryAll(By.css('input'));
+         inputs[0].triggerEventHandler('change', createChangeEvent('11'));
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '11:');
+         expect(fixture.componentInstance.model).toBeNull();
 
-            inputs[1].triggerEventHandler('change', createChangeEvent('5'));
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, '11:05');
-            expect(fixture.componentInstance.model).toEqual('11:05:00');
+         inputs[1].triggerEventHandler('change', createChangeEvent('5'));
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, '11:05');
+         expect(fixture.componentInstance.model).toEqual('11:05:00');
 
-            inputs[0].triggerEventHandler('change', createChangeEvent('aa'));
-            fixture.detectChanges();
-            expectToDisplayTime(fixture.nativeElement, ':05');
-            expect(fixture.componentInstance.model).toBeNull();
-          });
-    });
+         inputs[0].triggerEventHandler('change', createChangeEvent('aa'));
+         fixture.detectChanges();
+         expectToDisplayTime(fixture.nativeElement, ':05');
+         expect(fixture.componentInstance.model).toBeNull();
+       }));
   });
 
   describe('on push', () => {
 
-    it('should render initial model value', async(async() => {
+    it('should render initial model value', fakeAsync(() => {
          const fixture =
              createOnPushTestComponent(`<ngb-timepicker [ngModel]="{hour: 13, minute: 30}"></ngb-timepicker>`);
          fixture.detectChanges();
-         await fixture.whenStable();
+         tick();
          fixture.detectChanges();
          expectToDisplayTime(fixture.nativeElement, '13:30');
        }));

--- a/src/toast/toast.spec.ts
+++ b/src/toast/toast.spec.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {async, ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 
 import {createGenericTestComponent, isBrowserVisible} from '../test/common';
 import {NgbToastModule} from './toast.module';
@@ -137,54 +137,54 @@ if (isBrowserVisible('ngb-toast animations')) {
 
     [true, false].forEach(reduceMotion => {
 
-      it(`should run the transition when creating a toast (force-reduced-motion = ${reduceMotion})`, async(() => {
-           const fixture = TestBed.createComponent(TestAnimationComponent);
-           fixture.componentInstance.reduceMotion = reduceMotion;
-           fixture.detectChanges();
+      it(`should run the transition when creating a toast (force-reduced-motion = ${reduceMotion})`, () => {
+        const fixture = TestBed.createComponent(TestAnimationComponent);
+        fixture.componentInstance.reduceMotion = reduceMotion;
+        fixture.detectChanges();
 
-           const toastEl = getToastElement(fixture.nativeElement);
+        const toastEl = getToastElement(fixture.nativeElement);
 
-           spyOn(fixture.componentInstance, 'onShown').and.callFake(() => {
-             expect(window.getComputedStyle(toastEl).opacity).toBe('1');
-             expect(toastEl).not.toHaveCssClass('showing');
-             expect(toastEl).toHaveCssClass('show');
-             expect(toastEl).toHaveCssClass('fade');
-           });
+        spyOn(fixture.componentInstance, 'onShown').and.callFake(() => {
+          expect(window.getComputedStyle(toastEl).opacity).toBe('1');
+          expect(toastEl).not.toHaveCssClass('showing');
+          expect(toastEl).toHaveCssClass('show');
+          expect(toastEl).toHaveCssClass('fade');
+        });
 
-           expect(toastEl).toHaveCssClass('fade');
-           if (reduceMotion) {
-             expect(window.getComputedStyle(toastEl).opacity).toBe('1');
-             expect(toastEl).toHaveCssClass('show');
-           } else {
-             expect(window.getComputedStyle(toastEl).opacity).toBe('0');
-             expect(toastEl).not.toHaveCssClass('show');
-             expect(toastEl).toHaveCssClass('showing');
-           }
-         }));
+        expect(toastEl).toHaveCssClass('fade');
+        if (reduceMotion) {
+          expect(window.getComputedStyle(toastEl).opacity).toBe('1');
+          expect(toastEl).toHaveCssClass('show');
+        } else {
+          expect(window.getComputedStyle(toastEl).opacity).toBe('0');
+          expect(toastEl).not.toHaveCssClass('show');
+          expect(toastEl).toHaveCssClass('showing');
+        }
+      });
 
-      it(`should run the transition when closing a toast (force-reduced-motion = ${reduceMotion})`, async(() => {
-           const fixture = TestBed.createComponent(TestAnimationComponent);
-           fixture.componentInstance.reduceMotion = reduceMotion;
-           fixture.detectChanges();
+      it(`should run the transition when closing a toast (force-reduced-motion = ${reduceMotion})`, () => {
+        const fixture = TestBed.createComponent(TestAnimationComponent);
+        fixture.componentInstance.reduceMotion = reduceMotion;
+        fixture.detectChanges();
 
-           const toastEl = getToastElement(fixture.nativeElement);
-           const buttonEl = fixture.nativeElement.querySelector('button');
+        const toastEl = getToastElement(fixture.nativeElement);
+        const buttonEl = fixture.nativeElement.querySelector('button');
 
-           spyOn(fixture.componentInstance, 'onShown').and.callFake(() => {
-             expect(window.getComputedStyle(toastEl).opacity).toBe('1');
-             expect(toastEl).toHaveCssClass('show');
-             expect(toastEl).toHaveCssClass('fade');
+        spyOn(fixture.componentInstance, 'onShown').and.callFake(() => {
+          expect(window.getComputedStyle(toastEl).opacity).toBe('1');
+          expect(toastEl).toHaveCssClass('show');
+          expect(toastEl).toHaveCssClass('fade');
 
-             buttonEl.click();
-           });
+          buttonEl.click();
+        });
 
-           spyOn(fixture.componentInstance, 'onHidden').and.callFake(() => {
-             expect(window.getComputedStyle(toastEl).opacity).toBe('0');
-             expect(toastEl).not.toHaveCssClass('show');
-             expect(toastEl).toHaveCssClass('fade');
-             expect(toastEl).toHaveCssClass('hide');
-           });
-         }));
+        spyOn(fixture.componentInstance, 'onHidden').and.callFake(() => {
+          expect(window.getComputedStyle(toastEl).opacity).toBe('0');
+          expect(toastEl).not.toHaveCssClass('show');
+          expect(toastEl).toHaveCssClass('fade');
+          expect(toastEl).toHaveCssClass('hide');
+        });
+      });
     });
   });
 }

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -1,5 +1,5 @@
 import {ChangeDetectionStrategy, Component, DebugElement, ViewChild} from '@angular/core';
-import {async, ComponentFixture, fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
 import {FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators} from '@angular/forms';
 import {By} from '@angular/platform-browser';
 import {merge, Observable, Subject} from 'rxjs';
@@ -80,7 +80,7 @@ describe('ngb-typeahead', () => {
 
   describe('valueaccessor', () => {
 
-    it('should format values when no formatter provided', async(() => {
+    it('should format values when no formatter provided', fakeAsync(() => {
          const fixture = createTestComponent('<input [(ngModel)]="model" [ngbTypeahead]="findNothing" />');
 
          const el = fixture.nativeElement;
@@ -89,25 +89,21 @@ describe('ngb-typeahead', () => {
 
          comp.model = 'text';
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               expectInputValue(el, 'text');
+         tick();
+         expectInputValue(el, 'text');
 
-               comp.model = null;
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expectInputValue(el, '');
+         comp.model = null;
+         fixture.detectChanges();
+         tick();
+         expectInputValue(el, '');
 
-               comp.model = {};
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => { expectInputValue(el, '[object Object]'); });
+         comp.model = {};
+         fixture.detectChanges();
+         tick();
+         expectInputValue(el, '[object Object]');
        }));
 
-    it('should format values with custom formatter provided', async(() => {
+    it('should format values with custom formatter provided', fakeAsync(() => {
          const html =
              '<input [(ngModel)]="model" [ngbTypeahead]="findNothing" [inputFormatter]="uppercaseObjFormatter"/>';
          const fixture = createTestComponent(html);
@@ -117,18 +113,16 @@ describe('ngb-typeahead', () => {
 
          comp.model = null;
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               expectInputValue(el, '');
+         tick();
+         expectInputValue(el, '');
 
-               comp.model = {value: 'text'};
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => { expectInputValue(el, 'TEXT'); });
+         comp.model = {value: 'text'};
+         fixture.detectChanges();
+         tick();
+         expectInputValue(el, 'TEXT');
        }));
 
-    it('should use custom input formatter with falsy values', async(() => {
+    it('should use custom input formatter with falsy values', fakeAsync(() => {
          const html = '<input [(ngModel)]="model" [ngbTypeahead]="findNothing" [inputFormatter]="uppercaseFormatter"/>';
          const fixture = createTestComponent(html);
          const el = fixture.nativeElement;
@@ -137,22 +131,18 @@ describe('ngb-typeahead', () => {
 
          comp.model = null;
          fixture.detectChanges();
-         fixture.whenStable()
-             .then(() => {
-               expectInputValue(el, '');
+         tick();
+         expectInputValue(el, '');
 
-               comp.model = 0;
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => {
-               expectInputValue(el, '0');
+         comp.model = 0;
+         fixture.detectChanges();
+         tick();
+         expectInputValue(el, '0');
 
-               comp.model = false;
-               fixture.detectChanges();
-               return fixture.whenStable();
-             })
-             .then(() => { expectInputValue(el, 'FALSE'); });
+         comp.model = false;
+         fixture.detectChanges();
+         tick();
+         expectInputValue(el, 'FALSE');
        }));
   });
 
@@ -164,26 +154,25 @@ describe('ngb-typeahead', () => {
       expect(getWindow(compiled)).toBeNull();
     });
 
-    it('should not be opened when the model changes', async(() => {
+    it('should not be opened when the model changes', fakeAsync(() => {
          const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
          const compiled = fixture.nativeElement;
 
          fixture.componentInstance.model = 'one';
          fixture.detectChanges();
-         fixture.whenStable().then(() => { expect(getWindow(compiled)).toBeNull(); });
+         tick();
+         expect(getWindow(compiled)).toBeNull();
        }));
 
-    it('should be opened when there are results', async(() => {
-         const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
-         const compiled = fixture.nativeElement;
+    it('should be opened when there are results', () => {
+      const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
+      const compiled = fixture.nativeElement;
 
-         fixture.whenStable().then(() => {
-           changeInput(compiled, 'one');
-           fixture.detectChanges();
-           expectWindowResults(compiled, ['+one', 'one more']);
-           expect(fixture.componentInstance.model).toBe('one');
-         });
-       }));
+      changeInput(compiled, 'one');
+      fixture.detectChanges();
+      expectWindowResults(compiled, ['+one', 'one more']);
+      expect(fixture.componentInstance.model).toBe('one');
+    });
 
     it('should be closed when there no results', () => {
       const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="findNothing"/>`);
@@ -192,65 +181,59 @@ describe('ngb-typeahead', () => {
       expect(getWindow(compiled)).toBeNull();
     });
 
-    it('should work when returning null as results', async(() => {
-         const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="findNull"/>`);
-         const compiled = fixture.nativeElement;
+    it('should work when returning null as results', () => {
+      const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="findNull"/>`);
+      const compiled = fixture.nativeElement;
 
-         fixture.whenStable().then(() => {
-           changeInput(compiled, 'one');
-           fixture.detectChanges();
-           expect(getWindow(compiled)).toBeNull();
-         });
-       }));
+      changeInput(compiled, 'one');
+      fixture.detectChanges();
+      expect(getWindow(compiled)).toBeNull();
+    });
 
-    it('should select the result on click, close window and fill the input', async(() => {
-         const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
-         const compiled = fixture.nativeElement;
+    it('should select the result on click, close window and fill the input', () => {
+      const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
+      const compiled = fixture.nativeElement;
 
-         fixture.whenStable().then(() => {
-           // clicking selected
-           changeInput(compiled, 'o');
-           fixture.detectChanges();
-           expectWindowResults(compiled, ['+one', 'one more']);
+      // clicking selected
+      changeInput(compiled, 'o');
+      fixture.detectChanges();
+      expectWindowResults(compiled, ['+one', 'one more']);
 
-           getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
-           fixture.detectChanges();
-           expect(getWindow(compiled)).toBeNull();
-           expectInputValue(compiled, 'one');
-           expect(fixture.componentInstance.model).toBe('one');
+      getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
+      fixture.detectChanges();
+      expect(getWindow(compiled)).toBeNull();
+      expectInputValue(compiled, 'one');
+      expect(fixture.componentInstance.model).toBe('one');
 
-           // clicking not selected
-           changeInput(compiled, 'o');
-           fixture.detectChanges();
-           expectWindowResults(compiled, ['+one', 'one more']);
-           expectInputValue(compiled, 'o');
+      // clicking not selected
+      changeInput(compiled, 'o');
+      fixture.detectChanges();
+      expectWindowResults(compiled, ['+one', 'one more']);
+      expectInputValue(compiled, 'o');
 
-           getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
-           fixture.detectChanges();
-           expect(getWindow(compiled)).toBeNull();
-           expectInputValue(compiled, 'one');
-         });
-       }));
+      getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
+      fixture.detectChanges();
+      expect(getWindow(compiled)).toBeNull();
+      expectInputValue(compiled, 'one');
+    });
 
-    it('should select the result on ENTER, close window and fill the input', async(() => {
-         const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
-         const compiled = fixture.nativeElement;
+    it('should select the result on ENTER, close window and fill the input', () => {
+      const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
+      const compiled = fixture.nativeElement;
 
-         fixture.whenStable().then(() => {
-           changeInput(compiled, 'o');
-           fixture.detectChanges();
-           expectWindowResults(compiled, ['+one', 'one more']);
+      changeInput(compiled, 'o');
+      fixture.detectChanges();
+      expectWindowResults(compiled, ['+one', 'one more']);
 
-           const event = createKeyDownEvent(Key.Enter);
-           getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-           fixture.detectChanges();
-           expect(getWindow(compiled)).toBeNull();
-           expectInputValue(compiled, 'one');
-           expect(fixture.componentInstance.model).toBe('one');
-           expect(event.preventDefault).toHaveBeenCalled();
-           expect(event.stopPropagation).toHaveBeenCalled();
-         });
-       }));
+      const event = createKeyDownEvent(Key.Enter);
+      getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+      fixture.detectChanges();
+      expect(getWindow(compiled)).toBeNull();
+      expectInputValue(compiled, 'one');
+      expect(fixture.componentInstance.model).toBe('one');
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(event.stopPropagation).toHaveBeenCalled();
+    });
 
     it('should select the result on TAB, close window and fill the input', () => {
       const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
@@ -484,27 +467,25 @@ describe('ngb-typeahead', () => {
 
   describe('objects', () => {
 
-    it('should work with custom objects as values', async(() => {
-         const fixture = createTestComponent(`
+    it('should work with custom objects as values', () => {
+      const fixture = createTestComponent(`
              <input type="text" [(ngModel)]="model" [ngbTypeahead]="findObjects"
                     [inputFormatter]="formatter" [resultFormatter]="uppercaseObjFormatter"/>`);
-         const compiled = fixture.nativeElement;
+      const compiled = fixture.nativeElement;
 
-         fixture.whenStable().then(() => {
-           changeInput(compiled, 'o');
-           fixture.detectChanges();
-           expectWindowResults(compiled, ['+ONE', 'ONE MORE']);
+      changeInput(compiled, 'o');
+      fixture.detectChanges();
+      expectWindowResults(compiled, ['+ONE', 'ONE MORE']);
 
-           const event = createKeyDownEvent(Key.Enter);
-           getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-           fixture.detectChanges();
-           expect(getWindow(compiled)).toBeNull();
-           expect(getNativeInput(compiled).value).toBe('1 one');
-           expect(fixture.componentInstance.model).toEqual({id: 1, value: 'one'});
-         });
-       }));
+      const event = createKeyDownEvent(Key.Enter);
+      getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+      fixture.detectChanges();
+      expect(getWindow(compiled)).toBeNull();
+      expect(getNativeInput(compiled).value).toBe('1 one');
+      expect(fixture.componentInstance.model).toEqual({id: 1, value: 'one'});
+    });
 
-    it('should allow to assign ngModel custom objects', async(() => {
+    it('should allow to assign ngModel custom objects', fakeAsync(() => {
          const fixture = createTestComponent(`
              <input type="text" [(ngModel)]="model" [ngbTypeahead]="findObjects"
                     [inputFormatter]="formatter" [resultFormatter]="uppercaseObjFormatter"/>`);
@@ -512,32 +493,30 @@ describe('ngb-typeahead', () => {
 
          fixture.componentInstance.model = {id: 1, value: 'one'};
          fixture.detectChanges();
-         fixture.whenStable().then(() => {
-           expect(getWindow(compiled)).toBeNull();
-           expect(getNativeInput(compiled).value).toBe('1 one');
-         });
+         tick();
+         expect(getWindow(compiled)).toBeNull();
+         expect(getNativeInput(compiled).value).toBe('1 one');
        }));
   });
 
   describe('forms', () => {
 
-    it('should work with template-driven form validation', async(() => {
+    it('should work with template-driven form validation', fakeAsync(() => {
          const html = `
             <form>
               <input type="text" [(ngModel)]="model" name="control" required [ngbTypeahead]="findObjects" />
             </form>`;
          const fixture = createTestComponent(html);
-         fixture.whenStable().then(() => {
-           fixture.detectChanges();
-           const compiled = fixture.nativeElement;
-           expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
-           expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
+         tick();
+         fixture.detectChanges();
+         const compiled = fixture.nativeElement;
+         expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
+         expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
 
-           changeInput(compiled, 'o');
-           fixture.detectChanges();
-           expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
-           expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
-         });
+         changeInput(compiled, 'o');
+         fixture.detectChanges();
+         expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
+         expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
        }));
 
     it('should work with model-driven form validation', () => {
@@ -558,110 +537,106 @@ describe('ngb-typeahead', () => {
     });
 
 
-    it('should support disabled state', async(() => {
+    it('should support disabled state', fakeAsync(() => {
          const html = `
             <form>
               <input type="text" [(ngModel)]="model" name="control" [disabled]="true" [ngbTypeahead]="findObjects" />
             </form>`;
          const fixture = createTestComponent(html);
-         fixture.whenStable().then(() => {
-           fixture.detectChanges();
-           const compiled = fixture.nativeElement;
-           expect(getNativeInput(compiled).disabled).toBeTruthy();
-         });
+         tick();
+         fixture.detectChanges();
+         const compiled = fixture.nativeElement;
+         expect(getNativeInput(compiled).disabled).toBeTruthy();
        }));
 
-    it('should only propagate model changes on select when the editable option is on', async(() => {
+    it('should only propagate model changes on select when the editable option is on', fakeAsync(() => {
          const html = `
             <form>
               <input type="text" [(ngModel)]="model" name="control" required [ngbTypeahead]="find" [editable]="false"/>
             </form>`;
          const fixture = createTestComponent(html);
-         fixture.whenStable().then(() => {
-           fixture.detectChanges();
-           const compiled = fixture.nativeElement;
-           expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
-           expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
+         tick();
+         fixture.detectChanges();
+         const compiled = fixture.nativeElement;
+         expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
+         expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
 
-           changeInput(compiled, 'o');
-           fixture.detectChanges();
-           expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
-           expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
-           expect(fixture.componentInstance.model).toBeUndefined();
+         changeInput(compiled, 'o');
+         fixture.detectChanges();
+         expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
+         expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
+         expect(fixture.componentInstance.model).toBeUndefined();
 
-           const event = createKeyDownEvent(Key.Enter);
-           getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-           fixture.detectChanges();
-           expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
-           expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
-           expect(fixture.componentInstance.model).toBe('one');
-         });
+         const event = createKeyDownEvent(Key.Enter);
+         getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+         fixture.detectChanges();
+         expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
+         expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
+         expect(fixture.componentInstance.model).toBe('one');
        }));
 
-    it('should clear model on user input when the editable option is on', async(() => {
+    it('should clear model on user input when the editable option is on', fakeAsync(() => {
          const html = `
             <form>
               <input type="text" [(ngModel)]="model" name="control" required [ngbTypeahead]="find" [editable]="false"/>
             </form>`;
          const fixture = createTestComponent(html);
-         fixture.whenStable().then(() => {
-           fixture.detectChanges();
-           const compiled = fixture.nativeElement;
-           expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
-           expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
+         tick();
+         fixture.detectChanges();
+         const compiled = fixture.nativeElement;
+         expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
+         expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
 
-           changeInput(compiled, 'o');
-           fixture.detectChanges();
-           expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
-           expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
-           expect(fixture.componentInstance.model).toBeUndefined();
+         changeInput(compiled, 'o');
+         fixture.detectChanges();
+         expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
+         expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
+         expect(fixture.componentInstance.model).toBeUndefined();
 
-           const event = createKeyDownEvent(Key.Enter);
-           getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-           fixture.detectChanges();
-           expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
-           expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
-           expect(fixture.componentInstance.model).toBe('one');
+         const event = createKeyDownEvent(Key.Enter);
+         getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+         fixture.detectChanges();
+         expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
+         expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
+         expect(fixture.componentInstance.model).toBe('one');
 
-           changeInput(compiled, 'tw');
-           fixture.detectChanges();
-           expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
-           expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
-           expect(fixture.componentInstance.model).toBeUndefined();
-         });
+         changeInput(compiled, 'tw');
+         fixture.detectChanges();
+         expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
+         expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
+         expect(fixture.componentInstance.model).toBeUndefined();
        }));
 
-    it('should clear model on user input when the editable option is on and no search was triggered', async(() => {
+    it('should clear model on user input when the editable option is on and no search was triggered', fakeAsync(() => {
          const html = `
             <form>
               <input type="text" [(ngModel)]="model" name="control" required [ngbTypeahead]="findFilter" [editable]="false"/>
             </form>`;
          const fixture = createTestComponent(html);
-         fixture.whenStable().then(() => {
-           fixture.detectChanges();
-           const compiled = fixture.nativeElement;
-           expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
-           expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
+         tick();
+         fixture.detectChanges();
+         const compiled = fixture.nativeElement;
+         expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
+         expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
 
-           changeInput(compiled, 'one');
-           fixture.detectChanges();
-           expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
-           expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
-           expect(fixture.componentInstance.model).toBeUndefined();
+         changeInput(compiled, 'one');
+         fixture.detectChanges();
+         expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
+         expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
+         expect(fixture.componentInstance.model).toBeUndefined();
 
-           const event = createKeyDownEvent(Key.Enter);
-           getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-           fixture.detectChanges();
-           expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
-           expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
-           expect(fixture.componentInstance.model).toBe('one');
+         const event = createKeyDownEvent(Key.Enter);
+         getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+         fixture.detectChanges();
+         expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
+         expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
+         expect(fixture.componentInstance.model).toBe('one');
 
-           changeInput(compiled, '');
-           fixture.detectChanges();
-           expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
-           expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
-           expect(fixture.componentInstance.model).toBeUndefined();
-         });
+         changeInput(compiled, '');
+         fixture.detectChanges();
+         expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
+         expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
+         expect(fixture.componentInstance.model).toBeUndefined();
        }));
   });
 
@@ -679,17 +654,17 @@ describe('ngb-typeahead', () => {
       expect(fixture.componentInstance.selectEventValue).toBe('one');
     });
 
-    it('should not propagate model when preventDefault() is called on selectEvent', async(() => {
-         const fixture = createTestComponent(
-             '<input [(ngModel)]="model" [ngbTypeahead]="find" (selectItem)="$event.preventDefault()"/>');
+    it('should not propagate model when preventDefault() is called on selectEvent', () => {
+      const fixture = createTestComponent(
+          '<input [(ngModel)]="model" [ngbTypeahead]="find" (selectItem)="$event.preventDefault()"/>');
 
-         // clicking selected
-         changeInput(fixture.nativeElement, 'o');
-         fixture.detectChanges();
-         getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
-         fixture.detectChanges();
-         fixture.whenStable().then(() => { expect(fixture.componentInstance.model).toBe('o'); });
-       }));
+      // clicking selected
+      changeInput(fixture.nativeElement, 'o');
+      fixture.detectChanges();
+      getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
+      fixture.detectChanges();
+      expect(fixture.componentInstance.model).toBe('o');
+    });
   });
 
   describe('container', () => {
@@ -769,120 +744,115 @@ describe('ngb-typeahead', () => {
       expect(input.getAttribute('aria-autocomplete')).toBe('both');
     });
 
-    it('should have the correct ARIA attributes when interacting with input', async(() => {
+    it('should have the correct ARIA attributes when interacting with input', fakeAsync(() => {
          const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
          const compiled = fixture.nativeElement;
          const input = getNativeInput(compiled);
+         tick();
+
+         changeInput(compiled, 'o');
          fixture.detectChanges();
+         expectWindowResults(compiled, ['+one', 'one more']);
+         expect(input.getAttribute('aria-expanded')).toBe('true');
+         expect(input.getAttribute('aria-owns')).toMatch(/ngb-typeahead-[0-9]+/);
+         expect(input.getAttribute('aria-activedescendant')).toMatch(/ngb-typeahead-[0-9]+-0/);
 
-         fixture.whenStable().then(() => {
-           changeInput(compiled, 'o');
-           fixture.detectChanges();
-           expectWindowResults(compiled, ['+one', 'one more']);
-           expect(input.getAttribute('aria-expanded')).toBe('true');
-           expect(input.getAttribute('aria-owns')).toMatch(/ngb-typeahead-[0-9]+/);
-           expect(input.getAttribute('aria-activedescendant')).toMatch(/ngb-typeahead-[0-9]+-0/);
+         let event = createKeyDownEvent(Key.ArrowDown);
+         getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+         fixture.detectChanges();
+         expect(input.getAttribute('aria-activedescendant')).toMatch(/ngb-typeahead-[0-9]+-1/);
 
-           let event = createKeyDownEvent(Key.ArrowDown);
-           getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-           fixture.detectChanges();
-           expect(input.getAttribute('aria-activedescendant')).toMatch(/ngb-typeahead-[0-9]+-1/);
-
-           event = createKeyDownEvent(Key.Enter);
-           getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-           fixture.detectChanges();
-           expect(input.getAttribute('aria-expanded')).toBe('false');
-           expect(input.getAttribute('aria-owns')).toBeNull();
-           expect(input.getAttribute('aria-activedescendant')).toBeNull();
-         });
+         event = createKeyDownEvent(Key.Enter);
+         getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+         fixture.detectChanges();
+         expect(input.getAttribute('aria-expanded')).toBe('false');
+         expect(input.getAttribute('aria-owns')).toBeNull();
+         expect(input.getAttribute('aria-activedescendant')).toBeNull();
        }));
   });
 
   if (!isBrowser(['ie', 'edge'])) {
     describe('hint', () => {
 
-      it('should show hint when an item starts with user input', async(() => {
+      it('should show hint when an item starts with user input', fakeAsync(() => {
            const fixture = createTestComponent(
                `<input type="text" [(ngModel)]="model" [ngbTypeahead]="findAnywhere" [showHint]="true"/>`);
            const compiled = fixture.nativeElement;
            const inputEl = getNativeInput(compiled);
 
-           fixture.whenStable().then(() => {
-             changeInput(compiled, 'on');
-             fixture.detectChanges();
-             expectWindowResults(compiled, ['+one', 'one more']);
-             expect(inputEl.value).toBe('one');
-             expect(inputEl.selectionStart).toBe(2);
-             expect(inputEl.selectionEnd).toBe(3);
+           tick();
 
-             const event = createKeyDownEvent(Key.ArrowDown);
-             getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-             fixture.detectChanges();
-             expect(inputEl.value).toBe('one more');
-             expect(inputEl.selectionStart).toBe(2);
-             expect(inputEl.selectionEnd).toBe(8);
-           });
+           changeInput(compiled, 'on');
+           fixture.detectChanges();
+           expectWindowResults(compiled, ['+one', 'one more']);
+           expect(inputEl.value).toBe('one');
+           expect(inputEl.selectionStart).toBe(2);
+           expect(inputEl.selectionEnd).toBe(3);
+
+           const event = createKeyDownEvent(Key.ArrowDown);
+           getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+           fixture.detectChanges();
+           expect(inputEl.value).toBe('one more');
+           expect(inputEl.selectionStart).toBe(2);
+           expect(inputEl.selectionEnd).toBe(8);
          }));
 
-      it('should show hint with no selection when an item does not starts with user input', async(() => {
+      it('should show hint with no selection when an item does not starts with user input', fakeAsync(() => {
            const fixture = createTestComponent(
                `<input type="text" [(ngModel)]="model" [ngbTypeahead]="findAnywhere" [showHint]="true"/>`);
            const compiled = fixture.nativeElement;
            const inputEl = getNativeInput(compiled);
+           tick();
 
-           fixture.whenStable().then(() => {
-             changeInput(compiled, 'ne');
-             fixture.detectChanges();
-             expectWindowResults(compiled, ['+one', 'one more']);
-             expect(inputEl.value).toBe('one');
-             expect(inputEl.selectionStart).toBe(inputEl.selectionEnd);
+           changeInput(compiled, 'ne');
+           fixture.detectChanges();
+           expectWindowResults(compiled, ['+one', 'one more']);
+           expect(inputEl.value).toBe('one');
+           expect(inputEl.selectionStart).toBe(inputEl.selectionEnd);
 
-             const event = createKeyDownEvent(Key.ArrowDown);
-             getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-             fixture.detectChanges();
-             expect(inputEl.value).toBe('one more');
-             expect(inputEl.selectionStart).toBe(inputEl.selectionEnd);
-           });
+           const event = createKeyDownEvent(Key.ArrowDown);
+           getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+           fixture.detectChanges();
+           expect(inputEl.value).toBe('one more');
+           expect(inputEl.selectionStart).toBe(inputEl.selectionEnd);
          }));
 
-      it('should take input formatter into account when displaying hints', async(() => {
+      it('should take input formatter into account when displaying hints', fakeAsync(() => {
            const fixture = createTestComponent(`<input type="text" [(ngModel)]="model"
                 [ngbTypeahead]="findAnywhere"
                 [inputFormatter]="uppercaseFormatter"
                 [showHint]="true"/>`);
            const compiled = fixture.nativeElement;
            const inputEl = getNativeInput(compiled);
+           tick();
 
-           fixture.whenStable().then(() => {
-             changeInput(compiled, 'on');
-             fixture.detectChanges();
-             expectWindowResults(compiled, ['+one', 'one more']);
-             expect(inputEl.value).toBe('onE');
-             expect(inputEl.selectionStart).toBe(2);
-             expect(inputEl.selectionEnd).toBe(3);
+           changeInput(compiled, 'on');
+           fixture.detectChanges();
+           expectWindowResults(compiled, ['+one', 'one more']);
+           expect(inputEl.value).toBe('onE');
+           expect(inputEl.selectionStart).toBe(2);
+           expect(inputEl.selectionEnd).toBe(3);
 
-             const event = createKeyDownEvent(Key.ArrowDown);
-             getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-             fixture.detectChanges();
-             expect(inputEl.value).toBe('onE MORE');
-             expect(inputEl.selectionStart).toBe(2);
-             expect(inputEl.selectionEnd).toBe(8);
-           });
+           const event = createKeyDownEvent(Key.ArrowDown);
+           getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
+           fixture.detectChanges();
+           expect(inputEl.value).toBe('onE MORE');
+           expect(inputEl.selectionStart).toBe(2);
+           expect(inputEl.selectionEnd).toBe(8);
          }));
 
-      it('should not show hint when there is no result selected', async(() => {
+      it('should not show hint when there is no result selected', fakeAsync(() => {
            const fixture = createTestComponent(
                `<input type="text" [(ngModel)]="model" [ngbTypeahead]="find" [showHint]="true" [focusFirst]="false"/>`);
            fixture.detectChanges();
            const compiled = fixture.nativeElement;
            const inputEl = getNativeInput(compiled);
+           tick();
 
-           fixture.whenStable().then(() => {
-             changeInput(compiled, 'on');
-             fixture.detectChanges();
-             expectWindowResults(compiled, ['one', 'one more']);
-             expect(inputEl.value).toBe('on');
-           });
+           changeInput(compiled, 'on');
+           fixture.detectChanges();
+           expectWindowResults(compiled, ['one', 'one more']);
+           expect(inputEl.value).toBe('on');
          }));
 
       describe('should clear input properly when model get reset to empty string', () => {
@@ -890,10 +860,9 @@ describe('ngb-typeahead', () => {
          `<input type="text" [(ngModel)]="model" [showHint]="true" [ngbTypeahead]="find" />`]
             .forEach((html, index) => {
               const showHint = index === 1;
-              it(`${index === 0 ? 'without' : 'with'} showHint activated`, async(async() => {
+              it(`${index === 0 ? 'without' : 'with'} showHint activated`, fakeAsync(() => {
                    const fixture = createTestComponent(html);
-                   fixture.detectChanges();
-                   await fixture.whenStable();
+                   tick();
 
                    const compiled = fixture.nativeElement;
                    changeInput(compiled, 'on');
@@ -903,7 +872,7 @@ describe('ngb-typeahead', () => {
 
                    fixture.componentInstance.model = '';
                    fixture.detectChanges();
-                   await fixture.whenStable();
+                   tick();
 
                    document.body.click();
                    fixture.detectChanges();


### PR DESCRIPTION
This addresses the `async` function deprecation introduced in `Angular 10`:

```
WARNING: 65:53     deprecation  async is deprecated: use `waitForAsync()`, (expected removal in v12)
```

Went through all unit tests and used `fakeAsync` where possible instead.