### PR TITLE
Minor build fixes for v9

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -206,7 +206,8 @@
               "node_modules/bootstrap/dist/css/bootstrap.css",
               "e2e-app/src/style/app.scss"
             ],
-            "scripts": []
+            "scripts": [],
+            "progress": false
           },
           "configurations": {
             "production": {
@@ -231,13 +232,11 @@
           "builder": "ngx-build-plus:dev-server",
           "options": {
             "browserTarget": "e2e-app:build",
-            "progress": false,
             "extraWebpackConfig": "e2e-app/coverage.webpack.js"
           },
           "configurations": {
             "production": {
-              "browserTarget": "e2e-app:build:production",
-              "progress": false
+              "browserTarget": "e2e-app:build:production"
             }
           }
         },

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -5,8 +5,7 @@
     "outDir": "../out-tsc/demo",
     "paths": {
       "@ng-bootstrap/ng-bootstrap": ["src/app/ng-bootstrap"]
-    },
-    "target": "es2018"
+    }
   },
   "files": [
     "src/main.ts",

--- a/e2e-app/tsconfig.json
+++ b/e2e-app/tsconfig.json
@@ -5,8 +5,7 @@
     "outDir": "../out-tsc/e2e-app",
     "paths": {
       "@ng-bootstrap/ng-bootstrap": ["../src/index"]
-    },
-    "target": "es2018"
+    }
   },
   "files": [
     "src/main.ts",

--- a/src/.browserslistrc
+++ b/src/.browserslistrc
@@ -1,13 +1,8 @@
 # Source: https://github.com/twbs/bootstrap/blob/v4.1.3/.browserslistrc
+# And intersection with Angular list: https://angular.io/guide/browser-support#browser-support
 
->= 1%
-last 1 major version
+last 2 major versions
 not dead
-Chrome >= 45
-Firefox >= 38
-Edge >= 12
-Explorer >= 11
-iOS >= 9
-Safari >= 9
-Android >= 4.4
-Opera >= 30
+Firefox ESR
+Edge 18
+IE 11

--- a/ssr-app/tsconfig.json
+++ b/ssr-app/tsconfig.json
@@ -4,7 +4,6 @@
     "baseUrl": "./",
     "outDir": "../out-tsc/ssr-app",
     "types": [],
-    "target": "es2018",
     "paths": {
       "@ng-bootstrap/ng-bootstrap": ["../dist/ng-bootstrap"]
     }


### PR DESCRIPTION
- downgrade target to `es2015`
- adjust ng-bootstrap `.browserslistrc`
- clean up deprecated flag