### PR TITLE
feat(accordion): added inputs to NgbPanel to allow local custom styling

### DIFF
--- a/src/accordion/accordion.ts
+++ b/src/accordion/accordion.ts
@@ -117,6 +117,27 @@ export class NgbPanel implements AfterContentChecked {
   @Input() cardClass: string;
 
   /**
+   * An optional style applied to the accordion button element that represents the button in the accordion header.
+   *
+   *
+   */
+  @Input() buttonStyle: {[klass: string]: any;};
+
+  /**
+   * An optional style applied to the accordion header element that wraps the title.
+   *
+   *
+   */
+  @Input() headerStyle: {[klass: string]: any;};
+
+  /**
+   * An optional style applied to the accordion body element that wraps the content.
+   *
+   *
+   */
+  @Input() bodyStyle: {[klass: string]: any;};
+
+  /**
    * An event emitted when the panel is shown, after the transition. It has no payload.
    *
    * @since 8.0.0
@@ -185,19 +206,19 @@ export interface NgbPanelChangeEvent {
   host: {'class': 'accordion', 'role': 'tablist', '[attr.aria-multiselectable]': '!closeOtherPanels'},
   template: `
     <ng-template #t ngbPanelHeader let-panel>
-      <button class="accordion-button" [ngbPanelToggle]="panel">
+      <button class="accordion-button" [ngStyle]="panel.buttonStyle" [ngbPanelToggle]="panel">
         {{panel.title}}<ng-template [ngTemplateOutlet]="panel.titleTpl?.templateRef"></ng-template>
       </button>
     </ng-template>
     <ng-template ngFor let-panel [ngForOf]="panels">
       <div [class]="'accordion-item ' + (panel.cardClass || '')">
-        <div role="tab" id="{{panel.id}}-header" [class]="'accordion-header ' + (panel.type ? 'bg-'+panel.type: type ? 'bg-'+type : '')">
+        <div role="tab" id="{{panel.id}}-header" [class]="'accordion-header ' + (panel.type ? 'bg-'+panel.type: type ? 'bg-'+type : '')" [ngStyle]="panel.headerStyle">
           <ng-template [ngTemplateOutlet]="panel.headerTpl?.templateRef || t"
                        [ngTemplateOutletContext]="{$implicit: panel, opened: panel.isOpen}"></ng-template>
         </div>
         <div id="{{panel.id}}" role="tabpanel" [attr.aria-labelledby]="panel.id + '-header'"
              *ngIf="!destroyOnHide || panel.isOpen || panel.transitionRunning">
-          <div class="accordion-body">
+          <div class="accordion-body" [ngStyle]="panel.bodyStyle">
             <ng-template [ngTemplateOutlet]="panel.contentTpl?.templateRef || null"></ng-template>
           </div>
         </div>


### PR DESCRIPTION
Hi,
I recently learned that changing the default style of `NgbAccordion `on a component level is hard to achieve. According to issue #1107 it only seems to be possible when using a global stylesheet or when setting `ViewEncapsulation.None`. I also do not consider `::ng-deep` a desirable solution since it is deprecated according to the Angular [documentation](https://angular.io/guide/component-styles#deprecated-deep--and-ng-deep)

The responses for the issues #1107 and #2564 show that multiple people try to achieve a styling on component level. For example, I personally would like to be able to adjust the padding of the div with the `accordion-body` class. I only want to do this for some of my components that use `NgbAccordion`. I do not want to apply a global theme or set `ViewEncapsulation.None`.

In my opinion there should be a way to achieve this. Therefore I would like to propose a change of the API of the accordion component. The `NgbPanel ` already has an optional input, called `cardClass`, to set a class for styling the card. In Bootstrap 5 terms this would style the “accordion-item” (see [bootstrap accordion example](https://getbootstrap.com/docs/5.0/components/accordion/#example) ). I suggest to add more inputs that provide similar “access” to the `accordion-header`, `accordion-button` and the `accordion-body. ` Those inputs could be of type `{ [klass: string]: any; }` which is the type of the [ngStyle directive](https://angular.io/api/common/NgStyle#properties) and would allow to overwrite properties of those Bootstrap css classes and to add a custom style on component level.

I think it could add to the flexibility of the styling of the Accordion component. It would also change the Accordion component to be closer to how an Accordion would behave when using plain Bootstrap. When using plain Bootstrap it is possible to extend or overwrite the Bootstrap style locally on every single div of an Accordion.

This proposal should not cause breaking changes since it only adds optional functionality. Also this way of allowing to style specific component parts could easily be transferred to other NgBootstrap components to offer this feature for all components.

This is the first time I am trying to contribute to this project. I am not sure if it is a good practice to start with a pull request rather than with opening an issue and discussing this feature proposal first. But this pull request should make clear what and how I was trying to achieve things. Also I am not sure if choosing to work on the bootstrap5 branch is considered good for this purpose.


Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.
