### PR TITLE
fix(dropdown): fix for menu alignment issue mentioned in #4100

### DIFF
--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -513,6 +513,16 @@ export class NgbDropdown implements AfterContentInit, OnDestroy {
         renderer.removeClass(bodyContainer, 'dropdown');
         renderer.addClass(bodyContainer, dropdownClass);
       }
+
+      // We need to trim the value because custom properties can also include spaces
+      const isEnd = getComputedStyle(this._menu.nativeElement).getPropertyValue('--bs-position').trim() === 'end';
+      if (isEnd) {
+        renderer.setStyle(this._menu.nativeElement, 'left', 'auto');
+        renderer.setStyle(this._menu.nativeElement, 'right', '0');
+      } else {
+        renderer.removeStyle(this._menu.nativeElement, 'left');
+        renderer.removeStyle(this._menu.nativeElement, 'right');
+      }
     }
   }
 }


### PR DESCRIPTION
bootstrap v5 no longer sets `right: 0` as part of the `dropdown-menu-end` style rule. Instead it does the positioning using javascript by checking the elements computed styles and looking for `--bs-position: end;` in the CSS to figure out if the element should be positioned on the right.
Source :https://github.com/twbs/bootstrap/blob/23fd488c380c347a3d0121a49b6285bdd65418a2/js/src/dropdown.js#L285

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
