### PR TITLE
fix(accordion): broken collapse animation

### DIFF
--- a/src/accordion/accordion.ts
+++ b/src/accordion/accordion.ts
@@ -195,9 +195,11 @@ export interface NgbPanelChangeEvent {
           <ng-template [ngTemplateOutlet]="panel.headerTpl?.templateRef || t"
                        [ngTemplateOutletContext]="{$implicit: panel, opened: panel.isOpen}"></ng-template>
         </div>
-        <div id="{{panel.id}}" class="accordion-body" role="tabpanel" [attr.aria-labelledby]="panel.id + '-header'"
+        <div id="{{panel.id}}" role="tabpanel" [attr.aria-labelledby]="panel.id + '-header'"
              *ngIf="!destroyOnHide || panel.isOpen || panel.transitionRunning">
-          <ng-template [ngTemplateOutlet]="panel.contentTpl?.templateRef || null"></ng-template>
+          <div class="accordion-body">
+            <ng-template [ngTemplateOutlet]="panel.contentTpl?.templateRef || null"></ng-template>
+          </div>
         </div>
       </div>
     </ng-template>


### PR DESCRIPTION
The issue comes from the accordion-body, which is defined on the root element where the body template is generated. (the class accordion-body has a padding).

The Bootstrap 5 markup requires a second container, as [in this documentation](https://getbootstrap.com/docs/5.0/components/accordion/#example). (It was the case in the main branch, I don't know why I removed this level 😕).