### PR TITLE
fix(modal): allows to set an HTMLElement as container in NgbModalConfig

### DIFF
--- a/src/modal/modal-config.ts
+++ b/src/modal/modal-config.ts
@@ -123,7 +123,7 @@ export class NgbModalConfig implements Required<NgbModalOptions> {
   backdrop: boolean | 'static' = true;
   beforeDismiss: () => boolean | Promise<boolean>;
   centered: boolean;
-  container: string;
+  container: string | HTMLElement;
   injector: Injector;
   keyboard = true;
   scrollable: boolean;


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [X] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [X] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.

Fixes: #4160 