### PR TITLE
Use production build for Playwright tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_script:
 
 script:
   - yarn ci && yarn scripts:test
-  - yarn global add codecov && codecov --disable=gcov -f coverage/lcov.info -F unit && codecov --disable=gcov -f coverage-e2e-chromium/lcov.info -F e2e-chromium && codecov --disable=gcov -f coverage-e2e-firefox/lcov.info -F e2e-firefox && codecov --disable=gcov -f coverage-e2e-webkit/lcov.info -F e2e-webkit
+  - yarn global add codecov && codecov --disable=gcov -f coverage/lcov.info -F unit && codecov --disable=gcov -f coverage-e2e/lcov.info -F e2e
   - ./scripts/sauce_connect_block.sh
   - yarn saucelabs
   - yarn saucelabs:ie

--- a/angular.json
+++ b/angular.json
@@ -207,8 +207,7 @@
                 }
               ],
               "optimization": true,
-              "outputHashing": "all",
-              "sourceMap": false,
+              "sourceMap": true,
               "namedChunks": false,
               "aot": true,
               "extractLicenses": true,

--- a/e2e-app/setup.pw-spec.ts
+++ b/e2e-app/setup.pw-spec.ts
@@ -12,29 +12,27 @@ beforeAll(async() => {
   }
 });
 
-afterAll(async() => {
-  try {
-    console.log('Retrieving coverage...');
-    const coverage: string = await page().evaluate('JSON.stringify(window.__coverage__);');
-    if (coverage) {
-      console.log(`Coverage retrieved (${coverage.length} bytes)`);
-      fs.mkdirSync(path.join(__dirname, '..', '.nyc_output'));
-      fs.writeFileSync(path.join(__dirname, '..', '.nyc_output', 'out.json'), coverage);
-      const NYC = require('nyc');
-      const nycInstance = new NYC({
-        cwd: path.join(__dirname, '..'),
-        reportDir: `coverage-e2e-${browserName}`,
-        reporter: ['lcov', 'json', 'text-summary']
-      });
-      nycInstance.report();
-      nycInstance.cleanup();
-      console.log('Coverage saved successfully!');
-    } else {
-      console.log('No coverage data!');
+if (browserName === 'chromium') {
+  afterAll(async() => {
+    try {
+      console.log('Retrieving coverage...');
+      const coverage: string = await page().evaluate('JSON.stringify(window.__coverage__);');
+      if (coverage) {
+        console.log(`Coverage retrieved (${coverage.length} bytes)`);
+        fs.mkdirSync(path.join(__dirname, '..', '.nyc_output'));
+        fs.writeFileSync(path.join(__dirname, '..', '.nyc_output', 'out.json'), coverage);
+        const NYC = require('nyc');
+        const nycInstance = new NYC(
+            {cwd: path.join(__dirname, '..'), reportDir: `coverage-e2e`, reporter: ['lcov', 'json', 'text-summary']});
+        nycInstance.report();
+        nycInstance.cleanup();
+        console.log('Coverage saved successfully!');
+      } else {
+        console.log('No coverage data!');
+      }
+    } catch (error) {
+      console.log('Error in onComplete:', error);
+      process.exit(1);
     }
-  } catch (error) {
-    console.log('Error in onComplete:', error);
-    process.exit(1);
-  }
-
-});
+  });
+}

--- a/e2e-app/src/app/tools.pw-po.ts
+++ b/e2e-app/src/app/tools.pw-po.ts
@@ -73,15 +73,14 @@ export const expectFocused = async(selector, message) => {
 let hasBeenLoaded = false;
 export const openUrl = async(url: string) => {
   const currentPage = page();
-  if (hasBeenLoaded) {
+  if (hasBeenLoaded && process.env.BROWSER !== 'webkit') {
     await currentPage.click(`#navigate-home`);
     await currentPage.waitForSelector('ng-component', {state: 'detached'});
     await currentPage.click(`#navigate-${url.replace('/', '-')}`);
     await currentPage.waitForSelector('ng-component');
   } else {
-    console.log('Go to page', `${baseUrl}/${url}`);
     await currentPage.goto(`${baseUrl}/${url}`);
-    await currentPage.waitForSelector('app-root');
+    await currentPage.waitForSelector('ng-component');
     hasBeenLoaded = true;
   }
 };

--- a/e2e-app/tsconfig.json
+++ b/e2e-app/tsconfig.json
@@ -22,5 +22,9 @@
   "exclude": [
     "src/**/*.po.ts",
     "src/**/*.e2e-spec.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "strictTemplates": false,
+    "fullTemplateTypeCheck": false
+  }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "playwright:firefox": "wait-on http://localhost:4200 && ts-node --project e2e-app/tsconfig.spec.json node_modules/jasmine/bin/jasmine --config=e2e-app/jasmine.json BROWSER=firefox",
     "playwright:webkit": "wait-on http://localhost:4200 && ts-node --project e2e-app/tsconfig.spec.json node_modules/jasmine/bin/jasmine --config=e2e-app/jasmine.json BROWSER=webkit",
     "e2e": "yarn e2e-app:lint && yarn e2e:playwright && yarn demo:e2e",
-    "e2e:playwright": "concurrently --success first --kill-others \"yarn e2e-app:serve\" \"yarn playwright && yarn playwright:firefox && yarn playwright:webkit\"",
+    "e2e:playwright": "concurrently --success first --kill-others \"yarn e2e-app:serve --prod\" \"yarn playwright && yarn playwright:firefox && yarn playwright:webkit\"",
     "demo": "yarn demo:docs && yarn demo:stackblitzes && yarn demo:serve",
     "demo:ie": "yarn demo -c ie",
     "ssr": "yarn ssr-app:lint && yarn ssr-app:build && yarn ssr-app:e2e",

--- a/playwright/controller.ts
+++ b/playwright/controller.ts
@@ -27,7 +27,7 @@ export class Playwright {
       this._context = await browserInstance.newContext(this._contextOptions);
 
       // Default timeout used to wait for selector/actions requiring timeout
-      this._context.setDefaultTimeout(2000);
+      this._context.setDefaultTimeout(60000);
     }
   }
 


### PR DESCRIPTION
- use `--prod` for e2e-app build when running e2e tests
- extract coverage only from chromium (no point in doing it for all browsers)
- reload the page properly between each test (fixes webkit issues)