### PR TITLE
test(modal): migrate e2e tests to Playwright

### DIFF
--- a/e2e-app/playwright.conf.ts
+++ b/e2e-app/playwright.conf.ts
@@ -4,7 +4,8 @@ import {Browsers, Playwright} from '../playwright/controller';
 type BrowserName = 'chromium' | 'firefox' | 'webkit';
 
 export const baseUrl = 'http://localhost:4200/#';
-export const browserName: BrowserName = (process.env.BROWSER || 'chromium').trim() as BrowserName;
+process.env.BROWSER = (process.env.BROWSER || 'chromium').trim();
+export const browserName: BrowserName = process.env.BROWSER as BrowserName;
 
 console.log('Test suite is configured for browser:', browserName);
 

--- a/e2e-app/src/app/dropdown/position/dropdown-position.pw-spec.ts
+++ b/e2e-app/src/app/dropdown/position/dropdown-position.pw-spec.ts
@@ -1,6 +1,7 @@
 import {getBoundingBox, openUrl} from '../../tools.pw-po';
 import {test} from '../../../../playwright.conf';
 import {openDropdown} from '../dropdown';
+import {waitForModalCount} from '../../modal/modal';
 
 const removeFromDom = async() => await test.page.click('#isInDom-false');
 
@@ -27,13 +28,22 @@ const togglePlacement = async(placement: 'top-left' | 'bottom-left' | 'top-right
       await test.page.waitForSelector(`body > div > ${selector}Menu`);
       const bodyBox = await getBoundingBox(`body > div > ${selector}Menu`);
 
-      expect(bodyBox).toEqual(inlineBox, `Positions should give the same results when placed on ${placement}`);
+      for (const[key, value] of Object.entries(inlineBox)) {
+        expect(bodyBox[key])
+            .toBeGreaterThanOrEqual(
+                value - 1, `Position ${key} should give the same results when placed on ${placement}`);
+        expect(bodyBox[key])
+            .toBeLessThanOrEqual(
+                value + 1, `Position '${key}' should give the same results when placed on ${placement}`);
+      }
 
       // Reset
       await toggleContainer(null);
     };
 
     beforeEach(async() => await openUrl('dropdown/position', 'h3:text("Dropdown positioning")'));
+
+    afterEach(async() => { await waitForModalCount(0); });
 
     it(`should keep the same position when appended to widget or body`, async() => {
       await openDropdown('should open dropdown', selector);

--- a/e2e-app/src/app/modal/autoclose/modal-autoclose.pw-spec.ts
+++ b/e2e-app/src/app/modal/autoclose/modal-autoclose.pw-spec.ts
@@ -1,0 +1,113 @@
+import {test} from '../../../../playwright.conf';
+import {Key, openUrl, sendKey, mouseMove} from '../../tools.pw-po';
+import {waitForModalCount, waitForNoChange, SELECTOR_MODAL_DIALOG, SELECTOR_MODAL_WINDOW} from '../modal';
+
+import {
+  clickOnClose,
+  clickOnReset,
+  waitDismissReason,
+  openModal,
+} from './modal-autoclose';
+
+describe('Modal', () => {
+  beforeEach(async() => {
+    await openUrl('modal/autoclose', 'h3:text("Modal autoclose tests")');
+    await clickOnReset();
+  });
+
+  afterEach(async() => { await waitForModalCount(0); });
+
+  it('should close modal from the inside', async() => {
+    await openModal();
+
+    // close
+    await clickOnClose();
+    await waitDismissReason('Closed', `Modal should have been closed`);
+  });
+
+  it('should close modal on ESC', async() => {
+    await openModal();
+
+    // close
+    await sendKey(Key.ESC);
+    await waitForModalCount(0);
+    await waitDismissReason('Escape', `Modal should have been dismissed with 'Escape' reason`);
+  });
+
+  it(`should NOT close modal on ESC when keyboard === 'false'`, async() => {
+    await openModal('no-keyboard');
+    await sendKey(Key.ESC);
+    await waitForNoChange();
+    await waitForModalCount(1, 'The modal should stay opened on ESC');
+    await clickOnClose();
+
+  });
+
+  it('should close modal on backdrop click', async() => {
+    await openModal();
+
+    // dialog click
+    await test.page.click(SELECTOR_MODAL_DIALOG);
+    await waitForNoChange();
+    await waitForModalCount(1, 'The modal should stay opened on dialog click');
+
+    // Close
+    await test.page.click(SELECTOR_MODAL_WINDOW);
+    await waitForModalCount(0, 'The modal should be closed on backdrop click');
+    await waitDismissReason('Click', `Modal should have been dismissed with 'Click' reason`);
+
+  });
+
+  it('should close modal when dragging from backdrop -> dialog', async() => {
+    await openModal();
+    await mouseMove(SELECTOR_MODAL_WINDOW);
+    await test.page.mouse.down();
+    await mouseMove(SELECTOR_MODAL_DIALOG);
+    await test.page.mouse.up();
+
+    await waitForModalCount(0, 'The modal should be closed on drag from backdrop -> dialog');
+    await waitDismissReason('Click', `Modal should have been dismissed with 'Click' reason`);
+  });
+
+  it('should NOT close modal when dragging from dialog -> backdrop', async() => {
+    await openModal();
+    await mouseMove(SELECTOR_MODAL_DIALOG);
+    await test.page.mouse.down();
+    await mouseMove(SELECTOR_MODAL_WINDOW);
+    await test.page.mouse.up();
+
+    await waitForNoChange();
+    await waitForModalCount(1, 'The modal should stay opened on drag from dialog -> backdrop');
+    await clickOnClose();
+  });
+
+  it(`should NOT close modal on 'static' backdrop click`, async() => {
+    await openModal('backdrop-static');
+
+    // dialog click
+    await test.page.click(SELECTOR_MODAL_DIALOG);
+    await waitForNoChange();
+    await waitForModalCount(1, 'The modal should stay opened on dialog click');
+
+    // close
+    await test.page.click(SELECTOR_MODAL_WINDOW);
+    await waitForNoChange();
+    await waitForModalCount(1, 'The modal should stay opened on backdrop click');
+    await clickOnClose();
+  });
+
+  it(`should NOT close modal on click with no backdrop`, async() => {
+    await openModal('backdrop-false');
+
+    // dialog click
+    await test.page.click(SELECTOR_MODAL_DIALOG);
+    await waitForNoChange();
+    await waitForModalCount(1, 'The modal should stay opened on dialog click');
+
+    // close
+    await test.page.click(SELECTOR_MODAL_WINDOW);
+    await waitForNoChange();
+    await waitForModalCount(1, 'The modal should stay opened on backdrop click');
+    await clickOnClose();
+  });
+});

--- a/e2e-app/src/app/modal/autoclose/modal-autoclose.ts
+++ b/e2e-app/src/app/modal/autoclose/modal-autoclose.ts
@@ -1,0 +1,26 @@
+import {test} from '../../../../playwright.conf';
+import {timeoutMessage} from '../../tools.pw-po';
+import {waitForModalCount} from '../modal';
+
+export const clickOnReset = async() => {
+  await test.page.click('#reset-button');
+};
+
+export const clickOnClose = async() => {
+  await test.page.click('#modal-close-button');
+  await waitForModalCount(0);
+};
+
+export const openModal = async(option = '') => {
+  if (option !== '') {
+    await test.page.click(`#option-${option}`);
+  }
+
+  await test.page.click('#open-modal');
+  await waitForModalCount(1);
+};
+
+export const waitDismissReason = async(expected, error) => {
+  await timeoutMessage(
+      test.page.waitForFunction(`document.querySelector('#dismiss-reason').textContent === '${expected}'`), error);
+};

--- a/e2e-app/src/app/modal/focus/modal-focus.pw-spec.ts
+++ b/e2e-app/src/app/modal/focus/modal-focus.pw-spec.ts
@@ -1,0 +1,134 @@
+import {test} from '../../../../playwright.conf';
+import {Key, openUrl, sendKey, waitForFocus} from '../../tools.pw-po';
+import {waitForModalCount, SELECTOR_MODAL_WINDOW} from '../modal';
+
+import {
+  openModal,
+  SELECTOR_MODAL_CONTENT,
+  SELECTOR_DISMISS_BUTTON,
+  SELECTOR_CLOSE_BUTTON,
+  SELECTOR_MODAL_INPUT,
+  SELECTOR_MODAL_HEADER,
+} from './modal-focus';
+
+describe('Modal', () => {
+
+  beforeEach(async() => await openUrl('modal/focus', 'h3:text("Modal focus tests")'));
+
+  afterEach(async() => {
+    await sendKey(Key.ESC);
+    await waitForModalCount(0);
+  });
+
+  it('should close modal on ESC and re-focus trigger button', async() => {
+    await openModal('simple');
+
+    // close
+    await sendKey(Key.ESC);
+    await waitForModalCount(0, 'The modal should be closed on ESC');
+
+    await waitForFocus('#open-modal-simple', 'Should focus trigger button after closing');
+  });
+
+  it('should close modal on window click and re-focus trigger button', async() => {
+    await openModal('simple');
+
+    // close
+    await test.page.click(SELECTOR_MODAL_WINDOW);
+    await waitForModalCount(0, 'The modal should be closed on click');
+
+    // button should be focused
+    await waitForFocus('#open-modal-simple', 'Should focus trigger button after closing');
+  });
+
+  it('should focus body if opener is not focusable', async() => {
+    await openModal('disable');
+
+    // close
+    await sendKey(Key.ESC);
+    await waitForModalCount(0, 'The modal should be closed on ESC');
+
+    // body should be focused
+    await waitForFocus('body', 'Should focus body after closing');
+
+  });
+
+  it('should focus modal window if there is no focusable content after opening', async() => {
+    await openModal('simple');
+
+    // window should be focused
+    expect(await test.page.textContent(SELECTOR_MODAL_CONTENT)).toBe('Modal content');
+    await waitForFocus(SELECTOR_MODAL_WINDOW, 'ngb-modal-window should be focused');
+
+  });
+
+  it('should focus first focusable element after opening', async() => {
+    await openModal('template');
+    await waitForFocus(SELECTOR_DISMISS_BUTTON, 'Modal dismiss button should be focused');
+  });
+
+  it('should focus element with [ngbAutofocus] after opening', async() => {
+    await openModal('autofocus');
+    await waitForFocus(SELECTOR_CLOSE_BUTTON, 'Modal close button should be focused, because of ngbAutoFocus');
+  });
+
+  it('should trap focus inside opened modal (Tab)', async() => {
+    await openModal('template');
+
+    // dismiss -> input -> close -> dismiss
+    await waitForFocus(SELECTOR_DISMISS_BUTTON, 'Modal dismiss button should be focused');
+
+    await sendKey(Key.Tab);
+    await waitForFocus(SELECTOR_MODAL_INPUT, 'Modal input should be focused');
+
+    await sendKey(Key.Tab);
+    await waitForFocus(SELECTOR_CLOSE_BUTTON, 'Modal close button should be focused');
+
+    await sendKey(Key.Tab);
+    await waitForFocus(SELECTOR_DISMISS_BUTTON, 'Modal dismiss button should be focused');
+
+  });
+
+  it('should trap focus inside opened modal (Shift + Tab)', async() => {
+    await openModal('template');
+
+    // dismiss -> close -> input -> dismiss
+    await waitForFocus(SELECTOR_DISMISS_BUTTON, 'Modal dismiss button should be focused');
+
+    await sendKey('Shift+' + Key.Tab);
+    await waitForFocus(SELECTOR_CLOSE_BUTTON, 'Modal close button should be focused');
+
+    await sendKey('Shift+' + Key.Tab);
+    await waitForFocus(SELECTOR_MODAL_INPUT, 'Modal input should be focused');
+
+    await sendKey('Shift+' + Key.Tab);
+    await waitForFocus(SELECTOR_DISMISS_BUTTON, 'Modal dismiss button should be focused');
+
+  });
+
+  it('should keep focus trap inside the modal when clicking on content and navigating away (Tab)', async() => {
+    await openModal('template');
+
+    // click on the header
+    await test.page.click(SELECTOR_MODAL_HEADER);
+    await waitForFocus(SELECTOR_MODAL_WINDOW, 'Modal window should be focused');
+
+    // re-focus
+    await sendKey(Key.Tab);
+    await waitForFocus(SELECTOR_DISMISS_BUTTON, 'Modal dismiss button should be focused');
+
+  });
+
+  it('should keep focus trap inside the modal when clicking on content and navigating away (Shift + Tab)', async() => {
+    await openModal('template');
+
+    // click on the header
+    await test.page.click(SELECTOR_MODAL_HEADER);
+    await waitForFocus(SELECTOR_MODAL_WINDOW, 'Modal window should be focused');
+
+    // re-focus
+    await sendKey('Shift+' + Key.Tab);
+    await waitForFocus(SELECTOR_CLOSE_BUTTON, 'Modal close button should be focused');
+
+  });
+});

--- a/e2e-app/src/app/modal/focus/modal-focus.ts
+++ b/e2e-app/src/app/modal/focus/modal-focus.ts
@@ -1,0 +1,14 @@
+import {focusElement, Key, sendKey} from '../../tools.pw-po';
+import {waitForModalCount} from '../modal';
+
+export const SELECTOR_MODAL_CONTENT = 'div.modal-content';
+export const SELECTOR_DISMISS_BUTTON = 'div.modal-header >> button';
+export const SELECTOR_CLOSE_BUTTON = 'div.modal-footer >> button';
+export const SELECTOR_MODAL_INPUT = 'div.modal-body >> input';
+export const SELECTOR_MODAL_HEADER = 'div.modal-header';
+
+export const openModal = async(type: string) => {
+  await focusElement(`#open-modal-${type}`);
+  await sendKey(Key.Enter);
+  await waitForModalCount(1);
+};

--- a/e2e-app/src/app/modal/modal.ts
+++ b/e2e-app/src/app/modal/modal.ts
@@ -1,0 +1,40 @@
+import {test} from '../../../playwright.conf';
+import {timeoutMessage} from '../tools.pw-po';
+export const SELECTOR_MODAL_DIALOG = '.modal-dialog';
+export const SELECTOR_MODAL_WINDOW = 'ngb-modal-window';
+
+const defaultErrorMessage = (modalNumber) => {
+  return modalNumber ? `Number of expected modals : ${modalNumber}` : `There should be no open modal windows`;
+};
+
+/**
+ *
+ * @param modalNumber Expected modal number
+ * @param errorMessage
+ */
+export const waitForModalCount = async(modalNumber, errorMessage = defaultErrorMessage(modalNumber)) => {
+  // These successive waiting functions, done in this order, render the test suite more stable.
+  await timeoutMessage(
+      test.page.waitForFunction(
+          modalNumber ? `document.body.className.indexOf('modal-open') > -1` :
+                        `document.body.className.indexOf('modal-open') === -1`),
+      errorMessage);
+  await timeoutMessage(
+      test.page.waitForFunction(`document.querySelectorAll('${SELECTOR_MODAL_WINDOW}').length === ${modalNumber}`),
+      errorMessage);
+  await timeoutMessage(
+      test.page.waitForFunction(`document.querySelectorAll('${SELECTOR_MODAL_DIALOG}').length === ${modalNumber}`),
+      errorMessage);
+
+  if (process.env.BROWSER === 'webkit') {
+    // Need some extra time for webkit, otherwise the modal tests are not stable.
+    await test.page.waitForTimeout(50);
+  }
+};
+
+/**
+ * Wait a short time before checking that nothing changed
+ */
+export const waitForNoChange = async() => {
+  await test.page.waitForTimeout(25);
+};

--- a/e2e-app/src/app/modal/nesting/modal-nesting.pw-spec.ts
+++ b/e2e-app/src/app/modal/nesting/modal-nesting.pw-spec.ts
@@ -1,0 +1,78 @@
+import {test} from '../../../../playwright.conf';
+import {Key, openUrl, sendKey, waitForFocus, timeoutMessage} from '../../tools.pw-po';
+import {waitForModalCount} from '../modal';
+
+import {
+  openModal,
+  pressButton,
+  SELECTOR_DATEPICKER,
+  SELECTOR_DATEPICKER_BUTTON,
+  SELECTOR_DROPDOWN_BUTTON,
+  SELECTOR_DROPDOWN,
+  SELECTOR_TYPEAHEAD_INPUT,
+  SELECTOR_TYPEAHEAD_DROPDOWN,
+} from './modal-nesting';
+
+import {SELECTOR_DAY} from '../../datepicker/datepicker';
+
+describe('Modal nested components', () => {
+  beforeEach(async() => await openUrl('modal/nesting', 'h3:text("Modal nesting tests")'));
+
+  afterEach(async() => { await waitForModalCount(0); });
+
+  it('should close only datepicker, then modal on ESC', async() => {
+    await openModal();
+
+    // open datepicker
+    await pressButton(SELECTOR_DATEPICKER_BUTTON);
+    await timeoutMessage(test.page.waitForSelector(SELECTOR_DATEPICKER), `Datepicker should be opened`);
+    await waitForFocus(SELECTOR_DAY(new Date(2018, 0, 1)), `01 JAN 2018 should be focused`);
+
+    // close datepicker
+    await sendKey(Key.ESC);
+    await timeoutMessage(
+        test.page.waitForSelector(SELECTOR_DATEPICKER, {state: 'detached'}), `Datepicker should be closed`);
+    await waitForFocus(SELECTOR_DATEPICKER_BUTTON, `Datepicker open button should be focused`);
+    await waitForModalCount(1, `Modal should stay opened`);
+
+    await sendKey(Key.ESC);
+  });
+
+  it('should close only dropdown, then modal on ESC', async() => {
+    await openModal();
+
+    // open dropdown
+    await pressButton(SELECTOR_DROPDOWN_BUTTON);
+    await timeoutMessage(test.page.waitForSelector(SELECTOR_DROPDOWN), `Dropdown should be opened`);
+    await waitForFocus(SELECTOR_DROPDOWN_BUTTON, `Dropdown button should be focused`);
+
+    // close dropdown
+    await sendKey(Key.ESC);
+    await timeoutMessage(
+        test.page.waitForSelector(SELECTOR_DROPDOWN, {state: 'detached'}), `Dropdown should be closed`);
+    await waitForFocus(SELECTOR_DROPDOWN_BUTTON, `Dropdown open button should be focused`);
+    await waitForModalCount(1, `Modal should stay opened`);
+
+    await sendKey(Key.ESC);
+  });
+
+  it('should close only typeahead, then modal on ESC', async() => {
+    await openModal();
+
+    // open typeahead
+    await test.page.click(SELECTOR_TYPEAHEAD_INPUT);
+    await sendKey(Key.Space);
+    await timeoutMessage(test.page.waitForSelector(SELECTOR_TYPEAHEAD_DROPDOWN), `Typeahead should be opened`);
+    await waitForFocus(SELECTOR_TYPEAHEAD_INPUT, `Typeahead input should be focused`);
+
+    // close typeahead
+    await sendKey(Key.ESC);
+    await timeoutMessage(
+        test.page.waitForSelector(SELECTOR_TYPEAHEAD_DROPDOWN, {state: 'detached'}), `Typeahead should be
+                closed`);
+    await waitForFocus(SELECTOR_TYPEAHEAD_INPUT, `Typeahead input should be focused`);
+    await waitForModalCount(1, `Modal should stay opened`);
+
+    await sendKey(Key.ESC);
+  });
+});

--- a/e2e-app/src/app/modal/nesting/modal-nesting.ts
+++ b/e2e-app/src/app/modal/nesting/modal-nesting.ts
@@ -1,0 +1,21 @@
+import {test} from '../../../../playwright.conf';
+import {focusElement, Key, sendKey} from '../../tools.pw-po';
+import {waitForModalCount} from '../modal';
+
+export const SELECTOR_DATEPICKER = 'ngb-datepicker';
+export const SELECTOR_DATEPICKER_BUTTON = '#datepicker-button';
+export const SELECTOR_DROPDOWN_BUTTON = '#dropdown';
+export const SELECTOR_DROPDOWN = '[ngbDropdown].show';
+export const SELECTOR_TYPEAHEAD_INPUT = '#typeahead';
+export const SELECTOR_TYPEAHEAD_DROPDOWN = 'ngb-typeahead-window.show';
+
+
+export const openModal = async() => {
+  await test.page.click(`#open-modal`);
+  await waitForModalCount(1);
+};
+
+export const pressButton = async(buttonSelector) => {
+  await focusElement(buttonSelector);
+  await sendKey(Key.Enter);
+};

--- a/e2e-app/src/app/modal/stack-confirmation/modal-stack-confirmation.component.html
+++ b/e2e-app/src/app/modal/stack-confirmation/modal-stack-confirmation.component.html
@@ -1,4 +1,4 @@
-<h3>Modal closure confirmation test</h3>
+<h3>Modal stack confirmation test</h3>
 
 <ng-template #modal let-modal>
   <div id="modal" class="modal-header">

--- a/e2e-app/src/app/modal/stack-confirmation/modal-stack-confirmation.pw-spec.ts
+++ b/e2e-app/src/app/modal/stack-confirmation/modal-stack-confirmation.pw-spec.ts
@@ -1,0 +1,78 @@
+import {test} from '../../../../playwright.conf';
+import {Key, openUrl, sendKey} from '../../tools.pw-po';
+import {waitForModalCount} from '../modal';
+
+import {
+  openModal,
+  clickOnModal,
+  SELECTOR_CLOSE_BUTTON,
+  SELECTOR_DISMISS_BUTTON,
+  SELECTOR_CONFIRM_BUTTON,
+} from './modal-stack-confirmation';
+
+describe('Modal stack with confirmation', () => {
+
+  beforeEach(async() => await openUrl('modal/stack-confirmation', 'h3:text("Modal stack confirmation test")'));
+
+  afterEach(async() => { await waitForModalCount(0); });
+
+  it('should close modals correctly using close button', async() => {
+    await openModal();
+
+    // close with button
+    await test.page.click(SELECTOR_CLOSE_BUTTON);
+    await waitForModalCount(2, 'Confirmation modal should be opened');
+
+    // cancel closure with button
+    await test.page.click(SELECTOR_DISMISS_BUTTON);
+    await waitForModalCount(1, 'Confirmation modal should be dismissed');
+
+    // close again
+    await test.page.click(SELECTOR_CLOSE_BUTTON);
+    await waitForModalCount(2, 'Confirmation modal should be re-opened');
+
+    // close all modals
+    await test.page.click(SELECTOR_CONFIRM_BUTTON);
+
+  });
+
+  it('should close modals correctly using ESC', async() => {
+    await openModal();
+
+    // close with Escape
+    await sendKey(Key.ESC);
+    await waitForModalCount(2, 'Confirmation modal should be opened');
+
+    // cancel closure with Escape
+    await sendKey(Key.ESC);
+    await waitForModalCount(1, 'Confirmation modal should be dismissed');
+
+    // close again
+    await sendKey(Key.ESC);
+    await waitForModalCount(2, 'Confirmation modal should be re-opened');
+
+    // close all modals
+    await test.page.click(SELECTOR_CONFIRM_BUTTON);
+  });
+
+  it('should close modals correctly using backdrop click', async() => {
+    await openModal();
+
+    // close with click
+    await clickOnModal(0);
+    await waitForModalCount(2, 'Confirmation modal should be opened');
+
+    // cancel closure with click
+    await clickOnModal(1);
+    await waitForModalCount(1, 'Confirmation modal should be dismissed');
+
+    // close again
+    await clickOnModal(0);
+    await waitForModalCount(2, 'Confirmation modal should be re-opened');
+
+    // close all modals
+    await test.page.click(SELECTOR_CONFIRM_BUTTON);
+
+  });
+
+});

--- a/e2e-app/src/app/modal/stack-confirmation/modal-stack-confirmation.ts
+++ b/e2e-app/src/app/modal/stack-confirmation/modal-stack-confirmation.ts
@@ -1,0 +1,18 @@
+import {test} from '../../../../playwright.conf';
+import {SELECTOR_MODAL_WINDOW, waitForModalCount} from '../modal';
+
+export const SELECTOR_MODAL_BUTTON = '#open-modal';
+export const SELECTOR_STACK_MODAL = '#stack-modal';
+export const SELECTOR_CLOSE_BUTTON = '#close';
+export const SELECTOR_CONFIRM_BUTTON = '#confirm';
+export const SELECTOR_DISMISS_BUTTON = '#dismiss';
+
+export const openModal = async() => {
+  await test.page.click(SELECTOR_MODAL_BUTTON);
+  await waitForModalCount(1);
+};
+
+export const clickOnModal = async(index) => {
+  const modals = await test.page.$$(SELECTOR_MODAL_WINDOW);
+  await modals[index].click();
+};

--- a/e2e-app/src/app/modal/stack/modal-stack.component.html
+++ b/e2e-app/src/app/modal/stack/modal-stack.component.html
@@ -1,4 +1,4 @@
-<h3>Modal nesting tests</h3>
+<h3>Modal stack tests</h3>
 
 <ng-template #t let-modal>
   <div id="modal" class="modal-header">

--- a/e2e-app/src/app/modal/stack/modal-stack.pw-spec.ts
+++ b/e2e-app/src/app/modal/stack/modal-stack.pw-spec.ts
@@ -1,0 +1,39 @@
+import {test} from '../../../../playwright.conf';
+import {Key, openUrl, sendKey, waitForFocus} from '../../tools.pw-po';
+import {waitForModalCount} from '../modal';
+
+import {
+  openModal,
+  openStackModal,
+  SELECTOR_STACK_MODAL,
+  SELECTOR_STACK_MODAL_BUTTON,
+  SELECTOR_CLOSE_ICON
+} from './modal-stack';
+
+describe('Modal stack', () => {
+
+  beforeEach(async() => await openUrl('modal/stack', 'h3:text("Modal stack tests")'));
+
+  afterEach(async() => { await waitForModalCount(0); });
+
+  it('should keep tab on the first modal after the second modal has closed', async() => {
+    await openModal();
+    await openStackModal();
+    await waitForModalCount(2);
+
+    // close the stack modal
+    await sendKey(Key.ESC);
+    await test.page.waitForSelector(SELECTOR_STACK_MODAL, {state: 'detached'});
+    await waitForModalCount(1);
+
+    // Check that the button is focused again
+    await waitForFocus(SELECTOR_STACK_MODAL_BUTTON, 'Button element not focused');
+    await sendKey(Key.Tab);
+
+    await waitForFocus(SELECTOR_CLOSE_ICON, 'Close icon not focused');
+
+    // close the main modal
+    await sendKey(Key.ESC);
+  });
+
+});

--- a/e2e-app/src/app/modal/stack/modal-stack.ts
+++ b/e2e-app/src/app/modal/stack/modal-stack.ts
@@ -1,0 +1,20 @@
+import {test} from '../../../../playwright.conf';
+import {focusElement, Key, sendKey} from '../../tools.pw-po';
+import {waitForModalCount} from '../modal';
+
+export const SELECTOR_MODAL_BUTTON = '#open-modal';
+export const SELECTOR_MODAL = '#modal';
+export const SELECTOR_STACK_MODAL_BUTTON = '#open-inner-modal';
+export const SELECTOR_STACK_MODAL = '#stack-modal';
+export const SELECTOR_CLOSE_ICON = 'button.close';
+
+export const openModal = async() => {
+  await test.page.click(SELECTOR_MODAL_BUTTON);
+  await waitForModalCount(1);
+};
+
+export const openStackModal = async() => {
+  await focusElement(SELECTOR_STACK_MODAL_BUTTON);
+  await sendKey(Key.Enter);
+  await test.page.waitForSelector(SELECTOR_STACK_MODAL);
+};

--- a/e2e-app/src/app/tooltip/focus/tooltip-focus.pw-spec.ts
+++ b/e2e-app/src/app/tooltip/focus/tooltip-focus.pw-spec.ts
@@ -1,5 +1,4 @@
-import {openUrl} from '../../tools.pw-po';
-import {test} from '../../../../playwright.conf';
+import {focusElement, openUrl} from '../../tools.pw-po';
 import {expectTooltipToBeClosed, expectTooltipToBeOpen} from '../tooltip';
 
 describe('Tooltip Focus', () => {
@@ -8,11 +7,11 @@ describe('Tooltip Focus', () => {
 
   it(`should work when triggers === 'focus'`, async() => {
     // focusin to show
-    await test.page.focus('#btn-tooltip');
+    await focusElement('#btn-tooltip');
     await expectTooltipToBeOpen(`Tooltip should be visible when tooltip button gains focus`);
 
     // focusout to hide
-    await test.page.focus('#btn-after');
+    await focusElement('#btn-after');
     await expectTooltipToBeClosed(`Tooltip should not be visible when tooltip button looses focus`);
   });
 });

--- a/e2e-app/src/app/typeahead/focus/typeahead-focus.pw-spec.ts
+++ b/e2e-app/src/app/typeahead/focus/typeahead-focus.pw-spec.ts
@@ -1,4 +1,4 @@
-import {waitForFocus, Key, openUrl, sendKey, timeoutMessage, js} from '../../tools.pw-po';
+import {focusElement, waitForFocus, Key, openUrl, sendKey, timeoutMessage, js} from '../../tools.pw-po';
 import {test} from '../../../../playwright.conf';
 import {SELECTOR_TYPEAHEAD, SELECTOR_TYPEAHEAD_ITEMS, SELECTOR_TYPEAHEAD_WINDOW} from '../typeahead';
 
@@ -78,8 +78,7 @@ describe('Typeahead', () => {
 
     if (process.env.BROWSER !== 'webkit') {
       it(`should select element on tab`, async() => {
-        await test.page.focus(SELECTOR_TYPEAHEAD);
-        await waitForFocus(SELECTOR_TYPEAHEAD);
+        await focusElement(SELECTOR_TYPEAHEAD);
         await sendKey(Key.Tab);
         await waitForTypeaheadFocused();
         await waitForDropDownClosed();

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "ng-packagr": "^11.0.2",
     "ngx-build-plus": "^11.0.0",
     "nyc": "14.1.1",
-    "playwright": "^1.8.0",
+    "playwright": "^1.8.1",
     "prismjs": "1.22.0",
     "protractor": "~7.0.0",
     "rimraf": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9154,10 +9154,10 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.8.0.tgz#8eca2250967ee892b9fdfec44e2358455ab0f8e3"
-  integrity sha512-urMJDLX92KawbkWKrt3chVVBPQsuuNwlS5St7I5YQENXAEItoyUqX7FjiYaoPgXifKqe1+BKC+7pBAq1QUkgSw==
+playwright@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.8.1.tgz#0a26035d1b5f2c31d9a4da09d649b4992f989d1e"
+  integrity sha512-nmuiDEDwB/SdAxiZQS5pLqPS3XXN8OJ1LKvTSiAbJvu+AUf7f0RD7nuq9xB0C08Emd6stx9yBMhANvD12k/+GQ==
   dependencies:
     commander "^6.1.0"
     debug "^4.1.1"


### PR DESCRIPTION
Enable Playwright tests for the modal.

I still have an issue locally with FF and webkit:
  - from time to time, a modal backdrop stay in the dom, so the remaining tests fail,
  - It happens only with when some specs files are run together (including the modal ones of course),
  - It never happens on Chrome,
  - The more difficult, it's random (sometime it passes).

Let's see if there is the same issue on Travis.