### PR TITLE
docs(buttons): mark button directives as deprecated

### DIFF
--- a/demo/src/app/components/buttons/buttons-warning.component.ts
+++ b/demo/src/app/components/buttons/buttons-warning.component.ts
@@ -1,0 +1,20 @@
+import {ChangeDetectionStrategy, Component} from '@angular/core';
+
+@Component({
+  selector: 'ngbd-buttons-warning',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <ngb-alert type="danger" [dismissible]="false" class="mb-5 d-flex flex-row">
+      <div class="me-2">
+        <svg:svg ngbdIcon="lightbulb" fill="currentColor" />
+      </div>
+      <div>
+        Button directives are deprecated since version <span class="badge bg-info text-dark">12.0.0</span>
+        and will be removed in <span class="badge bg-info text-dark">13.0.0</span>.
+        Please use <a routerLink="/components/buttons/overview" fragment="bootstrap-5">native Angular code </a> as a more flexible alternative.
+      </div>
+    </ngb-alert>
+  `
+})
+export class NgbdButtonsWarningComponent {
+}

--- a/demo/src/app/components/buttons/buttons.module.ts
+++ b/demo/src/app/components/buttons/buttons.module.ts
@@ -1,19 +1,26 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-import { NgModule } from '@angular/core';
+import {NgModule} from '@angular/core';
 
-import { NgbdSharedModule } from '../../shared';
-import { ComponentWrapper } from '../../shared/component-wrapper/component-wrapper.component';
-import { NgbdComponentsSharedModule, NgbdDemoList } from '../shared';
-import { NgbdApiPage } from '../shared/api-page/api.component';
-import { NgbdExamplesPage } from '../shared/examples-page/examples.component';
-import { NgbdButtonsCheckbox } from './demos/checkbox/buttons-checkbox';
-import { NgbdButtonsCheckboxModule } from './demos/checkbox/buttons-checkbox.module';
-import { NgbdButtonsCheckboxReactiveModule } from './demos/checkboxreactive/buttons-checkbox-reactive.module';
-import { NgbdButtonsCheckboxreactive } from './demos/checkboxreactive/buttons-checkboxreactive';
-import { NgbdButtonsRadio } from './demos/radio/buttons-radio';
-import { NgbdButtonsRadioModule } from './demos/radio/buttons-radio.module';
-import { NgbdButtonsRadioReactiveModule } from './demos/radioreactive/buttons-radio-reactive.module';
-import { NgbdButtonsRadioreactive } from './demos/radioreactive/buttons-radioreactive';
+import {NgbdSharedModule} from '../../shared';
+import {ComponentWrapper} from '../../shared/component-wrapper/component-wrapper.component';
+import {NgbdComponentsSharedModule, NgbdDemoList} from '../shared';
+import {NgbdApiPage} from '../shared/api-page/api.component';
+import {NgbdExamplesPage} from '../shared/examples-page/examples.component';
+import {NgbdButtonsCheckbox} from './demos/checkbox/buttons-checkbox';
+import {NgbdButtonsCheckboxModule} from './demos/checkbox/buttons-checkbox.module';
+import {NgbdButtonsCheckboxReactiveModule} from './demos/checkboxreactive/buttons-checkbox-reactive.module';
+import {NgbdButtonsCheckboxreactive} from './demos/checkboxreactive/buttons-checkboxreactive';
+import {NgbdButtonsRadio} from './demos/radio/buttons-radio';
+import {NgbdButtonsRadioModule} from './demos/radio/buttons-radio.module';
+import {NgbdButtonsRadioReactiveModule} from './demos/radioreactive/buttons-radio-reactive.module';
+import {NgbdButtonsRadioreactive} from './demos/radioreactive/buttons-radioreactive';
+import {NgbdButtonsOverviewComponent} from './overview/buttons-overview.component';
+import {NgbdButtonsWarningComponent} from './buttons-warning.component';
+
+const OVERVIEW = {
+  'bootstrap-5': 'Bootstrap 5',
+  'bootstrap-4': 'Bootstrap 4'
+};
 
 const DEMOS = {
   checkbox: {
@@ -43,14 +50,16 @@ const DEMOS = {
 };
 
 export const ROUTES = [
-  { path: '', pathMatch: 'full', redirectTo: 'examples' },
+  { path: '', pathMatch: 'full', redirectTo: 'overview' },
   {
     path: '',
     component: ComponentWrapper,
     data: {
-      bootstrap: 'https://getbootstrap.com/docs/%version%/components/buttons/#checkbox-and-radio-buttons'
+      bootstrap: 'https://getbootstrap.com/docs/4.6/components/buttons/#checkbox-and-radio-buttons',
+      header: NgbdButtonsWarningComponent
     },
     children: [
+      { path: 'overview', component: NgbdButtonsOverviewComponent },
       { path: 'examples', component: NgbdExamplesPage },
       { path: 'api', component: NgbdApiPage }
     ]
@@ -65,10 +74,14 @@ export const ROUTES = [
     NgbdButtonsCheckboxReactiveModule,
     NgbdButtonsRadioModule,
     NgbdButtonsRadioReactiveModule
+  ],
+  declarations: [
+    NgbdButtonsOverviewComponent,
+    NgbdButtonsWarningComponent
   ]
 })
 export class NgbdButtonsModule {
   constructor(demoList: NgbdDemoList) {
-    demoList.register('buttons', DEMOS);
+    demoList.register('buttons', DEMOS, OVERVIEW);
   }
 }

--- a/demo/src/app/components/buttons/overview/buttons-overview.component.html
+++ b/demo/src/app/components/buttons/overview/buttons-overview.component.html
@@ -1,0 +1,65 @@
+<p>
+  Buttons is a set of directives that helps creating Bootstrap radio buttons and checkboxes
+</p>
+
+<ngbd-overview-section [section]="sections['bootstrap-5']">
+
+  <ngbd-api-docs-badge [since]="{version: '12.0.0'}"></ngbd-api-docs-badge>
+
+  <p>
+    With the release of Bootstrap 5, there is not much interest in having a dedicated set of directives to manage
+    button groups. Markup and styles have changed.
+    Everything works out of the box with pure Angular without 3rd party libraries.
+  </p>
+
+  <p>
+    Here is how buttons might look like with pure Angular and Bootstrap 5 CSS.
+  </p>
+
+  <h4>Radio Buttons</h4>
+
+  <div class="btn-group" role="group" aria-label="Radio Buttons with Bootstrap 5">
+    <input type="radio" [formControl]="radio" [value]="1" class="btn-check" id="btnradio1" autocomplete="off">
+    <label class="btn btn-outline-primary" for="btnradio1">One</label>
+
+    <input type="radio" [formControl]="radio" [value]="2" class="btn-check" id="btnradio2" autocomplete="off">
+    <label class="btn btn-outline-primary" for="btnradio2">Two</label>
+  </div>
+
+  <pre class="mt-4">Value: {{ radio.value }}</pre>
+
+  <ngbd-code [snippet]="DEMO_5_RADIOS"></ngbd-code>
+
+  <h4>Checkboxes</h4>
+
+  <div class="btn-group" [formGroup]="checkbox" role="group" aria-label="Checkboxes with Bootstrap 5">
+    <input type="checkbox" formControlName="one" class="btn-check" id="btncheck1" autocomplete="off">
+    <label class="btn btn-outline-primary" for="btncheck1">One</label>
+
+    <input type="checkbox" formControlName="two" class="btn-check" id="btncheck2" autocomplete="off">
+    <label class="btn btn-outline-primary" for="btncheck2">Two</label>
+  </div>
+
+  <pre class="mt-4">Value: {{ checkbox.value | json }}</pre>
+
+  <ngbd-code [snippet]="DEMO_5_CHECKBOXES"></ngbd-code>
+
+</ngbd-overview-section>
+
+
+<ngbd-overview-section [section]="sections['bootstrap-4']">
+
+  <ngbd-api-docs-badge [deprecated]="{version: '12.0.0'}"></ngbd-api-docs-badge>
+
+  <p>
+    Before Bootstrap 5 we've used a set of directives (<code>NgbLabel</code>, <code>NgbButton</code>, etc.) to handle
+    button groups as checkboxes or radios. Several CSS classes had to applied dynamically to the labels.
+  </p>
+
+  <h4>Radio Buttons</h4>
+  <ngbd-code [snippet]="DEMO_4_RADIOS"></ngbd-code>
+
+  <h4>Checkboxes</h4>
+  <ngbd-code [snippet]="DEMO_4_CHECKBOXES"></ngbd-code>
+
+</ngbd-overview-section>

--- a/demo/src/app/components/buttons/overview/buttons-overview.component.ts
+++ b/demo/src/app/components/buttons/overview/buttons-overview.component.ts
@@ -1,0 +1,85 @@
+import {Component} from '@angular/core';
+
+import {Snippet} from '../../../shared/code/snippet';
+import {NgbdDemoList} from '../../shared';
+import {NgbdOverview} from '../../shared/overview';
+import {FormControl, FormGroup} from '@angular/forms';
+
+
+@Component({
+  selector: 'ngbd-buttons-overview',
+  templateUrl: './buttons-overview.component.html',
+  host: {'[class.overview]': 'true'}
+})
+export class NgbdButtonsOverviewComponent {
+
+  radio = new FormControl(1);
+  checkbox = new FormGroup({
+    'one': new FormControl(true),
+    'two': new FormControl(false)
+  });
+
+  DEMO_4_CHECKBOXES = Snippet({
+    lang: 'html',
+    code: `
+      <div class="btn-group" role="group">
+        <label class="btn-primary" ngbButtonLabel>
+          <input type="checkbox" class="btn-check" ngbButton [(ngModel)]="model.left"> One
+        </label>
+        <label class="btn-primary" ngbButtonLabel>
+          <input type="checkbox" class="btn-check" ngbButton [(ngModel)]="model.middle"> Two
+        </label>
+      </div>
+    `,
+  });
+
+  DEMO_4_RADIOS = Snippet({
+    lang: 'html',
+    code: `
+      <div class="btn-group" role="group" ngbRadioGroup name="radioBasic" [(ngModel)]="model">
+        <label ngbButtonLabel class="btn-primary">
+          <input ngbButton type="radio" class="btn-check" [value]="1"> One
+        </label>
+        <label ngbButtonLabel class="btn-primary">
+          <input ngbButton type="radio" class="btn-check" [value]="2"> Two
+        </label>
+      </div>
+    `,
+  });
+
+  DEMO_5_CHECKBOXES = Snippet({
+    lang: 'html',
+    code: `
+      <div class="btn-group" [formGroup]="checkbox" role="group" aria-label="Checkboxes with Bootstrap 5">
+        <input type="checkbox" formControlName="one" class="btn-check" id="btncheck1" autocomplete="off">
+        <label class="btn btn-outline-primary" for="btncheck1">One</label>
+
+        <input type="checkbox" formControlName="two" class="btn-check" id="btncheck2" autocomplete="off">
+        <label class="btn btn-outline-primary" for="btncheck2">Two</label>
+      </div>
+
+      <pre">Value: {{ checkbox.value | json }}</pre>
+    `,
+  });
+
+  DEMO_5_RADIOS = Snippet({
+    lang: 'html',
+    code: `
+      <div class="btn-group" role="group" aria-label="Radio Buttons with Bootstrap 5">
+        <input type="radio" [formControl]="radio" [value]="1" class="btn-check" id="btnradio1" autocomplete="off">
+        <label class="btn btn-outline-primary" for="btnradio1">One</label>
+
+        <input type="radio" [formControl]="radio" [value]="2" class="btn-check" id="btnradio2" autocomplete="off">
+        <label class="btn btn-outline-primary" for="btnradio2">Two</label>
+      </div>
+
+      <pre>Value: {{ radio.value }}</pre>
+    `,
+  });
+
+  sections: NgbdOverview = {};
+
+  constructor(demoList: NgbdDemoList) {
+    this.sections = demoList.getOverviewSections('buttons');
+  }
+}

--- a/src/buttons/buttons.module.ts
+++ b/src/buttons/buttons.module.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import {NgModule} from '@angular/core';
 import {NgbButtonLabel} from './label';
 import {NgbCheckBox} from './checkbox';
@@ -10,6 +11,9 @@ export {NgbRadio, NgbRadioGroup} from './radio';
 
 const NGB_BUTTON_DIRECTIVES = [NgbButtonLabel, NgbCheckBox, NgbRadioGroup, NgbRadio];
 
+/**
+ * @deprecated 12.0.0 Please use native Angular code instead
+ */
 @NgModule({declarations: NGB_BUTTON_DIRECTIVES, exports: NGB_BUTTON_DIRECTIVES})
 export class NgbButtonsModule {
 }

--- a/src/buttons/checkbox.spec.ts
+++ b/src/buttons/checkbox.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {createGenericTestComponent} from '../test/common';

--- a/src/buttons/checkbox.ts
+++ b/src/buttons/checkbox.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import {ChangeDetectorRef, Directive, forwardRef, Input} from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 
@@ -8,6 +9,8 @@ import {NgbButtonLabel} from './label';
  *
  * Integrates with forms, so the value of a checked button is bound to the underlying form control
  * either in a reactive or template-driven way.
+ *
+ * @deprecated 12.0.0 Please use native Angular code instead
  */
 @Directive({
   selector: '[ngbButton][type=checkbox]',

--- a/src/buttons/label.ts
+++ b/src/buttons/label.ts
@@ -1,5 +1,9 @@
+/* eslint-disable */
 import {Directive} from '@angular/core';
 
+/**
+ * @deprecated 12.0.0 Please use native Angular code instead
+ */
 @Directive({
   selector: '[ngbButtonLabel]',
   host:

--- a/src/buttons/radio.spec.ts
+++ b/src/buttons/radio.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import {ChangeDetectionStrategy, Component} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {FormControl, FormGroup, FormsModule, NgModel, ReactiveFormsModule, Validators} from '@angular/forms';

--- a/src/buttons/radio.ts
+++ b/src/buttons/radio.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import {ChangeDetectorRef, Directive, ElementRef, forwardRef, Input, OnDestroy, Renderer2} from '@angular/core';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 
@@ -10,6 +11,8 @@ let nextId = 0;
  *
  * Integrates with forms, so the value of a checked button is bound to the underlying form control
  * either in a reactive or template-driven way.
+ *
+ * @deprecated 12.0.0 Please use native Angular code instead
  */
 @Directive({
   selector: '[ngbRadioGroup]',
@@ -70,6 +73,8 @@ export class NgbRadioGroup implements ControlValueAccessor {
 /**
  * A directive that marks an input of type "radio" as a part of the
  * [`NgbRadioGroup`](#/components/buttons/api#NgbRadioGroup).
+ *
+ * @deprecated 12.0.0 Please use native Angular code instead
  */
 @Directive({
   selector: '[ngbButton][type=radio]',

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import {NgModule} from '@angular/core';
 
 import {NgbAccordionModule} from './accordion/accordion.module';
 import {NgbAlertModule} from './alert/alert.module';
+/* eslint-disable-next-line deprecation/deprecation */
 import {NgbButtonsModule} from './buttons/buttons.module';
 import {NgbCarouselModule} from './carousel/carousel.module';
 import {NgbCollapseModule} from './collapse/collapse.module';
@@ -33,6 +34,7 @@ export {
   NgbPanelToggle
 } from './accordion/accordion.module';
 export {NgbAlert, NgbAlertConfig, NgbAlertModule} from './alert/alert.module';
+/* eslint-disable-next-line deprecation/deprecation */
 export {NgbButtonLabel, NgbButtonsModule, NgbCheckBox, NgbRadio, NgbRadioGroup} from './buttons/buttons.module';
 export {
   NgbCarousel,
@@ -142,6 +144,7 @@ export {NgbConfig} from './ngb-config';
 
 
 const NGB_MODULES = [
+  /* eslint-disable-next-line deprecation/deprecation */
   NgbAccordionModule, NgbAlertModule, NgbButtonsModule, NgbCarouselModule, NgbCollapseModule, NgbDatepickerModule,
   NgbDropdownModule, NgbModalModule, NgbNavModule, NgbPaginationModule, NgbPopoverModule, NgbProgressbarModule,
   NgbRatingModule, NgbTimepickerModule, NgbToastModule, NgbTooltipModule, NgbTypeaheadModule


### PR DESCRIPTION
We forgot to do it properly for the 12.0.0
In Bootstrap 5 CSS there is no more need it button directives, everything can be handled with pure Angular.

This change:
- adds the 'overview' page detailing changes between Bootstrap 4 and 5
- marks button directives as deprecated

Fixes #4257

---

<details>
<summary>
Overview page looks like this:
</summary>

![localhost_4200_](https://user-images.githubusercontent.com/8074436/156188252-8bd7b486-695e-4f27-8964-45151027e0d9.png)

</details>

