### PR TITLE
fix: replace the division by math.div for sass

### DIFF
--- a/src/popover/popover.scss
+++ b/src/popover/popover.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 
 $arrow-size: 1rem;
 
@@ -5,7 +6,7 @@ ngb-popover-window {
   &.bs-popover-top > .arrow,
   &.bs-popover-bottom > .arrow {
     left: 50%;
-    margin-left: -$arrow-size / 2;
+    margin-left: -(math.div($arrow-size, 2));
   }
 
   &.bs-popover-top-left > .arrow,
@@ -22,7 +23,7 @@ ngb-popover-window {
   &.bs-popover-left > .arrow,
   &.bs-popover-right > .arrow {
     top: 50%;
-    margin-top: -$arrow-size / 2;
+    margin-top: -(math.div($arrow-size, 2));
   }
 
   &.bs-popover-left-top > .arrow,

--- a/src/tooltip/tooltip.scss
+++ b/src/tooltip/tooltip.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 
 $arrow-size: 0.8rem;
 
@@ -10,7 +11,7 @@ ngb-tooltip-window {
 
   &.bs-tooltip-top .arrow,
   &.bs-tooltip-bottom .arrow {
-    left: calc(50% - #{$arrow-size / 2});
+    left: calc(50% - math.div($arrow-size, 2));
   }
 
   &.bs-tooltip-top-left .arrow,
@@ -26,7 +27,7 @@ ngb-tooltip-window {
 
   &.bs-tooltip-left .arrow,
   &.bs-tooltip-right .arrow {
-    top: calc(50% - #{$arrow-size / 2});
+    top: calc(50% - math.div($arrow-size, 2));
   }
 
   &.bs-tooltip-left-top .arrow,


### PR DESCRIPTION
The division is now deprecated with sass-dart, and must be replaced by math.div