### PR TITLE
fix(rating): avoid inconsistent disabling

### DIFF
--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -439,31 +439,84 @@ describe('ngb-rating', () => {
 
     it('updates aria-disabled when readonly', () => {
       const fixture = createTestComponent('<ngb-rating></ngb-rating>');
-      let ratingEl = fixture.debugElement.query(By.directive(NgbRating));
+      const ratingEl = fixture.debugElement.query(By.directive(NgbRating));
+      const ratingComp = <NgbRating>ratingEl.componentInstance;
+
       fixture.detectChanges();
       expect(ratingEl.attributes['aria-disabled'] == null).toBeTruthy();
 
-      let ratingComp = <NgbRating>ratingEl.componentInstance;
       ratingComp.readonly = true;
+      fixture.detectChanges();
+      expect(ratingEl.attributes['aria-disabled']).toBe('true');
+    });
+
+    it('updates aria-disabled when disabled', () => {
+      const fixture = createTestComponent('<ngb-rating></ngb-rating>');
+      const ratingEl = fixture.debugElement.query(By.directive(NgbRating));
+      const ratingComp = <NgbRating>ratingEl.componentInstance;
+
+      fixture.detectChanges();
+      expect(ratingEl.attributes['aria-disabled'] == null).toBeTruthy();
+
+      ratingComp.setDisabledState(true);
       fixture.detectChanges();
       expect(ratingEl.attributes['aria-disabled']).toBe('true');
     });
   });
 
-  it('should set tabindex to -1 when readonly', () => {
-    const fixture = createTestComponent('<ngb-rating [readonly]="true"></ngb-rating>');
-    let ratingEl = fixture.debugElement.query(By.directive(NgbRating));
+  describe('tabindex support', () => {
+    it('updates tabindex when readonly', () => {
+      const fixture = createTestComponent('<ngb-rating></ngb-rating>');
+      const ratingEl = fixture.debugElement.query(By.directive(NgbRating));
+      const ratingComp = <NgbRating>ratingEl.componentInstance;
 
-    fixture.detectChanges();
-    expect(ratingEl.nativeElement.getAttribute('tabindex')).toEqual('-1');
-  });
+      fixture.detectChanges();
+      expect(ratingEl.nativeElement.getAttribute('tabindex')).toEqual('0');
 
-  it('should set tabindex to 0 when not readonly', () => {
-    const fixture = createTestComponent('<ngb-rating></ngb-rating>');
-    let ratingEl = fixture.debugElement.query(By.directive(NgbRating));
+      ratingComp.readonly = true;
+      fixture.detectChanges();
+      expect(ratingEl.nativeElement.getAttribute('tabindex')).toEqual('-1');
+    });
 
-    fixture.detectChanges();
-    expect(ratingEl.nativeElement.getAttribute('tabindex')).toEqual('0');
+    it('updates tabindex when disabled', () => {
+      const fixture = createTestComponent('<ngb-rating></ngb-rating>');
+      const ratingEl = fixture.debugElement.query(By.directive(NgbRating));
+      const ratingComp = <NgbRating>ratingEl.componentInstance;
+
+      fixture.detectChanges();
+      expect(ratingEl.nativeElement.getAttribute('tabindex')).toEqual('0');
+
+      ratingComp.setDisabledState(true);
+      fixture.detectChanges();
+      expect(ratingEl.nativeElement.getAttribute('tabindex')).toEqual('-1');
+    });
+
+    it('should preserve tabindex for readonly component when disabled is false', () => {
+      const fixture = createTestComponent('<ngb-rating [readonly]="true"></ngb-rating>');
+      const ratingEl = fixture.debugElement.query(By.directive(NgbRating));
+      const ratingComp = <NgbRating>ratingEl.componentInstance;
+
+      fixture.detectChanges();
+      expect(ratingEl.nativeElement.getAttribute('tabindex')).toEqual('-1');
+
+      ratingComp.setDisabledState(false);
+      fixture.detectChanges();
+      expect(ratingEl.nativeElement.getAttribute('tabindex')).toEqual('-1');
+    });
+
+    it('should preserve tabindex for disabled component when readonly is false', () => {
+      const fixture = createTestComponent('<ngb-rating [readonly]="true"></ngb-rating>');
+      const ratingEl = fixture.debugElement.query(By.directive(NgbRating));
+      const ratingComp = <NgbRating>ratingEl.componentInstance;
+
+      ratingComp.setDisabledState(true);
+      fixture.detectChanges();
+      expect(ratingEl.nativeElement.getAttribute('tabindex')).toEqual('-1');
+
+      ratingComp.readonly = false;
+      fixture.detectChanges();
+      expect(ratingEl.nativeElement.getAttribute('tabindex')).toEqual('-1');
+    });
   });
 
   describe('keyboard support', () => {

--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -466,22 +466,6 @@ describe('ngb-rating', () => {
     expect(ratingEl.nativeElement.getAttribute('tabindex')).toEqual('0');
   });
 
-  it('should set disabled attribute when readonly', () => {
-    const fixture = createTestComponent('<ngb-rating [readonly]="true"></ngb-rating>');
-    let ratingEl = fixture.debugElement.query(By.directive(NgbRating));
-
-    fixture.detectChanges();
-    expect(ratingEl.nativeElement.getAttribute('disabled')).toBe('true');
-  });
-
-  it('should not set disabled attribute when not readonly', () => {
-    const fixture = createTestComponent('<ngb-rating></ngb-rating>');
-    let ratingEl = fixture.debugElement.query(By.directive(NgbRating));
-
-    fixture.detectChanges();
-    expect(ratingEl.nativeElement.getAttribute('disabled')).toBeNull();
-  });
-
   describe('keyboard support', () => {
 
     it('should handle arrow keys', () => {

--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -450,17 +450,36 @@ describe('ngb-rating', () => {
     });
   });
 
-  it('should set tabindex to -1 when disabled', () => {
+  it('should set tabindex to -1 when readonly', () => {
+    const fixture = createTestComponent('<ngb-rating [readonly]="true"></ngb-rating>');
+    let ratingEl = fixture.debugElement.query(By.directive(NgbRating));
+
+    fixture.detectChanges();
+    expect(ratingEl.nativeElement.getAttribute('tabindex')).toEqual('-1');
+  });
+
+  it('should set tabindex to 0 when not readonly', () => {
     const fixture = createTestComponent('<ngb-rating></ngb-rating>');
     let ratingEl = fixture.debugElement.query(By.directive(NgbRating));
-    let ratingComp = <NgbRating>ratingEl.componentInstance;
 
     fixture.detectChanges();
     expect(ratingEl.nativeElement.getAttribute('tabindex')).toEqual('0');
+  });
 
-    ratingComp.disabled = true;
+  it('should set disabled attribute when readonly', () => {
+    const fixture = createTestComponent('<ngb-rating [readonly]="true"></ngb-rating>');
+    let ratingEl = fixture.debugElement.query(By.directive(NgbRating));
+
     fixture.detectChanges();
-    expect(ratingEl.nativeElement.getAttribute('tabindex')).toEqual('-1');
+    expect(ratingEl.nativeElement.getAttribute('disabled')).toBe('true');
+  });
+
+  it('should not set disabled attribute when not readonly', () => {
+    const fixture = createTestComponent('<ngb-rating></ngb-rating>');
+    let ratingEl = fixture.debugElement.query(By.directive(NgbRating));
+
+    fixture.detectChanges();
+    expect(ratingEl.nativeElement.getAttribute('disabled')).toBeNull();
   });
 
   describe('keyboard support', () => {

--- a/src/rating/rating.ts
+++ b/src/rating/rating.ts
@@ -45,7 +45,6 @@ export interface StarTemplateContext {
     '[tabindex]': 'readonly ? -1 : 0',
     'role': 'slider',
     'aria-valuemin': '0',
-    '[attr.disabled]': 'readonly || null',
     '[attr.aria-valuemax]': 'max',
     '[attr.aria-valuenow]': 'nextRate',
     '[attr.aria-valuetext]': 'ariaValueText()',

--- a/src/rating/rating.ts
+++ b/src/rating/rating.ts
@@ -42,13 +42,13 @@ export interface StarTemplateContext {
   encapsulation: ViewEncapsulation.None,
   host: {
     'class': 'd-inline-flex',
-    '[tabindex]': 'readonly ? -1 : 0',
+    '[tabindex]': 'isInteractive() ? 0 : -1',
     'role': 'slider',
     'aria-valuemin': '0',
     '[attr.aria-valuemax]': 'max',
     '[attr.aria-valuenow]': 'nextRate',
     '[attr.aria-valuetext]': 'ariaValueText()',
-    '[attr.aria-disabled]': 'readonly ? true : null',
+    '[attr.aria-disabled]': '!isInteractive() || null',
     '(blur)': 'handleBlur()',
     '(keydown)': 'handleKeyDown($event)',
     '(mouseleave)': 'reset()'
@@ -67,6 +67,7 @@ export interface StarTemplateContext {
 })
 export class NgbRating implements ControlValueAccessor,
     OnInit, OnChanges {
+  private _disabled = false;
   contexts: StarTemplateContext[] = [];
   nextRate: number;
 
@@ -130,7 +131,7 @@ export class NgbRating implements ControlValueAccessor,
 
   ariaValueText() { return `${this.nextRate} out of ${this.max}`; }
 
-  isInteractive(): boolean { return !this.readonly; }
+  isInteractive(): boolean { return !this.readonly && !this._disabled; }
 
   enter(value: number): void {
     if (this.isInteractive()) {
@@ -192,7 +193,7 @@ export class NgbRating implements ControlValueAccessor,
     this._updateState(this.rate);
   }
 
-  setDisabledState(isDisabled: boolean) { this.readonly = isDisabled; }
+  setDisabledState(isDisabled: boolean) { this._disabled = isDisabled; }
 
   update(value: number, internalChange = true): void {
     const newRate = getValueInRange(value, this.max, 0);

--- a/src/rating/rating.ts
+++ b/src/rating/rating.ts
@@ -42,9 +42,10 @@ export interface StarTemplateContext {
   encapsulation: ViewEncapsulation.None,
   host: {
     'class': 'd-inline-flex',
-    '[tabindex]': 'disabled ? -1 : 0',
+    '[tabindex]': 'readonly ? -1 : 0',
     'role': 'slider',
     'aria-valuemin': '0',
+    '[attr.disabled]': 'readonly || null',
     '[attr.aria-valuemax]': 'max',
     '[attr.aria-valuenow]': 'nextRate',
     '[attr.aria-valuetext]': 'ariaValueText()',
@@ -68,7 +69,6 @@ export interface StarTemplateContext {
 export class NgbRating implements ControlValueAccessor,
     OnInit, OnChanges {
   contexts: StarTemplateContext[] = [];
-  disabled = false;
   nextRate: number;
 
 
@@ -131,7 +131,7 @@ export class NgbRating implements ControlValueAccessor,
 
   ariaValueText() { return `${this.nextRate} out of ${this.max}`; }
 
-  isInteractive(): boolean { return !this.readonly && !this.disabled; }
+  isInteractive(): boolean { return !this.readonly; }
 
   enter(value: number): void {
     if (this.isInteractive()) {
@@ -193,7 +193,7 @@ export class NgbRating implements ControlValueAccessor,
     this._updateState(this.rate);
   }
 
-  setDisabledState(isDisabled: boolean) { this.disabled = isDisabled; }
+  setDisabledState(isDisabled: boolean) { this.readonly = isDisabled; }
 
   update(value: number, internalChange = true): void {
     const newRate = getValueInRange(value, this.max, 0);


### PR DESCRIPTION
Hello! I've noticed that rating component has inconsistent disabling feature. It wasn't fully disabled. You can use tab for focusing readonly element. Also I reworked `disabled` property.

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
