### PR TITLE
demo: removed redundant class 'title-fragment' for api-docs titles

### DIFF
--- a/demo/src/app/components/shared/api-docs/api-docs-class.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs-class.component.html
@@ -1,7 +1,6 @@
 <div class="api-doc-component" [class.deprecated]="apiDocs.deprecated">
   <h3>
     <a
-      class="title-fragment"
       routerLink="."
       fragment="{{apiDocs.className}}" ngbdFragment
       title="Anchor link to: {{apiDocs.className}}"

--- a/demo/src/app/components/shared/api-docs/api-docs-config.component.html
+++ b/demo/src/app/components/shared/api-docs/api-docs-config.component.html
@@ -1,7 +1,6 @@
 <div (click)="trackSourceClick()" class="api-doc-component" [class.deprecated]="apiDocs.deprecated">
   <h3>
     <a
-      class="title-fragment"
       routerLink="."
       fragment="{{apiDocs.className}}"
       ngbdFragment


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [ x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [ x] built and tested the changes locally.
 - [ ] added/updated any applicable API documentation.
 - [ ] added/updated any applicable tests.
 - [x ] added/updated any applicable demos.
