### PR TITLE
fix(tooltip/popover): enable pointer events only for tooltip/popover content

### DIFF
--- a/src/popover/popover.scss
+++ b/src/popover/popover.scss
@@ -2,6 +2,13 @@
 $arrow-size: 1rem;
 
 ngb-popover-window {
+  pointer-events: none;
+
+  .popover-header,
+  .popover-body {
+    pointer-events: auto;
+  }
+
   &.bs-popover-top > .arrow,
   &.bs-popover-bottom > .arrow {
     left: 50%;

--- a/src/tooltip/tooltip.scss
+++ b/src/tooltip/tooltip.scss
@@ -2,6 +2,12 @@
 $arrow-size: 0.8rem;
 
 ngb-tooltip-window {
+  pointer-events: none;
+
+  .tooltip-inner {
+    pointer-events: auto;
+  }
+
   &.bs-tooltip-top .arrow,
   &.bs-tooltip-bottom .arrow {
     left: calc(50% - #{$arrow-size / 2});


### PR DESCRIPTION
This fixes #3997. I was able to reproduce the problem in the issue manually with tooltips and popovers on the demo site in Chrome, but writing automated tests for it would not be straightforward. It could be possible with a test that simulates moving the mouse slowly on top of a tooltip/popover, but I'm not sure if that's worth the effort.

I did verify that if I completely disable pointer events from these elements (i.e. omit the `"pointer-events: auto;"` definitions), several "Tooltip Autoclose" and "Popover Autoclose" e2e tests fail. So at least the existing tests verify that these changes don't cause regressions in those scenarios.