### PR TITLE
test(typeahead): fix test failing in FF 83

### DIFF
--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -705,7 +705,7 @@ describe('ngb-typeahead', () => {
       const input = getNativeInput(fixture.nativeElement);
 
       expect(input.getAttribute('autocomplete')).toBe('off');
-      expect(input.getAttribute('autocapitalize')).toBe('off');
+      expect(['off', 'none']).toContain(input.getAttribute('autocapitalize') !);
       expect(input.getAttribute('autocorrect')).toBe('off');
     });
 


### PR DESCRIPTION
`<input autocapitalize />` attribute accepts either 'off' or 'none'.
https://html.spec.whatwg.org/multipage/interaction.html#autocap-hint-none

Fixes #3912