### PR TITLE
build: re-enable console warning reporting in e2e tests

### DIFF
--- a/e2e-app/coverage.webpack.js
+++ b/e2e-app/coverage.webpack.js
@@ -2,6 +2,16 @@ module.exports = {
   module: {
     rules: [
       {
+        test: /bootstrap\.css$/,
+        use: [
+          {
+            // This loader is used to remove from bootstrap during the e2e-app build
+            // the :lang(en) selector that causes a warning.
+            loader: require.resolve('./removeLangSelector'),
+          },
+        ],
+      },
+      {
         test: /\.(js|ts)$/,
         use: [
           {

--- a/e2e-app/removeLangSelector.js
+++ b/e2e-app/removeLangSelector.js
@@ -1,0 +1,5 @@
+// This loader is used to remove from bootstrap during the e2e-app build
+// the :lang(en) selector that causes a warning.
+module.exports = function (file) {
+  return file.replace(/:lang\(en\)/g, "");
+};

--- a/e2e-app/setup.e2e-spec.ts
+++ b/e2e-app/setup.e2e-spec.ts
@@ -16,7 +16,7 @@ beforeAll(async() => {
   // Listen for all console events and handle errors
   test.page.on('console', async msg => {
     const type = msg.type();
-    if (type === 'error') {
+    if (type === 'error' || type === 'warning') {
       const output = ['Unexpected console error:'];
       for (const m of msg.args()) {
         output.push(await m.jsonValue());


### PR DESCRIPTION
Reverts commit a8b2575ceadca25f8b6c3c1b07f50e4cabf49e87 and adds a webpack loader to remove from bootstrap during the e2e-app build the `:lang(en)` selector that causes the warning.

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
