### PR TITLE
refactor: inline providers with forwardRef()

### DIFF
--- a/src/buttons/checkbox.ts
+++ b/src/buttons/checkbox.ts
@@ -3,13 +3,6 @@ import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 
 import {NgbButtonLabel} from './label';
 
-const NGB_CHECKBOX_VALUE_ACCESSOR = {
-  provide: NG_VALUE_ACCESSOR,
-  useExisting: forwardRef(() => NgbCheckBox),
-  multi: true
-};
-
-
 /**
  * Allows to easily create Bootstrap-style checkbox buttons.
  *
@@ -25,7 +18,7 @@ const NGB_CHECKBOX_VALUE_ACCESSOR = {
     '(focus)': 'focused = true',
     '(blur)': 'focused = false'
   },
-  providers: [NGB_CHECKBOX_VALUE_ACCESSOR]
+  providers: [{provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => NgbCheckBox), multi: true}]
 })
 export class NgbCheckBox implements ControlValueAccessor {
   static ngAcceptInputType_disabled: boolean | '';

--- a/src/buttons/radio.ts
+++ b/src/buttons/radio.ts
@@ -3,12 +3,6 @@ import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 
 import {NgbButtonLabel} from './label';
 
-const NGB_RADIO_VALUE_ACCESSOR = {
-  provide: NG_VALUE_ACCESSOR,
-  useExisting: forwardRef(() => NgbRadioGroup),
-  multi: true
-};
-
 let nextId = 0;
 
 /**
@@ -17,7 +11,11 @@ let nextId = 0;
  * Integrates with forms, so the value of a checked button is bound to the underlying form control
  * either in a reactive or template-driven way.
  */
-@Directive({selector: '[ngbRadioGroup]', host: {'role': 'radiogroup'}, providers: [NGB_RADIO_VALUE_ACCESSOR]})
+@Directive({
+  selector: '[ngbRadioGroup]',
+  host: {'role': 'radiogroup'},
+  providers: [{provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => NgbRadioGroup), multi: true}]
+})
 export class NgbRadioGroup implements ControlValueAccessor {
   private _radios: Set<NgbRadio> = new Set<NgbRadio>();
   private _value = null;

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -42,18 +42,6 @@ import {NgbInputDatepickerConfig} from './datepicker-input-config';
 import {NgbDatepickerConfig} from './datepicker-config';
 import {isString} from '../util/util';
 
-const NGB_DATEPICKER_VALUE_ACCESSOR = {
-  provide: NG_VALUE_ACCESSOR,
-  useExisting: forwardRef(() => NgbInputDatepicker),
-  multi: true
-};
-
-const NGB_DATEPICKER_VALIDATOR = {
-  provide: NG_VALIDATORS,
-  useExisting: forwardRef(() => NgbInputDatepicker),
-  multi: true
-};
-
 /**
  * A directive that allows to stick a datepicker popup to an input field.
  *
@@ -70,7 +58,8 @@ const NGB_DATEPICKER_VALIDATOR = {
     '[disabled]': 'disabled'
   },
   providers: [
-    NGB_DATEPICKER_VALUE_ACCESSOR, NGB_DATEPICKER_VALIDATOR,
+    {provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => NgbInputDatepicker), multi: true},
+    {provide: NG_VALIDATORS, useExisting: forwardRef(() => NgbInputDatepicker), multi: true},
     {provide: NgbDatepickerConfig, useExisting: NgbInputDatepickerConfig}
   ],
 })

--- a/src/datepicker/datepicker-month.spec.ts
+++ b/src/datepicker/datepicker-month.spec.ts
@@ -4,7 +4,7 @@ import {createGenericTestComponent} from '../test/common';
 import {Component, Injectable} from '@angular/core';
 
 import {NgbDatepickerModule} from './datepicker.module';
-import {NgbDatepicker, NgbDatepickerContent, NGB_DATEPICKER_VALUE_ACCESSOR} from './datepicker';
+import {NgbDatepicker, NgbDatepickerContent} from './datepicker';
 import {NgbDatepickerKeyboardService} from './datepicker-keyboard-service';
 import {NgbDatepickerService} from './datepicker-service';
 import {NgbDatepickerMonth} from './datepicker-month';
@@ -230,11 +230,8 @@ describe('ngb-datepicker-month', () => {
         NgbDatepickerModule,
         {set: {exports: [NgbDatepicker, NgbDatepickerContent, NgbDatepickerMonth, NgbDatepickerDayView]}});
     TestBed.overrideComponent(NgbDatepicker, {
-      set: {
-        providers: [
-          NGB_DATEPICKER_VALUE_ACCESSOR, {provide: NgbDatepickerService, useClass: MockDatepickerService},
-          NgbDatepickerKeyboardService
-        ]
+      add: {
+        providers: [{provide: NgbDatepickerService, useClass: MockDatepickerService}, NgbDatepickerKeyboardService]
       }
     });
     TestBed.configureTestingModule({

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -33,12 +33,6 @@ import {NgbDatepickerI18n} from './datepicker-i18n';
 import {isChangedDate, isChangedMonth} from './datepicker-tools';
 import {hasClassName} from '../util/util';
 
-export const NGB_DATEPICKER_VALUE_ACCESSOR = {
-  provide: NG_VALUE_ACCESSOR,
-  useExisting: forwardRef(() => NgbDatepicker),
-  multi: true
-};
-
 /**
  * An event emitted right before the navigation happens and the month displayed by the datepicker changes.
  */
@@ -164,7 +158,8 @@ export class NgbDatepickerContent {
 
     <ng-template [ngTemplateOutlet]="footerTemplate"></ng-template>
   `,
-  providers: [NGB_DATEPICKER_VALUE_ACCESSOR, NgbDatepickerService]
+  providers:
+      [{provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => NgbDatepicker), multi: true}, NgbDatepickerService]
 })
 export class NgbDatepicker implements OnDestroy,
     OnChanges, OnInit, ControlValueAccessor {

--- a/src/rating/rating.ts
+++ b/src/rating/rating.ts
@@ -33,12 +33,6 @@ export interface StarTemplateContext {
   index: number;
 }
 
-const NGB_RATING_VALUE_ACCESSOR = {
-  provide: NG_VALUE_ACCESSOR,
-  useExisting: forwardRef(() => NgbRating),
-  multi: true
-};
-
 /**
  * A directive that helps visualising and interacting with a star rating bar.
  */
@@ -69,7 +63,7 @@ const NGB_RATING_VALUE_ACCESSOR = {
       </span>
     </ng-template>
   `,
-  providers: [NGB_RATING_VALUE_ACCESSOR]
+  providers: [{provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => NgbRating), multi: true}]
 })
 export class NgbRating implements ControlValueAccessor,
     OnInit, OnChanges {

--- a/src/timepicker/timepicker.ts
+++ b/src/timepicker/timepicker.ts
@@ -17,12 +17,6 @@ import {NgbTimepickerI18n} from './timepicker-i18n';
 
 const FILTER_REGEX = /[^0-9]/g;
 
-const NGB_TIMEPICKER_VALUE_ACCESSOR = {
-  provide: NG_VALUE_ACCESSOR,
-  useExisting: forwardRef(() => NgbTimepicker),
-  multi: true
-};
-
 /**
  * A directive that helps with wth picking hours, minutes and seconds.
  */
@@ -112,7 +106,7 @@ const NGB_TIMEPICKER_VALUE_ACCESSOR = {
       </div>
     </fieldset>
   `,
-  providers: [NGB_TIMEPICKER_VALUE_ACCESSOR]
+  providers: [{provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => NgbTimepicker), multi: true}]
 })
 export class NgbTimepicker implements ControlValueAccessor,
     OnChanges {

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -33,13 +33,6 @@ import {isDefined, toString} from '../util/util';
 import {NgbTypeaheadConfig} from './typeahead-config';
 import {NgbTypeaheadWindow, ResultTemplateContext} from './typeahead-window';
 
-
-const NGB_TYPEAHEAD_VALUE_ACCESSOR = {
-  provide: NG_VALUE_ACCESSOR,
-  useExisting: forwardRef(() => NgbTypeahead),
-  multi: true
-};
-
 /**
  * An event emitted right before an item is selected from the result list.
  */
@@ -77,7 +70,7 @@ let nextWindowId = 0;
     '[attr.aria-owns]': 'isPopupOpen() ? popupId : null',
     '[attr.aria-expanded]': 'isPopupOpen()'
   },
-  providers: [NGB_TYPEAHEAD_VALUE_ACCESSOR]
+  providers: [{provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => NgbTypeahead), multi: true}]
 })
 export class NgbTypeahead implements ControlValueAccessor,
     OnInit, OnDestroy {


### PR DESCRIPTION
To fix dead code elimination in Angular 11.

See https://github.com/angular/angular-cli/issues/19572#issuecomment-741017976 for more details. The *inline* option was chosen as ng-bootstrap does not need to export these providers and they're only used by a single component. This option appears the simplest to me, it is less likely to regress in the future and should work independently of whether consumer uses Angular CLI or custom tooling to build their application. At the cost of slightly worse code readability.

Fixes #3904

Not sure how to add a test for size regressions. Any suggestions?

So far tested manually on the reproduction from the issue and it results in 3.3K according to source-map-explorer.

<img width="1899" alt="image" src="https://user-images.githubusercontent.com/823594/101545396-7dedf300-39a7-11eb-8479-07b52d976b2b.png">


Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
