### PR TITLE
Bs5 positioning classes (BREAKING CHANGE)

### DIFF
--- a/demo/src/app/components/datepicker/demos/config/datepicker-config.ts
+++ b/demo/src/app/components/datepicker/demos/config/datepicker-config.ts
@@ -1,18 +1,12 @@
 import {Component} from '@angular/core';
-import {
-  NgbCalendar,
-  NgbDate,
-  NgbDateStruct,
-  NgbInputDatepickerConfig
-} from '@ng-bootstrap/ng-bootstrap';
+import {NgbCalendar, NgbDate, NgbDateStruct, NgbInputDatepickerConfig} from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
   selector: 'ngbd-datepicker-config',
   templateUrl: './datepicker-config.html',
-  providers: [NgbInputDatepickerConfig] // add config to the component providers
+  providers: [NgbInputDatepickerConfig]  // add config to the component providers
 })
 export class NgbdDatepickerConfig {
-
   model: NgbDateStruct;
 
   constructor(config: NgbInputDatepickerConfig, calendar: NgbCalendar) {
@@ -30,6 +24,6 @@ export class NgbdDatepickerConfig {
     config.autoClose = 'outside';
 
     // setting datepicker popup to open above the input
-    config.placement = ['top-left', 'top-right'];
+    config.placement = ['top-start', 'top-end'];
   }
 }

--- a/demo/src/app/components/dropdown/demos/basic/dropdown-basic.html
+++ b/demo/src/app/components/dropdown/demos/basic/dropdown-basic.html
@@ -11,7 +11,7 @@
   </div>
 
   <div class="col text-right">
-    <div ngbDropdown placement="top-right" class="d-inline-block">
+    <div ngbDropdown placement="top-end" class="d-inline-block">
       <button class="btn btn-outline-primary" id="dropdownBasic2" ngbDropdownToggle>Toggle dropup</button>
       <div ngbDropdownMenu aria-labelledby="dropdownBasic2">
         <button ngbDropdownItem>Action - 1</button>

--- a/demo/src/app/components/dropdown/demos/config/dropdown-config.ts
+++ b/demo/src/app/components/dropdown/demos/config/dropdown-config.ts
@@ -4,12 +4,12 @@ import {NgbDropdownConfig} from '@ng-bootstrap/ng-bootstrap';
 @Component({
   selector: 'ngbd-dropdown-config',
   templateUrl: './dropdown-config.html',
-  providers: [NgbDropdownConfig] // add NgbDropdownConfig to the component providers
+  providers: [NgbDropdownConfig]  // add NgbDropdownConfig to the component providers
 })
 export class NgbdDropdownConfig {
   constructor(config: NgbDropdownConfig) {
     // customize default values of dropdowns used by this component tree
-    config.placement = 'top-left';
+    config.placement = 'top-start';
     config.autoClose = false;
   }
 }

--- a/demo/src/app/components/dropdown/demos/navbar/dropdown-navbar.html
+++ b/demo/src/app/components/dropdown/demos/navbar/dropdown-navbar.html
@@ -6,7 +6,7 @@
 </p>
 <p>
   In order to align a dropdown in a navbar to the right while still keeping correct behavior when the navbar is
-  collapsed, the CSS class <code>dropdown-menu-right</code> must be added to the dropdown menu.
+  collapsed, the CSS class <code>dropdown-menu-end</code> must be added to the dropdown menu.
   The second dropdown in this example illustrates it.
 </p>
 <p>
@@ -47,14 +47,14 @@
         <a class="nav-link" tabindex="0" ngbDropdownToggle id="navbarDropdown2" role="button">
           Static right
         </a>
-        <div ngbDropdownMenu aria-labelledby="navbarDropdown2" class="dropdown-menu dropdown-menu-right">
+        <div ngbDropdownMenu aria-labelledby="navbarDropdown2" class="dropdown-menu dropdown-menu-end">
           <a ngbDropdownItem href="#" (click)="$event.preventDefault()">Action</a>
           <a ngbDropdownItem href="#" (click)="$event.preventDefault()">Another action</a>
           <a ngbDropdownItem href="#" (click)="$event.preventDefault()">Something else here</a>
         </div>
       </li>
 
-      <li class="nav-item" ngbDropdown display="dynamic" placement="bottom-right">
+      <li class="nav-item" ngbDropdown display="dynamic" placement="bottom-end">
         <a class="nav-link" tabindex="0" ngbDropdownToggle id="navbarDropdown3" role="button">
           Dynamic
         </a>

--- a/demo/src/app/components/popover/demos/basic/popover-basic.html
+++ b/demo/src/app/components/popover/demos/basic/popover-basic.html
@@ -3,7 +3,7 @@
   Popover on top
 </button>
 
-<button type="button" class="btn btn-outline-secondary mr-2" placement="right"
+<button type="button" class="btn btn-outline-secondary mr-2" placement="end"
         ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on right">
   Popover on right
 </button>
@@ -13,7 +13,7 @@
   Popover on bottom
 </button>
 
-<button type="button" class="btn btn-outline-secondary mr-2" placement="left"
+<button type="button" class="btn btn-outline-secondary mr-2" placement="start"
         ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus." popoverTitle="Popover on left">
   Popover on left
 </button>

--- a/demo/src/app/components/popover/demos/config/popover-config.ts
+++ b/demo/src/app/components/popover/demos/config/popover-config.ts
@@ -4,12 +4,12 @@ import {NgbPopoverConfig} from '@ng-bootstrap/ng-bootstrap';
 @Component({
   selector: 'ngbd-popover-config',
   templateUrl: './popover-config.html',
-  providers: [NgbPopoverConfig] // add NgbPopoverConfig to the component providers
+  providers: [NgbPopoverConfig]  // add NgbPopoverConfig to the component providers
 })
 export class NgbdPopoverConfig {
   constructor(config: NgbPopoverConfig) {
     // customize default values of popovers used by this component tree
-    config.placement = 'right';
+    config.placement = 'end';
     config.triggers = 'hover';
   }
 }

--- a/demo/src/app/components/tooltip/demos/basic/tooltip-basic.html
+++ b/demo/src/app/components/tooltip/demos/basic/tooltip-basic.html
@@ -1,12 +1,12 @@
 <button type="button" class="btn btn-outline-secondary mr-2" placement="top" ngbTooltip="Tooltip on top">
   Tooltip on top
 </button>
-<button type="button" class="btn btn-outline-secondary mr-2" placement="right" ngbTooltip="Tooltip on right">
+<button type="button" class="btn btn-outline-secondary mr-2" placement="end" ngbTooltip="Tooltip on right">
   Tooltip on right
 </button>
 <button type="button" class="btn btn-outline-secondary mr-2" placement="bottom" ngbTooltip="Tooltip on bottom">
   Tooltip on bottom
 </button>
-<button type="button" class="btn btn-outline-secondary mr-2" placement="left" ngbTooltip="Tooltip on left">
+<button type="button" class="btn btn-outline-secondary mr-2" placement="start" ngbTooltip="Tooltip on left">
   Tooltip on left
 </button>

--- a/demo/src/app/components/tooltip/demos/config/tooltip-config.ts
+++ b/demo/src/app/components/tooltip/demos/config/tooltip-config.ts
@@ -4,12 +4,12 @@ import {NgbTooltipConfig} from '@ng-bootstrap/ng-bootstrap';
 @Component({
   selector: 'ngbd-tooltip-config',
   templateUrl: './tooltip-config.html',
-  providers: [NgbTooltipConfig] // add NgbTooltipConfig to the component providers
+  providers: [NgbTooltipConfig]  // add NgbTooltipConfig to the component providers
 })
 export class NgbdTooltipConfig {
   constructor(config: NgbTooltipConfig) {
     // customize default values of tooltips used by this component tree
-    config.placement = 'right';
+    config.placement = 'end';
     config.triggers = 'click';
   }
 }

--- a/demo/src/app/shared/component-wrapper/component-wrapper.component.html
+++ b/demo/src/app/shared/component-wrapper/component-wrapper.component.html
@@ -46,7 +46,7 @@
               </svg>
             </span>
 
-            <div class="dropdown-menu-right" ngbDropdownMenu>
+            <div class="dropdown-menu-end" ngbDropdownMenu>
               <ng-template ngFor [ngForOf]="tableOfContents" let-topic>
                 <a *ngIf="topic.title else divider" class="dropdown-item" [routerLink]="['.', this.activeTab]"
                   [fragment]="topic.fragment">{{topic.title}}</a>

--- a/demo/src/app/shared/page-wrapper/page-wrapper.component.html
+++ b/demo/src/app/shared/page-wrapper/page-wrapper.component.html
@@ -40,7 +40,7 @@
               <svg aria-hidden="true" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M464 32H48C21.49 32 0 53.49 0 80v352c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V80c0-26.51-21.49-48-48-48zm-6 400H54a6 6 0 0 1-6-6V86a6 6 0 0 1 6-6h404a6 6 0 0 1 6 6v340a6 6 0 0 1-6 6zm-42-92v24c0 6.627-5.373 12-12 12H204c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h200c6.627 0 12 5.373 12 12zm0-96v24c0 6.627-5.373 12-12 12H204c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h200c6.627 0 12 5.373 12 12zm0-96v24c0 6.627-5.373 12-12 12H204c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h200c6.627 0 12 5.373 12 12zm-252 12c0 19.882-16.118 36-36 36s-36-16.118-36-36 16.118-36 36-36 36 16.118 36 36zm0 96c0 19.882-16.118 36-36 36s-36-16.118-36-36 16.118-36 36-36 36 16.118 36 36zm0 96c0 19.882-16.118 36-36 36s-36-16.118-36-36 16.118-36 36-36 36 16.118 36 36z"></path></svg>
             </span>
 
-            <div class="dropdown-menu-right" ngbDropdownMenu>
+            <div class="dropdown-menu-end" ngbDropdownMenu>
               <a *ngFor="let topic of tableOfContents"
                  class="dropdown-item" routerLink="." [fragment]="topic.fragment">{{topic.title}}</a>
             </div>

--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -1,5 +1,17 @@
 // styles in src/style directory are applied to the whole page
 
+// Temporary fix, as this classes are required for the positioning
+// They existed in bs4, and we must remove them after popper implementation
+.dropdown-menu {
+  &[x-placement^="top"],
+  &[x-placement^="end"],
+  &[x-placement^="bottom"],
+  &[x-placement^="start"] {
+    right: auto;
+    bottom: auto;
+  }
+}
+
 header.navbar {
   background: linear-gradient(135deg, #0143a3, #0273d4);
 }

--- a/e2e-app/src/app/dropdown/position/dropdown-position.component.html
+++ b/e2e-app/src/app/dropdown/position/dropdown-position.component.html
@@ -27,10 +27,10 @@
       <button class="btn btn-outline-secondary" id="container-null" (click)="toggleContainer(null)">Append to widget</button>
     </div>
     <div>
-      <button class="btn btn-outline-secondary mr-1 ml-2" id="placement-top-left" (click)="togglePlacement('top-left')">On top-left</button>
-      <button class="btn btn-outline-secondary mr-1" id="placement-bottom-left" (click)="togglePlacement('bottom-left')">On bottom-left</button>
-      <button class="btn btn-outline-secondary mr-1 ml-2" id="placement-top-right" (click)="togglePlacement('top-right')">On top-right</button>
-      <button class="btn btn-outline-secondary mr-1" id="placement-bottom-right" (click)="togglePlacement('bottom-right')">On bottom-right</button>
+      <button class="btn btn-outline-secondary mr-1 ml-2" id="placement-top-start" (click)="togglePlacement('top-start')">On top-start</button>
+      <button class="btn btn-outline-secondary mr-1" id="placement-bottom-start" (click)="togglePlacement('bottom-start')">On bottom-start</button>
+      <button class="btn btn-outline-secondary mr-1 ml-2" id="placement-top-end" (click)="togglePlacement('top-end')">On top-end</button>
+      <button class="btn btn-outline-secondary mr-1" id="placement-bottom-end" (click)="togglePlacement('bottom-end')">On bottom-end</button>
     </div>
   </div>
 

--- a/e2e-app/src/app/dropdown/position/dropdown-position.component.ts
+++ b/e2e-app/src/app/dropdown/position/dropdown-position.component.ts
@@ -3,7 +3,7 @@ import {Component} from '@angular/core';
 @Component({templateUrl: './dropdown-position.component.html'})
 export class DropdownPositionComponent {
   isInDom = true;
-  placement = 'top-left';
+  placement = 'top-start';
   container: null | 'body' = null;
 
   togglePlacement(placement) { this.placement = placement; }

--- a/e2e-app/src/app/dropdown/position/dropdown-position.e2e-spec.ts
+++ b/e2e-app/src/app/dropdown/position/dropdown-position.e2e-spec.ts
@@ -55,10 +55,10 @@ const roundLocation = function(location) {
       const dropdown = dropdownPage.getDropdown(selector);
       await dropdownPage.open(dropdown);
 
-      await expectSamePositions('bottom-left');
-      await expectSamePositions('top-left');
-      await expectSamePositions('bottom-right');
-      await expectSamePositions('top-right');
+      await expectSamePositions('bottom-start');
+      await expectSamePositions('top-start');
+      await expectSamePositions('bottom-end');
+      await expectSamePositions('top-end');
 
     });
 
@@ -75,11 +75,11 @@ const roundLocation = function(location) {
       await dropdownPositionPage.toggleContainer('body');
       await dropdownPage.open(dropdown);
 
-      await dropdownPositionPage.togglePlacement('bottom-left');
+      await dropdownPositionPage.togglePlacement('bottom-start');
       expect(await dropdownPage.getBodyContainers().count())
           .toBe(1, `Dropdown menu container should be found on the body`);
 
-      await dropdownPositionPage.togglePlacement('top-left');
+      await dropdownPositionPage.togglePlacement('top-start');
       expect(await dropdownPage.getBodyContainers().count())
           .toBe(1, `Dropdown menu container should be found on the body`);
 

--- a/e2e-app/src/app/dropdown/position/dropdown-position.po.ts
+++ b/e2e-app/src/app/dropdown/position/dropdown-position.po.ts
@@ -5,7 +5,7 @@ export class DropdownPositionPage {
 
   async toggleContainer(container: null | 'body') { await $(`#container-${container || 'null'}`).click(); }
 
-  async togglePlacement(placement: 'top-left' | 'bottom-left' | 'top-right' | 'bottom-right') {
+  async togglePlacement(placement: 'top-start' | 'bottom-start' | 'top-end' | 'bottom-end') {
     await $(`#placement-${placement}`).click();
   }
 }

--- a/e2e-app/src/app/tooltip/position/tooltip-position.component.html
+++ b/e2e-app/src/app/tooltip/position/tooltip-position.component.html
@@ -2,9 +2,9 @@
 
 <form id="default">
   <div class="my-3">
-    <button class="btn btn-outline-secondary mx-1" id="flex-left" (click)="setPosition('start')">Left</button>
+    <button class="btn btn-outline-secondary mx-1" id="flex-start" (click)="setPosition('start')">Left</button>
     <button class="btn btn-outline-secondary mx-1" id="flex-center" (click)="setPosition('center')">Center</button>
-    <button class="btn btn-outline-secondary mx-1" id="flex-right" (click)="setPosition('end')">Right</button>
+    <button class="btn btn-outline-secondary mx-1" id="flex-end" (click)="setPosition('end')">Right</button>
   </div>
   <div class="d-flex {{flexPosition}}">
     <div class="d-flex flex-column">
@@ -12,14 +12,14 @@
         Normal tooltip
       </button>
 
-      <button id="btn-innerHtml" type="button" container="body" triggers="click" class="btn btn-outline-secondary" [placement]="['top', 'top-left', 'top-right']" [ngbTooltip]="tooltipHtml">
+      <button id="btn-innerHtml" type="button" container="body" triggers="click" class="btn btn-outline-secondary" [placement]="['top', 'top-start', 'top-end']" [ngbTooltip]="tooltipHtml">
           InnerHtml
       </button>
 
       <button id="btn-body-off" type="button" container="body" triggers="click" class="btn btn-outline-secondary" placement="auto" [ngbTooltip]="content">
         body off
       </button>
-      <button id="btn-default" type="button" container="body" triggers="click" class="btn btn-outline-secondary" placement="left left-top left-bottom" [ngbTooltip]="content">
+      <button id="btn-default" type="button" container="body" triggers="click" class="btn btn-outline-secondary" placement="left start-top start-bottom" [ngbTooltip]="content">
         Default placement
       </button>
 
@@ -27,7 +27,7 @@
     <ng-template #tooltipHtml><div [innerHtml]="content"></div></ng-template>
   </div>
   <div class="m-3">
-    <button id="btn-fixed" type="button" triggers="click" class="btn btn-outline-secondary position-fixed" [placement]="['top', 'top-left', 'top-right']" [ngbTooltip]="tooltipHtml" [ngStyle]="{'left': fixedPositionLeft, 'right': fixedPositionRight}">
+    <button id="btn-fixed" type="button" triggers="click" class="btn btn-outline-secondary position-fixed" [placement]="['top', 'top-start', 'top-end']" [ngbTooltip]="tooltipHtml" [ngStyle]="{'left': fixedPositionLeft, 'right': fixedPositionRight}">
       Fixed
     </button>
   </div>

--- a/e2e-app/src/app/tooltip/position/tooltip-position.e2e-spec.ts
+++ b/e2e-app/src/app/tooltip/position/tooltip-position.e2e-spec.ts
@@ -38,7 +38,7 @@ describe('Tooltip Position', () => {
       yDiff = (tooltipLocation.y + tooltipSize.height) - btnLocation.y;
       if (secondary === 'left') {
         xDiff = tooltipLocation.x - btnLocation.x;
-      } else if (secondary === 'right') {
+      } else if (secondary === 'end') {
         xDiff = (tooltipLocation.x + tooltipSize.width) - (btnLocation.x + btnSize.width);
       } else {
         xDiff = (tooltipLocation.x + tooltipSize.width / 2) - (btnLocation.x + (btnSize.width / 2));
@@ -50,7 +50,7 @@ describe('Tooltip Position', () => {
       xDiff = (tooltipLocation.x + tooltipSize.width) - btnLocation.x;
     }
 
-    if (primary === 'right') {
+    if (primary === 'end') {
       yDiff = (tooltipLocation.y + tooltipSize.height / 2) - (btnLocation.y + btnSize.height / 2);
       xDiff = tooltipLocation.x - (btnLocation.x + btnSize.width);
     }
@@ -70,11 +70,11 @@ describe('Tooltip Position', () => {
   beforeEach(async() => await openUrl('tooltip/position'));
 
   it(`should be well positionned on the left edge`, async() => {
-    await page.selectPosition('left');
-    await expectTooltipsPosition('normal', 'right');
-    await expectTooltipsPosition('innerHtml', 'top-left');
-    await expectTooltipsPosition('body-off', 'right');
-    await expectTooltipsPosition('fixed', 'top-left');
+    await page.selectPosition('start');
+    await expectTooltipsPosition('normal', 'end');
+    await expectTooltipsPosition('innerHtml', 'top-start');
+    await expectTooltipsPosition('body-off', 'end');
+    await expectTooltipsPosition('fixed', 'top-start');
   });
 
   it(`should be well positionned on the center`, async() => {
@@ -86,16 +86,16 @@ describe('Tooltip Position', () => {
   });
 
   it(`should be well positionned on the right edge`, async() => {
-    await page.selectPosition('right');
-    await expectTooltipsPosition('normal', 'left');
+    await page.selectPosition('end');
+    await expectTooltipsPosition('normal', 'start');
     await expectTooltipsPosition('innerHtml', 'top-right');
-    await expectTooltipsPosition('body-off', 'left');
+    await expectTooltipsPosition('body-off', 'start');
     await expectTooltipsPosition('fixed', 'top-right');
   });
 
   it(`should be positionned at the first placement by default`, async() => {
-    await page.selectPosition('left');
-    await expectTooltipsPosition('default', 'left', ['left-bottom']);
+    await page.selectPosition('start');
+    await expectTooltipsPosition('default', 'start', ['start-bottom']);
   });
 
 });

--- a/e2e-app/src/app/tooltip/position/tooltip-position.e2e-spec.ts
+++ b/e2e-app/src/app/tooltip/position/tooltip-position.e2e-spec.ts
@@ -88,9 +88,9 @@ describe('Tooltip Position', () => {
   it(`should be well positionned on the right edge`, async() => {
     await page.selectPosition('end');
     await expectTooltipsPosition('normal', 'start');
-    await expectTooltipsPosition('innerHtml', 'top-right');
+    await expectTooltipsPosition('innerHtml', 'top-end');
     await expectTooltipsPosition('body-off', 'start');
-    await expectTooltipsPosition('fixed', 'top-right');
+    await expectTooltipsPosition('fixed', 'top-end');
   });
 
   it(`should be positionned at the first placement by default`, async() => {

--- a/e2e-app/src/style/app.scss
+++ b/e2e-app/src/style/app.scss
@@ -1,1 +1,13 @@
 /* You can add global styles to this file, and also import other style files */
+
+// Temporary fix, as this classes are required for the positioning
+// They existed in bs4, and we must remove them after popper implementation
+.dropdown-menu {
+    &[x-placement^="top"],
+    &[x-placement^="end"],
+    &[x-placement^="bottom"],
+    &[x-placement^="start"] {
+      right: auto;
+      bottom: auto;
+    }
+  }

--- a/src/carousel/carousel-transition.ts
+++ b/src/carousel/carousel-transition.ts
@@ -5,19 +5,19 @@ import {reflow} from '../util/util';
  * Defines the carousel slide transition direction.
  */
 export enum NgbSlideEventDirection {
-  LEFT = 'left',
-  RIGHT = 'right'
+  START = 'start',
+  END = 'end'
 }
 
-export interface NgbCarouselCtx { direction: 'left' | 'right'; }
+export interface NgbCarouselCtx { direction: 'start' | 'end'; }
 
 const isBeingAnimated = ({classList}: HTMLElement) => {
-  return classList.contains('carousel-item-left') || classList.contains('carousel-item-right');
+  return classList.contains('carousel-item-start') || classList.contains('carousel-item-end');
 };
 
 const removeDirectionClasses = (classList: DOMTokenList) => {
-  classList.remove('carousel-item-left');
-  classList.remove('carousel-item-right');
+  classList.remove('carousel-item-start');
+  classList.remove('carousel-item-end');
 };
 
 const removeClasses = (classList: DOMTokenList) => {
@@ -42,7 +42,7 @@ export const ngbCarouselTransitionIn: NgbTransitionStartFn<NgbCarouselCtx> =
         removeDirectionClasses(classList);
       } else {
         // For the 'in' transition, a 'pre-class' is applied to the element to ensure its visibility
-        classList.add('carousel-item-' + (direction === NgbSlideEventDirection.LEFT ? 'next' : 'prev'));
+        classList.add('carousel-item-' + (direction === NgbSlideEventDirection.START ? 'next' : 'prev'));
         reflow(element);
         classList.add('carousel-item-' + direction);
       }

--- a/src/carousel/carousel.spec.ts
+++ b/src/carousel/carousel.spec.ts
@@ -375,7 +375,7 @@ describe('ngb-carousel', () => {
        indicatorElms[1].click();
        fixture.detectChanges();
        expect(fixture.componentInstance.carouselSlideCallBack).toHaveBeenCalledWith(jasmine.objectContaining({
-         direction: NgbSlideEventDirection.LEFT,
+         direction: NgbSlideEventDirection.START,
          source: NgbSlideEventSource.INDICATOR
        }));
 
@@ -383,7 +383,7 @@ describe('ngb-carousel', () => {
        indicatorElms[0].click();
        fixture.detectChanges();
        expect(fixture.componentInstance.carouselSlideCallBack).toHaveBeenCalledWith(jasmine.objectContaining({
-         direction: NgbSlideEventDirection.RIGHT,
+         direction: NgbSlideEventDirection.END,
          source: NgbSlideEventSource.INDICATOR,
        }));
 
@@ -391,7 +391,7 @@ describe('ngb-carousel', () => {
        indicatorElms[2].click();
        fixture.detectChanges();
        expect(fixture.componentInstance.carouselSlideCallBack).toHaveBeenCalledWith(jasmine.objectContaining({
-         direction: NgbSlideEventDirection.LEFT,
+         direction: NgbSlideEventDirection.START,
          source: NgbSlideEventSource.INDICATOR
        }));
 
@@ -441,12 +441,12 @@ describe('ngb-carousel', () => {
        prevControlElm.click();
        fixture.detectChanges();
        expect(fixture.componentInstance.carouselSlideCallBack).toHaveBeenCalledWith(jasmine.objectContaining({
-         direction: NgbSlideEventDirection.RIGHT,
+         direction: NgbSlideEventDirection.END,
          source: NgbSlideEventSource.ARROW_LEFT
        }));
        expect(spySingleCallBack.calls.allArgs()).toEqual([
-         [{isShown: false, direction: NgbSlideEventDirection.RIGHT, source: NgbSlideEventSource.ARROW_LEFT}, 'foo'],
-         [{isShown: true, direction: NgbSlideEventDirection.RIGHT, source: NgbSlideEventSource.ARROW_LEFT}, 'bar'],
+         [{isShown: false, direction: NgbSlideEventDirection.END, source: NgbSlideEventSource.ARROW_LEFT}, 'foo'],
+         [{isShown: true, direction: NgbSlideEventDirection.END, source: NgbSlideEventSource.ARROW_LEFT}, 'bar'],
        ]);
 
        spyCallBack.calls.reset();
@@ -454,12 +454,12 @@ describe('ngb-carousel', () => {
        nextControlElm.click();
        fixture.detectChanges();
        expect(fixture.componentInstance.carouselSlideCallBack).toHaveBeenCalledWith(jasmine.objectContaining({
-         direction: NgbSlideEventDirection.LEFT,
+         direction: NgbSlideEventDirection.START,
          source: NgbSlideEventSource.ARROW_RIGHT
        }));
        expect(spySingleCallBack.calls.allArgs()).toEqual([
-         [{isShown: false, direction: NgbSlideEventDirection.LEFT, source: NgbSlideEventSource.ARROW_RIGHT}, 'bar'],
-         [{isShown: true, direction: NgbSlideEventDirection.LEFT, source: NgbSlideEventSource.ARROW_RIGHT}, 'foo'],
+         [{isShown: false, direction: NgbSlideEventDirection.START, source: NgbSlideEventSource.ARROW_RIGHT}, 'bar'],
+         [{isShown: true, direction: NgbSlideEventDirection.START, source: NgbSlideEventSource.ARROW_RIGHT}, 'foo'],
        ]);
 
        spyCallBack.calls.reset();
@@ -467,12 +467,12 @@ describe('ngb-carousel', () => {
        prevControlElm.click();
        fixture.detectChanges();
        expect(fixture.componentInstance.carouselSlideCallBack).toHaveBeenCalledWith(jasmine.objectContaining({
-         direction: NgbSlideEventDirection.RIGHT,
+         direction: NgbSlideEventDirection.END,
          source: NgbSlideEventSource.ARROW_LEFT
        }));
        expect(spySingleCallBack.calls.allArgs()).toEqual([
-         [{isShown: false, direction: NgbSlideEventDirection.RIGHT, source: NgbSlideEventSource.ARROW_LEFT}, 'foo'],
-         [{isShown: true, direction: NgbSlideEventDirection.RIGHT, source: NgbSlideEventSource.ARROW_LEFT}, 'bar'],
+         [{isShown: false, direction: NgbSlideEventDirection.END, source: NgbSlideEventSource.ARROW_LEFT}, 'foo'],
+         [{isShown: true, direction: NgbSlideEventDirection.END, source: NgbSlideEventSource.ARROW_LEFT}, 'bar'],
        ]);
 
        discardPeriodicTasks();
@@ -517,7 +517,7 @@ describe('ngb-carousel', () => {
        fixture.detectChanges();
        expectActiveSlides(fixture.nativeElement, [false, true]);
        expect(spyCallBack).toHaveBeenCalledWith(jasmine.objectContaining({
-         direction: NgbSlideEventDirection.LEFT,
+         direction: NgbSlideEventDirection.START,
          source: NgbSlideEventSource.TIMER
        }));
 
@@ -782,7 +782,7 @@ describe('ngb-carousel', () => {
        discardPeriodicTasks();
      }));
 
-  it('should change on key arrowRight and arrowLeft', fakeAsync(() => {
+  it('should change on key arrowRight and arrowstart', fakeAsync(() => {
        const html = `
             <ngb-carousel [keyboard]="keyboard" [wrap]="false">
               <ng-template ngbSlide>foo</ng-template>
@@ -985,7 +985,7 @@ if (isBrowserVisible('ngb-carousel animations')) {
         expect(slideOne.className).toBe('carousel-item');
         expect(slideTwo.className).toBe('carousel-item active');
 
-        expect(payload).toEqual({prev: 'one', current: 'two', direction: 'left', paused: false, source: 'indicator'});
+        expect(payload).toEqual({prev: 'one', current: 'two', direction: 'start', paused: false, source: 'indicator'});
         expect(onSlidSpy).toHaveBeenCalledTimes(1);
         done();
       });
@@ -996,8 +996,8 @@ if (isBrowserVisible('ngb-carousel animations')) {
       indicators[1].click();
       fixture.detectChanges();
 
-      expect(slideOne.className).toBe('carousel-item active carousel-item-left');
-      expect(slideTwo.className).toBe('carousel-item carousel-item-next carousel-item-left');
+      expect(slideOne.className).toBe('carousel-item active carousel-item-start');
+      expect(slideTwo.className).toBe('carousel-item carousel-item-next carousel-item-start');
     });
 
     it(`should run slide transition (force-reduced-motion = true)`, () => {
@@ -1022,7 +1022,7 @@ if (isBrowserVisible('ngb-carousel animations')) {
       expect(slideTwo.className).toBe('carousel-item active');
 
       expect(onSlidSpy).toHaveBeenCalledWith(
-          {prev: 'one', current: 'two', direction: 'left', paused: false, source: 'indicator'});
+          {prev: 'one', current: 'two', direction: 'start', paused: false, source: 'indicator'});
       expect(onSlidSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -1041,7 +1041,7 @@ if (isBrowserVisible('ngb-carousel animations')) {
         expect(slideTwo.className).toBe('carousel-item');
         expect(slideThree.className).toBe('carousel-item');
 
-        expect(payload).toEqual({prev: 'two', current: 'one', direction: 'right', paused: false, source: 'indicator'});
+        expect(payload).toEqual({prev: 'two', current: 'one', direction: 'end', paused: false, source: 'indicator'});
         expect(onSlidSpy).toHaveBeenCalledTimes(1);
 
         done();
@@ -1053,16 +1053,16 @@ if (isBrowserVisible('ngb-carousel animations')) {
       indicators[1].click();
       fixture.detectChanges();
 
-      expect(slideOne.className).toBe('carousel-item active carousel-item-left');
-      expect(slideTwo.className).toBe('carousel-item carousel-item-next carousel-item-left');
+      expect(slideOne.className).toBe('carousel-item active carousel-item-start');
+      expect(slideTwo.className).toBe('carousel-item carousel-item-next carousel-item-start');
       expect(slideThree.className).toBe('carousel-item');
 
       // Reverse only possible when clicking on previous one
       indicators[2].click();
       fixture.detectChanges();
 
-      expect(slideOne.className).toBe('carousel-item active carousel-item-left');
-      expect(slideTwo.className).toBe('carousel-item carousel-item-next carousel-item-left');
+      expect(slideOne.className).toBe('carousel-item active carousel-item-start');
+      expect(slideTwo.className).toBe('carousel-item carousel-item-next carousel-item-start');
       expect(slideThree.className).toBe('carousel-item');
 
       // Reverse
@@ -1112,9 +1112,9 @@ if (isBrowserVisible('ngb-carousel animations')) {
       expect(slideThree.className).toBe('carousel-item');
 
       expect(onSlidSpy.calls.allArgs()).toEqual([
-        [{prev: 'one', current: 'two', direction: 'left', paused: false, source: 'indicator'}],
-        [{prev: 'two', current: 'three', direction: 'left', paused: false, source: 'indicator'}],
-        [{prev: 'three', current: 'one', direction: 'right', paused: false, source: 'indicator'}],
+        [{prev: 'one', current: 'two', direction: 'start', paused: false, source: 'indicator'}],
+        [{prev: 'two', current: 'three', direction: 'start', paused: false, source: 'indicator'}],
+        [{prev: 'three', current: 'one', direction: 'end', paused: false, source: 'indicator'}],
       ]);
 
       expect(onSlidSpy).toHaveBeenCalledTimes(3);

--- a/src/carousel/carousel.ts
+++ b/src/carousel/carousel.ts
@@ -329,14 +329,14 @@ export class NgbCarousel implements AfterContentChecked,
    * Navigates to the previous slide.
    */
   prev(source?: NgbSlideEventSource) {
-    this._cycleToSelected(this._getPrevSlide(this.activeId), NgbSlideEventDirection.RIGHT, source);
+    this._cycleToSelected(this._getPrevSlide(this.activeId), NgbSlideEventDirection.END, source);
   }
 
   /**
    * Navigates to the next slide.
    */
   next(source?: NgbSlideEventSource) {
-    this._cycleToSelected(this._getNextSlide(this.activeId), NgbSlideEventDirection.LEFT, source);
+    this._cycleToSelected(this._getNextSlide(this.activeId), NgbSlideEventDirection.START, source);
   }
 
   /**
@@ -345,7 +345,7 @@ export class NgbCarousel implements AfterContentChecked,
   pause() { this._pause$.next(true); }
 
   /**
-   * Restarts cycling through the slides from left to right.
+   * Restarts cycling through the slides from start to end.
    */
   cycle() { this._pause$.next(false); }
 
@@ -405,7 +405,7 @@ export class NgbCarousel implements AfterContentChecked,
     const currentActiveSlideIdx = this._getSlideIdxById(currentActiveSlideId);
     const nextActiveSlideIdx = this._getSlideIdxById(nextActiveSlideId);
 
-    return currentActiveSlideIdx > nextActiveSlideIdx ? NgbSlideEventDirection.RIGHT : NgbSlideEventDirection.LEFT;
+    return currentActiveSlideIdx > nextActiveSlideIdx ? NgbSlideEventDirection.END : NgbSlideEventDirection.START;
   }
 
   private _getSlideById(slideId: string): NgbSlide | null {
@@ -457,7 +457,7 @@ export interface NgbSlideEvent {
   /**
    * The slide event direction.
    *
-   * Possible values are `'left' | 'right'`.
+   * Possible values are `'start' | 'end'`.
    */
   direction: NgbSlideEventDirection;
 
@@ -492,7 +492,7 @@ export interface NgbSingleSlideEvent {
   /**
    * The slide event direction.
    *
-   * Possible values are `'left' | 'right'`.
+   * Possible values are `'start' | 'end'`.
    */
   direction: NgbSlideEventDirection;
 

--- a/src/datepicker/datepicker-input-config.spec.ts
+++ b/src/datepicker/datepicker-input-config.spec.ts
@@ -7,7 +7,7 @@ describe('NgbInputDatepickerConfig', () => {
     expect(config.autoClose).toBe(true);
     expect(config.container).toBeUndefined();
     expect(config.positionTarget).toBeUndefined();
-    expect(config.placement).toEqual(['bottom-left', 'bottom-right', 'top-left', 'top-right']);
+    expect(config.placement).toEqual(['bottom-start', 'bottom-end', 'top-start', 'top-end']);
     expect(config.restoreFocus).toBe(true);
   });
 });

--- a/src/datepicker/datepicker-input-config.ts
+++ b/src/datepicker/datepicker-input-config.ts
@@ -16,6 +16,6 @@ export class NgbInputDatepickerConfig extends NgbDatepickerConfig {
   autoClose: boolean | 'inside' | 'outside' = true;
   container: null | 'body';
   positionTarget: string | HTMLElement;
-  placement: PlacementArray = ['bottom-left', 'bottom-right', 'top-left', 'top-right'];
+  placement: PlacementArray = ['bottom-start', 'bottom-end', 'top-start', 'top-end'];
   restoreFocus: true | HTMLElement | string = true;
 }

--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -28,7 +28,7 @@ function customizeConfig(config: NgbInputDatepickerConfig) {
   config.autoClose = 'outside';
   config.container = 'body';
   config.positionTarget = 'positionTarget';
-  config.placement = ['bottom-left', 'top-right'];
+  config.placement = ['bottom-start', 'top-end'];
 }
 
 describe('NgbInputDatepicker', () => {

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -173,9 +173,9 @@ export class NgbInputDatepicker implements OnChanges,
   /**
    * The preferred placement of the datepicker popup.
    *
-   * Possible values are `"top"`, `"top-left"`, `"top-right"`, `"bottom"`, `"bottom-left"`,
-   * `"bottom-right"`, `"left"`, `"left-top"`, `"left-bottom"`, `"right"`, `"right-top"`,
-   * `"right-bottom"`
+   * Possible values are `"top"`, `"top-start"`, `"top-end"`, `"bottom"`, `"bottom-start"`,
+   * `"bottom-end"`, `"start"`, `"start-top"`, `"start-bottom"`, `"end"`, `"end-top"`,
+   * `"end-bottom"`
    *
    * Accepts an array of strings or a string with space separated possible values.
    *

--- a/src/dropdown/dropdown-config.spec.ts
+++ b/src/dropdown/dropdown-config.spec.ts
@@ -4,7 +4,7 @@ describe('ngb-dropdown-config', () => {
   it('should have sensible default values', () => {
     const config = new NgbDropdownConfig();
 
-    expect(config.placement).toEqual(['bottom-left', 'bottom-right', 'top-left', 'top-right']);
+    expect(config.placement).toEqual(['bottom-start', 'bottom-end', 'top-start', 'top-end']);
     expect(config.autoClose).toBe(true);
   });
 

--- a/src/dropdown/dropdown-config.ts
+++ b/src/dropdown/dropdown-config.ts
@@ -10,6 +10,6 @@ import {PlacementArray} from '../util/positioning';
 @Injectable({providedIn: 'root'})
 export class NgbDropdownConfig {
   autoClose: boolean | 'outside' | 'inside' = true;
-  placement: PlacementArray = ['bottom-left', 'bottom-right', 'top-left', 'top-right'];
+  placement: PlacementArray = ['bottom-start', 'bottom-end', 'top-start', 'top-end'];
   container: null | 'body';
 }

--- a/src/dropdown/dropdown.spec.ts
+++ b/src/dropdown/dropdown.spec.ts
@@ -338,7 +338,7 @@ describe('ngb-dropdown-toggle', () => {
 
   it(`should second placement if the first one doesn't fit`, () => {
     const html = `
-      <div ngbDropdown placement="left-top right-top">
+      <div ngbDropdown placement="start-top end-top">
           <button ngbDropdownToggle>
             <span class="toggle">Toggle dropdown</span>
           </button>

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -161,13 +161,13 @@ export class NgbDropdown implements AfterContentInit, OnDestroy {
   /**
    * The preferred placement of the dropdown.
    *
-   * Possible values are `"top"`, `"top-left"`, `"top-right"`, `"bottom"`, `"bottom-left"`,
-   * `"bottom-right"`, `"left"`, `"left-top"`, `"left-bottom"`, `"right"`, `"right-top"`,
-   * `"right-bottom"`
+   * Possible values are `"top"`, `"top-start"`, `"top-end"`, `"bottom"`, `"bottom-start"`,
+   * `"bottom-end"`, `"start"`, `"start-top"`, `"start-bottom"`, `"end"`, `"end-top"`,
+   * `"end-bottom"`
    *
    * Accepts an array of strings or a string with space separated possible values.
    *
-   * The default order of preference is `"bottom-left bottom-right top-left top-right"`
+   * The default order of preference is `"bottom-start bottom-end top-start top-end"`
    *
    * Please see the [positioning overview](#/positioning) for more details.
    */

--- a/src/popover/popover.scss
+++ b/src/popover/popover.scss
@@ -2,36 +2,36 @@
 $arrow-size: 1rem;
 
 ngb-popover-window {
-  &.bs-popover-top > .arrow,
-  &.bs-popover-bottom > .arrow {
+  &.bs-popover-top > .popover-arrow,
+  &.bs-popover-bottom > .popover-arrow {
     left: 50%;
     margin-left: -$arrow-size / 2;
   }
 
-  &.bs-popover-top-left > .arrow,
-  &.bs-popover-bottom-left > .arrow {
+  &.bs-popover-top-start > .popover-arrow,
+  &.bs-popover-bottom-start > .popover-arrow {
     left: 2em;
   }
 
-  &.bs-popover-top-right > .arrow,
-  &.bs-popover-bottom-right > .arrow {
+  &.bs-popover-top-end > .popover-arrow,
+  &.bs-popover-bottom-end > .popover-arrow {
     left: auto;
     right: 2em;
   }
 
-  &.bs-popover-left > .arrow,
-  &.bs-popover-right > .arrow {
+  &.bs-popover-start > .popover-arrow,
+  &.bs-popover-end > .popover-arrow {
     top: 50%;
     margin-top: -$arrow-size / 2;
   }
 
-  &.bs-popover-left-top > .arrow,
-  &.bs-popover-right-top > .arrow {
+  &.bs-popover-start-top > .popover-arrow,
+  &.bs-popover-end-top > .popover-arrow {
     top: 0.7em;
   }
 
-  &.bs-popover-left-bottom > .arrow,
-  &.bs-popover-right-bottom > .arrow {
+  &.bs-popover-start-bottom > .popover-arrow,
+  &.bs-popover-end-bottom > .popover-arrow {
     top: auto;
     bottom: 0.7em;
   }

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -391,7 +391,7 @@ describe('ngb-popover', () => {
   describe('positioning', () => {
 
     it('should use requested position', () => {
-      const fixture = createTestComponent(`<div ngbPopover="Great tip!" placement="left"></div>`);
+      const fixture = createTestComponent(`<div ngbPopover="Great tip!" placement="start"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
       triggerEvent(directive, 'click');
@@ -399,12 +399,12 @@ describe('ngb-popover', () => {
       const windowEl = getWindow(fixture.nativeElement);
 
       expect(windowEl).toHaveCssClass('popover');
-      expect(windowEl).toHaveCssClass('bs-popover-left');
+      expect(windowEl).toHaveCssClass('bs-popover-start');
       expect(windowEl.textContent.trim()).toBe('Great tip!');
     });
 
     it('should properly position popovers when a component is using the OnPush strategy', () => {
-      const fixture = createOnPushTestComponent(`<div ngbPopover="Great tip!" placement="left"></div>`);
+      const fixture = createOnPushTestComponent(`<div ngbPopover="Great tip!" placement="start"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
       triggerEvent(directive, 'click');
@@ -412,12 +412,12 @@ describe('ngb-popover', () => {
       const windowEl = getWindow(fixture.nativeElement);
 
       expect(windowEl).toHaveCssClass('popover');
-      expect(windowEl).toHaveCssClass('bs-popover-left');
+      expect(windowEl).toHaveCssClass('bs-popover-start');
       expect(windowEl.textContent.trim()).toBe('Great tip!');
     });
 
     it('should have proper arrow placement', () => {
-      const fixture = createTestComponent(`<div ngbPopover="Great tip!" placement="right-top"></div>`);
+      const fixture = createTestComponent(`<div ngbPopover="Great tip!" placement="end-top"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
       triggerEvent(directive, 'click');
@@ -425,14 +425,14 @@ describe('ngb-popover', () => {
       const windowEl = getWindow(fixture.nativeElement);
 
       expect(windowEl).toHaveCssClass('popover');
-      expect(windowEl).toHaveCssClass('bs-popover-right');
-      expect(windowEl).toHaveCssClass('bs-popover-right-top');
+      expect(windowEl).toHaveCssClass('bs-popover-end');
+      expect(windowEl).toHaveCssClass('bs-popover-end-top');
       expect(windowEl.textContent.trim()).toBe('Great tip!');
     });
 
     it('should accept placement in array (second value of the array should be applied)', () => {
       const fixture = createTestComponent(
-          `<div ngbPopover="Great tip!" [placement]="['left-top','top-left']" style="margin-top: 100px;"></div>`);
+          `<div ngbPopover="Great tip!" [placement]="['start-top','top-start']" style="margin-top: 100px;"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
       triggerEvent(directive, 'click');
@@ -441,13 +441,13 @@ describe('ngb-popover', () => {
 
       expect(windowEl).toHaveCssClass('popover');
       expect(windowEl).toHaveCssClass('bs-popover-top');
-      expect(windowEl).toHaveCssClass('bs-popover-top-left');
+      expect(windowEl).toHaveCssClass('bs-popover-top-start');
       expect(windowEl.textContent.trim()).toBe('Great tip!');
     });
 
     it('should accept placement with space separated values (second value should be applied)', () => {
       const fixture = createTestComponent(
-          `<div ngbPopover="Great tip!" placement="left-top top-left" style="margin-top: 100px;"></div>`);
+          `<div ngbPopover="Great tip!" placement="start-top top-start" style="margin-top: 100px;"></div>`);
       const directive = fixture.debugElement.query(By.directive(NgbPopover));
 
       triggerEvent(directive, 'click');
@@ -456,7 +456,7 @@ describe('ngb-popover', () => {
 
       expect(windowEl).toHaveCssClass('popover');
       expect(windowEl).toHaveCssClass('bs-popover-top');
-      expect(windowEl).toHaveCssClass('bs-popover-top-left');
+      expect(windowEl).toHaveCssClass('bs-popover-top-start');
       expect(windowEl.textContent.trim()).toBe('Great tip!');
     });
 

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -44,7 +44,7 @@ let nextId = 0;
     '[id]': 'id'
   },
   template: `
-    <div class="arrow"></div>
+    <div class="popover-arrow"></div>
     <h3 class="popover-header" *ngIf="title">
       <ng-template #simpleTitle>{{title}}</ng-template>
       <ng-template [ngTemplateOutlet]="isTitleTemplate() ? $any(title) : simpleTitle" [ngTemplateOutletContext]="context"></ng-template>
@@ -106,9 +106,9 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
   /**
    * The preferred placement of the popover.
    *
-   * Possible values are `"top"`, `"top-left"`, `"top-right"`, `"bottom"`, `"bottom-left"`,
-   * `"bottom-right"`, `"left"`, `"left-top"`, `"left-bottom"`, `"right"`, `"right-top"`,
-   * `"right-bottom"`
+   * Possible values are `"top"`, `"top-start"`, `"top-end"`, `"bottom"`, `"bottom-start"`,
+   * `"bottom-end"`, `"start"`, `"start-top"`, `"start-bottom"`, `"end"`, `"end-top"`,
+   * `"end-bottom"`
    *
    * Accepts an array of strings or a string with space separated possible values.
    *

--- a/src/tooltip/tooltip.scss
+++ b/src/tooltip/tooltip.scss
@@ -2,34 +2,34 @@
 $arrow-size: 0.8rem;
 
 ngb-tooltip-window {
-  &.bs-tooltip-top .arrow,
-  &.bs-tooltip-bottom .arrow {
+  &.bs-tooltip-top .tooltip-arrow,
+  &.bs-tooltip-bottom .tooltip-arrow {
     left: calc(50% - #{$arrow-size / 2});
   }
 
-  &.bs-tooltip-top-left .arrow,
-  &.bs-tooltip-bottom-left .arrow {
+  &.bs-tooltip-top-start .tooltip-arrow,
+  &.bs-tooltip-bottom-start .tooltip-arrow {
     left: 1em;
   }
 
-  &.bs-tooltip-top-right .arrow,
-  &.bs-tooltip-bottom-right .arrow {
+  &.bs-tooltip-top-end .tooltip-arrow,
+  &.bs-tooltip-bottom-end .tooltip-arrow {
     left: auto;
     right: 0.8rem;
   }
 
-  &.bs-tooltip-left .arrow,
-  &.bs-tooltip-right .arrow {
+  &.bs-tooltip-start .tooltip-arrow,
+  &.bs-tooltip-end .tooltip-arrow {
     top: calc(50% - #{$arrow-size / 2});
   }
 
-  &.bs-tooltip-left-top .arrow,
-  &.bs-tooltip-right-top .arrow {
+  &.bs-tooltip-start-top .tooltip-arrow,
+  &.bs-tooltip-end-top .tooltip-arrow {
     top: 0.4rem;
   }
 
-  &.bs-tooltip-left-bottom .arrow,
-  &.bs-tooltip-right-bottom .arrow {
+  &.bs-tooltip-start-bottom .tooltip-arrow,
+  &.bs-tooltip-end-bottom .tooltip-arrow {
     top: auto;
     bottom: 0.4rem;
   }

--- a/src/tooltip/tooltip.spec.ts
+++ b/src/tooltip/tooltip.spec.ts
@@ -287,7 +287,7 @@ describe('ngb-tooltip', () => {
     describe('positioning', () => {
 
       it('should use requested position', () => {
-        const fixture = createTestComponent(`<div ngbTooltip="Great tip!" placement="left"></div>`);
+        const fixture = createTestComponent(`<div ngbTooltip="Great tip!" placement="start"></div>`);
         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
         triggerEvent(directive, 'mouseenter');
@@ -295,12 +295,12 @@ describe('ngb-tooltip', () => {
         const windowEl = getWindow(fixture.nativeElement);
 
         expect(windowEl).toHaveCssClass('tooltip');
-        expect(windowEl).toHaveCssClass('bs-tooltip-left');
+        expect(windowEl).toHaveCssClass('bs-tooltip-start');
         expect(windowEl.textContent.trim()).toBe('Great tip!');
       });
 
       it('should properly position tooltips when a component is using the OnPush strategy', () => {
-        const fixture = createOnPushTestComponent(`<div ngbTooltip="Great tip!" placement="left"></div>`);
+        const fixture = createOnPushTestComponent(`<div ngbTooltip="Great tip!" placement="start"></div>`);
         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
         triggerEvent(directive, 'mouseenter');
@@ -308,12 +308,12 @@ describe('ngb-tooltip', () => {
         const windowEl = getWindow(fixture.nativeElement);
 
         expect(windowEl).toHaveCssClass('tooltip');
-        expect(windowEl).toHaveCssClass('bs-tooltip-left');
+        expect(windowEl).toHaveCssClass('bs-tooltip-start');
         expect(windowEl.textContent.trim()).toBe('Great tip!');
       });
 
       it('should have proper arrow placement', () => {
-        const fixture = createTestComponent(`<div ngbTooltip="Great tip!" placement="right-top"></div>`);
+        const fixture = createTestComponent(`<div ngbTooltip="Great tip!" placement="end-top"></div>`);
         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
         triggerEvent(directive, 'mouseenter');
@@ -321,14 +321,14 @@ describe('ngb-tooltip', () => {
         const windowEl = getWindow(fixture.nativeElement);
 
         expect(windowEl).toHaveCssClass('tooltip');
-        expect(windowEl).toHaveCssClass('bs-tooltip-right');
-        expect(windowEl).toHaveCssClass('bs-tooltip-right-top');
+        expect(windowEl).toHaveCssClass('bs-tooltip-end');
+        expect(windowEl).toHaveCssClass('bs-tooltip-end-top');
         expect(windowEl.textContent.trim()).toBe('Great tip!');
       });
 
       it('should accept placement in array (second value of the array should be applied)', () => {
         const fixture = createTestComponent(
-            `<div ngbTooltip="Great tip!" [placement]="['left-top','top-left']" style="margin-top: 100px;"></div>`);
+            `<div ngbTooltip="Great tip!" [placement]="['start-top','top-start']" style="margin-top: 100px;"></div>`);
         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
         triggerEvent(directive, 'mouseenter');
@@ -337,13 +337,13 @@ describe('ngb-tooltip', () => {
 
         expect(windowEl).toHaveCssClass('tooltip');
         expect(windowEl).toHaveCssClass('bs-tooltip-top');
-        expect(windowEl).toHaveCssClass('bs-tooltip-top-left');
+        expect(windowEl).toHaveCssClass('bs-tooltip-top-start');
         expect(windowEl.textContent.trim()).toBe('Great tip!');
       });
 
       it('should accept placement with space separated values (second value should be applied)', () => {
         const fixture = createTestComponent(
-            `<div ngbTooltip="Great tip!" placement="left-top top-left" style="margin-top: 100px;"></div>`);
+            `<div ngbTooltip="Great tip!" placement="start-top top-start" style="margin-top: 100px;"></div>`);
         const directive = fixture.debugElement.query(By.directive(NgbTooltip));
 
         triggerEvent(directive, 'mouseenter');
@@ -352,7 +352,7 @@ describe('ngb-tooltip', () => {
 
         expect(windowEl).toHaveCssClass('tooltip');
         expect(windowEl).toHaveCssClass('bs-tooltip-top');
-        expect(windowEl).toHaveCssClass('bs-tooltip-top-left');
+        expect(windowEl).toHaveCssClass('bs-tooltip-top-start');
         expect(windowEl.textContent.trim()).toBe('Great tip!');
       });
 

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -43,7 +43,7 @@ let nextId = 0;
     'role': 'tooltip',
     '[id]': 'id'
   },
-  template: `<div class="arrow"></div><div class="tooltip-inner"><ng-content></ng-content></div>`,
+  template: `<div class="tooltip-arrow"></div><div class="tooltip-inner"><ng-content></ng-content></div>`,
   styleUrls: ['./tooltip.scss']
 })
 export class NgbTooltipWindow {
@@ -82,9 +82,9 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
   /**
    * The preferred placement of the tooltip.
    *
-   * Possible values are `"top"`, `"top-left"`, `"top-right"`, `"bottom"`, `"bottom-left"`,
-   * `"bottom-right"`, `"left"`, `"left-top"`, `"left-bottom"`, `"right"`, `"right-top"`,
-   * `"right-bottom"`
+   * Possible values are `"top"`, `"top-start"`, `"top-end"`, `"bottom"`, `"bottom-start"`,
+   * `"bottom-end"`, `"start"`, `"start-top"`, `"start-bottom"`, `"end"`, `"end-top"`,
+   * `"end-bottom"`
    *
    * Accepts an array of strings or a string with space separated possible values.
    *

--- a/src/typeahead/typeahead-config.ts
+++ b/src/typeahead/typeahead-config.ts
@@ -13,5 +13,5 @@ export class NgbTypeaheadConfig {
   editable = true;
   focusFirst = true;
   showHint = false;
-  placement: PlacementArray = ['bottom-left', 'bottom-right', 'top-left', 'top-right'];
+  placement: PlacementArray = ['bottom-start', 'bottom-end', 'top-start', 'top-end'];
 }

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -156,17 +156,17 @@ export class NgbTypeahead implements ControlValueAccessor,
   /**
    * The preferred placement of the typeahead.
    *
-   * Possible values are `"top"`, `"top-left"`, `"top-right"`, `"bottom"`, `"bottom-left"`,
-   * `"bottom-right"`, `"left"`, `"left-top"`, `"left-bottom"`, `"right"`, `"right-top"`,
-   * `"right-bottom"`
+   * Possible values are `"top"`, `"top-start"`, `"top-end"`, `"bottom"`, `"bottom-start"`,
+   * `"bottom-end"`, `"start"`, `"start-top"`, `"start-bottom"`, `"end"`, `"end-top"`,
+   * `"end-bottom"`
    *
    * Accepts an array of strings or a string with space separated possible values.
    *
-   * The default order of preference is `"bottom-left bottom-right top-left top-right"`
+   * The default order of preference is `"bottom-start bottom-end top-start top-end"`
    *
    * Please see the [positioning overview](#/positioning) for more details.
    */
-  @Input() placement: PlacementArray = 'bottom-left';
+  @Input() placement: PlacementArray = 'bottom-start';
 
   /**
    * An event emitted right before an item is selected from the result list.

--- a/src/util/positioning.spec.ts
+++ b/src/util/positioning.spec.ts
@@ -118,9 +118,9 @@ describe('Positioning', () => {
     element.removeChild(childElement);
   });
 
-  it('should position the element top-left', () => {
+  it('should position the element top-start', () => {
 
-    let isInViewport = positioning.positionElements(element, targetElement, 'top-left');
+    let isInViewport = positioning.positionElements(element, targetElement, 'top-start');
 
     expect(isInViewport).toBe(true);
     checkPosition(targetElement, 40, 150);
@@ -133,15 +133,15 @@ describe('Positioning', () => {
     checkPosition(targetElement, 40, 250);
   });
 
-  it('should position the element top-right', () => {
-    let isInViewport = positioning.positionElements(element, targetElement, 'top-right');
+  it('should position the element top-end', () => {
+    let isInViewport = positioning.positionElements(element, targetElement, 'top-end');
 
     expect(isInViewport).toBe(true);
     checkPosition(targetElement, 40, 350);
   });
 
-  it('should position the element bottom-left', () => {
-    let isInViewport = positioning.positionElements(element, targetElement, 'bottom-left');
+  it('should position the element bottom-start', () => {
+    let isInViewport = positioning.positionElements(element, targetElement, 'bottom-start');
 
     expect(isInViewport).toBe(true);
     checkPosition(targetElement, 300, 150);
@@ -154,50 +154,50 @@ describe('Positioning', () => {
     checkPosition(targetElement, 300, 250);
   });
 
-  it('should position the element bottom-right', () => {
-    let isInViewport = positioning.positionElements(element, targetElement, 'bottom-right');
+  it('should position the element bottom-end', () => {
+    let isInViewport = positioning.positionElements(element, targetElement, 'bottom-end');
 
     expect(isInViewport).toBe(true);
     checkPosition(targetElement, 300, 350);
   });
 
-  it('should position the element left-top', () => {
-    let isInViewport = positioning.positionElements(element, targetElement, 'left-top');
+  it('should position the element start-top', () => {
+    let isInViewport = positioning.positionElements(element, targetElement, 'start-top');
 
     expect(isInViewport).toBe(true);
     checkPosition(targetElement, 100, 30);
   });
 
-  it('should position the element left-center', () => {
-    let isInViewport = positioning.positionElements(element, targetElement, 'left');
+  it('should position the element start-center', () => {
+    let isInViewport = positioning.positionElements(element, targetElement, 'start');
 
     expect(isInViewport).toBe(true);
     checkPosition(targetElement, 175, 30);
   });
 
-  it('should position the element left-bottom', () => {
-    let isInViewport = positioning.positionElements(element, targetElement, 'left-bottom');
+  it('should position the element start-bottom', () => {
+    let isInViewport = positioning.positionElements(element, targetElement, 'start-bottom');
 
     expect(isInViewport).toBe(true);
     checkPosition(targetElement, 250, 30);
   });
 
-  it('should position the element right-top', () => {
-    let isInViewport = positioning.positionElements(element, targetElement, 'right-top');
+  it('should position the element end-top', () => {
+    let isInViewport = positioning.positionElements(element, targetElement, 'end-top');
 
     expect(isInViewport).toBe(true);
     checkPosition(targetElement, 100, 450);
   });
 
-  it('should position the element right-center', () => {
-    let isInViewport = positioning.positionElements(element, targetElement, 'right');
+  it('should position the element end-center', () => {
+    let isInViewport = positioning.positionElements(element, targetElement, 'end');
 
     expect(isInViewport).toBe(true);
     checkPosition(targetElement, 175, 450);
   });
 
-  it('should position the element right-bottom', () => {
-    let isInViewport = positioning.positionElements(element, targetElement, 'right-bottom');
+  it('should position the element end-bottom', () => {
+    let isInViewport = positioning.positionElements(element, targetElement, 'end-bottom');
 
     expect(isInViewport).toBe(true);
     checkPosition(targetElement, 250, 450);

--- a/src/util/positioning.ts
+++ b/src/util/positioning.ts
@@ -114,10 +114,10 @@ export class Positioning {
       case 'bottom':
         topPosition = (hostElPosition.top + hostElPosition.height);
         break;
-      case 'left':
+      case 'start':
         leftPosition = (hostElPosition.left - (targetElement.offsetWidth + marginLeft + marginRight));
         break;
-      case 'right':
+      case 'end':
         leftPosition = (hostElPosition.left + hostElPosition.width);
         break;
     }
@@ -129,10 +129,10 @@ export class Positioning {
       case 'bottom':
         topPosition = hostElPosition.top + hostElPosition.height - targetElement.offsetHeight;
         break;
-      case 'left':
+      case 'start':
         leftPosition = hostElPosition.left;
         break;
-      case 'right':
+      case 'end':
         leftPosition = hostElPosition.left + hostElPosition.width - targetElement.offsetWidth;
         break;
       case 'center':
@@ -166,11 +166,11 @@ export const positionService = new Positioning();
  * Accept the placement array and applies the appropriate placement dependent on the viewport.
  * Returns the applied placement.
  * In case of auto placement, placements are selected in order
- *   'top', 'bottom', 'left', 'right',
- *   'top-left', 'top-right',
- *   'bottom-left', 'bottom-right',
- *   'left-top', 'left-bottom',
- *   'right-top', 'right-bottom'.
+ *   'top', 'bottom', 'start', 'end',
+ *   'top-start', 'top-end',
+ *   'bottom-start', 'bottom-end',
+ *   'start-top', 'start-bottom',
+ *   'end-top', 'end-bottom'.
  * */
 export function positionElements(
     hostElement: HTMLElement, targetElement: HTMLElement, placement: string | Placement | PlacementArray,
@@ -180,8 +180,8 @@ export function positionElements(
       Array.isArray(placement) ? placement : placement.split(placementSeparator) as Array<Placement>;
 
   const allowedPlacements = [
-    'top', 'bottom', 'left', 'right', 'top-left', 'top-right', 'bottom-left', 'bottom-right', 'left-top', 'left-bottom',
-    'right-top', 'right-bottom'
+    'top', 'bottom', 'start', 'end', 'top-start', 'top-end', 'bottom-start', 'bottom-end', 'start-top', 'start-bottom',
+    'end-top', 'end-bottom'
   ];
 
   const classList = targetElement.classList;
@@ -249,7 +249,7 @@ export function positionElements(
   return testPlacement;
 }
 
-export type Placement = 'auto' | 'top' | 'bottom' | 'left' | 'right' | 'top-left' | 'top-right' | 'bottom-left' |
-    'bottom-right' | 'left-top' | 'left-bottom' | 'right-top' | 'right-bottom';
+export type Placement = 'auto' | 'top' | 'bottom' | 'start' | 'end' | 'top-start' | 'top-end' | 'bottom-start' |
+    'bottom-end' | 'start-top' | 'start-bottom' | 'end-top' | 'end-bottom';
 
 export type PlacementArray = Placement | Array<Placement>| string;


### PR DESCRIPTION
Fixes the positioning in BS5 (without popper). 

Related to the Bootstrap migration section : https://getbootstrap.com/docs/5.0/migration/#components

  - Positioning classes have been renamed (mainly left and right -> start and end)
  - Arrow classes have been renamed for [popover and tooltip](https://getbootstrap.com/docs/5.0/migration/#popovers-1), to solve some positioning issues
  - Temporary missing classes have been added in demo\src\style\app.scss, as popper is not used yet in ngBootstrap
  - e2e tests will not pass as there other missing classes, impacting the layout

Breaking changes:

  - NgbSlideEventDirection : LEFT and RIGHT have been rename to START and END
