### PR TITLE
fix: dropdown and datepicker respond to autoClose input changes

### DIFF
--- a/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.e2e-spec.ts
+++ b/e2e-app/src/app/datepicker/autoclose/datepicker-autoclose.e2e-spec.ts
@@ -147,6 +147,21 @@ describe('Datepicker Autoclose', () => {
         await clickOnDay(DATE_OUTSIDE_AFTER);
         await expectDatepickerToBeClosed(`Datepicker should be closed on outside day click`);
       });
+      it(`should change autoClose setting dynamically`, async() => {
+        // initially set autoClose to 'inside' because selectAutoClose is an outside click
+        await selectAutoClose('inside');
+        await openDatepicker(`Open datepicker with autoclose 'inside'`);
+
+        // change autoClose to false whilst open
+        await selectAutoClose('false');
+        await clickOnDay(DATE_SELECT);
+        await expectDatepickerToBeOpen(`Datepicker should not close after autoClose is changed to false whilst open`);
+
+        // change autoClose to 'inside' whilst open
+        await selectAutoClose('inside');
+        await clickOnDay(DATE_SELECT);
+        await expectDatepickerToBeClosed(`Datepicker should close after autoClose is changed to 'inside' whilst open`);
+      });
     });
   }
 });

--- a/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.e2e-spec.ts
+++ b/e2e-app/src/app/dropdown/autoclose/dropdown-autoclose.e2e-spec.ts
@@ -180,5 +180,20 @@ containers.forEach((container) => {
       await sendKey(' ');
       await expectDropdownToBeHidden(`Dropdown should be closed on Space`);
     });
+    it(`should change autoClose setting dynamically`, async() => {
+      // initially set autoClose to 'inside' because selectAutoClose is an outside click
+      await selectAutoClose('inside');
+      await openDropdown(`Open dropdown with autoclose 'inside'`);
+
+      // change autoClose to false whilst open
+      await selectAutoClose('false');
+      await clickDropdownItem();
+      await expectDropdownToBeVisible(`Dropdown should not close after autoClose is changed to false whilst open`);
+
+      // change autoClose to 'inside' whilst open
+      await selectAutoClose('inside');
+      await clickDropdownItem();
+      await expectDropdownToBeHidden(`Dropdown should close after autoClose is changed to 'inside' whilst open`);
+    });
   });
 });


### PR DESCRIPTION
Closes #4219 

I added the feature to datepicker as well as dropdown because it's equally applicable there. popover, tooltip and typeahead also use autoClose but I can't imagine any use case for this feature in a non-interactive component.