### PR TITLE
fix(typeahead): improve 'ngbTypeahead' typings

### DIFF
--- a/demo/src/app/components/typeahead/demos/basic/typeahead-basic.ts
+++ b/demo/src/app/components/typeahead/demos/basic/typeahead-basic.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {Observable} from 'rxjs';
+import {Observable, OperatorFunction} from 'rxjs';
 import {debounceTime, distinctUntilChanged, map} from 'rxjs/operators';
 
 const states = ['Alabama', 'Alaska', 'American Samoa', 'Arizona', 'Arkansas', 'California', 'Colorado',
@@ -19,7 +19,7 @@ const states = ['Alabama', 'Alaska', 'American Samoa', 'Arizona', 'Arkansas', 'C
 export class NgbdTypeaheadBasic {
   public model: any;
 
-  search = (text$: Observable<string>) =>
+  search: OperatorFunction<string, readonly string[]> = (text$: Observable<string>) =>
     text$.pipe(
       debounceTime(200),
       distinctUntilChanged(),

--- a/demo/src/app/components/typeahead/demos/focus/typeahead-focus.ts
+++ b/demo/src/app/components/typeahead/demos/focus/typeahead-focus.ts
@@ -1,6 +1,6 @@
 import {Component, ViewChild} from '@angular/core';
 import {NgbTypeahead} from '@ng-bootstrap/ng-bootstrap';
-import {Observable, Subject, merge} from 'rxjs';
+import {Observable, Subject, merge, OperatorFunction} from 'rxjs';
 import {debounceTime, distinctUntilChanged, filter, map} from 'rxjs/operators';
 
 const states = ['Alabama', 'Alaska', 'American Samoa', 'Arizona', 'Arkansas', 'California', 'Colorado',
@@ -24,7 +24,7 @@ export class NgbdTypeaheadFocus {
   focus$ = new Subject<string>();
   click$ = new Subject<string>();
 
-  search = (text$: Observable<string>) => {
+  search: OperatorFunction<string, readonly string[]> = (text$: Observable<string>) => {
     const debouncedText$ = text$.pipe(debounceTime(200), distinctUntilChanged());
     const clicksWithClosedPopup$ = this.click$.pipe(filter(() => !this.instance.isPopupOpen()));
     const inputFocus$ = this.focus$;

--- a/demo/src/app/components/typeahead/demos/format/typeahead-format.ts
+++ b/demo/src/app/components/typeahead/demos/format/typeahead-format.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {Observable} from 'rxjs';
+import {Observable, OperatorFunction} from 'rxjs';
 import {debounceTime, distinctUntilChanged, map} from 'rxjs/operators';
 
 const states = ['Alabama', 'Alaska', 'American Samoa', 'Arizona', 'Arkansas', 'California', 'Colorado',
@@ -21,7 +21,7 @@ export class NgbdTypeaheadFormat {
 
   formatter = (result: string) => result.toUpperCase();
 
-  search = (text$: Observable<string>) =>
+  search: OperatorFunction<string, readonly string[]> = (text$: Observable<string>) =>
     text$.pipe(
       debounceTime(200),
       distinctUntilChanged(),

--- a/demo/src/app/components/typeahead/demos/http/typeahead-http.ts
+++ b/demo/src/app/components/typeahead/demos/http/typeahead-http.ts
@@ -1,6 +1,6 @@
 import {Component, Injectable} from '@angular/core';
 import {HttpClient, HttpParams} from '@angular/common/http';
-import {Observable, of} from 'rxjs';
+import {Observable, of, OperatorFunction} from 'rxjs';
 import {catchError, debounceTime, distinctUntilChanged, map, tap, switchMap} from 'rxjs/operators';
 
 const WIKI_URL = 'https://en.wikipedia.org/w/api.php';
@@ -22,7 +22,7 @@ export class WikipediaService {
     }
 
     return this.http
-      .get(WIKI_URL, {params: PARAMS.set('search', term)}).pipe(
+      .get<[any, string[]]>(WIKI_URL, {params: PARAMS.set('search', term)}).pipe(
         map(response => response[1])
       );
   }
@@ -41,7 +41,7 @@ export class NgbdTypeaheadHttp {
 
   constructor(private _service: WikipediaService) {}
 
-  search = (text$: Observable<string>) =>
+  search: OperatorFunction<string, readonly string[]> = (text$: Observable<string>) =>
     text$.pipe(
       debounceTime(300),
       distinctUntilChanged(),

--- a/demo/src/app/components/typeahead/demos/prevent-manual-entry/typeahead-prevent-manual-entry.ts
+++ b/demo/src/app/components/typeahead/demos/prevent-manual-entry/typeahead-prevent-manual-entry.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {Observable} from 'rxjs';
+import {Observable, OperatorFunction} from 'rxjs';
 import {debounceTime, distinctUntilChanged, map, filter} from 'rxjs/operators';
 
 type State = {id: number, name: string};
@@ -76,7 +76,7 @@ export class NgbdTypeaheadPreventManualEntry {
 
   formatter = (state: State) => state.name;
 
-  search = (text$: Observable<string>) => text$.pipe(
+  search: OperatorFunction<string, readonly {id, name}[]> = (text$: Observable<string>) => text$.pipe(
     debounceTime(200),
     distinctUntilChanged(),
     filter(term => term.length >= 2),

--- a/demo/src/app/components/typeahead/demos/template/typeahead-template.ts
+++ b/demo/src/app/components/typeahead/demos/template/typeahead-template.ts
@@ -1,5 +1,5 @@
 import {Component} from '@angular/core';
-import {Observable} from 'rxjs';
+import {Observable, OperatorFunction} from 'rxjs';
 import {debounceTime, map} from 'rxjs/operators';
 
 const statesWithFlags: {name: string, flag: string}[] = [
@@ -66,7 +66,7 @@ const statesWithFlags: {name: string, flag: string}[] = [
 export class NgbdTypeaheadTemplate {
   public model: any;
 
-  search = (text$: Observable<string>) =>
+  search: OperatorFunction<string, readonly {name, flag}[]> = (text$: Observable<string>) =>
     text$.pipe(
       debounceTime(200),
       map(term => term === '' ? []


### PR DESCRIPTION
Improves "search" function typings by using standard rxjs `OperatorFunction` type and making search function optional

```ts
// before
@Input() ngbTypeahead: (text: Observable<string>) => Observable<readonly any[]>;

// after
@Input() ngbTypeahead: OperatorFunction<string, readonly any[]>| null | undefined;
```

Fixes #3907