### PR TITLE
demo: removing custom padding in overview alerts

### DIFF
--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -375,8 +375,6 @@ ngbd-api-docs-config {
   .alert {
     border-left-width: 5px;
     border-radius: 0;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
   }
 }
 


### PR DESCRIPTION
Before this PR:
![image](https://user-images.githubusercontent.com/1152706/152139895-2f636d15-8349-4ba0-ae59-efc59eab739d.png)

After this PR:
![image](https://user-images.githubusercontent.com/1152706/152140013-af465c5f-9e3b-4398-85d1-e93bf993e61c.png)

Now, horizontal and vertical padding is more consistent.