### PR TITLE
feat(datepicker): allow configuring weekday format

### DIFF
--- a/demo/src/app/components/datepicker/demos/i18n/datepicker-i18n.ts
+++ b/demo/src/app/components/datepicker/demos/i18n/datepicker-i18n.ts
@@ -25,13 +25,8 @@ export class CustomDatepickerI18n extends NgbDatepickerI18n {
   }
 
   getWeekdayShortName(weekday: number): string {
-    return this.getWeekdayName(weekday);
-  }
-
-  getWeekdayName(weekday: number): string {
     return I18N_VALUES[this._i18n.language].weekdays[weekday - 1];
   }
-
   getMonthShortName(month: number): string {
     return I18N_VALUES[this._i18n.language].months[month - 1];
   }

--- a/demo/src/app/components/datepicker/demos/islamiccivil/datepicker-islamiccivil.ts
+++ b/demo/src/app/components/datepicker/demos/islamiccivil/datepicker-islamiccivil.ts
@@ -11,10 +11,6 @@ const MONTHS = ['محرم', 'صفر', 'ربيع الأول', 'ربيع الآخ�
 export class IslamicI18n extends NgbDatepickerI18n {
 
   getWeekdayShortName(weekday: number) {
-    return this.getWeekdayName(weekday);
-  }
-
-  getWeekdayName(weekday: number) {
     return WEEKDAYS[weekday - 1];
   }
 

--- a/demo/src/app/components/datepicker/demos/islamicumalqura/datepicker-islamicumalqura.ts
+++ b/demo/src/app/components/datepicker/demos/islamicumalqura/datepicker-islamicumalqura.ts
@@ -11,10 +11,6 @@ const MONTHS = ['محرم', 'صفر', 'ربيع الأول', 'ربيع الآخ�
 export class IslamicI18n extends NgbDatepickerI18n {
 
   getWeekdayShortName(weekday: number) {
-    return this.getWeekdayName(weekday);
-  }
-
-  getWeekdayName(weekday: number) {
     return WEEKDAYS[weekday - 1];
   }
 

--- a/demo/src/app/components/datepicker/demos/jalali/datepicker-jalali.ts
+++ b/demo/src/app/components/datepicker/demos/jalali/datepicker-jalali.ts
@@ -6,8 +6,7 @@ const MONTHS = ['فروردین', 'اردیبهشت', 'خرداد', 'تیر', '�
 
 @Injectable()
 export class NgbDatepickerI18nPersian extends NgbDatepickerI18n {
-  getWeekdayShortName(weekday: number) { return this.getWeekdayName(weekday); }
-  getWeekdayName(weekday: number) { return WEEKDAYS_SHORT[weekday - 1]; }
+  getWeekdayShortName(weekday: number) { return WEEKDAYS_SHORT[weekday - 1]; }
   getMonthShortName(month: number) { return MONTHS[month - 1]; }
   getMonthFullName(month: number) { return MONTHS[month - 1]; }
   getDayAriaLabel(date: NgbDateStruct): string { return `${date.year}-${this.getMonthFullName(date.month)}-${date.day}`; }

--- a/demo/src/app/components/datepicker/overview/datepicker-overview.component.ts
+++ b/demo/src/app/components/datepicker/overview/datepicker-overview.component.ts
@@ -184,7 +184,6 @@ export class NgbdDatepickerOverviewComponent {
         @Injectable()
         export abstract class NgbDatepickerI18n {
           abstract getWeekdayShortName(weekday: number): string;
-          abstract getWeekdayName(weekday: number): string;
           abstract getMonthShortName(month: number): string;
           abstract getMonthFullName(month: number): string;
           abstract getDayAriaLabel(date: NgbDateStruct): string;

--- a/src/datepicker/datepicker-config.ts
+++ b/src/datepicker/datepicker-config.ts
@@ -1,4 +1,5 @@
 import {Injectable, TemplateRef} from '@angular/core';
+import {TranslationWidth} from '@angular/common';
 import {DayTemplateContext} from './datepicker-day-template-context';
 import {NgbDateStruct} from './ngb-date-struct';
 
@@ -23,4 +24,5 @@ export class NgbDatepickerConfig {
   showWeekdays = true;
   showWeekNumbers = false;
   startDate: {year: number, month: number};
+  weekdays: TranslationWidth | boolean = TranslationWidth.Short;
 }

--- a/src/datepicker/datepicker-day-view.spec.ts
+++ b/src/datepicker/datepicker-day-view.spec.ts
@@ -4,8 +4,6 @@ import {Component} from '@angular/core';
 import {NgbDatepickerDayView} from './datepicker-day-view';
 import {NgbDate} from './ngb-date';
 import {NgbDatepickerI18n, NgbDatepickerI18nDefault} from './datepicker-i18n';
-import {NGB_DATEPICKER_WEEKDAY_FORMAT} from './datepicker-weekday-format';
-import {TranslationWidth} from '@angular/common';
 
 function getElement(element: HTMLElement): HTMLElement {
   return <HTMLElement>element.querySelector('[ngbDatepickerDayView]');
@@ -16,10 +14,7 @@ describe('ngbDatepickerDayView', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [TestComponent, NgbDatepickerDayView],
-      providers: [
-        {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nDefault},
-        {provide: NGB_DATEPICKER_WEEKDAY_FORMAT, useValue: TranslationWidth.Short}
-      ]
+      providers: [{provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nDefault}]
     });
   });
 

--- a/src/datepicker/datepicker-i18n.spec.ts
+++ b/src/datepicker/datepicker-i18n.spec.ts
@@ -25,11 +25,18 @@ describe('ngb-datepicker-i18n-default', () => {
     expect(i18n.getMonthFullName(13)).toBe('');
   });
 
-  it('should return weekday name', () => {
+  it('should return weekday short name', () => {
     expect(i18n.getWeekdayShortName(0)).toBe('');
     expect(i18n.getWeekdayShortName(1)).toBe('Mo');
     expect(i18n.getWeekdayShortName(7)).toBe('Su');
     expect(i18n.getWeekdayShortName(8)).toBe('');
+  });
+
+  it('should return weekday label', () => {
+    expect(i18n.getWeekdayLabel(0)).toBe('');
+    expect(i18n.getWeekdayLabel(1)).toBe('Mo');
+    expect(i18n.getWeekdayLabel(7)).toBe('Su');
+    expect(i18n.getWeekdayLabel(8)).toBe('');
   });
 
   it('should generate aria label for a date',

--- a/src/datepicker/datepicker-i18n.spec.ts
+++ b/src/datepicker/datepicker-i18n.spec.ts
@@ -1,18 +1,13 @@
 import {NgbDatepickerI18nDefault} from './datepicker-i18n';
 import {TestBed} from '@angular/core/testing';
 import {NgbDate} from './ngb-date';
-import {NGB_DATEPICKER_WEEKDAY_FORMAT} from './datepicker-weekday-format';
-import {TranslationWidth} from '@angular/common';
 
 describe('ngb-datepicker-i18n-default', () => {
 
   let i18n: NgbDatepickerI18nDefault;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers:
-          [NgbDatepickerI18nDefault, {provide: NGB_DATEPICKER_WEEKDAY_FORMAT, useValue: TranslationWidth.Short}]
-    });
+    TestBed.configureTestingModule({providers: [NgbDatepickerI18nDefault]});
     i18n = TestBed.inject(NgbDatepickerI18nDefault);
   });
 
@@ -31,10 +26,10 @@ describe('ngb-datepicker-i18n-default', () => {
   });
 
   it('should return weekday name', () => {
-    expect(i18n.getWeekdayName(0)).toBe('');
-    expect(i18n.getWeekdayName(1)).toBe('Mo');
-    expect(i18n.getWeekdayName(7)).toBe('Su');
-    expect(i18n.getWeekdayName(8)).toBe('');
+    expect(i18n.getWeekdayShortName(0)).toBe('');
+    expect(i18n.getWeekdayShortName(1)).toBe('Mo');
+    expect(i18n.getWeekdayShortName(7)).toBe('Su');
+    expect(i18n.getWeekdayShortName(8)).toBe('');
   });
 
   it('should generate aria label for a date',

--- a/src/datepicker/datepicker-i18n.ts
+++ b/src/datepicker/datepicker-i18n.ts
@@ -1,10 +1,9 @@
 import {Inject, Injectable, LOCALE_ID} from '@angular/core';
 import {FormStyle, getLocaleDayNames, getLocaleMonthNames, TranslationWidth, formatDate} from '@angular/common';
 import {NgbDateStruct} from './ngb-date-struct';
-import {NGB_DATEPICKER_WEEKDAY_FORMAT} from './datepicker-weekday-format';
 
-export function NGB_DATEPICKER_18N_FACTORY(locale, weekDayFormat) {
-  return new NgbDatepickerI18nDefault(locale, weekDayFormat);
+export function NGB_DATEPICKER_18N_FACTORY(locale) {
+  return new NgbDatepickerI18nDefault(locale);
 }
 
 /**
@@ -20,8 +19,7 @@ export function NGB_DATEPICKER_18N_FACTORY(locale, weekDayFormat) {
  * [Hebrew calendar demo](#/components/datepicker/calendars#hebrew) on how to extend this class and define
  * a custom provider for i18n.
  */
-@Injectable(
-    {providedIn: 'root', useFactory: NGB_DATEPICKER_18N_FACTORY, deps: [LOCALE_ID, NGB_DATEPICKER_WEEKDAY_FORMAT]})
+@Injectable({providedIn: 'root', useFactory: NGB_DATEPICKER_18N_FACTORY, deps: [LOCALE_ID]})
 export abstract class NgbDatepickerI18n {
   /**
    * Returns the short weekday name to display in the heading of the month view.
@@ -29,14 +27,6 @@ export abstract class NgbDatepickerI18n {
    * With default calendar we use ISO 8601: 'weekday' is 1=Mon ... 7=Sun.
    */
   abstract getWeekdayShortName(weekday: number): string;
-
-  /**
- * Returns the weekday name to display in the heading of the month view.
- * By default the format is short, but it can be changed with the NGB_DATEPICKER_WEEKDAY_FORMAT token.
- *
- * With default calendar we use ISO 8601: 'weekday' is 1=Mon ... 7=Sun.
- */
-  abstract getWeekdayName(weekday: number): string;
 
   /**
    * Returns the short month name to display in the date picker navigation.
@@ -98,24 +88,21 @@ export abstract class NgbDatepickerI18n {
  */
 @Injectable()
 export class NgbDatepickerI18nDefault extends NgbDatepickerI18n {
-  private _weekdays: readonly string[];
+  private _weekdaysShort: readonly string[];
   private _monthsShort: readonly string[];
   private _monthsFull: readonly string[];
 
-  constructor(
-      @Inject(LOCALE_ID) private _locale: string,
-      @Inject(NGB_DATEPICKER_WEEKDAY_FORMAT) weekDayFormat: TranslationWidth) {
+  constructor(@Inject(LOCALE_ID) private _locale: string) {
     super();
-    const weekdaysStartingOnSunday = getLocaleDayNames(_locale, FormStyle.Standalone, weekDayFormat);
-    this._weekdays = weekdaysStartingOnSunday.map((day, index) => weekdaysStartingOnSunday[(index + 1) % 7]);
+
+    const weekdaysStartingOnSunday = getLocaleDayNames(_locale, FormStyle.Standalone, TranslationWidth.Short);
+    this._weekdaysShort = weekdaysStartingOnSunday.map((day, index) => weekdaysStartingOnSunday[(index + 1) % 7]);
 
     this._monthsShort = getLocaleMonthNames(_locale, FormStyle.Standalone, TranslationWidth.Abbreviated);
     this._monthsFull = getLocaleMonthNames(_locale, FormStyle.Standalone, TranslationWidth.Wide);
   }
 
-  getWeekdayShortName(weekday: number): string { return this.getWeekdayName(weekday); }
-
-  getWeekdayName(weekday: number): string { return this._weekdays[weekday - 1] || ''; }
+  getWeekdayShortName(weekday: number): string { return this._weekdaysShort[weekday - 1] || ''; }
 
   getMonthShortName(month: number): string { return this._monthsShort[month - 1] || ''; }
 

--- a/src/datepicker/datepicker-i18n.ts
+++ b/src/datepicker/datepicker-i18n.ts
@@ -1,5 +1,5 @@
 import {Inject, Injectable, LOCALE_ID} from '@angular/core';
-import {FormStyle, getLocaleDayNames, getLocaleMonthNames, TranslationWidth, formatDate} from '@angular/common';
+import {formatDate, FormStyle, getLocaleDayNames, getLocaleMonthNames, TranslationWidth} from '@angular/common';
 import {NgbDateStruct} from './ngb-date-struct';
 
 export function NGB_DATEPICKER_18N_FACTORY(locale) {
@@ -25,8 +25,17 @@ export abstract class NgbDatepickerI18n {
    * Returns the short weekday name to display in the heading of the month view.
    *
    * With default calendar we use ISO 8601: 'weekday' is 1=Mon ... 7=Sun.
+   *
+   * @deprecated 9.1.0, use 'getWeekdayLabel' instead
    */
   abstract getWeekdayShortName(weekday: number): string;
+
+  /**
+   * Returns the weekday label using specified width
+   *
+   * @since 9.1.0
+   */
+  getWeekdayLabel(weekday: number, width?: TranslationWidth): string { return this.getWeekdayShortName(weekday); }
 
   /**
    * Returns the short month name to display in the date picker navigation.
@@ -88,21 +97,24 @@ export abstract class NgbDatepickerI18n {
  */
 @Injectable()
 export class NgbDatepickerI18nDefault extends NgbDatepickerI18n {
-  private _weekdaysShort: readonly string[];
   private _monthsShort: readonly string[];
   private _monthsFull: readonly string[];
 
   constructor(@Inject(LOCALE_ID) private _locale: string) {
     super();
 
-    const weekdaysStartingOnSunday = getLocaleDayNames(_locale, FormStyle.Standalone, TranslationWidth.Short);
-    this._weekdaysShort = weekdaysStartingOnSunday.map((day, index) => weekdaysStartingOnSunday[(index + 1) % 7]);
-
     this._monthsShort = getLocaleMonthNames(_locale, FormStyle.Standalone, TranslationWidth.Abbreviated);
     this._monthsFull = getLocaleMonthNames(_locale, FormStyle.Standalone, TranslationWidth.Wide);
   }
 
-  getWeekdayShortName(weekday: number): string { return this._weekdaysShort[weekday - 1] || ''; }
+  getWeekdayShortName(weekday: number): string { return this.getWeekdayLabel(weekday, TranslationWidth.Short); }
+
+  getWeekdayLabel(weekday: number, width?: TranslationWidth): string {
+    const weekdaysStartingOnSunday =
+        getLocaleDayNames(this._locale, FormStyle.Standalone, width === undefined ? TranslationWidth.Short : width);
+    const weekdays = weekdaysStartingOnSunday.map((day, index) => weekdaysStartingOnSunday[(index + 1) % 7]);
+    return weekdays[weekday - 1] || '';
+  }
 
   getMonthShortName(month: number): string { return this._monthsShort[month - 1] || ''; }
 

--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -747,6 +747,17 @@ describe('NgbInputDatepicker', () => {
       expect(dp.showWeekdays).toBeTruthy();
     });
 
+    it('should propagate the "weekdays" option', () => {
+      const fixture = createTestCmpt(`<input ngbDatepicker [weekdays]="false">`);
+      const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);
+
+      dpInput.open();
+      fixture.detectChanges();
+
+      const dp = fixture.debugElement.query(By.css('ngb-datepicker')).injector.get(NgbDatepicker);
+      expect(dp.weekdays).toBeFalse();
+    });
+
     it('should propagate the "showWeekNumbers" option', () => {
       const fixture = createTestCmpt(`<input ngbDatepicker [showWeekNumbers]="true">`);
       const dpInput = fixture.debugElement.query(By.directive(NgbInputDatepicker)).injector.get(NgbInputDatepicker);

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -17,7 +17,7 @@ import {
   TemplateRef,
   ViewContainerRef
 } from '@angular/core';
-import {DOCUMENT} from '@angular/common';
+import {DOCUMENT, TranslationWidth} from '@angular/common';
 import {
   AbstractControl,
   ControlValueAccessor,
@@ -69,12 +69,14 @@ export class NgbInputDatepicker implements OnChanges,
   static ngAcceptInputType_disabled: boolean | '';
   static ngAcceptInputType_navigation: string;
   static ngAcceptInputType_outsideDays: string;
+  static ngAcceptInputType_weekdays: boolean | number;
 
   private _cRef: ComponentRef<NgbDatepicker>| null = null;
   private _disabled = false;
   private _elWithFocus: HTMLElement | null = null;
   private _model: NgbDate | null = null;
   private _inputValue: string;
+  private _showWeekdays: boolean;
   private _zoneSubscription: any;
 
   /**
@@ -197,8 +199,16 @@ export class NgbInputDatepicker implements OnChanges,
 
   /**
    * If `true`, weekdays will be displayed.
+   *
+   * @deprecated 9.1.0, please use 'weekdays' instead
    */
-  @Input() showWeekdays: boolean;
+  @Input()
+  set showWeekdays(weekdays: boolean) {
+    this.weekdays = weekdays;
+    this._showWeekdays = weekdays;
+  }
+
+  get showWeekdays(): boolean { return this._showWeekdays; }
 
   /**
    * If `true`, week numbers will be displayed.
@@ -230,6 +240,17 @@ export class NgbInputDatepicker implements OnChanges,
    * @since 4.2.0
    */
   @Input() positionTarget: string | HTMLElement;
+
+  /**
+   * The way weekdays should be displayed.
+   *
+   * * `true` - weekdays are displayed using default width
+   * * `false` - weekdays are not displayed
+   * * `TranslationWidth` - weekdays are displayed using specified width
+   *
+   * @since 9.1.0
+   */
+  @Input() weekdays: TranslationWidth | boolean;
 
   /**
    * An event emitted when user selects a date using keyboard or mouse.
@@ -453,7 +474,7 @@ export class NgbInputDatepicker implements OnChanges,
 
   private _applyDatepickerInputs(datepickerInstance: NgbDatepicker): void {
     ['dayTemplate', 'dayTemplateData', 'displayMonths', 'firstDayOfWeek', 'footerTemplate', 'markDisabled', 'minDate',
-     'maxDate', 'navigation', 'outsideDays', 'showNavigation', 'showWeekdays', 'showWeekNumbers']
+     'maxDate', 'navigation', 'outsideDays', 'showNavigation', 'showWeekNumbers', 'weekdays']
         .forEach((optionName: string) => {
           if (this[optionName] !== undefined) {
             datepickerInstance[optionName] = this[optionName];

--- a/src/datepicker/datepicker-month.spec.ts
+++ b/src/datepicker/datepicker-month.spec.ts
@@ -25,21 +25,12 @@ const createTestComponent = () => createGenericTestComponent(
 `,
     TestComponent) as ComponentFixture<TestComponent>;
 
-function getWeekdays(element: HTMLElement): HTMLElement[] {
-  return <HTMLElement[]>Array.from(element.querySelectorAll('.ngb-dp-weekday'));
-}
-
 function getWeekNumbers(element: HTMLElement): HTMLElement[] {
   return <HTMLElement[]>Array.from(element.querySelectorAll('.ngb-dp-week-number'));
 }
 
 function getDates(element: HTMLElement): HTMLElement[] {
   return <HTMLElement[]>Array.from(element.querySelectorAll('.ngb-dp-day'));
-}
-
-function expectWeekdays(element: HTMLElement, weekdays: string[]) {
-  const result = getWeekdays(element).map(td => td.innerText.trim());
-  expect(result).toEqual(weekdays);
 }
 
 function expectWeekNumbers(element: HTMLElement, weeknumbers: string[]) {
@@ -60,7 +51,7 @@ class MockDatepickerService extends NgbDatepickerService {
       lastDate: new NgbDate(2016, 8, 31),
       year: 2016,
       number: 8,
-      weekdays: [1, 2],
+      weekdays: ['Mo', 'Tu'],
       weeks: [
         // month: 7, 8
         {
@@ -239,18 +230,6 @@ describe('ngb-datepicker-month', () => {
       imports: [NgbDatepickerModule],
       providers: [{provide: NgbDatepickerService, useClass: MockDatepickerService}]
     });
-  });
-
-  it('should show/hide weekdays', () => {
-    const fixture = createTestComponent();
-    fixture.componentInstance.showWeekNumbers = false;
-    fixture.detectChanges();
-
-    expectWeekdays(fixture.nativeElement, ['Mo', 'Tu']);
-
-    fixture.componentInstance.showWeekdays = false;
-    fixture.detectChanges();
-    expectWeekdays(fixture.nativeElement, []);
   });
 
   it('should show/hide week numbers', () => {

--- a/src/datepicker/datepicker-month.ts
+++ b/src/datepicker/datepicker-month.ts
@@ -20,11 +20,9 @@ import {NgbDateStruct} from './ngb-date-struct';
   encapsulation: ViewEncapsulation.None,
   styleUrls: ['./datepicker-month.scss'],
   template: `
-    <div *ngIf="datepicker.showWeekdays" class="ngb-dp-week ngb-dp-weekdays" role="row">
+    <div *ngIf="viewModel.weekdays.length > 0" class="ngb-dp-week ngb-dp-weekdays" role="row">
       <div *ngIf="datepicker.showWeekNumbers" class="ngb-dp-weekday ngb-dp-showweek"></div>
-      <div *ngFor="let w of viewModel.weekdays" class="ngb-dp-weekday small" role="columnheader">
-        {{ i18n.getWeekdayShortName(w) }}
-      </div>
+      <div *ngFor="let weekday of viewModel.weekdays" class="ngb-dp-weekday small" role="columnheader">{{ weekday }}</div>
     </div>
     <ng-template ngFor let-week [ngForOf]="viewModel.weeks">
       <div *ngIf="!week.collapsed" class="ngb-dp-week" role="row">

--- a/src/datepicker/datepicker-month.ts
+++ b/src/datepicker/datepicker-month.ts
@@ -23,7 +23,7 @@ import {NgbDateStruct} from './ngb-date-struct';
     <div *ngIf="datepicker.showWeekdays" class="ngb-dp-week ngb-dp-weekdays" role="row">
       <div *ngIf="datepicker.showWeekNumbers" class="ngb-dp-weekday ngb-dp-showweek"></div>
       <div *ngFor="let w of viewModel.weekdays" class="ngb-dp-weekday small" role="columnheader">
-        {{ i18n.getWeekdayName(w) }}
+        {{ i18n.getWeekdayShortName(w) }}
       </div>
     </div>
     <ng-template ngFor let-week [ngForOf]="viewModel.weeks">

--- a/src/datepicker/datepicker-service.spec.ts
+++ b/src/datepicker/datepicker-service.spec.ts
@@ -5,8 +5,6 @@ import {NgbDate} from './ngb-date';
 import {Subscription} from 'rxjs';
 import {DatepickerViewModel} from './datepicker-view-model';
 import {NgbDatepickerI18n, NgbDatepickerI18nDefault} from './datepicker-i18n';
-import {NGB_DATEPICKER_WEEKDAY_FORMAT} from './datepicker-weekday-format';
-import {TranslationWidth} from '@angular/common';
 
 describe('ngb-datepicker-service', () => {
 
@@ -28,8 +26,7 @@ describe('ngb-datepicker-service', () => {
     TestBed.configureTestingModule({
       providers: [
         NgbDatepickerService, {provide: NgbCalendar, useClass: NgbCalendarGregorian},
-        {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nDefault},
-        {provide: NGB_DATEPICKER_WEEKDAY_FORMAT, useValue: TranslationWidth.Short}
+        {provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nDefault}
       ]
     });
 

--- a/src/datepicker/datepicker-service.spec.ts
+++ b/src/datepicker/datepicker-service.spec.ts
@@ -5,6 +5,7 @@ import {NgbDate} from './ngb-date';
 import {Subscription} from 'rxjs';
 import {DatepickerViewModel} from './datepicker-view-model';
 import {NgbDatepickerI18n, NgbDatepickerI18nDefault} from './datepicker-i18n';
+import {TranslationWidth} from '@angular/common';
 
 describe('ngb-datepicker-service', () => {
 
@@ -232,18 +233,18 @@ describe('ngb-datepicker-service', () => {
     it(`should generate a month with firstDayOfWeek=1 by default`, () => {
       service.focus(new NgbDate(2017, 5, 5));
       expect(model.months.length).toBe(1);
-      expect(model.months[0].weekdays[0]).toBe(1);
+      expect(model.months[0].weekdays[0]).toBe('Mo');
     });
 
     it(`should generate weeks starting with 'firstDayOfWeek'`, () => {
       service.set({firstDayOfWeek: 2});
       service.focus(new NgbDate(2017, 5, 5));
       expect(model.months.length).toBe(1);
-      expect(model.months[0].weekdays[0]).toBe(2);
+      expect(model.months[0].weekdays[0]).toBe('Tu');
 
       service.set({firstDayOfWeek: 4});
       expect(model.months.length).toBe(1);
-      expect(model.months[0].weekdays[0]).toBe(4);
+      expect(model.months[0].weekdays[0]).toBe('Th');
     });
 
     it(`should update months when 'firstDayOfWeek' changes`, () => {
@@ -259,6 +260,29 @@ describe('ngb-datepicker-service', () => {
       expect(model.firstDayOfWeek).toBe(3);
       const newFirstDate = getDay(0).date;
       expect(newFirstDate).toEqual(new NgbDate(2017, 4, 26));
+    });
+  });
+
+  describe(`weekday`, () => {
+
+    it(`should update visibility and width correctly`, () => {
+      // default values
+      service.focus(new NgbDate(2017, 5, 1));
+      expect(model.weekdayWidth).toBe(TranslationWidth.Short);
+      expect(model.weekdaysVisible).toBeTrue();
+      expect(model.months[0].weekdays).toEqual(['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']);
+
+      // Specific width
+      service.set({weekdays: TranslationWidth.Narrow});
+      expect(model.weekdayWidth).toBe(TranslationWidth.Narrow);
+      expect(model.weekdaysVisible).toBeTrue();
+      expect(model.months[0].weekdays).toEqual(['M', 'T', 'W', 'T', 'F', 'S', 'S']);
+
+      // false
+      service.set({weekdays: false});
+      expect(model.weekdayWidth).toBe(TranslationWidth.Short);
+      expect(model.weekdaysVisible).toBeFalse();
+      expect(model.months[0].weekdays).toEqual([]);
     });
   });
 

--- a/src/datepicker/datepicker-tools.spec.ts
+++ b/src/datepicker/datepicker-tools.spec.ts
@@ -13,12 +13,11 @@ import {NgbDate} from './ngb-date';
 import {NgbCalendarGregorian} from './ngb-calendar';
 import {DatepickerViewModel, NgbMarkDisabled, MonthViewModel} from './datepicker-view-model';
 import {NgbDatepickerI18nDefault} from './datepicker-i18n';
-import {TranslationWidth} from '@angular/common';
 
 describe(`datepicker-tools`, () => {
 
   const calendar = new NgbCalendarGregorian();
-  const i18n = new NgbDatepickerI18nDefault('en', TranslationWidth.Short);
+  const i18n = new NgbDatepickerI18nDefault('en');
 
   describe(`dateComparator()`, () => {
 

--- a/src/datepicker/datepicker-tools.spec.ts
+++ b/src/datepicker/datepicker-tools.spec.ts
@@ -1,17 +1,18 @@
+import {TranslationWidth} from '@angular/common';
 import {
   buildMonth,
   buildMonths,
   checkDateInRange,
   dateComparator,
   generateSelectBoxMonths,
+  generateSelectBoxYears,
   getFirstViewDate,
   isChangedMonth,
-  isDateSelectable,
-  generateSelectBoxYears
+  isDateSelectable
 } from './datepicker-tools';
 import {NgbDate} from './ngb-date';
 import {NgbCalendarGregorian} from './ngb-calendar';
-import {DatepickerViewModel, NgbMarkDisabled, MonthViewModel} from './datepicker-view-model';
+import {DatepickerViewModel, MonthViewModel, NgbMarkDisabled} from './datepicker-view-model';
 import {NgbDatepickerI18nDefault} from './datepicker-i18n';
 
 describe(`datepicker-tools`, () => {
@@ -112,14 +113,16 @@ describe(`datepicker-tools`, () => {
     months.forEach(refMonth => {
       it(`should build month (${refMonth.date.year} - ${refMonth.date.month}) correctly`, () => {
 
-        let month = buildMonth(calendar, refMonth.date, { firstDayOfWeek: 1 } as DatepickerViewModel, i18n);
+        let month = buildMonth(calendar, refMonth.date, {
+          firstDayOfWeek: 1, weekdayWidth: TranslationWidth.Short, weekdaysVisible: true
+        } as DatepickerViewModel, i18n);
 
         expect(month).toBeTruthy();
         expect(month.year).toEqual(refMonth.date.year);
         expect(month.number).toEqual(refMonth.date.month);
         expect(month.firstDate).toEqual(new NgbDate(refMonth.date.year, refMonth.date.month, 1));
         expect(month.lastDate).toEqual(new NgbDate(refMonth.date.year, refMonth.date.month, refMonth.lastDay));
-        expect(month.weekdays).toEqual([1, 2, 3, 4, 5, 6, 7]);
+        expect(month.weekdays).toEqual(['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']);
         expect(month.weeks.length).toBe(6);
 
         // First week, first day
@@ -199,13 +202,17 @@ describe(`datepicker-tools`, () => {
 
     it(`should rotate days of the week`, () => {
       // SUN = 7
-      let month = buildMonth(calendar, new NgbDate(2017, 5, 5), { firstDayOfWeek: 7 } as DatepickerViewModel, i18n);
-      expect(month.weekdays).toEqual([7, 1, 2, 3, 4, 5, 6]);
+      let month = buildMonth(calendar, new NgbDate(2017, 5, 5), {
+        firstDayOfWeek: 7, weekdaysVisible: true, weekdayWidth: TranslationWidth.Short
+      } as DatepickerViewModel, i18n);
+      expect(month.weekdays).toEqual(['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']);
       expect(month.weeks[0].days[0].date).toEqual(new NgbDate(2017, 4, 30));
 
       // WED = 3
-      month = buildMonth(calendar, new NgbDate(2017, 5, 5), { firstDayOfWeek: 3 } as DatepickerViewModel, i18n);
-      expect(month.weekdays).toEqual([3, 4, 5, 6, 7, 1, 2]);
+      month = buildMonth(calendar, new NgbDate(2017, 5, 5), {
+        firstDayOfWeek: 3, weekdaysVisible: true, weekdayWidth: TranslationWidth.Short
+      } as DatepickerViewModel, i18n);
+      expect(month.weekdays).toEqual(['We', 'Th', 'Fr', 'Sa', 'Su', 'Mo', 'Tu']);
       expect(month.weeks[0].days[0].date).toEqual(new NgbDate(2017, 4, 26));
     });
   });

--- a/src/datepicker/datepicker-tools.ts
+++ b/src/datepicker/datepicker-tools.ts
@@ -132,7 +132,8 @@ export function buildMonths(
 export function buildMonth(
     calendar: NgbCalendar, date: NgbDate, state: DatepickerViewModel, i18n: NgbDatepickerI18n,
     month: MonthViewModel = {} as MonthViewModel): MonthViewModel {
-  const {dayTemplateData, minDate, maxDate, firstDayOfWeek, markDisabled, outsideDays} = state;
+  const {dayTemplateData, minDate, maxDate, firstDayOfWeek, markDisabled, outsideDays, weekdayWidth, weekdaysVisible} =
+      state;
   const calendarToday = calendar.getToday();
 
   month.firstDate = <any>null;
@@ -144,6 +145,11 @@ export function buildMonth(
 
   date = getFirstViewDate(calendar, date, firstDayOfWeek);
 
+  // clearing weekdays, if not visible
+  if (!weekdaysVisible) {
+    month.weekdays.length = 0;
+  }
+
   // month has weeks
   for (let week = 0; week < calendar.getWeeksPerMonth(); week++) {
     let weekObject = month.weeks[week];
@@ -154,8 +160,8 @@ export function buildMonth(
 
     // week has days
     for (let day = 0; day < calendar.getDaysPerWeek(); day++) {
-      if (week === 0) {
-        month.weekdays[day] = calendar.getWeekday(date);
+      if (week === 0 && weekdaysVisible) {
+        month.weekdays[day] = i18n.getWeekdayLabel(calendar.getWeekday(date), weekdayWidth);
       }
 
       const newDate = new NgbDate(date.year, date.month, date.day);

--- a/src/datepicker/datepicker-view-model.ts
+++ b/src/datepicker/datepicker-view-model.ts
@@ -1,6 +1,7 @@
 import {NgbDate} from './ngb-date';
 import {NgbDateStruct} from './ngb-date-struct';
 import {DayTemplateContext} from './datepicker-day-template-context';
+import {TranslationWidth} from '@angular/common';
 
 export type NgbMarkDisabled = (date: NgbDateStruct, current?: {year: number, month: number}) => boolean;
 export type NgbDayTemplateData = (date: NgbDateStruct, current?: {year: number, month: number}) => any;
@@ -25,7 +26,7 @@ export type MonthViewModel = {
   number: number,
   year: number,
   weeks: WeekViewModel[],
-  weekdays: number[]
+  weekdays: string[]
 };
 
 // clang-format off
@@ -50,7 +51,9 @@ export type DatepickerViewModel = {
     years: number[],
     months: number[]
   },
-  selectedDate: NgbDate | null
+  selectedDate: NgbDate | null,
+  weekdayWidth: TranslationWidth,
+  weekdaysVisible: boolean
 };
 // clang-format on
 

--- a/src/datepicker/datepicker-weekday-format.ts
+++ b/src/datepicker/datepicker-weekday-format.ts
@@ -1,3 +1,0 @@
-import {InjectionToken} from '@angular/core';
-
-export const NGB_DATEPICKER_WEEKDAY_FORMAT = new InjectionToken('NgbDatePickerWeekDayFormat');

--- a/src/datepicker/datepicker.module.ts
+++ b/src/datepicker/datepicker.module.ts
@@ -1,5 +1,5 @@
 import {NgModule} from '@angular/core';
-import {CommonModule, TranslationWidth} from '@angular/common';
+import {CommonModule} from '@angular/common';
 import {FormsModule} from '@angular/forms';
 import {NgbDatepicker, NgbDatepickerContent} from './datepicker';
 import {NgbDatepickerMonth} from './datepicker-month';
@@ -7,7 +7,6 @@ import {NgbDatepickerNavigation} from './datepicker-navigation';
 import {NgbInputDatepicker} from './datepicker-input';
 import {NgbDatepickerDayView} from './datepicker-day-view';
 import {NgbDatepickerNavigationSelect} from './datepicker-navigation-select';
-import {NGB_DATEPICKER_WEEKDAY_FORMAT} from './datepicker-weekday-format';
 
 export {NgbDatepicker, NgbDatepickerContent, NgbDatepickerNavigateEvent, NgbDatepickerState} from './datepicker';
 export {NgbInputDatepicker} from './datepicker-input';
@@ -31,7 +30,6 @@ export {NgbDateNativeAdapter} from './adapters/ngb-date-native-adapter';
 export {NgbDateNativeUTCAdapter} from './adapters/ngb-date-native-utc-adapter';
 export {NgbDateParserFormatter} from './ngb-date-parser-formatter';
 export {NgbDatepickerKeyboardService} from './datepicker-keyboard-service';
-export {NGB_DATEPICKER_WEEKDAY_FORMAT} from './datepicker-weekday-format';
 
 @NgModule({
   declarations: [
@@ -40,7 +38,6 @@ export {NGB_DATEPICKER_WEEKDAY_FORMAT} from './datepicker-weekday-format';
   ],
   exports: [NgbDatepicker, NgbDatepickerContent, NgbInputDatepicker, NgbDatepickerMonth],
   imports: [CommonModule, FormsModule],
-  providers: [{provide: NGB_DATEPICKER_WEEKDAY_FORMAT, useValue: TranslationWidth.Short}],
   entryComponents: [NgbDatepicker]
 })
 export class NgbDatepickerModule {

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -17,6 +17,7 @@ import {NgbDatepickerDayView} from './datepicker-day-view';
 import {NgbDatepickerKeyboardService} from './datepicker-keyboard-service';
 import {NgbDatepickerNavigationSelect} from './datepicker-navigation-select';
 import {NgbDatepickerNavigation} from './datepicker-navigation';
+import {TranslationWidth} from '@angular/common';
 
 const createTestComponent = (html: string) =>
     createGenericTestComponent(html, TestComponent) as ComponentFixture<TestComponent>;
@@ -39,6 +40,11 @@ function getFocusableDays(element: DebugElement): DebugElement[] {
 
 function getSelectedDays(element: DebugElement): DebugElement[] {
   return <DebugElement[]>Array.from(element.queryAll(By.css('div.ngb-dp-day > div.bg-primary')));
+}
+
+function getWeekdays(element: HTMLElement): string[] {
+  return (<HTMLElement[]>Array.from(element.querySelectorAll('.ngb-dp-weekday')) || [])
+      .map(el => el.textContent !.trim());
 }
 
 function focusDay() {
@@ -124,6 +130,7 @@ function expectSameValues(datepicker: NgbDatepicker, config: NgbDatepickerConfig
   expect(datepicker.showWeekdays).toBe(config.showWeekdays);
   expect(datepicker.showWeekNumbers).toBe(config.showWeekNumbers);
   expect(datepicker.startDate).toEqual(config.startDate);
+  expect(datepicker.weekdays).toBe(config.weekdays);
 }
 
 function customizeConfig(config: NgbDatepickerConfig) {
@@ -139,6 +146,7 @@ function customizeConfig(config: NgbDatepickerConfig) {
   config.showWeekdays = false;
   config.showWeekNumbers = true;
   config.startDate = {year: 2015, month: 1};
+  config.weekdays = TranslationWidth.Abbreviated;
 }
 
 describe('ngb-datepicker', () => {
@@ -215,6 +223,34 @@ describe('ngb-datepicker', () => {
     fixture.detectChanges();
     expect(getMonthSelect(fixture.nativeElement).value).toBe(currentMonth);
     expect(getYearSelect(fixture.nativeElement).value).toBe(currentYear);
+  });
+
+  it(`should display weekdays by default`, () => {
+    const fixture = createTestComponent(`<ngb-datepicker [startDate]="date"></ngb-datepicker>`);
+    expect(getWeekdays(fixture.nativeElement)).toEqual(['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']);
+  });
+
+  it(`should allow customizing the way weekdays are displayed (showWeekdays)`, () => {
+    const fixture =
+        createTestComponent(`<ngb-datepicker [startDate]="date" [showWeekdays]="showWeekdays"></ngb-datepicker>`);
+    expect(getWeekdays(fixture.nativeElement)).toEqual(['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']);
+
+    fixture.componentInstance.showWeekdays = false;
+    fixture.detectChanges();
+    expect(getWeekdays(fixture.nativeElement)).toEqual([]);
+  });
+
+  it(`should allow cusotmizing the way weekdays are displayed (weekdays)`, () => {
+    const fixture = createTestComponent(`<ngb-datepicker [startDate]="date" [weekdays]="weekdays"></ngb-datepicker>`);
+    expect(getWeekdays(fixture.nativeElement)).toEqual(['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']);
+
+    fixture.componentInstance.weekdays = false;
+    fixture.detectChanges();
+    expect(getWeekdays(fixture.nativeElement)).toEqual([]);
+
+    fixture.componentInstance.weekdays = TranslationWidth.Narrow;
+    fixture.detectChanges();
+    expect(getWeekdays(fixture.nativeElement)).toEqual(['M', 'T', 'W', 'T', 'F', 'S', 'S']);
   });
 
   it(`should allow navigation work when startDate value changes`, () => {
@@ -1260,6 +1296,7 @@ class TestComponent {
   disabledForm = new FormGroup({control: new FormControl({value: null, disabled: true})});
   model;
   showWeekdays = true;
+  weekdays: boolean | TranslationWidth = true;
   dayTemplateData = () => '!';
   markDisabled = (date: NgbDateStruct) => { return NgbDate.from(date) !.equals(new NgbDate(2016, 8, 22)); };
   onNavigate = (event) => {};

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -21,6 +21,8 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
+import {TranslationWidth} from '@angular/common';
+
 import {NgbCalendar} from './ngb-calendar';
 import {NgbDate} from './ngb-date';
 import {DatepickerServiceInputs, NgbDatepickerService} from './datepicker-service';
@@ -166,6 +168,7 @@ export class NgbDatepicker implements OnDestroy,
   static ngAcceptInputType_autoClose: boolean | string;
   static ngAcceptInputType_navigation: string;
   static ngAcceptInputType_outsideDays: string;
+  static ngAcceptInputType_weekdays: boolean | number;
 
   model: DatepickerViewModel;
 
@@ -176,6 +179,7 @@ export class NgbDatepicker implements OnDestroy,
   private _controlValue: NgbDate | null = null;
   private _destroyed$ = new Subject<void>();
   private _publicState: NgbDatepickerState = <any>{};
+  private _showWeekdays: boolean;
 
   /**
    * The reference to a custom template for the day.
@@ -260,8 +264,16 @@ export class NgbDatepicker implements OnDestroy,
 
   /**
    * If `true`, weekdays will be displayed.
+   *
+   * @deprecated 9.1.0, please use 'weekdays' instead
    */
-  @Input() showWeekdays: boolean;
+  @Input()
+  set showWeekdays(weekdays: boolean) {
+    this.weekdays = weekdays;
+    this._showWeekdays = weekdays;
+  }
+
+  get showWeekdays(): boolean { return this._showWeekdays; }
 
   /**
    * If `true`, week numbers will be displayed.
@@ -277,6 +289,17 @@ export class NgbDatepicker implements OnDestroy,
    * You could use `navigateTo(date)` method as an alternative.
    */
   @Input() startDate: {year: number, month: number, day?: number};
+
+  /**
+   * The way weekdays should be displayed.
+   *
+   * * `true` - weekdays are displayed using default width
+   * * `false` - weekdays are not displayed
+   * * `TranslationWidth` - weekdays are displayed using specified width
+   *
+   * @since 9.1.0
+   */
+  @Input() weekdays: TranslationWidth | boolean;
 
   /**
    * An event emitted right before the navigation happens and displayed month changes.
@@ -302,7 +325,7 @@ export class NgbDatepicker implements OnDestroy,
       config: NgbDatepickerConfig, cd: ChangeDetectorRef, private _elementRef: ElementRef<HTMLElement>,
       private _ngbDateAdapter: NgbDateAdapter<any>, private _ngZone: NgZone) {
     ['dayTemplate', 'dayTemplateData', 'displayMonths', 'firstDayOfWeek', 'footerTemplate', 'markDisabled', 'minDate',
-     'maxDate', 'navigation', 'outsideDays', 'showWeekdays', 'showWeekNumbers', 'startDate']
+     'maxDate', 'navigation', 'outsideDays', 'showWeekdays', 'showWeekNumbers', 'startDate', 'weekdays']
         .forEach(input => this[input] = config[input]);
 
     _service.dateSelect$.pipe(takeUntil(this._destroyed$)).subscribe(date => { this.dateSelect.emit(date); });
@@ -430,7 +453,7 @@ export class NgbDatepicker implements OnDestroy,
     if (this.model === undefined) {
       const inputs: DatepickerServiceInputs = {};
       ['dayTemplateData', 'displayMonths', 'markDisabled', 'firstDayOfWeek', 'navigation', 'minDate', 'maxDate',
-       'outsideDays']
+       'outsideDays', 'weekdays']
           .forEach(name => inputs[name] = this[name]);
       this._service.set(inputs);
 
@@ -443,8 +466,13 @@ export class NgbDatepicker implements OnDestroy,
 
   ngOnChanges(changes: SimpleChanges) {
     const inputs: DatepickerServiceInputs = {};
+
+    if (changes.showWeekdays) {
+      inputs['weekdays'] = this.weekdays;
+    }
+
     ['dayTemplateData', 'displayMonths', 'markDisabled', 'firstDayOfWeek', 'navigation', 'minDate', 'maxDate',
-     'outsideDays']
+     'outsideDays', 'weekdays']
         .filter(name => name in changes)
         .forEach(name => inputs[name] = this[name]);
     this._service.set(inputs);

--- a/src/datepicker/hebrew/datepicker-i18n-hebrew.spec.ts
+++ b/src/datepicker/hebrew/datepicker-i18n-hebrew.spec.ts
@@ -50,10 +50,10 @@ describe('datepicker-i18n-hebrew', () => {
   });
 
   it('should return weekday name', () => {
-    expect(i18n.getWeekdayName(0)).toBe('');
-    expect(i18n.getWeekdayName(1)).toBe('שני');
-    expect(i18n.getWeekdayName(7)).toBe('ראשון');
-    expect(i18n.getWeekdayName(8)).toBe('');
+    expect(i18n.getWeekdayShortName(0)).toBe('');
+    expect(i18n.getWeekdayShortName(1)).toBe('שני');
+    expect(i18n.getWeekdayShortName(7)).toBe('ראשון');
+    expect(i18n.getWeekdayShortName(8)).toBe('');
   });
 
   it('should generate aria label for a date',

--- a/src/datepicker/hebrew/datepicker-i18n-hebrew.ts
+++ b/src/datepicker/hebrew/datepicker-i18n-hebrew.ts
@@ -20,9 +20,7 @@ export class NgbDatepickerI18nHebrew extends NgbDatepickerI18n {
     return isHebrewLeapYear(year) ? MONTHS_LEAP[month - 1] || '' : MONTHS[month - 1] || '';
   }
 
-  getWeekdayShortName(weekday: number): string { return this.getWeekdayName(weekday); }
-
-  getWeekdayName(weekday: number): string { return WEEKDAYS[weekday - 1] || ''; }
+  getWeekdayShortName(weekday: number): string { return WEEKDAYS[weekday - 1] || ''; }
 
   getDayAriaLabel(date: NgbDateStruct): string {
     return `${hebrewNumerals(date.day)} ${this.getMonthFullName(date.month, date.year)} ${hebrewNumerals(date.year)}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,8 +70,7 @@ export {
   NgbDatepickerState,
   NgbDateStruct,
   NgbInputDatepicker,
-  NgbPeriod,
-  NGB_DATEPICKER_WEEKDAY_FORMAT
+  NgbPeriod
 } from './datepicker/datepicker.module';
 export {
   NgbDropdown,


### PR DESCRIPTION
- reverts the #3803, because of breaking changes and different API
- introduces new `@Input() weekday: boolean | TranslationWidth` in `NgbDatepicker` and `NgbInputDatepicker`
- introduces new `getWeekdayLabel(date, width)` in `NgbDatepickerI18n`

Fixes #2516