### PR TITLE
fix(test): increase timeout in datepicker-focus.e2e-spec (especially for webkit)

### DIFF
--- a/e2e-app/src/app/datepicker/focus/datepicker-focus.e2e-spec.ts
+++ b/e2e-app/src/app/datepicker/focus/datepicker-focus.e2e-spec.ts
@@ -234,7 +234,7 @@ test.describe('Datepicker', () => {
     await getPage().waitForSelector(dayElement);
     let message = '';
     try {
-      await getPage().click(dayElement, {timeout: 200});
+      await getPage().click(dayElement, {timeout: 500});
     } catch (e) {
       message = e.message;
     }


### PR DESCRIPTION
It looks like this test sometimes fails on webkit because of a timeout that is too small.

(cf for example https://github.com/ng-bootstrap/ng-bootstrap/actions/runs/1910949270)