### PR TITLE
Remove input tag requirement on typeahead

### DIFF
--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -56,7 +56,7 @@ let nextWindowId = 0;
  * A directive providing a simple way of creating powerful typeaheads from any text input.
  */
 @Directive({
-  selector: 'input[ngbTypeahead]',
+  selector: '[ngbTypeahead]',
   exportAs: 'ngbTypeahead',
   host: {
     '(blur)': 'handleBlur()',


### PR DESCRIPTION
So it could be used on contenteditable, and also restrictions are boring

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
