### PR TITLE
fix(popover,tooltip): run transaction inside angular zone

### DIFF
--- a/src/util/popup.ts
+++ b/src/util/popup.ts
@@ -39,10 +39,10 @@ export class PopupService<T> {
 
     const {nativeElement} = this._windowRef.location;
     const onStable$ = this._ngZone.onStable.asObservable().pipe(take(1));
-    const transition$ = onStable$.pipe(
-        mergeMap(
-            () => ngbRunTransition(
-                nativeElement, ({classList}) => classList.add('show'), {animation, runningTransition: 'continue'})));
+    const transition$ = onStable$.pipe(mergeMap(() => this._ngZone.run(() => {
+      return ngbRunTransition(
+          nativeElement, ({classList}) => classList.add('show'), {animation, runningTransition: 'continue'});
+    })));
 
     return {windowRef: this._windowRef, transition$};
   }


### PR DESCRIPTION
Forcing to run ngbRunTransition inside angular zone, because NgZone.onStable is called outside angular zone.

closes #3896