### PR TITLE
fix(carousel): update active class when the content changes

### DIFF
--- a/src/carousel/carousel.spec.ts
+++ b/src/carousel/carousel.spec.ts
@@ -336,6 +336,7 @@ describe('ngb-carousel', () => {
     fixture.componentInstance.slides = ['c', 'd'];
     fixture.detectChanges();
     expect(getSlidesText(fixture.nativeElement)).toEqual(['c', 'd']);
+    expectActiveSlides(fixture.nativeElement, [true, false]);
   });
 
   it('should change slide on indicator click', fakeAsync(() => {

--- a/src/test/test-styles.css
+++ b/src/test/test-styles.css
@@ -74,6 +74,7 @@
 
 .ngb-test-after {
   opacity: 0;
+  transition: none;
 }
 
 .ngb-test-hide-outer {

--- a/src/util/transition/ngbTransition.spec.ts
+++ b/src/util/transition/ngbTransition.spec.ts
@@ -233,7 +233,7 @@ if (isBrowserVisible('ngbRunTransition')) {
       expect(completeSpy1).toHaveBeenCalled();
       expect(element.classList.contains('ngb-test-during')).toBe(false);
       expect(element.classList.contains('ngb-test-after')).toBe(true);
-      expect(window.getComputedStyle(element).opacity).toBe('0');
+      expectOpacity(element, '0');
     });
 
     it(`should create and allow modifying context when running a new transition`, (done) => {

--- a/src/util/transition/ngbTransition.spec.ts
+++ b/src/util/transition/ngbTransition.spec.ts
@@ -1,4 +1,4 @@
-import {ngbRunTransition, NgbTransitionStartFn} from './ngbTransition';
+import {ngbCompleteTransition, ngbRunTransition, NgbTransitionStartFn} from './ngbTransition';
 import createSpy = jasmine.createSpy;
 import {Component, ElementRef, ViewChild} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -201,6 +201,39 @@ if (isBrowserVisible('ngbRunTransition')) {
       expect(nextSpy1).not.toHaveBeenCalled();
       expect(errorSpy1).not.toHaveBeenCalled();
       expect(completeSpy1).toHaveBeenCalled();
+    });
+
+    it(`should complete a transition with ngbCompleteTransition'`, () => {
+      const startFn = ({classList}: HTMLElement) => {
+        classList.add('ngb-test-during');
+        return () => {
+          classList.remove('ngb-test-during');
+          classList.add('ngb-test-after');
+        };
+      };
+
+      // starting first
+      const nextSpy1 = createSpy();
+      const errorSpy1 = createSpy();
+      const completeSpy1 = createSpy();
+
+      ngbRunTransition(element, startFn, {animation: true, runningTransition: 'stop'})
+          .subscribe(nextSpy1, errorSpy1, completeSpy1);
+
+      // first transition is on-going, start function was called
+      expect(nextSpy1).not.toHaveBeenCalled();
+      expect(completeSpy1).not.toHaveBeenCalled();
+      expect(element.classList.contains('ngb-test-during')).toBe(true);
+      expect(element.classList.contains('ngb-test-after')).toBe(false);
+      expect(window.getComputedStyle(element).opacity).toBe('1');
+
+      ngbCompleteTransition(element);
+
+      expect(nextSpy1).toHaveBeenCalled();
+      expect(completeSpy1).toHaveBeenCalled();
+      expect(element.classList.contains('ngb-test-during')).toBe(false);
+      expect(element.classList.contains('ngb-test-after')).toBe(true);
+      expect(window.getComputedStyle(element).opacity).toBe('0');
     });
 
     it(`should create and allow modifying context when running a new transition`, (done) => {

--- a/src/util/transition/ngbTransition.ts
+++ b/src/util/transition/ngbTransition.ts
@@ -15,7 +15,7 @@ export interface NgbTransitionOptions<T> {
 
 export interface NgbTransitionCtx<T> {
   transition$: Subject<any>;
-  stop: () => void;
+  complete: () => void;
   context: T;
 }
 
@@ -70,7 +70,7 @@ export const ngbRunTransition =
           const stop$ = transition$.pipe(endWith(true));
           runningTransitions.set(element, {
             transition$,
-            stop: () => {
+            complete: () => {
               finishTransition$.next();
               finishTransition$.complete();
             },
@@ -100,5 +100,5 @@ export const ngbRunTransition =
         };
 
 export const ngbCompleteTransition = (element: HTMLElement) => {
-  runningTransitions.get(element) ?.stop();
+  runningTransitions.get(element) ?.complete();
 };


### PR DESCRIPTION
fix #3911 

This fix force the (missing) active class on the active slide, when the content has changed. Any running transition is stopped, but trying to keep all the current classes (to try to continue the transition with the new content) produces some strange behaviors.