### PR TITLE
Re-enable the pointer events on popover

### DIFF
--- a/src/popover/popover.scss
+++ b/src/popover/popover.scss
@@ -2,13 +2,6 @@
 $arrow-size: 1rem;
 
 ngb-popover-window {
-  pointer-events: none;
-
-  .popover-header,
-  .popover-body {
-    pointer-events: auto;
-  }
-
   &.bs-popover-top > .arrow,
   &.bs-popover-bottom > .arrow {
     left: 50%;


### PR DESCRIPTION
fix #4103.

This PR reverts partially the PR #4076 which fixed #3997 (the fix on the tooltip has been kept for now). A unified solution needs to be found.