### PR TITLE
demo(alert): drop deep css selector

### DIFF
--- a/demo/src/app/components/alert/demos/custom/alert-custom.ts
+++ b/demo/src/app/components/alert/demos/custom/alert-custom.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
   selector: 'ngbd-alert-custom',
   templateUrl: './alert-custom.html',
   styles: [`
-    :host >>> .alert-custom {
+    :host .alert-custom {
       color: #99004d;
       background-color: #f169b4;
       border-color: #800040;


### PR DESCRIPTION
This removes warning from thewq: build output:
```txt
Warning:  > .../ng-bootstrap/demo/src/app/components/alert/demos/custom/alert-custom.ts-angular-inline--4.css:2:11:
warning: Unexpected ">"
2 │     :host >>> .alert-custom {
```

Thanks!

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.