### PR TITLE
test: waitForFocus instead of expectFocused

### DIFF
--- a/e2e-app/setup.pw-spec.ts
+++ b/e2e-app/setup.pw-spec.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import {browserName, test, page, launchOptions} from './playwright.conf';
 
 beforeAll(async() => {
+  Error.stackTraceLimit = Infinity;
   jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000000;
   try {
     console.log(`Launch browser ${browserName} with`, launchOptions);

--- a/e2e-app/src/app/datepicker/focus/datepicker-focus.pw-spec.ts
+++ b/e2e-app/src/app/datepicker/focus/datepicker-focus.pw-spec.ts
@@ -1,5 +1,5 @@
 import {test} from '../../../../playwright.conf';
-import {expectFocused, Key, openUrl, sendKey} from '../../tools.pw-po';
+import {waitForFocus, Key, openUrl, sendKey} from '../../tools.pw-po';
 import {
   openDatepicker,
   SELECTOR_DATEPICKER,
@@ -44,25 +44,25 @@ describe('Datepicker', () => {
 
   it(`should focus today when opened`, async() => {
     await openDatepicker();
-    await expectFocused(SELECTOR_DAY(new Date()), `Today's date should be focused`);
+    await waitForFocus(SELECTOR_DAY(new Date()), `Today's date should be focused`);
   });
 
   it(`should focus selected day when opened`, async() => {
     await preSelectDate();  // 10 AUG 2018
     await openDatepicker();
-    await expectFocused(SELECTOR_DAY(new Date(2018, 7, 10)), `Selected date should be focused`);
+    await waitForFocus(SELECTOR_DAY(new Date(2018, 7, 10)), `Selected date should be focused`);
   });
 
   it(`should focus 1st day of {year, month} startDate day when opened`, async() => {
     await selectStartDate('month-only');  // startDate = AUG 2018
     await openDatepicker();
-    await expectFocused(SELECTOR_DAY(new Date(2018, 7, 1)), `First day of startDate should be focused`);
+    await waitForFocus(SELECTOR_DAY(new Date(2018, 7, 1)), `First day of startDate should be focused`);
   });
 
   it(`should focus {year, month, day} startDate day when opened`, async() => {
     await selectStartDate('month-and-day');  // startDate = 10 AUG 2018
     await openDatepicker();
-    await expectFocused(SELECTOR_DAY(new Date(2018, 7, 10)), `First day of startDate should be focused`);
+    await waitForFocus(SELECTOR_DAY(new Date(2018, 7, 10)), `First day of startDate should be focused`);
   });
 
   it(`should be closed on toggle element click and focus it`, async() => {
@@ -73,7 +73,7 @@ describe('Datepicker', () => {
     await test.page.waitForSelector(SELECTOR_DATEPICKER, {state: 'detached'});
 
     // check toggle is focused
-    await expectFocused(SELECTOR_TOGGLE, `Toggle element should stay focused after datepicker is closed`);
+    await waitForFocus(SELECTOR_TOGGLE, `Toggle element should stay focused after datepicker is closed`);
   });
 
   it(`should be closed on Escape and re-focus toggle element`, async() => {
@@ -84,7 +84,7 @@ describe('Datepicker', () => {
     await test.page.waitForSelector(SELECTOR_DATEPICKER, {state: 'detached'});
 
     // check toggle is focused
-    await expectFocused(SELECTOR_TOGGLE, `Toggle element become re-focused after datepicker is closed`);
+    await waitForFocus(SELECTOR_TOGGLE, `Toggle element become re-focused after datepicker is closed`);
   });
 
   it(`should be closed on date selection and re-focus toggle element`, async() => {
@@ -95,7 +95,7 @@ describe('Datepicker', () => {
     await test.page.waitForSelector(SELECTOR_DATEPICKER, {state: 'detached'});
 
     // check toggle is focused
-    await expectFocused(SELECTOR_TOGGLE, `Toggle element become re-focused after datepicker is closed`);
+    await waitForFocus(SELECTOR_TOGGLE, `Toggle element become re-focused after datepicker is closed`);
   });
 
   if (process.env.BROWSER !== 'webkit') {
@@ -103,44 +103,44 @@ describe('Datepicker', () => {
       await openDatepicker();
 
       // today -> prev. month -> month -> year -> next month -> today -> ...
-      await expectFocused(SELECTOR_DAY(new Date()), `Today's date should be focused`);
+      await waitForFocus(SELECTOR_DAY(new Date()), `Today's date should be focused`);
 
       await sendKey(Key.Tab);
-      await expectFocused(SELECTOR_PREV_MONTH, `Previous Month arrow should be focused`);
+      await waitForFocus(SELECTOR_PREV_MONTH, `Previous Month arrow should be focused`);
 
       await sendKey(Key.Tab);
-      await expectFocused(SELECTOR_MONTH_SELECT, `Month select box should be focused`);
+      await waitForFocus(SELECTOR_MONTH_SELECT, `Month select box should be focused`);
 
       await sendKey(Key.Tab);
-      await expectFocused(SELECTOR_YEAR_SELECT, `Year select box should be focused`);
+      await waitForFocus(SELECTOR_YEAR_SELECT, `Year select box should be focused`);
 
       await sendKey(Key.Tab);
-      await expectFocused(SELECTOR_NEXT_MONTH, `Next Month arrow should be focused`);
+      await waitForFocus(SELECTOR_NEXT_MONTH, `Next Month arrow should be focused`);
 
       await sendKey(Key.Tab);
-      await expectFocused(SELECTOR_DAY(new Date()), `Today's date should be focused`);
+      await waitForFocus(SELECTOR_DAY(new Date()), `Today's date should be focused`);
     });
 
     it(`should trap focus inside opened popup with (Shift+Tab)`, async() => {
       await openDatepicker();
 
       // today -> next month -> year -> month -> prev. month -> today -> ...
-      await expectFocused(SELECTOR_DAY(new Date()), `Today's date should be focused`);
+      await waitForFocus(SELECTOR_DAY(new Date()), `Today's date should be focused`);
 
       await sendKey('Shift+Tab');
-      await expectFocused(SELECTOR_NEXT_MONTH, `Next Month arrow should be focused`);
+      await waitForFocus(SELECTOR_NEXT_MONTH, `Next Month arrow should be focused`);
 
       await sendKey('Shift+Tab');
-      await expectFocused(SELECTOR_YEAR_SELECT, `Year select box should be focused`);
+      await waitForFocus(SELECTOR_YEAR_SELECT, `Year select box should be focused`);
 
       await sendKey('Shift+Tab');
-      await expectFocused(SELECTOR_MONTH_SELECT, `Month select box should be focused`);
+      await waitForFocus(SELECTOR_MONTH_SELECT, `Month select box should be focused`);
 
       await sendKey('Shift+Tab');
-      await expectFocused(SELECTOR_PREV_MONTH, `Previous Month arrow should be focused`);
+      await waitForFocus(SELECTOR_PREV_MONTH, `Previous Month arrow should be focused`);
 
       await sendKey('Shift+Tab');
-      await expectFocused(SELECTOR_DAY(new Date()), `Today's date should be focused`);
+      await waitForFocus(SELECTOR_DAY(new Date()), `Today's date should be focused`);
     });
   }
 
@@ -153,7 +153,7 @@ describe('Datepicker', () => {
 
     // skipping one months
     await test.page.click(SELECTOR_NEXT_MONTH);
-    await expectFocused(SELECTOR_NEXT_MONTH, `Next month arrow should be focused`);
+    await waitForFocus(SELECTOR_NEXT_MONTH, `Next month arrow should be focused`);
 
     // make sure we changed month
     await test.page.waitForSelector(SELECTOR_DAY(firstDate), {state: 'detached'});
@@ -168,7 +168,7 @@ describe('Datepicker', () => {
 
     // focus next month
     await test.page.click(SELECTOR_PREV_MONTH);
-    await expectFocused(SELECTOR_PREV_MONTH, `Previous month arrow should be focused`);
+    await waitForFocus(SELECTOR_PREV_MONTH, `Previous month arrow should be focused`);
 
     await test.page.waitForSelector(SELECTOR_DAY(lastDate), {state: 'detached'});
   });
@@ -178,7 +178,7 @@ describe('Datepicker', () => {
 
     // click on weekday header
     await test.page.click(SELECTOR_FIRST_WEEKDAY);
-    await expectFocused(SELECTOR_DAY(new Date()), `Today's date should stay focused`);
+    await waitForFocus(SELECTOR_DAY(new Date()), `Today's date should stay focused`);
   });
 
   if (process.env.BROWSER !== 'webkit') {
@@ -187,11 +187,11 @@ describe('Datepicker', () => {
 
       // focus input
       await test.page.click(SELECTOR_DATEPICKER_INPUT);
-      await expectFocused(SELECTOR_DATEPICKER_INPUT, `Datepicker input should be focused`);
+      await waitForFocus(SELECTOR_DATEPICKER_INPUT, `Datepicker input should be focused`);
 
       // tab should go back to datepicker
       await sendKey(Key.Tab);
-      await expectFocused(SELECTOR_PREV_MONTH, `Previous Month arrow should be focused`);
+      await waitForFocus(SELECTOR_PREV_MONTH, `Previous Month arrow should be focused`);
     });
   }
 
@@ -200,14 +200,14 @@ describe('Datepicker', () => {
 
     // focus input
     await test.page.click(SELECTOR_DATEPICKER_INPUT);
-    await expectFocused(SELECTOR_DATEPICKER_INPUT, `Datepicker input should be focused`);
+    await waitForFocus(SELECTOR_DATEPICKER_INPUT, `Datepicker input should be focused`);
 
     // close
     await sendKey(Key.ESC);
     await test.page.waitForSelector(SELECTOR_DATEPICKER, {state: 'detached'});
 
     // check input is still focused
-    await expectFocused(SELECTOR_DATEPICKER_INPUT, `Input element should stay focused after datepicker is closed`);
+    await waitForFocus(SELECTOR_DATEPICKER_INPUT, `Input element should stay focused after datepicker is closed`);
   });
 
   it(`should not allow any interactions when disabled`, async() => {
@@ -215,7 +215,7 @@ describe('Datepicker', () => {
     await preSelectDate();  // 10 AUG 2018
     await openDatepicker();
 
-    await expectFocused(SELECTOR_TOGGLE, `Toggling element should stay focused`);
+    await waitForFocus(SELECTOR_TOGGLE, `Toggling element should stay focused`);
 
     const dayElement = SELECTOR_DAY(new Date(2018, 7, 10));
     await test.page.waitForSelector(dayElement);
@@ -234,16 +234,16 @@ describe('Datepicker', () => {
       await preSelectDate();  // 10 AUG 2018
       await openDatepicker();
 
-      await expectFocused(SELECTOR_DAY(new Date(2018, 7, 10)), `10 AUG should be focused`);
+      await waitForFocus(SELECTOR_DAY(new Date(2018, 7, 10)), `10 AUG should be focused`);
 
       await sendKey(Key.ArrowUp);
-      await expectFocused(SELECTOR_DAY(new Date(2018, 7, 3)), `03 AUG should be focused`);
+      await waitForFocus(SELECTOR_DAY(new Date(2018, 7, 3)), `03 AUG should be focused`);
 
       await sendKey(Key.ArrowUp);
-      await expectFocused(SELECTOR_DAY(new Date(2018, 6, 27)), `27 JUL should be focused`);
+      await waitForFocus(SELECTOR_DAY(new Date(2018, 6, 27)), `27 JUL should be focused`);
 
       await sendKey(Key.ArrowDown);
-      await expectFocused(SELECTOR_DAY(new Date(2018, 7, 3)), `03 AUG should be focused`);
+      await waitForFocus(SELECTOR_DAY(new Date(2018, 7, 3)), `03 AUG should be focused`);
     });
 
     it(`should focus previous day with 'ArrowLeft'`, async() => {
@@ -253,7 +253,7 @@ describe('Datepicker', () => {
       yesterday.setDate(new Date().getDate() - 1);
 
       await sendKey(Key.ArrowLeft);
-      await expectFocused(SELECTOR_DAY(yesterday), `Yesterday should be focused`);
+      await waitForFocus(SELECTOR_DAY(yesterday), `Yesterday should be focused`);
     });
 
     it(`should focus next day with 'ArrowRight'`, async() => {
@@ -263,7 +263,7 @@ describe('Datepicker', () => {
       tomorrow.setDate(new Date().getDate() + 1);
 
       await sendKey(Key.ArrowRight);
-      await expectFocused(SELECTOR_DAY(tomorrow), `Tomorrow should be focused`);
+      await waitForFocus(SELECTOR_DAY(tomorrow), `Tomorrow should be focused`);
     });
 
     it(`should focus previous week with 'ArrowUp'`, async() => {
@@ -273,7 +273,7 @@ describe('Datepicker', () => {
       previousWeek.setDate(new Date().getDate() - 7);
 
       await sendKey(Key.ArrowUp);
-      await expectFocused(SELECTOR_DAY(previousWeek), `Today-7 days should be focused`);
+      await waitForFocus(SELECTOR_DAY(previousWeek), `Today-7 days should be focused`);
     });
 
     it(`should focus next week with 'ArrowDown'`, async() => {
@@ -283,7 +283,7 @@ describe('Datepicker', () => {
       nextWeek.setDate(new Date().getDate() + 7);
 
       await sendKey(Key.ArrowDown);
-      await expectFocused(SELECTOR_DAY(nextWeek), `Today+7 days should be focused`);
+      await waitForFocus(SELECTOR_DAY(nextWeek), `Today+7 days should be focused`);
     });
 
     it(`should focus first day of month with 'Home'`, async() => {
@@ -291,7 +291,7 @@ describe('Datepicker', () => {
       await openDatepicker();
 
       await sendKey(Key.Home);
-      await expectFocused(SELECTOR_DAY(new Date(2018, 7, 1)), `First day of month should be focused`);
+      await waitForFocus(SELECTOR_DAY(new Date(2018, 7, 1)), `First day of month should be focused`);
     });
 
     it(`should focus last day of month with 'End'`, async() => {
@@ -299,7 +299,7 @@ describe('Datepicker', () => {
       await openDatepicker();
 
       await sendKey(Key.End);
-      await expectFocused(SELECTOR_DAY(new Date(2018, 7, 31)), `Last day of month should be focused`);
+      await waitForFocus(SELECTOR_DAY(new Date(2018, 7, 31)), `Last day of month should be focused`);
     });
 
     it(`should focus same day of previous month with 'PageUp'`, async() => {
@@ -307,7 +307,7 @@ describe('Datepicker', () => {
       await openDatepicker();
 
       await sendKey(Key.PageUp);
-      await expectFocused(SELECTOR_DAY(new Date(2018, 6, 10)), `Same day of previous month should be focused`);
+      await waitForFocus(SELECTOR_DAY(new Date(2018, 6, 10)), `Same day of previous month should be focused`);
     });
 
     it(`should focus same day of next month with 'PageDown'`, async() => {
@@ -315,7 +315,7 @@ describe('Datepicker', () => {
       await openDatepicker();
 
       await sendKey(Key.PageDown);
-      await expectFocused(SELECTOR_DAY(new Date(2018, 8, 10)), `Same day of next month should be focused`);
+      await waitForFocus(SELECTOR_DAY(new Date(2018, 8, 10)), `Same day of next month should be focused`);
     });
 
     it(`should focus same day of previous year with 'Shift+PageUp'`, async() => {
@@ -323,7 +323,7 @@ describe('Datepicker', () => {
       await openDatepicker();
 
       await sendKey('Shift+PageUp');
-      await expectFocused(SELECTOR_DAY(new Date(2017, 7, 10)), `Same day of previous year should be focused`);
+      await waitForFocus(SELECTOR_DAY(new Date(2017, 7, 10)), `Same day of previous year should be focused`);
     });
 
     it(`should focus same day of next year with 'Shift+PageDown'`, async() => {
@@ -331,7 +331,7 @@ describe('Datepicker', () => {
       await openDatepicker();
 
       await sendKey('Shift+PageDown');
-      await expectFocused(SELECTOR_DAY(new Date(2019, 7, 10)), `Same day of next year should be focused`);
+      await waitForFocus(SELECTOR_DAY(new Date(2019, 7, 10)), `Same day of next year should be focused`);
     });
 
     it(`should focus min available day with 'Shift+Home'`, async() => {
@@ -339,7 +339,7 @@ describe('Datepicker', () => {
       await openDatepicker();
 
       await sendKey('Shift+Home');
-      await expectFocused(SELECTOR_DAY(new Date(2000, 0, 1)), `Min available day should be focused`);
+      await waitForFocus(SELECTOR_DAY(new Date(2000, 0, 1)), `Min available day should be focused`);
     });
 
     it(`should focus max available day with 'Shift+End'`, async() => {
@@ -347,7 +347,7 @@ describe('Datepicker', () => {
       await openDatepicker();
 
       await sendKey('Shift+End');
-      await expectFocused(SELECTOR_DAY(new Date(2100, 0, 1)), `Max available day should be focused`);
+      await waitForFocus(SELECTOR_DAY(new Date(2100, 0, 1)), `Max available day should be focused`);
     });
   });
 });

--- a/e2e-app/src/app/datepicker/multiple/datepicker-multiple.pw-spec.ts
+++ b/e2e-app/src/app/datepicker/multiple/datepicker-multiple.pw-spec.ts
@@ -1,10 +1,10 @@
-import {sendKey, openUrl, Key, expectFocused} from '../../tools.pw-po';
+import {sendKey, openUrl, Key, waitForFocus} from '../../tools.pw-po';
 import {clickOnDay, SELECTOR_DAY} from '../datepicker';
 import {test} from '../../../../playwright.conf';
 
 const expectActive = async(selector: string) => {
   await test.page.waitForSelector(selector + ' >> .active');
-  await expectFocused(selector, `active date should be focused`);
+  await waitForFocus(selector, `active date should be focused`);
 };
 
 describe('Datepicker multiple instances', () => {

--- a/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.pw-spec.ts
+++ b/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.pw-spec.ts
@@ -1,5 +1,5 @@
 import {test} from '../../../../playwright.conf';
-import {expectFocused, getBoundingBox, Key, offsetClick, openUrl, sendKey} from '../../tools.pw-po';
+import {waitForFocus, getBoundingBox, Key, offsetClick, openUrl, sendKey} from '../../tools.pw-po';
 import {
   clickDropdownItem,
   clickOutside,
@@ -54,14 +54,14 @@ containers.forEach((container) => {
       // enter
       await openDropdown(`Opening dropdown for enter`);
       await sendKey(Key.ArrowDown);
-      await expectFocused(SELECTOR_DROPDOWN_ITEM, `first dropdown item should be focused`);
+      await waitForFocus(SELECTOR_DROPDOWN_ITEM, `first dropdown item should be focused`);
       await sendKey(Key.Enter);
       await expectDropdownToBeHidden(`Dropdown should be closed on Enter`);
 
       // space
       await openDropdown(`Opening dropdown for space`);
       await sendKey(Key.ArrowDown);
-      await expectFocused(SELECTOR_DROPDOWN_ITEM, `first dropdown item should be focused`);
+      await waitForFocus(SELECTOR_DROPDOWN_ITEM, `first dropdown item should be focused`);
       await sendKey(Key.Space);
       await expectDropdownToBeHidden(`Dropdown should be closed on Space`);
     });
@@ -112,7 +112,7 @@ containers.forEach((container) => {
       await closeDropdown('Close dropdown');
       await openDropdown('Reopen dropdown');
       await sendKey(Key.ArrowDown);
-      await expectFocused(SELECTOR_DROPDOWN_ITEM, `first dropdown item should be focused`);
+      await waitForFocus(SELECTOR_DROPDOWN_ITEM, `first dropdown item should be focused`);
       await sendKey(Key.Enter);
       await expectDropdownToBeVisible(`Dropdown should NOT be closed on Enter`);
       await sendKey(Key.Space);
@@ -141,7 +141,7 @@ containers.forEach((container) => {
       await closeDropdown('Close dropdown');
       await openDropdown('Reopen dropdown');
       await sendKey(Key.ArrowDown);
-      await expectFocused(SELECTOR_DROPDOWN_ITEM, `first dropdown item should be focused`);
+      await waitForFocus(SELECTOR_DROPDOWN_ITEM, `first dropdown item should be focused`);
       await sendKey(Key.Enter);
       await expectDropdownToBeVisible(`Dropdown should NOT be closed on Enter`);
       await sendKey(Key.Space);
@@ -168,14 +168,14 @@ containers.forEach((container) => {
       // enter
       await openDropdown(`Opening dropdown for enter`);
       await sendKey(Key.ArrowDown);
-      await expectFocused(SELECTOR_DROPDOWN_ITEM, `first dropdown item should be focused`);
+      await waitForFocus(SELECTOR_DROPDOWN_ITEM, `first dropdown item should be focused`);
       await sendKey(Key.Enter);
       await expectDropdownToBeHidden(`Dropdown should be closed on Enter`);
 
       // space
       await openDropdown(`Opening dropdown for space`);
       await sendKey(Key.ArrowDown);
-      await expectFocused(SELECTOR_DROPDOWN_ITEM, `first dropdown item should be focused`);
+      await waitForFocus(SELECTOR_DROPDOWN_ITEM, `first dropdown item should be focused`);
       await sendKey(Key.Space);
       await expectDropdownToBeHidden(`Dropdown should be closed on Space`);
     });

--- a/e2e-app/src/app/dropdown/click/dropdown-click.pw-spec.ts
+++ b/e2e-app/src/app/dropdown/click/dropdown-click.pw-spec.ts
@@ -1,4 +1,4 @@
-import {openUrl, sendKey, Key, expectFocused} from '../../tools.pw-po';
+import {openUrl, sendKey, Key, waitForFocus} from '../../tools.pw-po';
 import {test} from '../../../../playwright.conf';
 import {isDropdownOpened} from '../dropdown';
 
@@ -7,11 +7,11 @@ const SELECTOR_DROPDOWN_ITEM = '[ngbDropdownItem]';
 
 const focusDropdownItem = async(index: number) => {
   await test.page.press(SELECTOR_DROPDOWN_TOGGLE, Key.ArrowDown);
-  await expectFocused(SELECTOR_DROPDOWN_TOGGLE, `dropdown should be focused`);
+  await waitForFocus(SELECTOR_DROPDOWN_TOGGLE, `dropdown should be focused`);
   for (let i = 0; i <= index; ++i) {
     await sendKey(Key.ArrowDown);
   }
-  await expectFocused(`${SELECTOR_DROPDOWN_ITEM}:nth-child(${index + 1})`, `Item should be focused`);
+  await waitForFocus(`${SELECTOR_DROPDOWN_ITEM}:nth-child(${index + 1})`, `Item should be focused`);
 };
 
 describe(`Dropdown user (click) handler`, () => {

--- a/e2e-app/src/app/dropdown/focus/dropdown-focus.pw-spec.ts
+++ b/e2e-app/src/app/dropdown/focus/dropdown-focus.pw-spec.ts
@@ -1,6 +1,6 @@
 import {isDropdownOpened, openDropdown} from '../dropdown';
 import {test} from '../../../../playwright.conf';
-import {sendKey, Key, expectFocused, openUrl} from '../../tools.pw-po';
+import {sendKey, Key, waitForFocus, openUrl} from '../../tools.pw-po';
 
 const SELECTOR_DROPDOWN = '[ngbDropdown]';
 const SELECTOR_DROPDOWN_TOGGLE = '[ngbDropdownToggle]';
@@ -8,7 +8,7 @@ const SELECTOR_DROPDOWN_ITEM = (item: number) => `#item-${item}`;
 
 const focusToggle = async() => {
   await test.page.focus(SELECTOR_DROPDOWN_TOGGLE);
-  await expectFocused(SELECTOR_DROPDOWN_TOGGLE, `dropdown toggle should be focused`);
+  await waitForFocus(SELECTOR_DROPDOWN_TOGGLE, `dropdown toggle should be focused`);
 };
 
 const selectContainer = async(container: string) => await test.page.click(`#container-${container}`);
@@ -34,114 +34,114 @@ describe(`Dropdown focus`, () => {
       it(`should open dropdown with 'Space' and focus toggling element`, async() => {
         await focusToggle();
         await sendKey(Key.Space);
-        await expectFocused(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
         expect(await isDropdownOpened()).toBeTruthy(`Dropdown should be opened on 'Space' press`);
       });
 
       it(`should open dropdown with 'Enter' and focus toggling element`, async() => {
         await focusToggle();
         await sendKey(Key.Enter);
-        await expectFocused(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
         expect(await isDropdownOpened()).toBeTruthy(`Dropdown should be opened on 'Enter' press`);
       });
 
       it(`should open dropdown with 'ArrowDown' and focus toggling element`, async() => {
         await focusToggle();
         await sendKey(Key.ArrowDown);
-        await expectFocused(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
         expect(await isDropdownOpened()).toBeTruthy(`Dropdown should be opened on 'ArrowDown' press`);
       });
 
       it(`should open dropdown with 'ArrowUp' and focus toggling element`, async() => {
         await focusToggle();
         await sendKey(Key.ArrowUp);
-        await expectFocused(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
         expect(await isDropdownOpened()).toBeTruthy(`Dropdown should be opened on 'ArrowUp' press`);
       });
 
       it(`should focus dropdown items with 'ArrowUp' / 'ArrowDown'`, async() => {
         // Open
         await openDropdown('Dropdown should be opened', SELECTOR_DROPDOWN, container === 'body');
-        await expectFocused(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
 
         // Down -> first
         await sendKey(Key.ArrowDown);
-        await expectFocused(SELECTOR_DROPDOWN_ITEM(1), `first dropdown item should be focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_ITEM(1), `first dropdown item should be focused`);
 
         // Down -> second
         await sendKey(Key.ArrowDown);
-        await expectFocused(SELECTOR_DROPDOWN_ITEM(2), `second dropdown item should be focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_ITEM(2), `second dropdown item should be focused`);
 
         // Down -> second
         await sendKey(Key.ArrowDown);
-        await expectFocused(SELECTOR_DROPDOWN_ITEM(2), `second dropdown item should stay focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_ITEM(2), `second dropdown item should stay focused`);
 
         // Up -> first
         await sendKey(Key.ArrowUp);
-        await expectFocused(SELECTOR_DROPDOWN_ITEM(1), `first dropdown item should be focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_ITEM(1), `first dropdown item should be focused`);
 
         // Up -> first
         await sendKey(Key.ArrowUp);
-        await expectFocused(SELECTOR_DROPDOWN_ITEM(1), `first dropdown item should stay focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_ITEM(1), `first dropdown item should stay focused`);
       });
 
       it(`should focus dropdown first and last items with 'Home' / 'End'`, async() => {
         // Open
         await openDropdown('Dropdown should be opened', SELECTOR_DROPDOWN, container === 'body');
-        await expectFocused(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
 
         // End -> last
         await sendKey(Key.End);
-        await expectFocused(SELECTOR_DROPDOWN_ITEM(2), `last dropdown item should be focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_ITEM(2), `last dropdown item should be focused`);
 
         // Home -> first
         await sendKey(Key.Home);
-        await expectFocused(SELECTOR_DROPDOWN_ITEM(1), `first dropdown item should be focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_ITEM(1), `first dropdown item should be focused`);
       });
 
       it(`should close dropdown with 'Escape' and focus toggling element (toggle was focused)`, async() => {
         await openDropdown('Dropdown should be opened', SELECTOR_DROPDOWN, container === 'body');
-        await expectFocused(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
 
         await sendKey(Key.ESC);
         expect(await isDropdownOpened()).toBeFalsy(`Dropdown should be closed on 'Escape' press`);
-        await expectFocused(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
       });
 
       it(`should close dropdown with 'Escape' and focus toggling element (item was focused)`, async() => {
         await openDropdown('Dropdown should be opened', SELECTOR_DROPDOWN, container === 'body');
-        await expectFocused(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
 
         await sendKey(Key.ArrowDown);
-        await expectFocused(SELECTOR_DROPDOWN_ITEM(1), `first dropdown item should be focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_ITEM(1), `first dropdown item should be focused`);
 
         await sendKey(Key.ESC);
         expect(await isDropdownOpened()).toBeFalsy(`Dropdown should be closed on 'Escape' press`);
-        await expectFocused(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
       });
 
       if (process.env.BROWSER !== 'webkit') {
         it(`should focus dropdown first item with Tab when dropdown is opened (toggle was focused)`, async() => {
           await openDropdown('Dropdown should be opened', SELECTOR_DROPDOWN, container === 'body');
-          await expectFocused(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
+          await waitForFocus(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
 
           // Tab -> first
           await sendKey(Key.Tab);
-          await expectFocused(SELECTOR_DROPDOWN_ITEM(1), `first dropdown item should be focused`);
+          await waitForFocus(SELECTOR_DROPDOWN_ITEM(1), `first dropdown item should be focused`);
         });
       }
 
       it(`should close dropdown with 'Tab' when focus is moved to another element`, async() => {
         await openDropdown('Dropdown should be opened', SELECTOR_DROPDOWN, container === 'body');
-        await expectFocused(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
 
         // Down -> first
         await sendKey(Key.ArrowDown);
-        await expectFocused(SELECTOR_DROPDOWN_ITEM(1), `first dropdown item should be focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_ITEM(1), `first dropdown item should be focused`);
 
         // Home -> last
         await sendKey(Key.End);
-        await expectFocused(SELECTOR_DROPDOWN_ITEM(2), `second dropdown item should be focused`);
+        await waitForFocus(SELECTOR_DROPDOWN_ITEM(2), `second dropdown item should be focused`);
 
         // Tab -> another element
         await sendKey(Key.Tab);
@@ -160,14 +160,14 @@ describe(`Dropdown focus`, () => {
     it(`should open dropdown with 'ArrowDown' and focus toggling element`, async() => {
       await focusToggle();
       await sendKey(Key.ArrowDown);
-      await expectFocused(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
+      await waitForFocus(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
       expect(await isDropdownOpened()).toBeTruthy(`Dropdown should be opened on 'ArrowDown' press`);
     });
 
     it(`should open dropdown with 'ArrowUp' and focus toggling element`, async() => {
       await focusToggle();
       await sendKey(Key.ArrowUp);
-      await expectFocused(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
+      await waitForFocus(SELECTOR_DROPDOWN_TOGGLE, `Toggling element should be focused`);
       expect(await isDropdownOpened()).toBeTruthy(`Dropdown should be opened on 'ArrowUp' press`);
     });
   });

--- a/e2e-app/src/app/timepicker/navigation/timepicker-navigation.pw-spec.ts
+++ b/e2e-app/src/app/timepicker/navigation/timepicker-navigation.pw-spec.ts
@@ -1,4 +1,4 @@
-import {expectFocused, getCaretPosition, openUrl, sendKey} from '../../tools.pw-po';
+import {waitForFocus, getCaretPosition, openUrl, sendKey} from '../../tools.pw-po';
 import {test} from '../../../../playwright.conf';
 import {SELECTOR_HOUR, SELECTOR_MIN, SELECTOR_SEC} from '../timepicker';
 
@@ -22,22 +22,22 @@ describe('Timepicker', () => {
       await focusInputBefore();
 
       await sendKey('Tab');
-      await expectFocused(SELECTOR_HOUR, 'Hour field should be focused');
+      await waitForFocus(SELECTOR_HOUR, 'Hour field should be focused');
       await sendKey('Tab');
-      await expectFocused(SELECTOR_MIN, 'Minute field should be focused');
+      await waitForFocus(SELECTOR_MIN, 'Minute field should be focused');
       await sendKey('Tab');
-      await expectFocused(SELECTOR_SEC, 'Second field should be focused');
+      await waitForFocus(SELECTOR_SEC, 'Second field should be focused');
       await sendKey('Tab');
-      await expectFocused(SELECTOR_AFTER, 'Input after should be focused');
+      await waitForFocus(SELECTOR_AFTER, 'Input after should be focused');
 
       await sendKey('Shift+Tab');
-      await expectFocused(SELECTOR_SEC, 'Second field should be focused');
+      await waitForFocus(SELECTOR_SEC, 'Second field should be focused');
       await sendKey('Shift+Tab');
-      await expectFocused(SELECTOR_MIN, 'Minute field should be focused');
+      await waitForFocus(SELECTOR_MIN, 'Minute field should be focused');
       await sendKey('Shift+Tab');
-      await expectFocused(SELECTOR_HOUR, 'Hour field should be focused');
+      await waitForFocus(SELECTOR_HOUR, 'Hour field should be focused');
       await sendKey('Shift+Tab');
-      await expectFocused(SELECTOR_BEFORE, 'Input before should be focused');
+      await waitForFocus(SELECTOR_BEFORE, 'Input before should be focused');
     });
   });
 

--- a/e2e-app/src/app/tools.pw-po.ts
+++ b/e2e-app/src/app/tools.pw-po.ts
@@ -59,14 +59,14 @@ export const offsetClick = async(selector, position) => {
 
 
 /**
- * Expects provided element to be focused
+ * Wait for the provided element to be focused
  *
- * @param el element to check
+ * @param selector element selector to check
  * @param message to display in case of error
  */
-export const expectFocused = async(selector, message) => {
-  const foo1Isfocused = await page().$eval(selector, (el) => el === document.activeElement);
-  expect(foo1Isfocused).toBeTruthy(message);
+export const waitForFocus = async(selector, message = `Unable to focus '${selector}'`) => {
+  const el = await page().$(selector);
+  await timeoutMessage(page().waitForFunction(function(_el) { return _el === document.activeElement; }, el), message);
 };
 
 /**
@@ -110,3 +110,21 @@ export const getBoundingBox = async(selector: string) => {
  */
 export const getCaretPosition = async(selector: string) =>
     await page().$eval(selector, (el: HTMLInputElement) => ({start: el.selectionStart, end: el.selectionEnd}));
+
+/**
+* Add a custom message on a playwright timeout failure
+* This is a workaround, waiting for the followinf PR to be merged:
+* {@link https://github.com/microsoft/playwright/pull/4778}
+* @template T
+* @param {Promise<T>} promise
+* @param {string} message
+* @return {Promise<T>}
+*/
+export const timeoutMessage = (promise, message) => {
+  return promise.catch(e => {
+    if (e instanceof require('playwright').errors.TimeoutError) {
+      e.message += '\n' + message;
+    }
+    throw e;
+  });
+};

--- a/e2e-app/src/app/typeahead/autoclose/typeahead-autoclose.pw-spec.ts
+++ b/e2e-app/src/app/typeahead/autoclose/typeahead-autoclose.pw-spec.ts
@@ -1,4 +1,4 @@
-import {openUrl, expectFocused, sendKey, Key} from '../../tools.pw-po';
+import {openUrl, waitForFocus, sendKey, Key} from '../../tools.pw-po';
 import {test} from '../../../../playwright.conf';
 import {getTypeaheadValue, SELECTOR_TYPEAHEAD, SELECTOR_TYPEAHEAD_ITEMS, SELECTOR_TYPEAHEAD_WINDOW} from '../typeahead';
 
@@ -56,7 +56,7 @@ describe('Typeahead Autoclose', () => {
 
     await clickOutside();
     await expectTypeaheadToBeClosed(`Dropdown should become hidden`);
-    await expectFocused(SELECTOR_OUTSIDE_BUTTON, `Clicked button should be focused`);
+    await waitForFocus(SELECTOR_OUTSIDE_BUTTON, `Clicked button should be focused`);
   });
 
   it(`should close typeahead on outside click and lose focus (with hint)`, async() => {
@@ -66,7 +66,7 @@ describe('Typeahead Autoclose', () => {
 
     await clickOutside();
     await expectTypeaheadToBeClosed(`Dropdown should become hidden`);
-    await expectFocused(SELECTOR_OUTSIDE_BUTTON, `Clicked button should be focused`);
+    await waitForFocus(SELECTOR_OUTSIDE_BUTTON, `Clicked button should be focused`);
     expect(await getTypeaheadValue()).toBe('o', `Hint should have been removed`);
   });
 
@@ -75,7 +75,7 @@ describe('Typeahead Autoclose', () => {
 
     await test.page.click(SELECTOR_TYPEAHEAD);
     await expectTypeaheadToBeOpen(`Dropdown should stay visible`);
-    await expectFocused(SELECTOR_TYPEAHEAD, `Typeahead input should stay focused`);
+    await waitForFocus(SELECTOR_TYPEAHEAD, `Typeahead input should stay focused`);
   });
 
   it(`should close typeahead on item click and stay focused`, async() => {
@@ -83,7 +83,7 @@ describe('Typeahead Autoclose', () => {
 
     await test.page.click(`${SELECTOR_TYPEAHEAD_ITEMS}:first-child`);
     await expectTypeaheadToBeClosed(`Dropdown should become hidden`);
-    await expectFocused(SELECTOR_TYPEAHEAD, `Typeahead input should stay focused`);
+    await waitForFocus(SELECTOR_TYPEAHEAD, `Typeahead input should stay focused`);
   });
 
   it(`should close typeahead on Escape and stay focused`, async() => {
@@ -91,7 +91,7 @@ describe('Typeahead Autoclose', () => {
 
     await sendKey(Key.ESC);
     await expectTypeaheadToBeClosed(`Dropdown should become hidden`);
-    await expectFocused(SELECTOR_TYPEAHEAD, `Typeahead input should stay focused`);
+    await waitForFocus(SELECTOR_TYPEAHEAD, `Typeahead input should stay focused`);
   });
 
   it(`should close typeahead on Escape and stay focused (with hint)`, async() => {
@@ -101,7 +101,7 @@ describe('Typeahead Autoclose', () => {
 
     await sendKey(Key.ESC);
     await expectTypeaheadToBeClosed(`Dropdown should become hidden`);
-    await expectFocused(SELECTOR_TYPEAHEAD, `Typeahead input should stay focused`);
+    await waitForFocus(SELECTOR_TYPEAHEAD, `Typeahead input should stay focused`);
     expect(await getTypeaheadValue()).toBe('o', `Hint should have been removed`);
   });
 });

--- a/e2e-app/src/app/typeahead/focus/typeahead-focus.pw-spec.ts
+++ b/e2e-app/src/app/typeahead/focus/typeahead-focus.pw-spec.ts
@@ -1,14 +1,14 @@
-import {expectFocused, Key, openUrl, sendKey} from '../../tools.pw-po';
+import {waitForFocus, Key, openUrl, sendKey} from '../../tools.pw-po';
 import {test} from '../../../../playwright.conf';
 import {getTypeaheadValue, SELECTOR_TYPEAHEAD, SELECTOR_TYPEAHEAD_ITEMS, SELECTOR_TYPEAHEAD_WINDOW} from '../typeahead';
 
 describe('Typeahead', () => {
 
-  const expectTypeaheadFocused = async() => await expectFocused(SELECTOR_TYPEAHEAD, `Typeahead should be focused`);
+  const expectTypeaheadFocused = async() => await waitForFocus(SELECTOR_TYPEAHEAD, `Typeahead should be focused`);
 
   const expectDropdownOpen = async(suggestions = 10) => {
     const items = await test.page.$$(SELECTOR_TYPEAHEAD_ITEMS);
-    expect(items.length).toBe(suggestions, `Wrong numbre of suggestions`);
+    expect(items.length).toBe(suggestions, `Wrong number of suggestions`);
   };
 
   const expectDropDownClosed = async() =>
@@ -55,8 +55,13 @@ describe('Typeahead', () => {
      });
 
   describe('Keyboard', () => {
-    it(`should be focused on item selection`, async() => {
+
+    beforeEach(async() => {
+      // Be sure that the mouse does not interfere with the highlighted items in dropdown
       await clickBefore();
+    });
+
+    it(`should be focused on item selection`, async() => {
       await sendKey(Key.Tab);
       await expectTypeaheadFocused();
       await expectDropdownOpen();
@@ -69,6 +74,7 @@ describe('Typeahead', () => {
     if (process.env.BROWSER !== 'webkit') {
       it(`should select element on tab`, async() => {
         await test.page.focus(SELECTOR_TYPEAHEAD);
+        await waitForFocus(SELECTOR_TYPEAHEAD);
         await sendKey(Key.Tab);
         await expectTypeaheadFocused();
         await expectDropDownClosed();


### PR DESCRIPTION
The purpose is to render the tests more stable with all the browsers