### PR TITLE
Playwright waitForSelector refactoring

### DIFF
--- a/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.pw-spec.ts
+++ b/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.pw-spec.ts
@@ -18,8 +18,7 @@ describe('Datepicker Autoclose', () => {
     describe(`displayMonths = ${displayMonths}`, () => {
 
       beforeEach(async() => {
-        await openUrl('datepicker/autoclose');
-        expect(await test.page.innerText('h3')).toContain('Datepicker autoclose tests closed');
+        await openUrl('datepicker/autoclose', 'h3:text("Datepicker autoclose")');
         await selectDisplayMonths(displayMonths);
       });
 

--- a/e2e-app/src/app/datepicker/focus/datepicker-focus.pw-spec.ts
+++ b/e2e-app/src/app/datepicker/focus/datepicker-focus.pw-spec.ts
@@ -37,10 +37,7 @@ const disableDatepicker = async() => await test.page.click('#disable');
 
 describe('Datepicker', () => {
 
-  beforeEach(async() => {
-    await openUrl('datepicker/focus');
-    expect(await test.page.textContent('h3')).toBe('Datepicker focus tests');
-  });
+  beforeEach(async() => await openUrl('datepicker/focus', 'h3:text("Datepicker focus")'));
 
   it(`should not be present on the page initially`,
      async() => await test.page.waitForSelector(SELECTOR_DATEPICKER, {state: 'detached'}));

--- a/e2e-app/src/app/datepicker/focus/datepicker-focus.pw-spec.ts
+++ b/e2e-app/src/app/datepicker/focus/datepicker-focus.pw-spec.ts
@@ -159,7 +159,7 @@ describe('Datepicker', () => {
     await expectFocused(SELECTOR_NEXT_MONTH, `Next month arrow should be focused`);
 
     // make sure we changed month
-    expect(await test.page.waitForSelector(SELECTOR_DAY(firstDate), {state: 'detached'}));
+    await test.page.waitForSelector(SELECTOR_DAY(firstDate), {state: 'detached'});
   });
 
   it(`should change month on click and keep 'prev' arrow focused`, async() => {

--- a/e2e-app/src/app/datepicker/multiple/datepicker-multiple.component.html
+++ b/e2e-app/src/app/datepicker/multiple/datepicker-multiple.component.html
@@ -1,4 +1,4 @@
-<h3>Datepicker focus tests</h3>
+<h3>Datepicker multiple</h3>
 
 <form>
   <div>

--- a/e2e-app/src/app/datepicker/multiple/datepicker-multiple.pw-spec.ts
+++ b/e2e-app/src/app/datepicker/multiple/datepicker-multiple.pw-spec.ts
@@ -9,7 +9,7 @@ const expectActive = async(selector: string) => {
 
 describe('Datepicker multiple instances', () => {
 
-  beforeEach(async() => await openUrl('datepicker/multiple'));
+  beforeEach(async() => await openUrl('datepicker/multiple', 'h3:text("Datepicker multiple")'));
 
   it('the instance tapped should gain focus', async() => {
 

--- a/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.pw-spec.ts
+++ b/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.pw-spec.ts
@@ -20,10 +20,7 @@ const containers = [null, 'body'];
 containers.forEach((container) => {
   describe(`Dropdown Autoclose with container = ${container}`, () => {
 
-    beforeEach(async() => {
-      await openUrl('dropdown/autoclose');
-      expect(await test.page.innerText('h3')).toContain('Dropdown autoclose tests');
-    });
+    beforeEach(async() => await openUrl('dropdown/autoclose', 'h3:text("Dropdown autoclose")'));
 
     it(`should not close when right clicking`, async() => {
       await selectAutoClose('true');

--- a/e2e-app/src/app/dropdown/click/dropdown-click.component.ts
+++ b/e2e-app/src/app/dropdown/click/dropdown-click.component.ts
@@ -2,6 +2,7 @@ import {Component} from '@angular/core';
 
 @Component({
   template: `
+    <h3>Dropdown click tests</h3>
     <form>
       <div class="form-group form-inline">
         <input type="text" class="form-control mr-1" style="width: 100px" placeholder="before" id="before"/>

--- a/e2e-app/src/app/dropdown/click/dropdown-click.pw-spec.ts
+++ b/e2e-app/src/app/dropdown/click/dropdown-click.pw-spec.ts
@@ -16,7 +16,7 @@ const focusDropdownItem = async(index: number) => {
 
 describe(`Dropdown user (click) handler`, () => {
 
-  beforeEach(async() => await openUrl('dropdown/click'));
+  beforeEach(async() => await openUrl('dropdown/click', 'h3:text("Dropdown click")'));
 
   it(`should call user (click) handler on 'Enter'`, async() => {
     await focusDropdownItem(0);

--- a/e2e-app/src/app/dropdown/focus/dropdown-focus.pw-spec.ts
+++ b/e2e-app/src/app/dropdown/focus/dropdown-focus.pw-spec.ts
@@ -16,7 +16,7 @@ const selectWithItems = async(withItems: boolean) => await test.page.click(`#ite
 
 describe(`Dropdown focus`, () => {
 
-  beforeEach(async() => await openUrl('dropdown/focus'));
+  beforeEach(async() => await openUrl('dropdown/focus', 'h3:text("Dropdown focus")'));
 
   const containers = ['inline', 'body'];
   containers.forEach((container) => {

--- a/e2e-app/src/app/dropdown/position/dropdown-position.pw-spec.ts
+++ b/e2e-app/src/app/dropdown/position/dropdown-position.pw-spec.ts
@@ -33,7 +33,7 @@ const togglePlacement = async(placement: 'top-left' | 'bottom-left' | 'top-right
       await toggleContainer(null);
     };
 
-    beforeEach(async() => await openUrl('dropdown/position'));
+    beforeEach(async() => await openUrl('dropdown/position', 'h3:text("Dropdown positioning")'));
 
     it(`should keep the same position when appended to widget or body`, async() => {
       await openDropdown('should open dropdown', selector);

--- a/e2e-app/src/app/popover/autoclose/popover-autoclose.pw-spec.ts
+++ b/e2e-app/src/app/popover/autoclose/popover-autoclose.pw-spec.ts
@@ -17,19 +17,16 @@ const selectAutoClose = async(type: string) => {
 
 const expectPopoverToBeOpen = async(message: string) => {
   await test.page.waitForSelector(SELECTOR_POPOVER);
-  expect(await test.page.$(SELECTOR_POPOVER)).toBeTruthy(message);
   expect(await test.page.textContent(SELECTOR_OPEN_STATUS)).toBe('open', message);
 };
 
 const expectPopoverToBeClosed = async(message: string) => {
   await test.page.waitForSelector(SELECTOR_POPOVER, {state: 'detached'});
-  expect(await test.page.$(SELECTOR_POPOVER)).toBeFalsy(message);
   expect(await test.page.textContent(SELECTOR_OPEN_STATUS)).toBe('closed', message);
 };
 
 const openPopover = async(message: string) => {
   await test.page.click('button[ngbPopover]');
-  await test.page.waitForSelector(SELECTOR_POPOVER);
   await expectPopoverToBeOpen(message);
 };
 

--- a/e2e-app/src/app/popover/autoclose/popover-autoclose.pw-spec.ts
+++ b/e2e-app/src/app/popover/autoclose/popover-autoclose.pw-spec.ts
@@ -32,7 +32,7 @@ const openPopover = async(message: string) => {
 
 describe('Popover Autoclose', () => {
 
-  beforeEach(async() => await openUrl('popover/autoclose'));
+  beforeEach(async() => await openUrl('popover/autoclose', 'h3:text("Popover autoclose")'));
 
   it(`should not close popover on right clicks`, async() => {
     await openPopover(`Opening popover for right clicks`);

--- a/e2e-app/src/app/timepicker/filter/timepicker-filter.pw-spec.ts
+++ b/e2e-app/src/app/timepicker/filter/timepicker-filter.pw-spec.ts
@@ -4,7 +4,7 @@ import {SELECTOR_HOUR, SELECTOR_MIN, SELECTOR_SEC} from '../timepicker';
 
 describe('Timepicker Filter', () => {
 
-  beforeEach(async() => await openUrl('timepicker/filter'));
+  beforeEach(async() => await openUrl('timepicker/filter', 'h3:text("Timepicker filtering")'));
 
   async function expectValue(expectedValue) {
     const hh = await test.page.$eval(SELECTOR_HOUR, (el: HTMLInputElement) => el.value);

--- a/e2e-app/src/app/timepicker/navigation/timepicker-navigation.pw-spec.ts
+++ b/e2e-app/src/app/timepicker/navigation/timepicker-navigation.pw-spec.ts
@@ -9,7 +9,7 @@ const focusInputBefore = async() => await test.page.click('#before');
 
 describe('Timepicker', () => {
 
-  beforeEach(async() => await openUrl('timepicker/navigation'));
+  beforeEach(async() => await openUrl('timepicker/navigation', 'h3:text("Timepicker navigation")'));
 
   async function expectCaretPosition(selector: string, position: number) {
     const {start, end} = await getCaretPosition(selector);

--- a/e2e-app/src/app/tools.pw-po.ts
+++ b/e2e-app/src/app/tools.pw-po.ts
@@ -73,16 +73,16 @@ export const expectFocused = async(selector, message) => {
  * Reopens internal URL by navigating to home url and then to desired one
  */
 let hasBeenLoaded = false;
-export const openUrl = async(url: string) => {
+export const openUrl = async(url: string, selector: string) => {
   const currentPage = page();
   if (hasBeenLoaded && process.env.BROWSER !== 'webkit') {
     await currentPage.click(`#navigate-home`);
     await currentPage.waitForSelector('ng-component', {state: 'detached'});
     await currentPage.click(`#navigate-${url.replace('/', '-')}`);
-    await currentPage.waitForSelector('ng-component');
+    await currentPage.waitForSelector(selector);
   } else {
     await currentPage.goto(`${baseUrl}/${url}`);
-    await currentPage.waitForSelector('ng-component');
+    await currentPage.waitForSelector(selector);
     hasBeenLoaded = true;
   }
 };

--- a/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.pw-spec.ts
+++ b/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.pw-spec.ts
@@ -1,6 +1,6 @@
-import {sendKey, openUrl, Key} from '../../tools.pw-po';
+import {Key, openUrl, sendKey} from '../../tools.pw-po';
 import {test} from '../../../../playwright.conf';
-import {expectTooltipToBeClosed, expectTooltipToBeOpen, SELECTOR_TOOLTIP} from '../tooltip';
+import {expectTooltipToBeClosed, expectTooltipToBeOpen} from '../tooltip';
 
 const clickOutside = async() => await test.page.click('#outside-button');
 const rightClickOutside = async() => await test.page.click('#outside-button', {button: 'right'});
@@ -20,7 +20,7 @@ const openTooltip = async(message: string) => {
 
 describe('Tooltip Autoclose', () => {
 
-  beforeEach(async() => await openUrl('tooltip/autoclose'));
+  beforeEach(async() => await openUrl('tooltip/autoclose', 'h3:text("Tooltip autoclose")'));
 
   it(`should not close tooltip on right clicks`, async() => {
     await openTooltip(`Opening tooltip for right clicks`);

--- a/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.pw-spec.ts
+++ b/e2e-app/src/app/tooltip/autoclose/tooltip-autoclose.pw-spec.ts
@@ -15,7 +15,6 @@ const selectAutoClose = async(type: string) => {
 
 const openTooltip = async(message: string) => {
   await test.page.click('button[ngbTooltip]');
-  await test.page.waitForSelector(SELECTOR_TOOLTIP);
   await expectTooltipToBeOpen(message);
 };
 

--- a/e2e-app/src/app/tooltip/focus/tooltip-focus.pw-spec.ts
+++ b/e2e-app/src/app/tooltip/focus/tooltip-focus.pw-spec.ts
@@ -4,7 +4,7 @@ import {expectTooltipToBeClosed, expectTooltipToBeOpen} from '../tooltip';
 
 describe('Tooltip Focus', () => {
 
-  beforeEach(async() => await openUrl('tooltip/focus'));
+  beforeEach(async() => await openUrl('tooltip/focus', 'h3:text("Tooltip focus")'));
 
   it(`should work when triggers === 'focus'`, async() => {
     // focusin to show

--- a/e2e-app/src/app/tooltip/position/tooltip-position.pw-spec.ts
+++ b/e2e-app/src/app/tooltip/position/tooltip-position.pw-spec.ts
@@ -57,7 +57,7 @@ describe('Tooltip Position', () => {
     await test.page.click(SELECTOR_BUTTON);
   };
 
-  beforeEach(async() => await openUrl('tooltip/position'));
+  beforeEach(async() => await openUrl('tooltip/position', 'h3:text("Tooltip positioning")'));
 
   it(`should be well positioned on the left edge`, async() => {
     await selectPosition('left');

--- a/e2e-app/src/app/tooltip/tooltip.ts
+++ b/e2e-app/src/app/tooltip/tooltip.ts
@@ -5,12 +5,10 @@ export const SELECTOR_TOOLTIP = 'ngb-tooltip-window';
 
 export const expectTooltipToBeOpen = async(message: string) => {
   await test.page.waitForSelector(SELECTOR_TOOLTIP);
-  expect(await test.page.$(SELECTOR_TOOLTIP)).toBeTruthy(message);
   expect(await test.page.textContent(SELECTOR_OPEN_STATUS)).toBe('open', message);
 };
 
 export const expectTooltipToBeClosed = async(message: string) => {
   await test.page.waitForSelector(SELECTOR_TOOLTIP, {state: 'detached'});
-  expect(await test.page.$(SELECTOR_TOOLTIP)).toBeFalsy(message);
   expect(await test.page.textContent(SELECTOR_OPEN_STATUS)).toBe('closed', message);
 };

--- a/e2e-app/src/app/typeahead/autoclose/typeahead-autoclose.pw-spec.ts
+++ b/e2e-app/src/app/typeahead/autoclose/typeahead-autoclose.pw-spec.ts
@@ -36,7 +36,7 @@ const openTypeahead = async() => {
 
 describe('Typeahead Autoclose', () => {
 
-  beforeEach(async() => await openUrl('typeahead/autoclose'));
+  beforeEach(async() => await openUrl('typeahead/autoclose', 'h3:text("Typeahead autoclose")'));
 
   it(`should not close typeahead on right clicks`, async() => {
     await openTypeahead();

--- a/e2e-app/src/app/typeahead/focus/typeahead-focus.component.html
+++ b/e2e-app/src/app/typeahead/focus/typeahead-focus.component.html
@@ -1,4 +1,4 @@
-<h3>Typeahead tests</h3>
+<h3>Typeahead focus tests</h3>
 
 <form>
   <div class="form-group form-inline">

--- a/e2e-app/src/app/typeahead/focus/typeahead-focus.pw-spec.ts
+++ b/e2e-app/src/app/typeahead/focus/typeahead-focus.pw-spec.ts
@@ -7,7 +7,6 @@ describe('Typeahead', () => {
   const expectTypeaheadFocused = async() => await expectFocused(SELECTOR_TYPEAHEAD, `Typeahead should be focused`);
 
   const expectDropdownOpen = async(suggestions = 10) => {
-    await test.page.waitForSelector(SELECTOR_TYPEAHEAD_WINDOW);
     const items = await test.page.$$(SELECTOR_TYPEAHEAD_ITEMS);
     expect(items.length).toBe(suggestions, `Wrong numbre of suggestions`);
   };

--- a/e2e-app/src/app/typeahead/focus/typeahead-focus.pw-spec.ts
+++ b/e2e-app/src/app/typeahead/focus/typeahead-focus.pw-spec.ts
@@ -19,7 +19,7 @@ describe('Typeahead', () => {
 
   const clickBefore = async() => await test.page.click('#first');
 
-  beforeEach(async() => await openUrl('typeahead/focus'));
+  beforeEach(async() => await openUrl('typeahead/focus', 'h3:text("Typeahead focus")'));
 
   it(`should be open after a second click`, async() => {
     await test.page.click(SELECTOR_TYPEAHEAD);

--- a/e2e-app/src/app/typeahead/validation/typeahead-validation.component.html
+++ b/e2e-app/src/app/typeahead/validation/typeahead-validation.component.html
@@ -1,4 +1,4 @@
-<h3>Typeahead tests</h3>
+<h3>Typeahead validation tests</h3>
 
 <form>
   <div class="form-group form-inline">

--- a/e2e-app/src/app/typeahead/validation/typeahead-validation.pw-spec.ts
+++ b/e2e-app/src/app/typeahead/validation/typeahead-validation.pw-spec.ts
@@ -4,7 +4,7 @@ import {test} from '../../../../playwright.conf';
 
 describe('Typeahead', () => {
 
-  beforeEach(async() => await openUrl('typeahead/validation'));
+  beforeEach(async() => await openUrl('typeahead/validation', 'h3:text("Typeahead validation")'));
 
   it(`should stay valid on item click`, async() => {
     await test.page.click(SELECTOR_TYPEAHEAD);


### PR DESCRIPTION
- removed redundant checks around `waitForSelector`
- added waiting for explicit conditions before each test, ex `await test.page.waitForSelector('h3:text("Datepicker autoclose")');` to ensure the page is actually loaded