### PR TITLE
feat(typeahead): allow custom class on window for modal issue

### DIFF
--- a/src/typeahead/typeahead-window.ts
+++ b/src/typeahead/typeahead-window.ts
@@ -21,7 +21,12 @@ export interface ResultTemplateContext {
   selector: 'ngb-typeahead-window',
   exportAs: 'ngbTypeaheadWindow',
   encapsulation: ViewEncapsulation.None,
-  host: {'(mousedown)': '$event.preventDefault()', 'class': 'dropdown-menu show', 'role': 'listbox', '[id]': 'id'},
+  host: {
+    '(mousedown)': '$event.preventDefault()',
+    '[class]': '"dropdown-menu show" + (windowClass ? " " + windowClass : "")',
+    'role': 'listbox',
+    '[id]': 'id'
+  },
   template: `
     <ng-template #rt let-result="result" let-term="term" let-formatter="formatter">
       <ngb-highlight [result]="formatter(result)" [term]="term"></ngb-highlight>
@@ -72,6 +77,11 @@ export class NgbTypeaheadWindow implements OnInit {
    * A template to override a matching result default display
    */
   @Input() resultTemplate: TemplateRef<ResultTemplateContext>;
+
+  /**
+  * A custom class to append to the typeahead window
+  */
+  @Input() windowClass: string;
 
   /**
    * Event raised when user selects a particular result row

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -406,6 +406,33 @@ describe('ngb-typeahead', () => {
          tick(250);
          expectWindowResults(compiled, ['+one', 'one more']);
        }));
+
+    it('should apply additional class when specified', () => {
+      const fixture =
+          createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find" windowClass="test"/>`);
+      const compiled = fixture.nativeElement;
+
+      // the results of the code below are already tested above
+      changeInput(compiled, 'one');
+      fixture.detectChanges();
+
+      const win = getWindow(compiled);
+      expect(win.classList).toContain('test');
+    });
+
+    it('should apply additional classes when specified', () => {
+      const fixture = createTestComponent(
+          `<input type="text" [(ngModel)]="model" [ngbTypeahead]="find" windowClass="test other"/>`);
+      const compiled = fixture.nativeElement;
+
+      // the results of the code below are already tested above
+      changeInput(compiled, 'one');
+      fixture.detectChanges();
+
+      const win = getWindow(compiled);
+      expect(win.classList).toContain('test');
+      expect(win.classList).toContain('other');
+    });
   });
 
   describe('with async typeahead function', () => {

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -169,6 +169,18 @@ export class NgbTypeahead implements ControlValueAccessor,
   @Input() placement: PlacementArray = 'bottom-left';
 
   /**
+  * A custom class to append to the typeahead window
+  *
+  * Accepts a string containing one or more CSS classes to be applied on the `ngb-typeahead-window`.
+  *
+  * This can be used to provide instance-specific styling. It was originally impelemented to allow overriding
+  * the `z-index` of the `ngb-typeahead-window` when using it inside a modal window.
+  *
+  * @since 8.1.0
+  */
+  @Input() windowClass: string;
+
+  /**
    * An event emitted right before an item is selected from the result list.
    *
    * Event payload is of type [`NgbTypeaheadSelectItemEvent`](#/components/typeahead/api#NgbTypeaheadSelectItemEvent).
@@ -303,6 +315,7 @@ export class NgbTypeahead implements ControlValueAccessor,
       this._windowRef.instance.id = this.popupId;
       this._windowRef.instance.selectEvent.subscribe((result: any) => this._selectResultClosePopup(result));
       this._windowRef.instance.activeChangeEvent.subscribe((activeId: string) => this.activeDescendant = activeId);
+      this._windowRef.instance.windowClass = this.windowClass;
 
       if (this.container === 'body') {
         this._document.querySelector(this.container).appendChild(this._windowRef.location.nativeElement);


### PR DESCRIPTION
This PR enables providing one or more custom classes to the typeahead window. It's intended to help solve #3778 as per [my comment](https://github.com/ng-bootstrap/ng-bootstrap/issues/3778#issuecomment-759833406).

I modeled the behavior and implementation after `windowClass` from `NgbModal`.The main intent here is allowing users to provide a custom `z-index` value along with the `container="body"` option for their specific needs. But ultimately, it can be used to override any attributes on the `ngb-typeahead-window`.

I did not feel we needed to update the demo, but I would be happy to do so if needed.

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.
