### PR TITLE
fix(collapse): no animations in production mode

### DIFF
--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -95,7 +95,7 @@ export function closest(element: HTMLElement, selector?: string): HTMLElement | 
  * @param element element where to apply the reflow
  */
 export function reflow(element: HTMLElement) {
-  return (element || document.body).offsetHeight;
+  return (element || document.body).getBoundingClientRect();
 }
 
 /**


### PR DESCRIPTION
This is caused by the Terser `pure_getters` optimization.
If used only once (ex. when importing ONLY `NgbCollapseModule`), the `reflow` function is broken:

```ts
// source
export function reflow(element: HTMLElement) {
  return (element || document.body).offsetHeight;
}

reflow(el);

// inlined in production
function(element) {
    element || document
}(element)
```

Fixes #3972