### PR TITLE
fix(datepicker): improve right arrow css selector

### DIFF
--- a/src/datepicker/datepicker-navigation.scss
+++ b/src/datepicker/datepicker-navigation.scss
@@ -15,12 +15,6 @@ ngb-datepicker-navigation {
     transform: rotate(-135deg);
   }
 
-  .right &-navigation-chevron {
-    transform: rotate(45deg);
-    margin-left: 0.15em;
-    margin-right: 0.25em;
-  }
-
   &-arrow {
     display: flex;
     flex: 1 1 auto;
@@ -32,6 +26,12 @@ ngb-datepicker-navigation {
 
     &.right {
       justify-content: flex-end;
+
+      .ngb-dp-navigation-chevron {
+        transform: rotate(45deg);
+        margin-left: 0.15em;
+        margin-right: 0.25em;
+      }
     }
 
   }


### PR DESCRIPTION
Now using `ngb-dp-arrow.right .ngb-dp-navigation-chevron` instead of `.right .ngb-dp-navigation-chevron`.

Fixes #3872