### PR TITLE
demo(accordion): fix custom header demo

### DIFF
--- a/demo/src/app/components/accordion/demos/header/accordion-header.html
+++ b/demo/src/app/components/accordion/demos/header/accordion-header.html
@@ -1,8 +1,8 @@
 <ngb-accordion #a="ngbAccordion" activeIds="custom-panel-1">
   <ngb-panel id="custom-panel-1">
     <ng-template ngbPanelHeader let-opened="opened">
-      <div class="p-2 d-flex align-items-center justify-content-between">
-        <h5 class="m-0">First panel - {{ opened ? 'opened' : 'collapsed' }}</h5>
+      <div class="accordion-button custom-header justify-content-between" [class.collapsed]="!opened">
+        <p class="m-0">First panel - {{ opened ? 'opened' : 'collapsed' }}</p>
         <button ngbPanelToggle class="btn btn-link p-0">Toggle first</button>
       </div>
     </ng-template>
@@ -16,9 +16,9 @@
     </ng-template>
   </ngb-panel>
   <ngb-panel>
-    <ng-template ngbPanelHeader>
-      <div class="p-2 d-flex align-items-center justify-content-between">
-        <h5 class="m-0">Second panel</h5>
+    <ng-template ngbPanelHeader let-opened="opened">
+      <div class="accordion-button custom-header justify-content-between" [class.collapsed]="!opened">
+        <p class="m-0">Second panel</p>
         <div>
           <button ngbPanelToggle class="btn btn-sm btn-outline-primary ms-2">Toggle second</button>
           <button type="button" class="btn btn-sm btn-outline-secondary ms-2" (click)="disabled = !disabled">
@@ -38,11 +38,24 @@
     </ng-template>
   </ngb-panel>
   <ngb-panel [disabled]="disabled" [cardClass]="disabled ? 'disabled' : ''">
-    <ng-template ngbPanelHeader>
-      <div class="p-2 d-flex align-items-center justify-content-between">
-        <button ngbPanelToggle class="btn btn-link container-fluid text-start ps-0">Third panel</button>
+    <ng-template ngbPanelHeader let-opened="opened">
+      <div class="accordion-button custom-header" [class.collapsed]="!opened">
+        <button ngbPanelToggle class="p-0 btn btn-link container-fluid text-start ps-0">Third panel</button>
         <p *ngIf="disabled" class="text-muted m-0 small">[I'm&nbsp;disabled]</p>
       </div>
+    </ng-template>
+    <ng-template ngbPanelContent>
+      Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia
+      aute, non cupidatat skateboard dolor brunch. Food truck quinoa nesciunt laborum eiusmod. Brunch 3 wolf moon tempor,
+      sunt aliqua put a bird on it squid single-origin coffee nulla assumenda shoreditch et. Nihil anim keffiyeh helvetica,
+      craft beer labore wes anderson cred nesciunt sapiente ea proident. Ad vegan excepteur butcher vice lomo. Leggings
+      occaecat craft beer farm-to-table, raw denim aesthetic synth nesciunt you probably haven't heard of them accusamus
+      labore sustainable VHS.
+    </ng-template>
+  </ngb-panel>
+  <ngb-panel>
+    <ng-template ngbPanelHeader>
+      <button ngbPanelToggle class="accordion-button">Default-looking "custom" panel</button>
     </ng-template>
     <ng-template ngbPanelContent>
       Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. 3 wolf moon officia

--- a/demo/src/app/components/accordion/demos/header/accordion-header.ts
+++ b/demo/src/app/components/accordion/demos/header/accordion-header.ts
@@ -8,6 +8,9 @@ import {Component, ViewEncapsulation} from '@angular/core';
     .card.disabled {
       opacity: 0.5;
     }
+    .custom-header::after {
+      content: none;
+    }
   `]
 })
 export class NgbdAccordionHeader {


### PR DESCRIPTION
The demo was broken because of missing `.accordion-button` class when doing custom headers

https://user-images.githubusercontent.com/8074436/124276798-8fb20600-db44-11eb-87ae-ef595e263f6f.mp4

https://user-images.githubusercontent.com/8074436/124276823-98a2d780-db44-11eb-8770-c20387eda87c.mp4
