### PR TITLE
fix(modal): set overflow-y on body when modal is active

### DIFF
--- a/src/modal/modal-stack.ts
+++ b/src/modal/modal-stack.ts
@@ -59,6 +59,7 @@ export class NgbModalStack {
     const removeBodyClass = () => {
       if (!this._modalRefs.length) {
         renderer.removeClass(this._document.body, 'modal-open');
+        renderer.setStyle(this._document.body, 'overflow-y', '');
         this._revertAriaHidden();
       }
     };
@@ -86,6 +87,7 @@ export class NgbModalStack {
     this._applyWindowOptions(windowCmptRef.instance, options);
     if (this._modalRefs.length === 1) {
       renderer.addClass(this._document.body, 'modal-open');
+      renderer.setStyle(this._document.body, 'overflow-y', 'hidden');
     }
 
     if (backdropCmptRef && backdropCmptRef.instance) {


### PR DESCRIPTION
setting the overflow-y style on the body to hidden when a modal is active. Fixes issue #4128

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
