### PR TITLE
fix(datepicker): ensure popup is shown above modal

### DIFF
--- a/e2e-app/src/app/app.module.ts
+++ b/e2e-app/src/app/app.module.ts
@@ -9,6 +9,7 @@ import {AppComponent} from './app.component';
 import {NavigationComponent} from './navigation.component';
 
 import {DatepickerAutoCloseComponent} from './datepicker/autoclose/datepicker-autoclose.component';
+import {DatepickerContainerComponent} from './datepicker/container/datepicker-container.component';
 import {DatepickerFocusComponent} from './datepicker/focus/datepicker-focus.component';
 import {DatepickerMultipleComponent} from './datepicker/multiple/datepicker-multiple.component';
 import {DropdownAutoCloseComponent} from './dropdown/autoclose/dropdown-autoclose.component';
@@ -36,6 +37,7 @@ import {TypeaheadValidationComponent} from './typeahead/validation/typeahead-val
     AppComponent,
     NavigationComponent,
     DatepickerAutoCloseComponent,
+    DatepickerContainerComponent,
     DatepickerFocusComponent,
     DatepickerMultipleComponent,
     DropdownAutoCloseComponent,

--- a/e2e-app/src/app/app.routing.ts
+++ b/e2e-app/src/app/app.routing.ts
@@ -2,6 +2,7 @@ import {ModuleWithProviders} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router';
 
 import {DatepickerAutoCloseComponent} from './datepicker/autoclose/datepicker-autoclose.component';
+import {DatepickerContainerComponent} from './datepicker/container/datepicker-container.component';
 import {DatepickerFocusComponent} from './datepicker/focus/datepicker-focus.component';
 import {DatepickerMultipleComponent} from './datepicker/multiple/datepicker-multiple.component';
 import {DropdownAutoCloseComponent} from './dropdown/autoclose/dropdown-autoclose.component';
@@ -28,6 +29,7 @@ export const routes: Routes = [
   {
     path: 'datepicker',
     children: [
+      {path: 'container', component: DatepickerContainerComponent},
       {path: 'focus', component: DatepickerFocusComponent},
       {path: 'autoclose', component: DatepickerAutoCloseComponent},
       {path: 'multiple', component: DatepickerMultipleComponent}

--- a/e2e-app/src/app/datepicker/container/datepicker-container.component.html
+++ b/e2e-app/src/app/datepicker/container/datepicker-container.component.html
@@ -1,0 +1,23 @@
+<h3>Datepicker container tests</h3>
+
+<ng-template #t let-modal>
+  <div class="modal-header">
+    <h4 class="modal-title">Modal with nested datepicker</h4>
+    <button type="button" class="btn-close" aria-label="Close" (click)="modal.dismiss()"></button>
+  </div>
+  <div class="modal-body">
+    <form>
+      <!-- container="body"-->
+      <div class="mb-3">
+        <label for="datepicker">Datepicker</label>
+        <div class="input-group">
+          <input id="datepicker" class="form-control" placeholder="yyyy-mm-dd" name="dp"
+                 ngbDatepicker #dp="ngbDatepicker" [startDate]="{year: 2022, month: 3}" container="body">
+          <button class="btn btn-outline-secondary" id="datepicker-button" (click)="dp.toggle()" type="button">Open</button>
+        </div>
+      </div>
+    </form>
+  </div>
+</ng-template>
+
+<button class="btn btn-outline-secondary ms-2" type="button" id="open-modal" (click)="openModal(t)">Open Modal</button>

--- a/e2e-app/src/app/datepicker/container/datepicker-container.component.ts
+++ b/e2e-app/src/app/datepicker/container/datepicker-container.component.ts
@@ -1,0 +1,9 @@
+import {Component, TemplateRef} from '@angular/core';
+import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
+
+@Component({templateUrl: './datepicker-container.component.html'})
+export class DatepickerContainerComponent {
+  constructor(private modalService: NgbModal) {}
+
+  openModal(content: TemplateRef<any>) { this.modalService.open(content); }
+}

--- a/e2e-app/src/app/datepicker/container/datepicker-container.e2e-spec.ts
+++ b/e2e-app/src/app/datepicker/container/datepicker-container.e2e-spec.ts
@@ -1,0 +1,41 @@
+import {expect} from '@playwright/test';
+import {getPage, setPage, test} from '../../../../baseTest';
+import {sendKey} from '../../tools.po';
+import {
+  openModal,
+  pressButton,
+  SELECTOR_DATEPICKER,
+  SELECTOR_DATEPICKER_BUTTON,
+  SELECTOR_MODAL_WINDOW,
+} from './datepicker-container.po';
+import {waitForModalCount} from "../../modal/modal.po";
+
+test.use({testURL: 'datepicker/container', testSelector: 'h3:text("Datepicker container tests")'});
+test.beforeEach(async({page}) => setPage(page));
+
+test.describe('Datepicker container components', () => {
+
+  const getZIndex = async(selector: string) =>
+      getPage().locator(selector).evaluate(element => parseInt(window.getComputedStyle(element).zIndex, 10));
+
+  test('should show datepicker above modal window with container="body"', async() => {
+    await openModal();
+
+    // open datepicker
+    await pressButton(SELECTOR_DATEPICKER_BUTTON);
+    await expect(getPage().locator(SELECTOR_DATEPICKER), `Datepicker should be opened`).toBeVisible();
+
+    const datepickerZIndex = await getZIndex(SELECTOR_DATEPICKER);
+    const modalZIndex = await getZIndex(SELECTOR_MODAL_WINDOW);
+
+    expect(datepickerZIndex, `Datepicker z-index should be defined`).not.toBeNaN();
+    expect(modalZIndex, `Modal window z-index should be defined`).not.toBeNaN();
+    expect(datepickerZIndex, `Datepicker should be shown above modal window`).toBeGreaterThanOrEqual(modalZIndex);
+
+    // close datepicker
+    await sendKey('Escape');
+    // close modal
+    await sendKey('Escape');
+    await waitForModalCount(0);
+  });
+});

--- a/e2e-app/src/app/datepicker/container/datepicker-container.po.ts
+++ b/e2e-app/src/app/datepicker/container/datepicker-container.po.ts
@@ -1,0 +1,17 @@
+import {focusElement, sendKey} from '../../tools.po';
+import {getPage} from "../../../../baseTest";
+import {waitForModalCount} from "../../modal/modal.po";
+
+export const SELECTOR_DATEPICKER = 'ngb-datepicker';
+export const SELECTOR_DATEPICKER_BUTTON = '#datepicker-button';
+export const SELECTOR_MODAL_WINDOW = 'ngb-modal-window';
+
+export const openModal = async() => {
+  await getPage().click('#open-modal');
+  await waitForModalCount(1);
+};
+
+export const pressButton = async(buttonSelector) => {
+  await focusElement(buttonSelector);
+  await sendKey('Enter');
+};

--- a/src/datepicker/datepicker.scss
+++ b/src/datepicker/datepicker.scss
@@ -14,7 +14,7 @@ ngb-datepicker {
 
 .ngb-dp {
   &-body {
-    z-index: 1050;
+    z-index: 1055;
   }
 
   &-header {


### PR DESCRIPTION
When using container="body", the datepicker's `z-index` must be equal
or above the modal window's one (as defined in `modal.scss`).

Fixes #4278

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [n/a] added/updated any applicable API documentation.
 - [n/a] added/updated any applicable demos.
