### PR TITLE
feat(offcanvas): implement offcanvas components and service

### DIFF
--- a/demo/src/app/app.module.ts
+++ b/demo/src/app/app.module.ts
@@ -29,12 +29,14 @@ import {I18nPage} from './pages/i18n/i18n.component';
 import {PositioningPage} from './pages/positioning/positioning.component';
 import {NgbdSharedModule} from './shared';
 import {NgbdDemoVersionsComponent} from './demo-versions.component';
+import {NgbdOffcanvasModule} from './components/offcanvas/offcanvas.module';
 
 
 const DEMOS = [
   NgbdAccordionModule, NgbdAlertModule, NgbdButtonsModule, NgbdCarouselModule, NgbdCollapseModule, NgbdDatepickerModule,
-  NgbdDropdownModule, NgbdModalModule, NgbdNavModule, NgbdPaginationModule, NgbdPopoverModule, NgbdProgressbarModule,
-  NgbdRatingModule, NgbdTableModule, NgbdTimepickerModule, NgbdToastModule, NgbdTooltipModule, NgbdTypeaheadModule
+  NgbdDropdownModule, NgbdModalModule, NgbdNavModule, NgbdOffcanvasModule, NgbdPaginationModule, NgbdPopoverModule, NgbdProgressbarModule,
+  NgbdRatingModule, NgbdTableModule, NgbdTimepickerModule, NgbdToastModule, NgbdTooltipModule,
+  NgbdTypeaheadModule
 ];
 
 const PAGES = [GettingStartedPage, AnimationsPage, I18nPage, PositioningPage];

--- a/demo/src/app/app.routing.ts
+++ b/demo/src/app/app.routing.ts
@@ -10,6 +10,7 @@ import {ROUTES as DATEPICKER_ROUTES} from './components/datepicker/datepicker.mo
 import {ROUTES as DROPDOWN_ROUTES} from './components/dropdown/dropdown.module';
 import {ROUTES as MODAL_ROUTES} from './components/modal/modal.module';
 import {ROUTES as NAV_ROUTES} from './components/nav/nav.module';
+import {ROUTES as OFFCANVAS_ROUTES} from './components/offcanvas/offcanvas.module';
 import {ROUTES as PAGINATION_ROUTES} from './components/pagination/pagination.module';
 import {ROUTES as POPOVER_ROUTES} from './components/popover/popover.module';
 import {ROUTES as PROGRESSBAR_ROUTES} from './components/progressbar/progressbar.module';
@@ -49,6 +50,7 @@ const routes: Routes = [
   {path: 'components/dropdown', children: DROPDOWN_ROUTES},
   {path: 'components/modal', children: MODAL_ROUTES},
   {path: 'components/nav', children: NAV_ROUTES},
+  {path: 'components/offcanvas', children: OFFCANVAS_ROUTES},
   {path: 'components/pagination', children: PAGINATION_ROUTES},
   {path: 'components/popover', children: POPOVER_ROUTES},
   {path: 'components/progressbar', children: PROGRESSBAR_ROUTES},

--- a/demo/src/app/components/components.e2e-spec.ts
+++ b/demo/src/app/components/components.e2e-spec.ts
@@ -5,8 +5,8 @@ const SELECTOR_SIDE_NAV_COMPONENT_LINKS = 'ngbd-side-nav >> a[href^="#/component
 const SELECTOR_CODE_BUTTONS = 'button.toggle-code';
 
 const COMPONENTS = [
-  'accordion', 'alert', 'buttons', 'carousel', 'collapse', 'datepicker', 'dropdown', 'modal', 'nav', 'pagination',
-  'popover', 'progressbar', 'rating', 'table', 'timepicker', 'toast', 'tooltip', 'typeahead'
+  'accordion', 'alert', 'buttons', 'carousel', 'collapse', 'datepicker', 'dropdown', 'modal', 'nav', 'offcanvas',
+  'pagination', 'popover', 'progressbar', 'rating', 'table', 'timepicker', 'toast', 'tooltip', 'typeahead'
 ];
 
 test.describe(`Components`, () => {

--- a/demo/src/app/components/offcanvas/demos/basic/offcanvas-basic.html
+++ b/demo/src/app/components/offcanvas/demos/basic/offcanvas-basic.html
@@ -1,0 +1,26 @@
+<ng-template #content let-offcanvas>
+  <div class="offcanvas-header">
+    <h4 class="offcanvas-title" id="offcanvas-basic-title">Profile update</h4>
+    <button type="button" class="btn-close" aria-label="Close" (click)="offcanvas.dismiss('Cross click')"></button>
+  </div>
+  <div class="offcanvas-body">
+    <form>
+      <div class="mb-3">
+        <label for="dateOfBirth">Date of birth</label>
+        <div class="input-group">
+          <input id="dateOfBirth" class="form-control" placeholder="yyyy-mm-dd" name="dp" ngbDatepicker #dp="ngbDatepicker">
+          <button class="btn btn-outline-secondary calendar" (click)="dp.toggle()" type="button"></button>
+        </div>
+      </div>
+    </form>
+    <div class="text-end">
+      <button type="button" class="btn btn-outline-dark" (click)="offcanvas.close('Save click')">Save</button>
+    </div>
+  </div>
+</ng-template>
+
+<button class="btn btn-lg btn-outline-primary" (click)="open(content)">Launch demo offcanvas</button>
+
+<hr>
+
+<pre>{{ closeResult }}</pre>

--- a/demo/src/app/components/offcanvas/demos/basic/offcanvas-basic.module.ts
+++ b/demo/src/app/components/offcanvas/demos/basic/offcanvas-basic.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+
+import { NgbdOffcanvasBasic } from './offcanvas-basic';
+
+@NgModule({
+  imports: [BrowserModule, NgbModule],
+  declarations: [NgbdOffcanvasBasic],
+  exports: [NgbdOffcanvasBasic],
+  bootstrap: [NgbdOffcanvasBasic]
+})
+export class NgbdOffcanvasBasicModule {}

--- a/demo/src/app/components/offcanvas/demos/basic/offcanvas-basic.ts
+++ b/demo/src/app/components/offcanvas/demos/basic/offcanvas-basic.ts
@@ -1,0 +1,31 @@
+import {Component} from '@angular/core';
+
+import {NgbOffcanvas, OffcanvasDismissReasons} from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+  selector: 'ngbd-offcanvas-basic',
+  templateUrl: './offcanvas-basic.html'
+})
+export class NgbdOffcanvasBasic {
+  closeResult = '';
+
+  constructor(private offcanvasService: NgbOffcanvas) {}
+
+  open(content) {
+    this.offcanvasService.open(content, {ariaLabelledBy: 'offcanvas-basic-title'}).result.then((result) => {
+      this.closeResult = `Closed with: ${result}`;
+    }, (reason) => {
+      this.closeResult = `Dismissed ${this.getDismissReason(reason)}`;
+    });
+  }
+
+  private getDismissReason(reason: any): string {
+    if (reason === OffcanvasDismissReasons.ESC) {
+      return 'by pressing ESC';
+    } else if (reason === OffcanvasDismissReasons.BACKDROP_CLICK) {
+      return 'by clicking on the backdrop';
+    } else {
+      return `with: ${reason}`;
+    }
+  }
+}

--- a/demo/src/app/components/offcanvas/demos/component/offcanvas-component.html
+++ b/demo/src/app/components/offcanvas/demos/component/offcanvas-component.html
@@ -1,12 +1,3 @@
 <p>You can pass an existing component as content of the offcanvas panel.</p>
 
-<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="open()">Launch with default options</button>
-<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="open({ position: 'end' })">Right position</button>
-<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="open({ position: 'top' })">Top position</button>
-<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="open({ position: 'bottom' })">Bottom position</button>
-<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="open({ backdrop: false })">No backdrop</button>
-<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="open({ scroll: true })">Scrolling enabled</button>
-<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="open({ keyboard: false })">Escape does not dismiss</button>
-<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="open({ animation: false })">No animation</button>
-<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="open({ backdropClass: 'bg-info' })">Custom backdrop class</button>
-<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="open({ panelClass: 'bg-info' })">Custom panel class</button>
+<button class="btn btn-lg btn-outline-primary" (click)="open()">Launch demo offcanvas</button>

--- a/demo/src/app/components/offcanvas/demos/component/offcanvas-component.html
+++ b/demo/src/app/components/offcanvas/demos/component/offcanvas-component.html
@@ -1,0 +1,12 @@
+<p>You can pass an existing component as content of the offcanvas panel.</p>
+
+<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="open()">Launch with default options</button>
+<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="open({ position: 'end' })">Right position</button>
+<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="open({ position: 'top' })">Top position</button>
+<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="open({ position: 'bottom' })">Bottom position</button>
+<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="open({ backdrop: false })">No backdrop</button>
+<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="open({ scroll: true })">Scrolling enabled</button>
+<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="open({ keyboard: false })">Escape does not dismiss</button>
+<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="open({ animation: false })">No animation</button>
+<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="open({ backdropClass: 'bg-info' })">Custom backdrop class</button>
+<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="open({ panelClass: 'bg-info' })">Custom panel class</button>

--- a/demo/src/app/components/offcanvas/demos/component/offcanvas-component.module.ts
+++ b/demo/src/app/components/offcanvas/demos/component/offcanvas-component.module.ts
@@ -9,6 +9,5 @@ import { NgbdOffcanvasComponent, NgbdOffcanvasContent } from './offcanvas-compon
   declarations: [NgbdOffcanvasComponent, NgbdOffcanvasContent],
   exports: [NgbdOffcanvasComponent],
   bootstrap: [NgbdOffcanvasComponent]
-  // entryComponents: [NgbdModalContent] // this line would be needed in Angular 8 or older
 })
 export class NgbdOffcanvasComponentModule {}

--- a/demo/src/app/components/offcanvas/demos/component/offcanvas-component.module.ts
+++ b/demo/src/app/components/offcanvas/demos/component/offcanvas-component.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+
+import { NgbdOffcanvasComponent, NgbdOffcanvasContent } from './offcanvas-component';
+
+@NgModule({
+  imports: [BrowserModule, NgbModule],
+  declarations: [NgbdOffcanvasComponent, NgbdOffcanvasContent],
+  exports: [NgbdOffcanvasComponent],
+  bootstrap: [NgbdOffcanvasComponent]
+  // entryComponents: [NgbdModalContent] // this line would be needed in Angular 8 or older
+})
+export class NgbdOffcanvasComponentModule {}

--- a/demo/src/app/components/offcanvas/demos/component/offcanvas-component.ts
+++ b/demo/src/app/components/offcanvas/demos/component/offcanvas-component.ts
@@ -1,0 +1,34 @@
+import { Component, Input } from '@angular/core';
+import { NgbActiveOffcanvas, NgbOffcanvas, NgbOffcanvasOptions } from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+  selector: 'ngbd-offcanvas-content',
+  template: `
+    <div class="offcanvas-header">
+      <h5 class="offcanvas-title">Offcanvas</h5>
+      <button type="button" class="btn-close text-reset" aria-label="Close" (click)="activeOffcanvas.dismiss('Cross click')"></button>
+    </div>
+    <div class="offcanvas-body">
+      <div>
+        Hello {{ name }}
+      </div>
+      <button type="button" class="btn btn-outline-dark" (click)="activeOffcanvas.close('Close click')">Close</button>
+    </div>
+  `
+})
+export class NgbdOffcanvasContent {
+  @Input() name;
+
+  constructor(public activeOffcanvas: NgbActiveOffcanvas) {
+  }
+}
+
+@Component({selector: 'ngbd-offcanvas-component', templateUrl: './offcanvas-component.html'})
+export class NgbdOffcanvasComponent {
+  constructor(private offcanvasService: NgbOffcanvas) {}
+
+  open(options?: NgbOffcanvasOptions) {
+    const offcanvasRef = this.offcanvasService.open(NgbdOffcanvasContent, options);
+    offcanvasRef.componentInstance.name = 'World';
+  }
+}

--- a/demo/src/app/components/offcanvas/demos/component/offcanvas-component.ts
+++ b/demo/src/app/components/offcanvas/demos/component/offcanvas-component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { NgbActiveOffcanvas, NgbOffcanvas, NgbOffcanvasOptions } from '@ng-bootstrap/ng-bootstrap';
+import { NgbActiveOffcanvas, NgbOffcanvas } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
   selector: 'ngbd-offcanvas-content',
@@ -23,12 +23,15 @@ export class NgbdOffcanvasContent {
   }
 }
 
-@Component({selector: 'ngbd-offcanvas-component', templateUrl: './offcanvas-component.html'})
+@Component({
+  selector: 'ngbd-offcanvas-component',
+  templateUrl: './offcanvas-component.html'}
+)
 export class NgbdOffcanvasComponent {
   constructor(private offcanvasService: NgbOffcanvas) {}
 
-  open(options?: NgbOffcanvasOptions) {
-    const offcanvasRef = this.offcanvasService.open(NgbdOffcanvasContent, options);
+  open() {
+    const offcanvasRef = this.offcanvasService.open(NgbdOffcanvasContent);
     offcanvasRef.componentInstance.name = 'World';
   }
 }

--- a/demo/src/app/components/offcanvas/demos/config/offcanvas-config.html
+++ b/demo/src/app/components/offcanvas/demos/config/offcanvas-config.html
@@ -1,0 +1,14 @@
+<ng-template #content let-offcanvas>
+  <div class="offcanvas-header">
+    <h4 class="offcanvas-title">Offcanvas title</h4>
+    <button type="button" class="btn-close" aria-label="Close" (click)="offcanvas.dismiss('Cross click')"></button>
+  </div>
+  <div class="offcanvas-body">
+    <p>One fine body&hellip;</p>
+    <div class="text-end">
+      <button type="button" class="btn btn-outline-dark" (click)="offcanvas.close('Close click')">Close</button>
+    </div>
+  </div>
+</ng-template>
+
+<button class="btn btn-lg btn-outline-primary" (click)="open(content)">Launch demo offcanvas</button>

--- a/demo/src/app/components/offcanvas/demos/config/offcanvas-config.module.ts
+++ b/demo/src/app/components/offcanvas/demos/config/offcanvas-config.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+
+import { NgbdOffcanvasConfig } from './offcanvas-config';
+
+@NgModule({
+  imports: [BrowserModule, NgbModule],
+  declarations: [NgbdOffcanvasConfig],
+  exports: [NgbdOffcanvasConfig],
+  bootstrap: [NgbdOffcanvasConfig]
+})
+export class NgbdOffcanvasConfigModule {}

--- a/demo/src/app/components/offcanvas/demos/config/offcanvas-config.ts
+++ b/demo/src/app/components/offcanvas/demos/config/offcanvas-config.ts
@@ -1,0 +1,22 @@
+import { Component } from '@angular/core';
+import { NgbOffcanvasConfig, NgbOffcanvas } from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+  selector: 'ngbd-offcanvas-config',
+  templateUrl: './offcanvas-config.html',
+  // add NgbOffcanvasConfig and NgbOffcanvas to the component providers
+  providers: [NgbOffcanvasConfig, NgbOffcanvas]
+})
+export class NgbdOffcanvasConfig {
+  constructor(config: NgbOffcanvasConfig, private offcanvasService: NgbOffcanvas) {
+    // customize default values of offcanvas used by this component tree
+    config.position = 'end';
+    config.backdropClass = 'bg-info';
+    config.keyboard = false;
+  }
+
+  open(content) {
+    this.offcanvasService.open(content);
+  }
+}
+

--- a/demo/src/app/components/offcanvas/demos/focus/offcanvas-focus.html
+++ b/demo/src/app/components/offcanvas/demos/focus/offcanvas-focus.html
@@ -1,0 +1,12 @@
+<p>First focusable element within the offcanvas will receive focus upon opening.
+You can configure to focus any other element by adding an <code>ngbAutofocus</code> attribute on it.</p>
+
+<button class="btn btn-outline-primary me-2" (click)="openFirstFocus()">
+  <div>First element focused</div>
+  <div class="text-dark" aria-hidden="true"><small>&times; button will be focused</small></div>
+</button>
+
+<button class="btn btn-outline-primary" (click)="openAutoFocus()">
+  <div>Element with `ngbAutofocus`</div>
+  <div class="text-dark" aria-hidden="true"><small>Ok button will be focused</small></div>
+</button>

--- a/demo/src/app/components/offcanvas/demos/focus/offcanvas-focus.module.ts
+++ b/demo/src/app/components/offcanvas/demos/focus/offcanvas-focus.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+
+import {
+  NgbdOffcanvasFirstFocus,
+  NgbdOffcanvasAutoFocus,
+  NgbdOffcanvasFocus
+} from './offcanvas-focus';
+
+@NgModule({
+  imports: [BrowserModule, NgbModule],
+  declarations: [NgbdOffcanvasFocus, NgbdOffcanvasFirstFocus, NgbdOffcanvasAutoFocus],
+  exports: [NgbdOffcanvasFocus],
+  bootstrap: [NgbdOffcanvasFocus]
+})
+export class NgbdOffcanvasFocusModule {}

--- a/demo/src/app/components/offcanvas/demos/focus/offcanvas-focus.ts
+++ b/demo/src/app/components/offcanvas/demos/focus/offcanvas-focus.ts
@@ -1,0 +1,56 @@
+import { Component } from '@angular/core';
+import { NgbActiveOffcanvas, NgbOffcanvas } from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+  selector: 'ngbd-offcanvas-firstfocus',
+  template: `
+    <div class="offcanvas-header">
+      <h4 class="offcanvas-title">Offcanvas title</h4>
+      <button type="button" class="btn-close" aria-label="Close" (click)="offcanvas.dismiss('Cross click')"></button>
+    </div>
+    <div class="offcanvas-body">
+      <p>One fine body&hellip;</p>
+      <div class="text-end">
+        <button type="button" class="btn btn-outline-dark" (click)="offcanvas.close('OK click')">OK</button>
+      </div>
+    </div>
+  `
+})
+export class NgbdOffcanvasFirstFocus {
+  constructor(readonly offcanvas: NgbActiveOffcanvas) {
+  }
+}
+
+@Component({
+  selector: 'ngbd-offcanvas-autofocus',
+  template: `
+    <div class="offcanvas-header">
+      <h4 class="offcanvas-title">Offcanvas title</h4>
+      <button type="button" class="btn-close" aria-label="Close" (click)="offcanvas.dismiss('Cross click')"></button>
+    </div>
+    <div class="offcanvas-body">
+      <p>One fine body&hellip;</p>
+      <div class="text-end">
+        <button ngbAutofocus type="button" class="btn btn-outline-dark" (click)="offcanvas.close('OK click')">OK</button>
+      </div>
+    </div>
+  `
+})
+export class NgbdOffcanvasAutoFocus {
+  constructor(readonly offcanvas: NgbActiveOffcanvas) {
+  }
+}
+
+@Component({ selector: 'ngbd-offcanvas-focus', templateUrl: './offcanvas-focus.html' })
+export class NgbdOffcanvasFocus {
+  constructor(private offcanvasService: NgbOffcanvas) {
+  }
+
+  openFirstFocus() {
+    this.offcanvasService.open(NgbdOffcanvasFirstFocus);
+  }
+
+  openAutoFocus() {
+    this.offcanvasService.open(NgbdOffcanvasAutoFocus);
+  }
+}

--- a/demo/src/app/components/offcanvas/demos/options/offcanvas-options.html
+++ b/demo/src/app/components/offcanvas/demos/options/offcanvas-options.html
@@ -1,0 +1,22 @@
+<ng-template #content let-offcanvas>
+  <div class="offcanvas-header">
+    <h4 class="offcanvas-title">Offcanvas title</h4>
+    <button type="button" class="btn-close" aria-label="Close" (click)="offcanvas.dismiss('Cross click')"></button>
+  </div>
+  <div class="offcanvas-body">
+    <p>One fine body&hellip;</p>
+    <div class="text-end">
+      <button type="button" class="btn btn-outline-dark" (click)="offcanvas.close('Close click')">Close</button>
+    </div>
+  </div>
+</ng-template>
+
+<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="openEnd(content)">Right position</button>
+<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="openTop(content)">Top position</button>
+<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="openBottom(content)">Bottom position</button>
+<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="openNoBackdrop(content)">No backdrop</button>
+<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="openScroll(content)">Scrolling of main content enabled</button>
+<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="openNoKeyboard(content)">Escape does not dismiss</button>
+<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="openNoAnimation(content)">No animation</button>
+<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="openCustomBackdropClass(content)">Custom backdrop class</button>
+<button class="btn btn-lg btn-outline-primary mb-2 me-2" (click)="openCustomPanelClass(content)">Custom panel class</button>

--- a/demo/src/app/components/offcanvas/demos/options/offcanvas-options.module.ts
+++ b/demo/src/app/components/offcanvas/demos/options/offcanvas-options.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+
+import { NgbdOffcanvasOptions } from './offcanvas-options';
+
+@NgModule({
+  imports: [BrowserModule, NgbModule],
+  declarations: [NgbdOffcanvasOptions],
+  exports: [NgbdOffcanvasOptions],
+  bootstrap: [NgbdOffcanvasOptions]
+})
+export class NgbdOffcanvasOptionsModule {}

--- a/demo/src/app/components/offcanvas/demos/options/offcanvas-options.ts
+++ b/demo/src/app/components/offcanvas/demos/options/offcanvas-options.ts
@@ -1,0 +1,49 @@
+import { Component, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { NgbOffcanvas } from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+  selector: 'ngbd-offcanvas-options',
+  templateUrl: './offcanvas-options.html',
+  encapsulation: ViewEncapsulation.None
+})
+export class NgbdOffcanvasOptions {
+  closeResult: string;
+
+  constructor(private offcanvasService: NgbOffcanvas) {}
+
+  openEnd(content: TemplateRef<any>) {
+    this.offcanvasService.open(content, { position: 'end' });
+  }
+
+  openTop(content: TemplateRef<any>) {
+    this.offcanvasService.open(content, { position: 'top' });
+  }
+
+  openBottom(content: TemplateRef<any>) {
+    this.offcanvasService.open(content, { position: 'bottom' });
+  }
+
+  openNoBackdrop(content: TemplateRef<any>) {
+    this.offcanvasService.open(content, { backdrop: false });
+  }
+
+  openScroll(content: TemplateRef<any>) {
+    this.offcanvasService.open(content, { scroll: true });
+  }
+
+  openNoKeyboard(content: TemplateRef<any>) {
+    this.offcanvasService.open(content, { keyboard: false });
+  }
+
+  openNoAnimation(content: TemplateRef<any>) {
+    this.offcanvasService.open(content, { animation: false });
+  }
+
+  openCustomBackdropClass(content: TemplateRef<any>) {
+    this.offcanvasService.open(content, { backdropClass: 'bg-info' });
+  }
+
+  openCustomPanelClass(content: TemplateRef<any>) {
+    this.offcanvasService.open(content, { panelClass: 'bg-info' });
+  }
+}

--- a/demo/src/app/components/offcanvas/offcanvas.module.ts
+++ b/demo/src/app/components/offcanvas/offcanvas.module.ts
@@ -6,15 +6,47 @@ import { ComponentWrapper } from '../../shared/component-wrapper/component-wrapp
 import { NgbdComponentsSharedModule, NgbdDemoList } from '../shared';
 import { NgbdApiPage } from '../shared/api-page/api.component';
 import { NgbdExamplesPage } from '../shared/examples-page/examples.component';
+import { NgbdOffcanvasBasicModule } from './demos/basic/offcanvas-basic.module';
+import { NgbdOffcanvasBasic } from './demos/basic/offcanvas-basic';
 import { NgbdOffcanvasComponentModule } from './demos/component/offcanvas-component.module';
 import { NgbdOffcanvasComponent } from './demos/component/offcanvas-component';
+import { NgbdOffcanvasOptionsModule } from './demos/options/offcanvas-options.module';
+import { NgbdOffcanvasOptions } from './demos/options/offcanvas-options';
+import { NgbdOffcanvasFocusModule } from './demos/focus/offcanvas-focus.module';
+import { NgbdOffcanvasFocus } from './demos/focus/offcanvas-focus';
+import { NgbdOffcanvasConfigModule } from './demos/config/offcanvas-config.module';
+import { NgbdOffcanvasConfig } from './demos/config/offcanvas-config';
 
 const DEMOS = {
+  basic: {
+    title: 'Basic offcanvas',
+    type: NgbdOffcanvasBasic,
+    code: require('!!raw-loader!./demos/basic/offcanvas-basic').default,
+    markup: require('!!raw-loader!./demos/basic/offcanvas-basic.html').default
+  },
   component: {
     title: 'Components as content',
     type: NgbdOffcanvasComponent,
     code: require('!!raw-loader!./demos/component/offcanvas-component').default,
     markup: require('!!raw-loader!./demos/component/offcanvas-component.html').default
+  },
+  options: {
+    title: 'Offcanvas options',
+    type: NgbdOffcanvasOptions,
+    code: require('!!raw-loader!./demos/options/offcanvas-options').default,
+    markup: require('!!raw-loader!./demos/options/offcanvas-options.html').default
+  },
+  focus: {
+    title: 'Focus management',
+    type: NgbdOffcanvasFocus,
+    code: require('!!raw-loader!./demos/focus/offcanvas-focus').default,
+    markup: require('!!raw-loader!./demos/focus/offcanvas-focus.html').default
+  },
+  config: {
+    title: 'Global configuration of Offcanvas',
+    type: NgbdOffcanvasConfig,
+    code: require('!!raw-loader!./demos/config/offcanvas-config').default,
+    markup: require('!!raw-loader!./demos/config/offcanvas-config.html').default
   }
 };
 
@@ -37,7 +69,11 @@ export const ROUTES = [
   imports: [
     NgbdSharedModule,
     NgbdComponentsSharedModule,
-    NgbdOffcanvasComponentModule
+    NgbdOffcanvasBasicModule,
+    NgbdOffcanvasComponentModule,
+    NgbdOffcanvasFocusModule,
+    NgbdOffcanvasOptionsModule,
+    NgbdOffcanvasConfigModule
   ]
 })
 export class NgbdOffcanvasModule {

--- a/demo/src/app/components/offcanvas/offcanvas.module.ts
+++ b/demo/src/app/components/offcanvas/offcanvas.module.ts
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import { NgModule } from '@angular/core';
+
+import { NgbdSharedModule } from '../../shared';
+import { ComponentWrapper } from '../../shared/component-wrapper/component-wrapper.component';
+import { NgbdComponentsSharedModule, NgbdDemoList } from '../shared';
+import { NgbdApiPage } from '../shared/api-page/api.component';
+import { NgbdExamplesPage } from '../shared/examples-page/examples.component';
+import { NgbdOffcanvasComponentModule } from './demos/component/offcanvas-component.module';
+import { NgbdOffcanvasComponent } from './demos/component/offcanvas-component';
+
+const DEMOS = {
+  component: {
+    title: 'Components as content',
+    type: NgbdOffcanvasComponent,
+    code: require('!!raw-loader!./demos/component/offcanvas-component').default,
+    markup: require('!!raw-loader!./demos/component/offcanvas-component.html').default
+  }
+};
+
+export const ROUTES = [
+  { path: '', pathMatch: 'full', redirectTo: 'examples' },
+  {
+    path: '',
+    component: ComponentWrapper,
+    data: {
+      bootstrap: 'https://getbootstrap.com/docs/%version%/components/offcanvas/'
+    },
+    children: [
+      { path: 'examples', component: NgbdExamplesPage },
+      { path: 'api', component: NgbdApiPage }
+    ]
+  }
+];
+
+@NgModule({
+  imports: [
+    NgbdSharedModule,
+    NgbdComponentsSharedModule,
+    NgbdOffcanvasComponentModule
+  ]
+})
+export class NgbdOffcanvasModule {
+  constructor(demoList: NgbdDemoList) {
+    demoList.register('offcanvas', DEMOS);
+  }
+}

--- a/demo/src/app/shared/side-nav/side-nav.component.ts
+++ b/demo/src/app/shared/side-nav/side-nav.component.ts
@@ -2,7 +2,7 @@ import {Component} from '@angular/core';
 import {Router} from '@angular/router';
 
 export const componentsList = [
-  'Accordion', 'Alert', 'Buttons', 'Carousel', 'Collapse', 'Datepicker', 'Dropdown', 'Modal', 'Nav', 'Pagination',
+  'Accordion', 'Alert', 'Buttons', 'Carousel', 'Collapse', 'Datepicker', 'Dropdown', 'Modal', 'Nav', 'Offcanvas', 'Pagination',
   'Popover', 'Progressbar', 'Rating', 'Table', 'Timepicker', 'Toast', 'Tooltip', 'Typeahead'
 ];
 

--- a/e2e-app/src/app/app.module.ts
+++ b/e2e-app/src/app/app.module.ts
@@ -20,6 +20,7 @@ import {ModalFocusComponent} from './modal/focus/modal-focus.component';
 import {ModalNestingComponent} from './modal/nesting/modal-nesting.component';
 import {ModalStackComponent} from './modal/stack/modal-stack.component';
 import {ModalStackConfirmationComponent} from './modal/stack-confirmation/modal-stack-confirmation.component';
+import {OffcanvasAutoCloseComponent} from './offcanvas/autoclose/offcanvas-autoclose.component';
 import {PopoverAutocloseComponent} from './popover/autoclose/popover-autoclose.component';
 import {TooltipAutocloseComponent} from './tooltip/autoclose/tooltip-autoclose.component';
 import {TooltipFocusComponent} from './tooltip/focus/tooltip-focus.component';
@@ -29,6 +30,11 @@ import {TypeaheadFocusComponent} from './typeahead/focus/typeahead-focus.compone
 import {TimepickerFilterComponent} from './timepicker/filter/timepicker-filter.component';
 import {TimepickerNavigationComponent} from './timepicker/navigation/timepicker-navigation.component';
 import {TypeaheadValidationComponent} from './typeahead/validation/typeahead-validation.component';
+import {OffcanvasFocusComponent} from './offcanvas/focus/offcanvas-focus.component';
+import {OffcanvasNestingComponent} from './offcanvas/nesting/offcanvas-nesting.component';
+import {
+  OffcanvasStackConfirmationComponent
+} from './offcanvas/stack-confirmation/offcanvas-stack-confirmation.component';
 
 
 @NgModule({
@@ -47,6 +53,10 @@ import {TypeaheadValidationComponent} from './typeahead/validation/typeahead-val
     ModalNestingComponent,
     ModalStackComponent,
     ModalStackConfirmationComponent,
+    OffcanvasAutoCloseComponent,
+    OffcanvasFocusComponent,
+    OffcanvasNestingComponent,
+    OffcanvasStackConfirmationComponent,
     PopoverAutocloseComponent,
     TooltipAutocloseComponent,
     TooltipFocusComponent,

--- a/e2e-app/src/app/app.routing.ts
+++ b/e2e-app/src/app/app.routing.ts
@@ -22,6 +22,12 @@ import {TypeaheadFocusComponent} from './typeahead/focus/typeahead-focus.compone
 import {TimepickerFilterComponent} from './timepicker/filter/timepicker-filter.component';
 import {TimepickerNavigationComponent} from './timepicker/navigation/timepicker-navigation.component';
 import {TypeaheadValidationComponent} from './typeahead/validation/typeahead-validation.component';
+import {OffcanvasAutoCloseComponent} from './offcanvas/autoclose/offcanvas-autoclose.component';
+import {OffcanvasFocusComponent} from './offcanvas/focus/offcanvas-focus.component';
+import {OffcanvasNestingComponent} from './offcanvas/nesting/offcanvas-nesting.component';
+import {
+  OffcanvasStackConfirmationComponent
+} from './offcanvas/stack-confirmation/offcanvas-stack-confirmation.component';
 
 
 export const routes: Routes = [
@@ -41,6 +47,14 @@ export const routes: Routes = [
       {path: 'nesting', component: ModalNestingComponent},
       {path: 'stack', component: ModalStackComponent},
       {path: 'stack-confirmation', component: ModalStackConfirmationComponent},
+    ]
+  },
+  {
+    path: 'offcanvas',
+    children: [
+      {path: 'autoclose', component: OffcanvasAutoCloseComponent}, {path: 'focus', component: OffcanvasFocusComponent},
+      {path: 'nesting', component: OffcanvasNestingComponent},
+      {path: 'stack-confirmation', component: OffcanvasStackConfirmationComponent}
     ]
   },
   {

--- a/e2e-app/src/app/offcanvas/autoclose/offcanvas-autoclose.component.html
+++ b/e2e-app/src/app/offcanvas/autoclose/offcanvas-autoclose.component.html
@@ -23,7 +23,7 @@
     <div class="col-12">
       <button class="btn btn-outline-secondary ms-3" id="reset-button" (click)="reset()">Reset</button>
       <button class="btn btn-outline-secondary ms-1" id="option-backdrop-false" (click)="options['backdrop'] = false">backdrop = false</button>
-      <button class="btn btn-outline-secondary ms-1" id="option-no-keyboard" (click)="options['keyboard'] = false">keyboard = 'false'</button>
+      <button class="btn btn-outline-secondary ms-1" id="option-no-keyboard" (click)="options['keyboard'] = false">keyboard = false</button>
     </div>
   </div>
 </form>

--- a/e2e-app/src/app/offcanvas/autoclose/offcanvas-autoclose.component.html
+++ b/e2e-app/src/app/offcanvas/autoclose/offcanvas-autoclose.component.html
@@ -1,0 +1,33 @@
+<h3>
+  Offcanvas autoclose tests
+  <span class="ms-1 badge bg-info text-dark" id="dismiss-reason">{{ reason }}</span>
+</h3>
+
+<!-- Offcanvas content -->
+<ng-template #content>
+  <div class="offcanvas-body">
+    <h2>Hello from offcanvas</h2>
+    <button id="offcanvas-close-button" class="btn btn-primary" (click)="closeOffcanvas()">Close offcanvas</button>
+  </div>
+</ng-template>
+
+<!-- Controls -->
+<form id="default" (contextmenu)="$event.preventDefault()">
+  <div class="mb-3 row row-cols-lg-auto">
+    <div class="col-12">
+      <div class="input-group">
+        <button class="btn btn-outline-secondary" type="button" id="open-offcanvas" (click)="openOffcanvas(content)">Open offcanvas</button>
+      </div>
+    </div>
+
+    <div class="col-12">
+      <button class="btn btn-outline-secondary ms-3" id="reset-button" (click)="reset()">Reset</button>
+      <button class="btn btn-outline-secondary ms-1" id="option-backdrop-false" (click)="options['backdrop'] = false">backdrop = false</button>
+      <button class="btn btn-outline-secondary ms-1" id="option-no-keyboard" (click)="options['keyboard'] = false">keyboard = 'false'</button>
+    </div>
+  </div>
+</form>
+
+<!-- Options -->
+<h4>Options</h4>
+<pre>{{ options | json }}</pre>

--- a/e2e-app/src/app/offcanvas/autoclose/offcanvas-autoclose.component.ts
+++ b/e2e-app/src/app/offcanvas/autoclose/offcanvas-autoclose.component.ts
@@ -1,0 +1,43 @@
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, TemplateRef} from '@angular/core';
+import {OffcanvasDismissReasons, NgbOffcanvas, NgbOffcanvasRef} from '@ng-bootstrap/ng-bootstrap';
+
+@Component({templateUrl: './offcanvas-autoclose.component.html', changeDetection: ChangeDetectionStrategy.OnPush})
+export class OffcanvasAutoCloseComponent {
+  private offcanvasRef: NgbOffcanvasRef | null = null;
+  reason = '';
+  options = {};
+
+  constructor(private offcanvasService: NgbOffcanvas, private cd: ChangeDetectorRef) {}
+
+  openOffcanvas(content?: TemplateRef<any>) {
+    this.offcanvasRef = this.offcanvasService.open(content, this.options);
+    this.offcanvasRef.result.then(
+        () => {
+          this.reason = `Closed`;
+          this.cd.markForCheck();
+        },
+        reason => {
+          if (reason === OffcanvasDismissReasons.BACKDROP_CLICK) {
+            this.reason = 'Click';
+          } else if (reason === OffcanvasDismissReasons.ESC) {
+            this.reason = 'Escape';
+          } else {
+            this.reason = 'Other';
+          }
+          this.cd.markForCheck();
+        });
+  }
+
+  closeOffcanvas() {
+    if (this.offcanvasRef) {
+      this.offcanvasRef.close();
+      this.offcanvasRef = null;
+    }
+  }
+
+  reset() {
+    this.closeOffcanvas();
+    this.reason = '';
+    this.options = {};
+  }
+}

--- a/e2e-app/src/app/offcanvas/autoclose/offcanvas-autoclose.e2e-spec.ts
+++ b/e2e-app/src/app/offcanvas/autoclose/offcanvas-autoclose.e2e-spec.ts
@@ -1,0 +1,76 @@
+import {test, getPage, setPage} from '../../../../baseTest';
+import {sendKey} from '../../tools.po';
+import {waitForOffcanvas, waitForNoChange, SELECTOR_OFFCANVAS, SELECTOR_BACKDROP} from '../offcanvas.po';
+
+import {
+  clickOnClose,
+  clickOnReset,
+  waitDismissReason,
+  openOffcanvas,
+} from './offcanvas-autoclose.po';
+
+test.use({testURL: 'offcanvas/autoclose', testSelector: 'h3:text("Offcanvas autoclose tests")'});
+test.beforeEach(async({page}) => setPage(page));
+
+test.describe('Offcanvas', () => {
+
+  test.beforeEach(async() => { await clickOnReset(); });
+
+  test.afterEach(async() => { await waitForOffcanvas('absent'); });
+
+  test('should close offcanvas from the inside', async() => {
+    await openOffcanvas();
+
+    // close
+    await clickOnClose();
+    await waitDismissReason('Closed', `Offcanvas should have been closed`);
+  });
+
+  test('should close offcanvas on ESC', async() => {
+    await openOffcanvas();
+
+    // close
+    await sendKey('Escape');
+    await waitForOffcanvas('absent');
+    await waitDismissReason('Escape', `Offcanvas should have been dismissed with 'Escape' reason`);
+  });
+
+  test(`should NOT close offcanvas on ESC when keyboard === 'false'`, async() => {
+    await openOffcanvas('no-keyboard');
+    await sendKey('Escape');
+    await waitForNoChange();
+    await waitForOffcanvas('present', 'The offcanvas should stay opened on ESC');
+    await clickOnClose();
+
+  });
+
+  test('should close offcanvas on backdrop click', async() => {
+    await openOffcanvas();
+
+    // dialog click
+    await getPage().click(SELECTOR_OFFCANVAS);
+    await waitForNoChange();
+    await waitForOffcanvas('present', 'The offcanvas should stay opened on dialog click');
+
+    // Close
+    await getPage().click(SELECTOR_BACKDROP);
+    await waitForOffcanvas('absent', 'The offcanvas should be closed on backdrop click');
+    await waitDismissReason('Click', `Offcanvas should have been dismissed with 'Click' reason`);
+
+  });
+
+  test(`should NOT close offcanvas on click with no backdrop`, async() => {
+    await openOffcanvas('backdrop-false');
+
+    // dialog click
+    await getPage().click(SELECTOR_OFFCANVAS);
+    await waitForNoChange();
+    await waitForOffcanvas('present', 'The offcanvas should stay opened on offcanvas click');
+
+    // close
+    await getPage().click(SELECTOR_OFFCANVAS);
+    await waitForNoChange();
+    await waitForOffcanvas('present', 'The offcanvas should stay opened on backdrop click');
+    await clickOnClose();
+  });
+});

--- a/e2e-app/src/app/offcanvas/autoclose/offcanvas-autoclose.po.ts
+++ b/e2e-app/src/app/offcanvas/autoclose/offcanvas-autoclose.po.ts
@@ -1,0 +1,25 @@
+import {expect} from '@playwright/test';
+import {getPage} from '../../../../baseTest';
+import {waitForOffcanvas} from '../offcanvas.po';
+
+export const clickOnReset = async() => {
+  await getPage().click('#reset-button');
+};
+
+export const clickOnClose = async() => {
+  await getPage().click('#offcanvas-close-button');
+  await waitForOffcanvas('absent');
+};
+
+export const openOffcanvas = async(option = '') => {
+  if (option !== '') {
+    await getPage().click(`#option-${option}`);
+  }
+
+  await getPage().click('#open-offcanvas');
+  await waitForOffcanvas('present');
+};
+
+export const waitDismissReason = async(expected, error) => {
+  await expect(getPage().locator('#dismiss-reason'), error).toHaveText(expected);
+};

--- a/e2e-app/src/app/offcanvas/focus/offcanvas-focus.component.html
+++ b/e2e-app/src/app/offcanvas/focus/offcanvas-focus.component.html
@@ -1,0 +1,39 @@
+<h3>Offcanvas focus tests</h3>
+
+
+<!-- Simple Offcanvas -->
+<button class="btn btn-outline-secondary" type="button" id="open-offcanvas-simple" (click)="openOffcanvas()">Simple Offcanvas</button>
+
+<!-- Closeable Offcanvas -->
+<ng-template #closeable let-offcanvas>
+  <div class="offcanvas-header">
+    <h4 class="offcanvas-title">Closeable offcanvas</h4>
+    <button type="button" class="btn-close" aria-label="Close" (click)="offcanvas.dismiss()"></button>
+  </div>
+  <div class="offcanvas-body">
+    <form>
+      <div class="mb-3">
+        <input class="form-control">
+      </div>
+    </form>
+    <button type="button" class="btn btn-outline-dark" (click)="offcanvas.close()">Close</button>
+  </div>
+</ng-template>
+
+<button class="btn btn-outline-secondary ms-2" type="button" id="open-offcanvas-template" (click)="openOffcanvas(closeable)">Template Offcanvas</button>
+
+<!-- Offcanvas with autofocus -->
+<ng-template #autofocus let-offcanvas>
+  <div class="offcanvas-header">
+    <h4 class="offcanvas-title">Autofocus offcanvas</h4>
+    <button type="button" class="btn-close" aria-label="Close" (click)="offcanvas.dismiss()"></button>
+  </div>
+  <div class="offcanvas-body">
+    <p>Close button should be focused</p>
+    <button ngbAutofocus type="button" class="btn btn-outline-dark" (click)="offcanvas.close()">Close</button>
+  </div>
+</ng-template>
+
+<button class="btn btn-outline-secondary ms-2" type="button" id="open-offcanvas-autofocus" (click)="openOffcanvas(autofocus)">Autofocus Offcanvas</button>
+
+<button class="btn btn-outline-secondary ms-2" type="button" id="open-offcanvas-disable" (click)="openAndDisable()" [disabled]="disabledButton">Open and disabled</button>

--- a/e2e-app/src/app/offcanvas/focus/offcanvas-focus.component.ts
+++ b/e2e-app/src/app/offcanvas/focus/offcanvas-focus.component.ts
@@ -1,0 +1,16 @@
+import {Component, TemplateRef} from '@angular/core';
+import {NgbOffcanvas} from '@ng-bootstrap/ng-bootstrap';
+
+@Component({templateUrl: './offcanvas-focus.component.html'})
+export class OffcanvasFocusComponent {
+  disabledButton = false;
+
+  constructor(private offcanvasService: NgbOffcanvas) {}
+
+  openOffcanvas(content?: TemplateRef<any>) { this.offcanvasService.open(content ? content : 'Offcanvas content'); }
+
+  openAndDisable(content?: TemplateRef<any>) {
+    this.disabledButton = true;
+    this.openOffcanvas(content);
+  }
+}

--- a/e2e-app/src/app/offcanvas/focus/offcanvas-focus.e2e-spec.ts
+++ b/e2e-app/src/app/offcanvas/focus/offcanvas-focus.e2e-spec.ts
@@ -1,0 +1,150 @@
+import {expect} from '@playwright/test';
+import {test, getPage, setPage} from '../../../../baseTest';
+import {sendKey} from '../../tools.po';
+import {waitForOffcanvas, SELECTOR_OFFCANVAS, SELECTOR_BACKDROP} from '../offcanvas.po';
+
+import {
+  openOffcanvas,
+  SELECTOR_OFFCANVAS_CONTENT,
+  SELECTOR_DISMISS_BUTTON,
+  SELECTOR_CLOSE_BUTTON,
+  SELECTOR_OFFCANVAS_INPUT,
+  SELECTOR_OFFCANVAS_HEADER,
+} from './offcanvas-focus.po';
+
+test.use({testURL: 'offcanvas/focus', testSelector: 'h3:text("Offcanvas focus tests")'});
+test.beforeEach(async({page}) => setPage(page));
+
+test.describe('Offcanvas', () => {
+
+  test.afterEach(async() => {
+    await sendKey('Escape');
+    await waitForOffcanvas('absent');
+  });
+
+  test('should close offcanvas on ESC and re-focus trigger button', async() => {
+    await openOffcanvas('simple');
+
+    // close
+    await sendKey('Escape');
+    await waitForOffcanvas('absent', 'The offcanvas should be closed on ESC');
+
+    await expect(getPage().locator('#open-offcanvas-simple'), 'Should focus trigger button after closing')
+        .toBeFocused();
+  });
+
+  test('should close offcanvas on backdrop click and re-focus trigger button', async() => {
+    await openOffcanvas('simple');
+
+    // close
+    await getPage().click(SELECTOR_BACKDROP);
+    await waitForOffcanvas('absent', 'The offcanvas should be closed on click');
+
+    // button should be focused
+    await expect(getPage().locator('#open-offcanvas-simple'), 'Should focus trigger button after closing')
+        .toBeFocused();
+  });
+
+  test('should focus body if opener is not focusable', async() => {
+    await openOffcanvas('disable');
+
+    // close
+    await sendKey('Escape');
+    await waitForOffcanvas('absent', 'The offcanvas should be closed on ESC');
+
+    // body should be focused
+    await expect(getPage().locator('body'), 'Should focus body after closing').toBeFocused();
+
+  });
+
+  // TODO I have no idea why this test does not pass
+  test.skip('should focus offcanvas panel if there is no focusable content after opening', async() => {
+    await openOffcanvas('simple');
+
+    // panel should be focused
+    await expect(getPage().locator(SELECTOR_OFFCANVAS_CONTENT)).toHaveText('Offcanvas content');
+    await expect(getPage().locator(SELECTOR_OFFCANVAS), 'ngb-offcanvas-panel should be focused').toBeFocused();
+
+  });
+
+  test('should focus first focusable element after opening', async() => {
+    await openOffcanvas('template');
+    await expect(getPage().locator(SELECTOR_DISMISS_BUTTON), 'Offcanvas dismiss button should be focused')
+        .toBeFocused();
+  });
+
+  test('should focus element with [ngbAutofocus] after opening', async() => {
+    await openOffcanvas('autofocus');
+    await expect(
+        getPage().locator(SELECTOR_CLOSE_BUTTON), 'Offcanvas close button should be focused, because of ngbAutoFocus')
+        .toBeFocused();
+  });
+
+  test('should trap focus inside opened offcanvas (Tab)', async() => {
+    await openOffcanvas('template');
+
+    // dismiss -> input -> close -> dismiss
+    await expect(getPage().locator(SELECTOR_DISMISS_BUTTON), 'Offcanvas dismiss button should be focused')
+        .toBeFocused();
+
+    await sendKey('Tab');
+    await expect(getPage().locator(SELECTOR_OFFCANVAS_INPUT), 'Offcanvas input should be focused').toBeFocused();
+
+    await sendKey('Tab');
+    await expect(getPage().locator(SELECTOR_CLOSE_BUTTON), 'Offcanvas close button should be focused').toBeFocused();
+
+    await sendKey('Tab');
+    await expect(getPage().locator(SELECTOR_DISMISS_BUTTON), 'Offcanvas dismiss button should be focused')
+        .toBeFocused();
+
+  });
+
+  test('should trap focus inside opened offcanvas (Shift + Tab)', async() => {
+    await openOffcanvas('template');
+
+    // dismiss -> close -> input -> dismiss
+    await expect(getPage().locator(SELECTOR_DISMISS_BUTTON), 'Offcanvas dismiss button should be focused')
+        .toBeFocused();
+
+    await sendKey('Shift+Tab');
+    await expect(getPage().locator(SELECTOR_CLOSE_BUTTON), 'Offcanvas close button should be focused').toBeFocused();
+
+    await sendKey('Shift+Tab');
+    await expect(getPage().locator(SELECTOR_OFFCANVAS_INPUT), 'Offcanvas input should be focused').toBeFocused();
+
+    await sendKey('Shift+Tab');
+    await expect(getPage().locator(SELECTOR_DISMISS_BUTTON), 'Offcanvas dismiss button should be focused')
+        .toBeFocused();
+
+  });
+
+  test('should keep focus trap inside the offcanvas when clicking on content and navigating away (Tab)', async() => {
+    await openOffcanvas('template');
+
+    // click on the header
+    await getPage().click(SELECTOR_OFFCANVAS_HEADER);
+    await expect(getPage().locator(SELECTOR_OFFCANVAS), 'Offcanvas panel should be focused').toBeFocused();
+
+    // re-focus
+    await sendKey('Tab');
+    await expect(getPage().locator(SELECTOR_DISMISS_BUTTON), 'Offcanvas dismiss button should be focused')
+        .toBeFocused();
+
+  });
+
+  test(
+      'should keep focus trap inside the offcanvas when clicking on content and navigating away (Shift + Tab)',
+      async() => {
+        await openOffcanvas('template');
+
+        // click on the header
+        await getPage().click(SELECTOR_OFFCANVAS_HEADER);
+        await expect(getPage().locator(SELECTOR_OFFCANVAS), 'Offcanvas panel should be focused').toBeFocused();
+
+        // re-focus
+        await sendKey('Shift+Tab');
+        await expect(getPage().locator(SELECTOR_CLOSE_BUTTON), 'Offcanvas close button should be focused')
+            .toBeFocused();
+
+      });
+});

--- a/e2e-app/src/app/offcanvas/focus/offcanvas-focus.po.ts
+++ b/e2e-app/src/app/offcanvas/focus/offcanvas-focus.po.ts
@@ -1,0 +1,14 @@
+import {focusElement, sendKey} from '../../tools.po';
+import {waitForOffcanvas} from '../offcanvas.po';
+
+export const SELECTOR_OFFCANVAS_CONTENT = 'div.offcanvas-content';
+export const SELECTOR_DISMISS_BUTTON = 'div.offcanvas-header >> button';
+export const SELECTOR_CLOSE_BUTTON = 'div.offcanvas-body >> button';
+export const SELECTOR_OFFCANVAS_INPUT = 'div.offcanvas-body >> input';
+export const SELECTOR_OFFCANVAS_HEADER = 'div.offcanvas-header';
+
+export const openOffcanvas = async(type: string) => {
+  await focusElement(`#open-offcanvas-${type}`);
+  await sendKey('Enter');
+  await waitForOffcanvas('present');
+};

--- a/e2e-app/src/app/offcanvas/nesting/offcanvas-nesting.component.html
+++ b/e2e-app/src/app/offcanvas/nesting/offcanvas-nesting.component.html
@@ -1,0 +1,46 @@
+<h3>Offcanvas nesting tests</h3>
+
+<ng-template #t let-offcanvas>
+  <div class="offcanvas-header">
+    <h4 class="offcanvas-title">Offcanvas with nested popups</h4>
+    <button type="button" class="btn-close" aria-label="Close" (click)="offcanvas.dismiss()"></button>
+  </div>
+  <div class="offcanvas-body">
+    <form>
+      <!-- datepicker -->
+      <div class="mb-3">
+        <label for="datepicker">Datepicker</label>
+        <div class="input-group">
+          <input id="datepicker" class="form-control" placeholder="yyyy-mm-dd" name="dp"
+                 ngbDatepicker #dp="ngbDatepicker" [startDate]="{year: 2018, month: 1}">
+          <button class="btn btn-outline-secondary" id="datepicker-button" (click)="dp.toggle()" type="button">Open</button>
+        </div>
+      </div>
+
+      <!-- dropdown -->
+      <div class="mb-3">
+        <label for="dropdown">Dropdown</label>
+        <div class="input-group">
+          <div ngbDropdown class="d-inline-block">
+            <button class="btn btn-outline-primary" id="dropdown" ngbDropdownToggle>Toggle dropdown</button>
+            <div ngbDropdownMenu aria-labelledby="dropdownBasic1">
+              <button ngbDropdownItem>Action - 1</button>
+              <button ngbDropdownItem>Another Action</button>
+              <button ngbDropdownItem>Something else is here</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- typeahead -->
+      <div class="mb-3">
+        <label for="typeahead">Typeahead</label>
+        <div class="input-group">
+          <input id="typeahead" type="text" name="tphd" class="form-control" [ngbTypeahead]="search"/>
+        </div>
+      </div>
+    </form>
+  </div>
+</ng-template>
+
+<button class="btn btn-outline-secondary ms-2" type="button" id="open-offcanvas" (click)="openOffcanvas(t)">Open Offcanvas</button>

--- a/e2e-app/src/app/offcanvas/nesting/offcanvas-nesting.component.ts
+++ b/e2e-app/src/app/offcanvas/nesting/offcanvas-nesting.component.ts
@@ -1,0 +1,13 @@
+import {Component, TemplateRef} from '@angular/core';
+import {NgbOffcanvas} from '@ng-bootstrap/ng-bootstrap';
+import {Observable} from 'rxjs';
+import {map} from 'rxjs/operators';
+
+@Component({templateUrl: './offcanvas-nesting.component.html'})
+export class OffcanvasNestingComponent {
+  constructor(private offcanvasService: NgbOffcanvas) {}
+
+  openOffcanvas(content: TemplateRef<any>) { this.offcanvasService.open(content); }
+
+  search = (text$: Observable<string>) => text$.pipe(map(() => ['one', 'two', 'three']));
+}

--- a/e2e-app/src/app/offcanvas/nesting/offcanvas-nesting.e2e-spec.ts
+++ b/e2e-app/src/app/offcanvas/nesting/offcanvas-nesting.e2e-spec.ts
@@ -1,0 +1,80 @@
+import {expect} from '@playwright/test';
+import {test, getPage, setPage} from '../../../../baseTest';
+import {sendKey} from '../../tools.po';
+import {waitForOffcanvas} from '../offcanvas.po';
+
+import {
+  openOffcanvas,
+  pressButton,
+  SELECTOR_DATEPICKER,
+  SELECTOR_DATEPICKER_BUTTON,
+  SELECTOR_DROPDOWN_BUTTON,
+  SELECTOR_DROPDOWN,
+  SELECTOR_TYPEAHEAD_INPUT,
+  SELECTOR_TYPEAHEAD_DROPDOWN,
+} from './offcanvas-nesting.po';
+
+import {SELECTOR_DAY} from '../../datepicker/datepicker.po';
+
+test.use({testURL: 'offcanvas/nesting', testSelector: 'h3:text("Offcanvas nesting tests")'});
+test.beforeEach(async({page}) => setPage(page));
+
+test.describe('Offcanvas nested components', () => {
+
+  test.afterEach(async() => { await waitForOffcanvas('absent'); });
+
+  test('should close only datepicker, then offcanvas on ESC', async() => {
+    await openOffcanvas();
+
+    // open datepicker
+    await pressButton(SELECTOR_DATEPICKER_BUTTON);
+    await expect(getPage().locator(SELECTOR_DATEPICKER), `Datepicker should be opened`).toBeVisible();
+    await expect(getPage().locator(SELECTOR_DAY(new Date(2018, 0, 1))), `01 JAN 2018 should be focused`).toBeFocused();
+
+    // close datepicker
+    await sendKey('Escape');
+    await expect(getPage().locator(SELECTOR_DATEPICKER), `Datepicker should be closed`).toHaveCount(0);
+    await expect(getPage().locator(SELECTOR_DATEPICKER_BUTTON), `Datepicker open button should be focused`)
+        .toBeFocused();
+    await waitForOffcanvas('present', `Offcanvas should stay opened`);
+
+    await sendKey('Escape');
+  });
+
+  test('should close only dropdown, then offcanvas on ESC', async() => {
+    await openOffcanvas();
+
+    // open dropdown
+    await pressButton(SELECTOR_DROPDOWN_BUTTON);
+    await expect(getPage().locator(SELECTOR_DROPDOWN), `Dropdown should be opened`).toBeVisible();
+    await expect(getPage().locator(SELECTOR_DROPDOWN_BUTTON), `Dropdown button should be focused`).toBeFocused();
+
+    // close dropdown
+    await sendKey('Escape');
+    await expect(getPage().locator(SELECTOR_DROPDOWN), `Dropdown should be closed`).toHaveCount(0);
+    await expect(getPage().locator(SELECTOR_DROPDOWN_BUTTON), `Dropdown open button should be focused`).toBeFocused();
+    await waitForOffcanvas('present', `Offcanvas should stay opened`);
+
+    await sendKey('Escape');
+  });
+
+  test('should close only typeahead, then offcanvas on ESC', async() => {
+    await openOffcanvas();
+
+    // open typeahead
+    await getPage().click(SELECTOR_TYPEAHEAD_INPUT);
+    await sendKey(' ');
+    await expect(getPage().locator(SELECTOR_TYPEAHEAD_DROPDOWN), `Typeahead should be opened`).toBeVisible();
+    await expect(getPage().locator(SELECTOR_TYPEAHEAD_INPUT), `Typeahead input should be focused`).toBeFocused();
+
+    // close typeahead
+    await sendKey('Escape');
+    await expect(getPage().locator(SELECTOR_TYPEAHEAD_DROPDOWN), `Typeahead should be
+                closed`)
+        .toHaveCount(0);
+    await expect(getPage().locator(SELECTOR_TYPEAHEAD_INPUT), `Typeahead input should be focused`).toBeFocused();
+    await waitForOffcanvas('present', `Offcanvas should stay opened`);
+
+    await sendKey('Escape');
+  });
+});

--- a/e2e-app/src/app/offcanvas/nesting/offcanvas-nesting.po.ts
+++ b/e2e-app/src/app/offcanvas/nesting/offcanvas-nesting.po.ts
@@ -1,0 +1,21 @@
+import {getPage} from '../../../../baseTest';
+import {focusElement, sendKey} from '../../tools.po';
+import {waitForOffcanvas} from '../offcanvas.po';
+
+export const SELECTOR_DATEPICKER = 'ngb-datepicker';
+export const SELECTOR_DATEPICKER_BUTTON = '#datepicker-button';
+export const SELECTOR_DROPDOWN_BUTTON = '#dropdown';
+export const SELECTOR_DROPDOWN = '[ngbDropdown].show';
+export const SELECTOR_TYPEAHEAD_INPUT = '#typeahead';
+export const SELECTOR_TYPEAHEAD_DROPDOWN = 'ngb-typeahead-window.show';
+
+
+export const openOffcanvas = async() => {
+  await getPage().click(`#open-offcanvas`);
+  await waitForOffcanvas('present');
+};
+
+export const pressButton = async(buttonSelector) => {
+  await focusElement(buttonSelector);
+  await sendKey('Enter');
+};

--- a/e2e-app/src/app/offcanvas/offcanvas.po.ts
+++ b/e2e-app/src/app/offcanvas/offcanvas.po.ts
@@ -1,0 +1,30 @@
+import {expect} from '@playwright/test';
+import {getPage, getBrowserName} from '../../../baseTest';
+export const SELECTOR_OFFCANVAS = 'ngb-offcanvas-panel';
+export const SELECTOR_BACKDROP = 'ngb-offcanvas-backdrop';
+
+const defaultErrorMessage = (state: 'present' | 'absent') => {
+  return `Expected offcanvas to be ${state}`;
+};
+
+/**
+ * @param state
+ * @param errorMessage
+ */
+export const waitForOffcanvas =
+    async(state: 'present' | 'absent' = 'present', errorMessage = defaultErrorMessage(state)) => {
+      // These successive waiting functions, done in this order, render the test suite more stable.
+      await expect(getPage().locator(SELECTOR_OFFCANVAS), errorMessage).toHaveCount(state === 'absent' ? 0 : 1);
+
+      if (getBrowserName() === 'webkit') {
+        // Need some extra time for webkit, otherwise the offcanvas tests are not stable.
+        await getPage().waitForTimeout(50);
+      }
+    };
+
+/**
+ * Wait a short time before checking that nothing changed
+ */
+export const waitForNoChange = async() => {
+  await getPage().waitForTimeout(25);
+};

--- a/e2e-app/src/app/offcanvas/stack-confirmation/offcanvas-stack-confirmation.component.html
+++ b/e2e-app/src/app/offcanvas/stack-confirmation/offcanvas-stack-confirmation.component.html
@@ -1,0 +1,23 @@
+<h3>Offcanvas stack confirmation test</h3>
+
+<ng-template #offcanvas let-offcanvas>
+  <div id="offcanvas" class="offcanvas-header">
+    <h4 class="offcanvas-title">Offcanvas with closure confirmation</h4>
+    <button id="close" type="button" class="btn-close" aria-label="Close" (click)="offcanvas.dismiss()"></button>
+  </div>
+  <div class="offcanvas-body">
+    <p>This offcanvas will trigger confirmation</p>
+  </div>
+</ng-template>
+
+<ng-template #confirmation let-modal>
+  <div id="stack-modal" class="modal-header">
+    <h4 class="modal-title">Are you sure you want to close the offcanvas?</h4>
+    <button id="dismiss" type="button" class="btn-close" aria-label="Close" (click)="modal.dismiss()"></button>
+  </div>
+  <div class="modal-body">
+    <button id="confirm" class="btn btn-primary" (click)="modal.close()">Yep</button>
+  </div>
+</ng-template>
+
+<button class="btn btn-outline-secondary ms-2" type="button" id="open-offcanvas" (click)="openOffcanvas(offcanvas)">Open Offcanvas</button>

--- a/e2e-app/src/app/offcanvas/stack-confirmation/offcanvas-stack-confirmation.component.ts
+++ b/e2e-app/src/app/offcanvas/stack-confirmation/offcanvas-stack-confirmation.component.ts
@@ -1,0 +1,13 @@
+import {Component, TemplateRef, ViewChild} from '@angular/core';
+import {NgbModal, NgbOffcanvas} from '@ng-bootstrap/ng-bootstrap';
+
+@Component({templateUrl: './offcanvas-stack-confirmation.component.html'})
+export class OffcanvasStackConfirmationComponent {
+  @ViewChild('confirmation', {static: true, read: TemplateRef}) confirmationTpl: TemplateRef<any>;
+
+  constructor(private modalService: NgbModal, private offcanvasService: NgbOffcanvas) {}
+
+  openOffcanvas(content: TemplateRef<any>) {
+    this.offcanvasService.open(content, {beforeDismiss: () => this.modalService.open(this.confirmationTpl).result});
+  }
+}

--- a/e2e-app/src/app/offcanvas/stack-confirmation/offcanvas-stack-confirmation.e2e-spec.ts
+++ b/e2e-app/src/app/offcanvas/stack-confirmation/offcanvas-stack-confirmation.e2e-spec.ts
@@ -1,0 +1,81 @@
+import {test, getPage, setPage} from '../../../../baseTest';
+import {sendKey} from '../../tools.po';
+import {waitForOffcanvas} from '../offcanvas.po';
+
+import {
+  openOffcanvas,
+  SELECTOR_CLOSE_BUTTON,
+  SELECTOR_DISMISS_BUTTON,
+  SELECTOR_CONFIRM_BUTTON,
+  waitForConfirmationModal,
+  clickOnOffcanvasBackdrop,
+  clickOnModalBackdrop,
+} from './offcanvas-stack-confirmation.po';
+
+test.use({testURL: 'offcanvas/stack-confirmation', testSelector: 'h3:text("Offcanvas stack confirmation test")'});
+test.beforeEach(async({page}) => setPage(page));
+
+test.describe('Offcanvas stack with confirmation', () => {
+
+  test.afterEach(async() => { await waitForOffcanvas('absent'); });
+
+  test('should close modal and offcanvas correctly using close button', async() => {
+    await openOffcanvas();
+
+    // close with button
+    await getPage().click(SELECTOR_CLOSE_BUTTON);
+    await waitForConfirmationModal('present', 'Confirmation modal should be opened');
+
+    // cancel closure with button
+    await getPage().click(SELECTOR_DISMISS_BUTTON);
+    await waitForConfirmationModal('absent', 'Confirmation modal should be dismissed');
+    await waitForOffcanvas('present', 'Offcanvas should still be present');
+
+    // close again
+    await getPage().click(SELECTOR_CLOSE_BUTTON);
+    await waitForConfirmationModal('present', 'Confirmation modal should be re-opened');
+
+    // close modal and offcanvas
+    await getPage().click(SELECTOR_CONFIRM_BUTTON);
+  });
+
+  test('should close modal and offcanvas correctly using ESC', async() => {
+    await openOffcanvas();
+
+    // close with Escape
+    await sendKey('Escape');
+    await waitForConfirmationModal('present', 'Confirmation modal should be opened');
+
+    // cancel closure with Escape
+    await sendKey('Escape');
+    await waitForConfirmationModal('absent', 'Confirmation modal should be dismissed');
+    await waitForOffcanvas('present', 'Offcanvas should still be present');
+
+    // close again
+    await sendKey('Escape');
+    await waitForConfirmationModal('present', 'Confirmation modal should be re-opened');
+
+    // close modal and offcanvas
+    await getPage().click(SELECTOR_CONFIRM_BUTTON);
+  });
+
+  test('should close modal and offcanvas correctly using backdrop click', async() => {
+    await openOffcanvas();
+
+    // close with click
+    await clickOnOffcanvasBackdrop();
+    await waitForConfirmationModal('present', 'Confirmation modal should be opened');
+
+    // cancel closure with click on modal backdrop
+    await clickOnModalBackdrop();
+    await waitForConfirmationModal('absent', 'Confirmation modal should be dismissed');
+
+    // close again
+    await clickOnOffcanvasBackdrop();
+    await waitForConfirmationModal('present', 'Confirmation modal should be re-opened');
+
+    // close all modals
+    await getPage().click(SELECTOR_CONFIRM_BUTTON);
+  });
+
+});

--- a/e2e-app/src/app/offcanvas/stack-confirmation/offcanvas-stack-confirmation.po.ts
+++ b/e2e-app/src/app/offcanvas/stack-confirmation/offcanvas-stack-confirmation.po.ts
@@ -1,0 +1,28 @@
+import {getPage} from '../../../../baseTest';
+import {SELECTOR_BACKDROP} from '../offcanvas.po';
+import {waitForOffcanvas} from '../offcanvas.po';
+import {expect} from '@playwright/test';
+
+export const SELECTOR_OFFCANVAS_BUTTON = '#open-offcanvas';
+export const SELECTOR_STACK_MODAL = '#stack-modal';
+export const SELECTOR_STACK_MODAL_BACKDROP = 'ngb-modal-window';
+export const SELECTOR_CLOSE_BUTTON = '#close';
+export const SELECTOR_CONFIRM_BUTTON = '#confirm';
+export const SELECTOR_DISMISS_BUTTON = '#dismiss';
+
+export const openOffcanvas = async() => {
+  await getPage().click(SELECTOR_OFFCANVAS_BUTTON);
+  await waitForOffcanvas('present');
+};
+
+export const clickOnOffcanvasBackdrop = async() => {
+  const modals = await getPage().locator(SELECTOR_BACKDROP).click();
+};
+
+export const clickOnModalBackdrop = async() => {
+  const modals = await getPage().locator(SELECTOR_STACK_MODAL_BACKDROP).click();
+};
+
+export const waitForConfirmationModal = async(state: 'present' | 'absent', errorMessage: string) => {
+  await expect(getPage().locator(SELECTOR_STACK_MODAL), errorMessage).toHaveCount(state === 'absent' ? 0 : 1);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {NgbTimepickerModule} from './timepicker/timepicker.module';
 import {NgbToastModule} from './toast/toast.module';
 import {NgbTooltipModule} from './tooltip/tooltip.module';
 import {NgbTypeaheadModule} from './typeahead/typeahead.module';
+import {NgbOffcanvasModule} from './offcanvas/offcanvas.module';
 
 
 
@@ -107,6 +108,15 @@ export {
   NgbNavPane
 } from './nav/nav.module';
 export {
+  OffcanvasDismissReasons,
+  NgbActiveOffcanvas,
+  NgbOffcanvas,
+  NgbOffcanvasConfig,
+  NgbOffcanvasModule,
+  NgbOffcanvasOptions,
+  NgbOffcanvasRef
+} from './offcanvas/offcanvas.module';
+export {
   NgbPagination,
   NgbPaginationConfig,
   NgbPaginationEllipsis,
@@ -146,8 +156,8 @@ export {NgbConfig} from './ngb-config';
 const NGB_MODULES = [
   /* eslint-disable-next-line deprecation/deprecation */
   NgbAccordionModule, NgbAlertModule, NgbButtonsModule, NgbCarouselModule, NgbCollapseModule, NgbDatepickerModule,
-  NgbDropdownModule, NgbModalModule, NgbNavModule, NgbPaginationModule, NgbPopoverModule, NgbProgressbarModule,
-  NgbRatingModule, NgbTimepickerModule, NgbToastModule, NgbTooltipModule, NgbTypeaheadModule
+  NgbDropdownModule, NgbModalModule, NgbNavModule, NgbOffcanvasModule, NgbPaginationModule, NgbPopoverModule,
+  NgbProgressbarModule, NgbRatingModule, NgbTimepickerModule, NgbToastModule, NgbTooltipModule, NgbTypeaheadModule
 ];
 
 @NgModule({imports: NGB_MODULES, exports: NGB_MODULES})

--- a/src/offcanvas/offcanvas-backdrop.spec.ts
+++ b/src/offcanvas/offcanvas-backdrop.spec.ts
@@ -1,0 +1,47 @@
+import {TestBed} from '@angular/core/testing';
+
+import {NgbOffcanvasBackdrop} from './offcanvas-backdrop';
+import {OffcanvasDismissReasons} from './offcanvas-dismiss-reasons';
+
+describe('ngb-offcanvas-backdrop', () => {
+
+  beforeEach(() => { TestBed.configureTestingModule({declarations: [NgbOffcanvasBackdrop]}); });
+
+  it('should render backdrop with required CSS classes', () => {
+    const fixture = TestBed.createComponent(NgbOffcanvasBackdrop);
+
+    fixture.detectChanges();
+    expect(fixture.nativeElement).toHaveCssClass('offcanvas-backdrop');
+    expect(fixture.nativeElement).toHaveCssClass('show');
+    expect(fixture.nativeElement).not.toHaveCssClass('fade');
+  });
+
+  it('should render correct CSS classes for animations', () => {
+    const fixture = TestBed.createComponent(NgbOffcanvasBackdrop);
+    fixture.componentInstance.animation = true;
+
+    fixture.detectChanges();
+    expect(fixture.nativeElement).toHaveCssClass('show');
+    expect(fixture.nativeElement).toHaveCssClass('fade');
+  });
+
+  it('should render custom CSS class', () => {
+    const fixture = TestBed.createComponent(NgbOffcanvasBackdrop);
+    fixture.componentInstance.backdropClass = 'custom-backdrop';
+
+    fixture.detectChanges();
+    expect(fixture.nativeElement).toHaveCssClass('custom-backdrop');
+  });
+
+  it('should emit dismiss event on click', () => {
+    const fixture = TestBed.createComponent(NgbOffcanvasBackdrop);
+    fixture.detectChanges();
+
+    let emittedEvent: any;
+    fixture.componentInstance.dismissEvent.subscribe(event => emittedEvent = event);
+    fixture.nativeElement.dispatchEvent(new Event('click'));
+    fixture.detectChanges();
+
+    expect(emittedEvent).toBe(OffcanvasDismissReasons.BACKDROP_CLICK);
+  });
+});

--- a/src/offcanvas/offcanvas-backdrop.spec.ts
+++ b/src/offcanvas/offcanvas-backdrop.spec.ts
@@ -33,13 +33,13 @@ describe('ngb-offcanvas-backdrop', () => {
     expect(fixture.nativeElement).toHaveCssClass('custom-backdrop');
   });
 
-  it('should emit dismiss event on click', () => {
+  it('should emit dismiss event on mousedown', () => {
     const fixture = TestBed.createComponent(NgbOffcanvasBackdrop);
     fixture.detectChanges();
 
     let emittedEvent: any;
     fixture.componentInstance.dismissEvent.subscribe(event => emittedEvent = event);
-    fixture.nativeElement.dispatchEvent(new Event('click'));
+    fixture.nativeElement.dispatchEvent(new Event('mousedown'));
     fixture.detectChanges();
 
     expect(emittedEvent).toBe(OffcanvasDismissReasons.BACKDROP_CLICK);

--- a/src/offcanvas/offcanvas-backdrop.ts
+++ b/src/offcanvas/offcanvas-backdrop.ts
@@ -15,7 +15,7 @@ import {OffcanvasDismissReasons} from './offcanvas-dismiss-reasons';
     '[class]': '"offcanvas-backdrop" + (backdropClass ? " " + backdropClass : "")',
     '[class.show]': '!animation',
     '[class.fade]': 'animation',
-    '(click)': 'dismiss()'
+    '(mousedown)': 'dismiss()'
   }
 })
 export class NgbOffcanvasBackdrop implements OnInit {

--- a/src/offcanvas/offcanvas-backdrop.ts
+++ b/src/offcanvas/offcanvas-backdrop.ts
@@ -1,0 +1,47 @@
+import {Component, ElementRef, EventEmitter, Input, NgZone, OnInit, Output, ViewEncapsulation} from '@angular/core';
+
+import {Observable} from 'rxjs';
+import {take} from 'rxjs/operators';
+
+import {ngbRunTransition} from '../util/transition/ngbTransition';
+import {reflow} from '../util/util';
+import {OffcanvasDismissReasons} from './offcanvas-dismiss-reasons';
+
+@Component({
+  selector: 'ngb-offcanvas-backdrop',
+  encapsulation: ViewEncapsulation.None,
+  template: '',
+  host: {
+    '[class]': '"offcanvas-backdrop" + (backdropClass ? " " + backdropClass : "")',
+    '[class.show]': '!animation',
+    '[class.fade]': 'animation',
+    '(click)': 'dismiss()'
+  }
+})
+export class NgbOffcanvasBackdrop implements OnInit {
+  @Input() animation: boolean;
+  @Input() backdropClass: string;
+
+  @Output('dismiss') dismissEvent = new EventEmitter();
+
+  constructor(private _el: ElementRef<HTMLElement>, private _zone: NgZone) {}
+
+  ngOnInit() {
+    this._zone.onStable.asObservable().pipe(take(1)).subscribe(() => {
+      ngbRunTransition(this._zone, this._el.nativeElement, (element: HTMLElement, animation: boolean) => {
+        if (animation) {
+          reflow(element);
+        }
+        element.classList.add('show');
+      }, {animation: this.animation, runningTransition: 'continue'});
+    });
+  }
+
+  hide(): Observable<void> {
+    return ngbRunTransition(
+        this._zone, this._el.nativeElement, ({classList}) => classList.remove('show'),
+        {animation: this.animation, runningTransition: 'stop'});
+  }
+
+  dismiss() { this.dismissEvent.emit(OffcanvasDismissReasons.BACKDROP_CLICK); }
+}

--- a/src/offcanvas/offcanvas-config.spec.ts
+++ b/src/offcanvas/offcanvas-config.spec.ts
@@ -1,0 +1,24 @@
+import {inject} from '@angular/core/testing';
+
+import {NgbConfig} from '../ngb-config';
+import {NgbOffcanvasConfig} from './offcanvas-config';
+
+describe('NgbOffcanvasConfig', () => {
+
+  it('should have sensible default values',
+     inject([NgbOffcanvasConfig, NgbConfig], (config: NgbOffcanvasConfig, ngbConfig: NgbConfig) => {
+
+       expect(config.animation).toBe(ngbConfig.animation);
+       expect(config.ariaDescribedBy).toBeUndefined();
+       expect(config.ariaLabelledBy).toBeUndefined();
+       expect(config.backdrop).toBeTrue();
+       expect(config.backdropClass).toBeUndefined();
+       expect(config.beforeDismiss).toBeUndefined();
+       expect(config.container).toBeUndefined();
+       expect(config.injector).toBeUndefined();
+       expect(config.keyboard).toBeTrue();
+       expect(config.panelClass).toBeUndefined();
+       expect(config.position).toBe('start');
+       expect(config.scroll).toBeFalse();
+     }));
+});

--- a/src/offcanvas/offcanvas-config.ts
+++ b/src/offcanvas/offcanvas-config.ts
@@ -1,0 +1,108 @@
+import {Injectable, Injector} from '@angular/core';
+import {NgbConfig} from '../ngb-config';
+
+/**
+ * Options available when opening new offcanvas windows with `NgbOffcanvas.open()` method.
+ */
+export interface NgbOffcanvasOptions {
+  /**
+   * If `true`, opening and closing will be animated.
+   */
+  animation?: boolean;
+
+  /**
+   * `aria-describedby` attribute value to set on the offcanvas panel.
+   */
+  ariaDescribedBy?: string;
+
+  /**
+   * `aria-labelledby` attribute value to set on the offcanvas panel.
+   */
+  ariaLabelledBy?: string;
+
+  /**
+   * If `true`, the backdrop element will be created for a given offcanvas.
+   *
+   * Default value is `true`.
+   */
+  backdrop?: boolean;
+
+  /**
+   * A custom class to append to the offcanvas backdrop.
+   */
+  backdropClass?: string;
+
+  /**
+   * Callback right before the modal will be dismissed.
+   *
+   * If this function returns:
+   * * `false`
+   * * a promise resolved with `false`
+   * * a promise that is rejected
+   *
+   * then the offcanvas won't be dismissed.
+   */
+  beforeDismiss?: () => boolean | Promise<boolean>;
+
+  /**
+   * A selector specifying the element all new offcanvas panels and backdrops should be appended to.
+   *
+   * If not specified, will be `body`.
+   */
+  container?: string | HTMLElement;
+
+  /**
+   * The `Injector` to use for offcanvas content.
+   */
+  injector?: Injector;
+
+  /**
+   * If `true`, the offcanvas will be closed when `Escape` key is pressed
+   *
+   * Default value is `true`.
+   */
+  keyboard?: boolean;
+
+  /**
+   * A custom class to append to the offcanvas panel.
+   */
+  panelClass?: string;
+
+  /**
+   * The position of the offcanvas
+   */
+  position?: 'start' | 'end' | 'top' | 'bottom';
+
+  /**
+   * Scroll content while offcanvas is open (false by default).
+   */
+  scroll?: boolean;
+}
+
+/**
+ * A configuration service for the [`NgbOffcanvas`](#/components/offcanvas/api#NgbOffcanvas) service.
+ *
+ * You can inject this service, typically in your root component, and customize the values of its properties in
+ * order to provide default values for all offcanvases used in the application.
+ */
+@Injectable({providedIn: 'root'})
+export class NgbOffcanvasConfig implements Required<NgbOffcanvasOptions> {
+  ariaDescribedBy: string;
+  ariaLabelledBy: string;
+  backdrop: boolean = true;
+  backdropClass: string;
+  beforeDismiss: () => boolean | Promise<boolean>;
+  container: string | HTMLElement;
+  injector: Injector;
+  keyboard = true;
+  panelClass: string;
+  position: 'start' | 'end' | 'top' | 'bottom';
+  scroll: boolean;
+
+  private _animation: boolean;
+
+  constructor(private _ngbConfig: NgbConfig) {}
+
+  get animation(): boolean { return (this._animation === undefined) ? this._ngbConfig.animation : this._animation; }
+  set animation(animation: boolean) { this._animation = animation; }
+}

--- a/src/offcanvas/offcanvas-config.ts
+++ b/src/offcanvas/offcanvas-config.ts
@@ -96,7 +96,7 @@ export class NgbOffcanvasConfig implements Required<NgbOffcanvasOptions> {
   injector: Injector;
   keyboard: boolean = true;
   panelClass: string;
-  position: 'start' | 'end' | 'top' | 'bottom';
+  position: 'start' | 'end' | 'top' | 'bottom' = 'start';
   scroll: boolean = false;
 
   private _animation: boolean;

--- a/src/offcanvas/offcanvas-config.ts
+++ b/src/offcanvas/offcanvas-config.ts
@@ -33,7 +33,7 @@ export interface NgbOffcanvasOptions {
   backdropClass?: string;
 
   /**
-   * Callback right before the modal will be dismissed.
+   * Callback right before the offcanvas will be dismissed.
    *
    * If this function returns:
    * * `false`

--- a/src/offcanvas/offcanvas-config.ts
+++ b/src/offcanvas/offcanvas-config.ts
@@ -94,10 +94,10 @@ export class NgbOffcanvasConfig implements Required<NgbOffcanvasOptions> {
   beforeDismiss: () => boolean | Promise<boolean>;
   container: string | HTMLElement;
   injector: Injector;
-  keyboard = true;
+  keyboard: boolean = true;
   panelClass: string;
   position: 'start' | 'end' | 'top' | 'bottom';
-  scroll: boolean;
+  scroll: boolean = false;
 
   private _animation: boolean;
 

--- a/src/offcanvas/offcanvas-dismiss-reasons.ts
+++ b/src/offcanvas/offcanvas-dismiss-reasons.ts
@@ -1,0 +1,4 @@
+export enum OffcanvasDismissReasons {
+  BACKDROP_CLICK,
+  ESC
+}

--- a/src/offcanvas/offcanvas-panel.spec.ts
+++ b/src/offcanvas/offcanvas-panel.spec.ts
@@ -1,0 +1,54 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {NgbOffcanvasPanel} from './offcanvas-panel';
+
+describe('ngb-offcanvas-panel', () => {
+
+  let fixture: ComponentFixture<NgbOffcanvasPanel>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({declarations: [NgbOffcanvasPanel]});
+    fixture = TestBed.createComponent(NgbOffcanvasPanel);
+  });
+
+  describe('basic rendering functionality', () => {
+
+    it('should render default offcanvas panel', () => {
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement).toHaveCssClass('offcanvas');
+      expect(fixture.nativeElement).toHaveCssClass('offcanvas-start');
+    });
+
+    it('should render default offcanvas panel with a specified position', () => {
+      fixture.componentInstance.position = 'end';
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement).toHaveCssClass('offcanvas-end');
+    });
+
+    it('should render default offcanvas panel with a specified class', () => {
+      fixture.componentInstance.panelClass = 'custom-class';
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement).toHaveCssClass('custom-class');
+    });
+
+    it('aria attributes', () => {
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.getAttribute('role')).toBe('dialog');
+
+      expect(fixture.nativeElement.getAttribute('aria-labelledby')).toBeFalsy();
+      expect(fixture.nativeElement.getAttribute('aria-describedby')).toBeFalsy();
+
+      fixture.componentInstance.ariaLabelledBy = 'label';
+      fixture.componentInstance.ariaDescribedBy = 'description';
+
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.getAttribute('aria-labelledby')).toBe('label');
+      expect(fixture.nativeElement.getAttribute('aria-describedby')).toBe('description');
+    });
+  });
+});

--- a/src/offcanvas/offcanvas-panel.ts
+++ b/src/offcanvas/offcanvas-panel.ts
@@ -68,6 +68,8 @@ export class NgbOffcanvasPanel implements OnInit,
     const {nativeElement} = this._elRef;
     const context: NgbTransitionOptions<any> = {animation: this.animation, runningTransition: 'stop'};
 
+    // TODO when we target Bootstrap 5.2+, the style.visibility handling can be removed, because Bootstrap has improved
+    // its CSS
     const offcanvasTransition$ = ngbRunTransition(this._zone, this._elRef.nativeElement, (element) => {
       nativeElement.classList.remove('show');
       return () => element.style.visibility = 'hidden';
@@ -87,6 +89,8 @@ export class NgbOffcanvasPanel implements OnInit,
   private _show() {
     const context: NgbTransitionOptions<any> = {animation: this.animation, runningTransition: 'continue'};
 
+    // TODO when we target Bootstrap 5.2+, the style.visibility handling can be removed, because Bootstrap has improved
+    // its CSS
     const offcanvasTransition$ =
         ngbRunTransition(this._zone, this._elRef.nativeElement, (element: HTMLElement, animation: boolean) => {
           if (animation) {

--- a/src/offcanvas/offcanvas-panel.ts
+++ b/src/offcanvas/offcanvas-panel.ts
@@ -32,6 +32,7 @@ import {reflow} from '../util/util';
     'tabindex': '-1',
     '[attr.aria-modal]': 'true',
     '[attr.aria-labelledby]': 'ariaLabelledBy',
+    '[attr.aria-describedby]': 'ariaDescribedBy',
   }
 })
 export class NgbOffcanvasPanel implements OnInit,
@@ -41,6 +42,7 @@ export class NgbOffcanvasPanel implements OnInit,
 
   @Input() animation: boolean;
   @Input() ariaLabelledBy?: string;
+  @Input() ariaDescribedBy?: string;
   @Input() keyboard = true;
   @Input() panelClass: string;
   @Input() position: 'start' | 'end' | 'top' | 'bottom' = 'start';

--- a/src/offcanvas/offcanvas-panel.ts
+++ b/src/offcanvas/offcanvas-panel.ts
@@ -1,0 +1,154 @@
+import {DOCUMENT} from '@angular/common';
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  Inject,
+  Input,
+  NgZone,
+  OnDestroy,
+  OnInit,
+  Output,
+  ViewEncapsulation
+} from '@angular/core';
+
+import {fromEvent, Observable, Subject} from 'rxjs';
+import {filter, take, takeUntil} from 'rxjs/operators';
+
+import {getFocusableBoundaryElements} from '../util/focus-trap';
+import {Key} from '../util/key';
+import {OffcanvasDismissReasons} from './offcanvas-dismiss-reasons';
+import {ngbRunTransition, NgbTransitionOptions} from '../util/transition/ngbTransition';
+import {reflow} from '../util/util';
+
+@Component({
+  selector: 'ngb-offcanvas-panel',
+  template: '<ng-content></ng-content>',
+  encapsulation: ViewEncapsulation.None,
+  styleUrls: [],
+  host: {
+    '[class]': '"offcanvas offcanvas-" + position  + (panelClass ? " " + panelClass : "")',
+    'role': 'dialog',
+    'tabindex': '-1',
+    '[attr.aria-modal]': 'true',
+    '[attr.aria-labelledby]': 'ariaLabelledBy',
+  }
+})
+export class NgbOffcanvasPanel implements OnInit,
+    OnDestroy {
+  private _closed$ = new Subject<void>();
+  private _elWithFocus: Element | null = null;  // element that is focused prior to offcanvas opening
+
+  @Input() animation: boolean;
+  @Input() ariaLabelledBy?: string;
+  @Input() keyboard = true;
+  @Input() panelClass: string;
+  @Input() position: 'start' | 'end' | 'top' | 'bottom' = 'start';
+
+  @Output('dismiss') dismissEvent = new EventEmitter();
+
+  shown = new Subject<void>();
+  hidden = new Subject<void>();
+
+  constructor(
+      @Inject(DOCUMENT) private _document: any, private _elRef: ElementRef<HTMLElement>, private _zone: NgZone) {}
+
+  dismiss(reason): void { this.dismissEvent.emit(reason); }
+
+  ngOnInit() {
+    this._elWithFocus = this._document.activeElement;
+    this._zone.onStable.asObservable().pipe(take(1)).subscribe(() => { this._show(); });
+  }
+
+  ngOnDestroy() { this._disableEventHandling(); }
+
+  hide(): Observable<any> {
+    const {nativeElement} = this._elRef;
+    const context: NgbTransitionOptions<any> = {animation: this.animation, runningTransition: 'stop'};
+
+    const offcanvasTransition$ = ngbRunTransition(this._zone, this._elRef.nativeElement, (element) => {
+      nativeElement.classList.remove('show');
+      return () => element.style.visibility = 'hidden';
+    }, context);
+
+    offcanvasTransition$.subscribe(() => {
+      this.hidden.next();
+      this.hidden.complete();
+    });
+
+    this._disableEventHandling();
+    this._restoreFocus();
+
+    return offcanvasTransition$;
+  }
+
+  private _show() {
+    const context: NgbTransitionOptions<any> = {animation: this.animation, runningTransition: 'continue'};
+
+    const offcanvasTransition$ =
+        ngbRunTransition(this._zone, this._elRef.nativeElement, (element: HTMLElement, animation: boolean) => {
+          if (animation) {
+            reflow(element);
+          }
+          element.classList.add('show');
+          element.style.visibility = 'visible';
+        }, context);
+
+    offcanvasTransition$.subscribe(() => {
+      this.shown.next();
+      this.shown.complete();
+    });
+
+    this._enableEventHandling();
+    this._setFocus();
+  }
+
+  private _enableEventHandling() {
+    const {nativeElement} = this._elRef;
+    this._zone.runOutsideAngular(() => {
+      fromEvent<KeyboardEvent>(nativeElement, 'keydown')
+          .pipe(
+              takeUntil(this._closed$),
+              /* eslint-disable-next-line deprecation/deprecation */
+              filter(e => e.which === Key.Escape))
+          .subscribe(event => {
+            if (this.keyboard) {
+              requestAnimationFrame(() => {
+                if (!event.defaultPrevented) {
+                  this._zone.run(() => this.dismiss(OffcanvasDismissReasons.ESC));
+                }
+              });
+            }
+          });
+    });
+  }
+
+  private _disableEventHandling() { this._closed$.next(); }
+
+  private _setFocus() {
+    const {nativeElement} = this._elRef;
+    if (!nativeElement.contains(document.activeElement)) {
+      const autoFocusable = nativeElement.querySelector(`[ngbAutofocus]`) as HTMLElement;
+      const firstFocusable = getFocusableBoundaryElements(nativeElement)[0];
+
+      const elementToFocus = autoFocusable || firstFocusable || nativeElement;
+      elementToFocus.focus();
+    }
+  }
+
+  private _restoreFocus() {
+    const body = this._document.body;
+    const elWithFocus = this._elWithFocus;
+
+    let elementToFocus;
+    if (elWithFocus && elWithFocus['focus'] && body.contains(elWithFocus)) {
+      elementToFocus = elWithFocus;
+    } else {
+      elementToFocus = body;
+    }
+    this._zone.runOutsideAngular(() => {
+      setTimeout(() => elementToFocus.focus());
+      this._elWithFocus = null;
+    });
+  }
+}

--- a/src/offcanvas/offcanvas-ref.ts
+++ b/src/offcanvas/offcanvas-ref.ts
@@ -1,0 +1,185 @@
+import {ComponentRef} from '@angular/core';
+
+import {Observable, of, Subject, zip} from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
+
+import {ContentRef} from '../util/popup';
+import {isPromise} from '../util/util';
+import {NgbOffcanvasBackdrop} from './offcanvas-backdrop';
+import {NgbOffcanvasPanel} from './offcanvas-panel';
+
+/**
+ * A reference to the currently opened (active) offcanvas.
+ *
+ * Instances of this class can be injected into your component passed as offcanvas content.
+ * So you can `.close()` or `.dismiss()` the offcanvas window from your component.
+ */
+export class NgbActiveOffcanvas {
+  /**
+   * Closes the offcanvas with an optional `result` value.
+   *
+   * The `NgbOffcanvasRef.result` promise will be resolved with the provided value.
+   */
+  close(result?: any): void {}
+
+  /**
+   * Dismisses the offcanvas with an optional `reason` value.
+   *
+   * The `NgbOffcanvasRef.result` promise will be rejected with the provided value.
+   */
+  dismiss(reason?: any): void {}
+}
+
+/**
+ * A reference to the newly opened offcanvas returned by the `NgbOffcanvas.open()` method.
+ */
+export class NgbOffcanvasRef {
+  private _closed = new Subject<any>();
+  private _dismissed = new Subject<any>();
+  private _hidden = new Subject<void>();
+  private _resolve: (result?: any) => void;
+  private _reject: (reason?: any) => void;
+
+  /**
+   * The instance of a component used for the offcanvas content.
+   *
+   * When a `TemplateRef` is used as the content or when the offcanvas is closed, will return `undefined`.
+   */
+  get componentInstance(): any {
+    if (this._contentRef && this._contentRef.componentRef) {
+      return this._contentRef.componentRef.instance;
+    }
+  }
+
+  /**
+   * The promise that is resolved when the offcanvas is closed and rejected when the offcanvas is dismissed.
+   */
+  result: Promise<any>;
+
+  /**
+   * The observable that emits when the offcanvas is closed via the `.close()` method.
+   *
+   * It will emit the result passed to the `.close()` method.
+   */
+  get closed(): Observable<any> { return this._closed.asObservable().pipe(takeUntil(this._hidden)); }
+
+  /**
+   * The observable that emits when the offcanvas is dismissed via the `.dismiss()` method.
+   *
+   * It will emit the reason passed to the `.dismissed()` method by the user, or one of the internal
+   * reasons like backdrop click or ESC key press.
+   */
+  get dismissed(): Observable<any> { return this._dismissed.asObservable().pipe(takeUntil(this._hidden)); }
+
+  /**
+   * The observable that emits when both offcanvas window and backdrop are closed and animations were finished.
+   * At this point offcanvas and backdrop elements will be removed from the DOM tree.
+   *
+   * This observable will be completed after emitting.
+   */
+  get hidden(): Observable<void> { return this._hidden.asObservable(); }
+
+  /**
+   * The observable that emits when offcanvas is fully visible and animation was finished.
+   * The offcanvas DOM element is always available synchronously after calling 'offcanvas.open()' service.
+   *
+   * This observable will be completed after emitting.
+   * It will not emit, if offcanvas is closed before open animation is finished.
+   */
+  get shown(): Observable<void> { return this._panelCmptRef.instance.shown.asObservable(); }
+
+  constructor(
+      private _panelCmptRef: ComponentRef<NgbOffcanvasPanel>, private _contentRef: ContentRef,
+      private _backdropCmptRef?: ComponentRef<NgbOffcanvasBackdrop>,
+      private _beforeDismiss?: () => boolean | Promise<boolean>) {
+    _panelCmptRef.instance.dismissEvent.subscribe((reason: any) => { this.dismiss(reason); });
+    if (_backdropCmptRef) {
+      _backdropCmptRef.instance.dismissEvent.subscribe((reason: any) => { this.dismiss(reason); });
+    }
+    this.result = new Promise((resolve, reject) => {
+      this._resolve = resolve;
+      this._reject = reject;
+    });
+    this.result.then(null, () => {});
+  }
+
+  /**
+   * Closes the offcanvas with an optional `result` value.
+   *
+   * The `NgbMobalRef.result` promise will be resolved with the provided value.
+   */
+  close(result?: any): void {
+    if (this._panelCmptRef) {
+      this._closed.next(result);
+      this._resolve(result);
+      this._removeOffcanvasElements();
+    }
+  }
+
+  private _dismiss(reason?: any) {
+    this._dismissed.next(reason);
+    this._reject(reason);
+    this._removeOffcanvasElements();
+  }
+
+  /**
+   * Dismisses the offcanvas with an optional `reason` value.
+   *
+   * The `NgbOffcanvasRef.result` promise will be rejected with the provided value.
+   */
+  dismiss(reason?: any): void {
+    if (this._panelCmptRef) {
+      if (!this._beforeDismiss) {
+        this._dismiss(reason);
+      } else {
+        const dismiss = this._beforeDismiss();
+        if (isPromise(dismiss)) {
+          dismiss.then(
+              result => {
+                if (result !== false) {
+                  this._dismiss(reason);
+                }
+              },
+              () => {});
+        } else if (dismiss !== false) {
+          this._dismiss(reason);
+        }
+      }
+    }
+  }
+
+  private _removeOffcanvasElements() {
+    const panelTransition$ = this._panelCmptRef.instance.hide();
+    const backdropTransition$ = this._backdropCmptRef ? this._backdropCmptRef.instance.hide() : of(undefined);
+
+    // hiding panel
+    panelTransition$.subscribe(() => {
+      const {nativeElement} = this._panelCmptRef.location;
+      nativeElement.parentNode.removeChild(nativeElement);
+      this._panelCmptRef.destroy();
+
+      if (this._contentRef && this._contentRef.viewRef) {
+        this._contentRef.viewRef.destroy();
+      }
+
+      this._panelCmptRef = <any>null;
+      this._contentRef = <any>null;
+    });
+
+    // hiding backdrop
+    backdropTransition$.subscribe(() => {
+      if (this._backdropCmptRef) {
+        const {nativeElement} = this._backdropCmptRef.location;
+        nativeElement.parentNode.removeChild(nativeElement);
+        this._backdropCmptRef.destroy();
+        this._backdropCmptRef = <any>null;
+      }
+    });
+
+    // all done
+    zip(panelTransition$, backdropTransition$).subscribe(() => {
+      this._hidden.next();
+      this._hidden.complete();
+    });
+  }
+}

--- a/src/offcanvas/offcanvas-stack.ts
+++ b/src/offcanvas/offcanvas-stack.ts
@@ -1,0 +1,201 @@
+import {DOCUMENT} from '@angular/common';
+import {
+  ApplicationRef,
+  ComponentFactoryResolver,
+  ComponentRef,
+  EventEmitter,
+  Inject,
+  Injectable,
+  Injector,
+  NgZone,
+  RendererFactory2,
+  TemplateRef
+} from '@angular/core';
+import {finalize, Subject} from 'rxjs';
+
+import {ngbFocusTrap} from '../util/focus-trap';
+import {ContentRef} from '../util/popup';
+import {ScrollBar} from '../util/scrollbar';
+import {isDefined, isString} from '../util/util';
+import {NgbActiveOffcanvas, NgbOffcanvasRef} from './offcanvas-ref';
+import {NgbOffcanvasOptions} from './offcanvas-config';
+import {NgbOffcanvasBackdrop} from './offcanvas-backdrop';
+import {NgbOffcanvasPanel} from './offcanvas-panel';
+
+@Injectable({providedIn: 'root'})
+export class NgbOffcanvasStack {
+  private _activePanelCmptHasChanged = new Subject<void>();
+  private _scrollBarRestoreFn: null | (() => void) = null;
+  private _backdropAttributes = ['animation', 'backdropClass'];
+  private _offcanvasRef?: NgbOffcanvasRef;
+  private _panelAttributes = ['animation', 'ariaDescribedBy', 'ariaLabelledBy', 'keyboard', 'panelClass', 'position'];
+  private _panelCmpt?: ComponentRef<NgbOffcanvasPanel>;
+  private _activeInstance: EventEmitter<NgbOffcanvasRef | undefined> = new EventEmitter();
+
+  constructor(
+      private _applicationRef: ApplicationRef, private _injector: Injector, @Inject(DOCUMENT) private _document: any,
+      private _scrollBar: ScrollBar, private _rendererFactory: RendererFactory2, private _ngZone: NgZone) {
+    // Trap focus on active PanelCmpt
+    this._activePanelCmptHasChanged.subscribe(() => {
+      if (this._panelCmpt) {
+        ngbFocusTrap(this._ngZone, this._panelCmpt.location.nativeElement, this._activePanelCmptHasChanged);
+      }
+    });
+  }
+
+  private _restoreScrollBar() {
+    const scrollBarRestoreFn = this._scrollBarRestoreFn;
+    if (scrollBarRestoreFn) {
+      this._scrollBarRestoreFn = null;
+      scrollBarRestoreFn();
+    }
+  }
+
+  private _hideScrollBar() {
+    if (!this._scrollBarRestoreFn) {
+      this._scrollBarRestoreFn = this._scrollBar.hide();
+    }
+  }
+
+  open(moduleCFR: ComponentFactoryResolver, contentInjector: Injector, content: any, options: NgbOffcanvasOptions):
+      NgbOffcanvasRef {
+    const containerEl = options.container instanceof HTMLElement ? options.container : isDefined(options.container) ?
+                                                                   this._document.querySelector(options.container) :
+                                                                   this._document.body;
+    const renderer = this._rendererFactory.createRenderer(null, null);
+
+    if (!containerEl) {
+      throw new Error(`The specified offcanvas container "${options.container || 'body'}" was not found in the DOM.`);
+    }
+
+    if (!options.scroll) {
+      this._hideScrollBar();
+    }
+
+    const activeOffcanvas = new NgbActiveOffcanvas();
+    const contentRef =
+        this._getContentRef(moduleCFR, options.injector || contentInjector, content, activeOffcanvas, options);
+
+    let backdropCmptRef: ComponentRef<NgbOffcanvasBackdrop>| undefined =
+        options.backdrop !== false ? this._attachBackdrop(moduleCFR, containerEl) : undefined;
+    let panelCmptRef: ComponentRef<NgbOffcanvasPanel> = this._attachWindowComponent(moduleCFR, containerEl, contentRef);
+    let ngbOffcanvasRef: NgbOffcanvasRef =
+        new NgbOffcanvasRef(panelCmptRef, contentRef, backdropCmptRef, options.beforeDismiss);
+
+    this._registerOffcanvasRef(ngbOffcanvasRef);
+    this._registerPanelCmpt(panelCmptRef);
+    ngbOffcanvasRef.hidden.pipe(finalize(() => this._restoreScrollBar())).subscribe();
+    activeOffcanvas.close = (result: any) => { ngbOffcanvasRef.close(result); };
+    activeOffcanvas.dismiss = (reason: any) => { ngbOffcanvasRef.dismiss(reason); };
+
+    this._applyPanelOptions(panelCmptRef.instance, options);
+
+    if (backdropCmptRef && backdropCmptRef.instance) {
+      this._applyBackdropOptions(backdropCmptRef.instance, options);
+      backdropCmptRef.changeDetectorRef.detectChanges();
+    }
+    panelCmptRef.changeDetectorRef.detectChanges();
+    return ngbOffcanvasRef;
+  }
+
+  get activeInstance() { return this._activeInstance; }
+
+  dismiss(reason?: any) { this._offcanvasRef ?.dismiss(reason); }
+
+  hasOpenOffcanvas(): boolean { return !!this._offcanvasRef; }
+
+  private _attachBackdrop(moduleCFR: ComponentFactoryResolver, containerEl: any): ComponentRef<NgbOffcanvasBackdrop> {
+    let backdropFactory = moduleCFR.resolveComponentFactory(NgbOffcanvasBackdrop);
+    let backdropCmptRef = backdropFactory.create(this._injector);
+    this._applicationRef.attachView(backdropCmptRef.hostView);
+    containerEl.appendChild(backdropCmptRef.location.nativeElement);
+    return backdropCmptRef;
+  }
+
+  private _attachWindowComponent(moduleCFR: ComponentFactoryResolver, containerEl: any, contentRef: any):
+      ComponentRef<NgbOffcanvasPanel> {
+    let panelFactory = moduleCFR.resolveComponentFactory(NgbOffcanvasPanel);
+    let panelCmptRef = panelFactory.create(this._injector, contentRef.nodes);
+    this._applicationRef.attachView(panelCmptRef.hostView);
+    containerEl.appendChild(panelCmptRef.location.nativeElement);
+    return panelCmptRef;
+  }
+
+  private _applyPanelOptions(windowInstance: NgbOffcanvasPanel, options: NgbOffcanvasOptions): void {
+    this._panelAttributes.forEach((optionName: string) => {
+      if (isDefined(options[optionName])) {
+        windowInstance[optionName] = options[optionName];
+      }
+    });
+  }
+
+  private _applyBackdropOptions(backdropInstance: NgbOffcanvasBackdrop, options: NgbOffcanvasOptions): void {
+    this._backdropAttributes.forEach((optionName: string) => {
+      if (isDefined(options[optionName])) {
+        backdropInstance[optionName] = options[optionName];
+      }
+    });
+  }
+
+  private _getContentRef(
+      moduleCFR: ComponentFactoryResolver, contentInjector: Injector, content: any, activeOffcanvas: NgbActiveOffcanvas,
+      options: NgbOffcanvasOptions): ContentRef {
+    if (!content) {
+      return new ContentRef([]);
+    } else if (content instanceof TemplateRef) {
+      return this._createFromTemplateRef(content, activeOffcanvas);
+    } else if (isString(content)) {
+      return this._createFromString(content);
+    } else {
+      return this._createFromComponent(moduleCFR, contentInjector, content, activeOffcanvas, options);
+    }
+  }
+
+  private _createFromTemplateRef(content: TemplateRef<any>, activeOffcanvas: NgbActiveOffcanvas): ContentRef {
+    const context = {
+      $implicit: activeOffcanvas,
+      close(result) { activeOffcanvas.close(result); },
+      dismiss(reason) { activeOffcanvas.dismiss(reason); }
+    };
+    const viewRef = content.createEmbeddedView(context);
+    this._applicationRef.attachView(viewRef);
+    return new ContentRef([viewRef.rootNodes], viewRef);
+  }
+
+  private _createFromString(content: string): ContentRef {
+    const component = this._document.createTextNode(`${content}`);
+    return new ContentRef([[component]]);
+  }
+
+  private _createFromComponent(
+      moduleCFR: ComponentFactoryResolver, contentInjector: Injector, content: any, context: NgbActiveOffcanvas,
+      options: NgbOffcanvasOptions): ContentRef {
+    const contentCmptFactory = moduleCFR.resolveComponentFactory(content);
+    const offcanvasContentInjector =
+        Injector.create({providers: [{provide: NgbActiveOffcanvas, useValue: context}], parent: contentInjector});
+    const componentRef = contentCmptFactory.create(offcanvasContentInjector);
+    const componentNativeEl = componentRef.location.nativeElement;
+    this._applicationRef.attachView(componentRef.hostView);
+    return new ContentRef([[componentNativeEl]], componentRef.hostView, componentRef);
+  }
+
+  private _registerOffcanvasRef(ngbOffcanvasRef: NgbOffcanvasRef) {
+    const unregisterOffcanvasRef = () => {
+      this._offcanvasRef = undefined;
+      this._activeInstance.emit(this._offcanvasRef);
+    };
+    this._offcanvasRef = ngbOffcanvasRef;
+    this._activeInstance.emit(this._offcanvasRef);
+    ngbOffcanvasRef.result.then(unregisterOffcanvasRef, unregisterOffcanvasRef);
+  }
+
+  private _registerPanelCmpt(ngbPanelCmpt: ComponentRef<NgbOffcanvasPanel>) {
+    this._panelCmpt = ngbPanelCmpt;
+    this._activePanelCmptHasChanged.next();
+
+    ngbPanelCmpt.onDestroy(() => {
+      this._panelCmpt = undefined;
+      this._activePanelCmptHasChanged.next();
+    });
+  }
+}

--- a/src/offcanvas/offcanvas-stack.ts
+++ b/src/offcanvas/offcanvas-stack.ts
@@ -62,8 +62,6 @@ export class NgbOffcanvasStack {
     const containerEl = options.container instanceof HTMLElement ? options.container : isDefined(options.container) ?
                                                                    this._document.querySelector(options.container) :
                                                                    this._document.body;
-    const renderer = this._rendererFactory.createRenderer(null, null);
-
     if (!containerEl) {
       throw new Error(`The specified offcanvas container "${options.container || 'body'}" was not found in the DOM.`);
     }

--- a/src/offcanvas/offcanvas-stack.ts
+++ b/src/offcanvas/offcanvas-stack.ts
@@ -8,7 +8,6 @@ import {
   Injectable,
   Injector,
   NgZone,
-  RendererFactory2,
   TemplateRef
 } from '@angular/core';
 import {finalize, Subject} from 'rxjs';
@@ -34,7 +33,7 @@ export class NgbOffcanvasStack {
 
   constructor(
       private _applicationRef: ApplicationRef, private _injector: Injector, @Inject(DOCUMENT) private _document: any,
-      private _scrollBar: ScrollBar, private _rendererFactory: RendererFactory2, private _ngZone: NgZone) {
+      private _scrollBar: ScrollBar, private _ngZone: NgZone) {
     // Trap focus on active PanelCmpt
     this._activePanelCmptHasChanged.subscribe(() => {
       if (this._panelCmpt) {
@@ -71,8 +70,7 @@ export class NgbOffcanvasStack {
     }
 
     const activeOffcanvas = new NgbActiveOffcanvas();
-    const contentRef =
-        this._getContentRef(moduleCFR, options.injector || contentInjector, content, activeOffcanvas, options);
+    const contentRef = this._getContentRef(moduleCFR, options.injector || contentInjector, content, activeOffcanvas);
 
     let backdropCmptRef: ComponentRef<NgbOffcanvasBackdrop>| undefined =
         options.backdrop !== false ? this._attachBackdrop(moduleCFR, containerEl) : undefined;
@@ -136,8 +134,8 @@ export class NgbOffcanvasStack {
   }
 
   private _getContentRef(
-      moduleCFR: ComponentFactoryResolver, contentInjector: Injector, content: any, activeOffcanvas: NgbActiveOffcanvas,
-      options: NgbOffcanvasOptions): ContentRef {
+      moduleCFR: ComponentFactoryResolver, contentInjector: Injector, content: any,
+      activeOffcanvas: NgbActiveOffcanvas): ContentRef {
     if (!content) {
       return new ContentRef([]);
     } else if (content instanceof TemplateRef) {
@@ -145,7 +143,7 @@ export class NgbOffcanvasStack {
     } else if (isString(content)) {
       return this._createFromString(content);
     } else {
-      return this._createFromComponent(moduleCFR, contentInjector, content, activeOffcanvas, options);
+      return this._createFromComponent(moduleCFR, contentInjector, content, activeOffcanvas);
     }
   }
 
@@ -166,8 +164,8 @@ export class NgbOffcanvasStack {
   }
 
   private _createFromComponent(
-      moduleCFR: ComponentFactoryResolver, contentInjector: Injector, content: any, context: NgbActiveOffcanvas,
-      options: NgbOffcanvasOptions): ContentRef {
+      moduleCFR: ComponentFactoryResolver, contentInjector: Injector, content: any,
+      context: NgbActiveOffcanvas): ContentRef {
     const contentCmptFactory = moduleCFR.resolveComponentFactory(content);
     const offcanvasContentInjector =
         Injector.create({providers: [{provide: NgbActiveOffcanvas, useValue: context}], parent: contentInjector});

--- a/src/offcanvas/offcanvas.module.ts
+++ b/src/offcanvas/offcanvas.module.ts
@@ -1,0 +1,12 @@
+import {NgModule} from '@angular/core';
+import {NgbOffcanvasBackdrop} from './offcanvas-backdrop';
+import {NgbOffcanvasPanel} from './offcanvas-panel';
+
+export {NgbOffcanvas} from './offcanvas';
+export {NgbOffcanvasConfig, NgbOffcanvasOptions} from './offcanvas-config';
+export {NgbOffcanvasRef, NgbActiveOffcanvas} from './offcanvas-ref';
+export {OffcanvasDismissReasons} from './offcanvas-dismiss-reasons';
+
+@NgModule({declarations: [NgbOffcanvasPanel, NgbOffcanvasBackdrop]})
+export class NgbOffcanvasModule {
+}

--- a/src/offcanvas/offcanvas.spec.ts
+++ b/src/offcanvas/offcanvas.spec.ts
@@ -320,13 +320,13 @@ describe('ngb-offcanvas', () => {
         expect(fixture.nativeElement).not.toHaveOffcanvas();
       });
 
-      it('should dismiss with backdrop click', async() => {
+      it('should dismiss with backdrop mousedown', async() => {
         let rejectReason: any;
         fixture.componentInstance.open('foo').result.catch((reason) => rejectReason = reason);
         fixture.detectChanges();
         expect(fixture.nativeElement).toHaveOffcanvas('foo');
 
-        document.querySelector('ngb-offcanvas-backdrop') ?.dispatchEvent(new Event('click'));
+        document.querySelector('ngb-offcanvas-backdrop') ?.dispatchEvent(new Event('mousedown'));
         fixture.detectChanges();
 
         expect(fixture.nativeElement).not.toHaveOffcanvas();

--- a/src/offcanvas/offcanvas.spec.ts
+++ b/src/offcanvas/offcanvas.spec.ts
@@ -766,7 +766,7 @@ describe('ngb-offcanvas', () => {
 
         constructor(private offcanvasService: NgbOffcanvas) {}
 
-        open(backdrop: boolean = true, keyboard = true) {
+        open(backdrop = true, keyboard = true) {
           return this.offcanvasService.open(this.content, {backdrop, keyboard});
         }
       }

--- a/src/offcanvas/offcanvas.spec.ts
+++ b/src/offcanvas/offcanvas.spec.ts
@@ -1,0 +1,979 @@
+import {CommonModule} from '@angular/common';
+import {Component, Injectable, Injector, NgModule, OnDestroy, ViewChild} from '@angular/core';
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {NgbOffcanvasConfig, NgbOffcanvasOptions} from './offcanvas-config';
+import {
+  NgbActiveOffcanvas,
+  NgbOffcanvas,
+  NgbOffcanvasModule,
+  NgbOffcanvasRef,
+  OffcanvasDismissReasons
+} from './offcanvas.module';
+import {isBrowserVisible} from '../test/common';
+import {NgbConfig} from '..';
+import {NgbConfigAnimation} from '../test/ngb-config-animation';
+import createSpy = jasmine.createSpy;
+
+const NOOP = () => {};
+
+@Injectable()
+class SpyService {
+  called = false;
+}
+
+@Injectable()
+class CustomSpyService {
+  called = false;
+}
+
+describe('ngb-offcanvas', () => {
+
+  let fixture: ComponentFixture<TestComponent>;
+
+  beforeEach(() => {
+    jasmine.addMatchers({
+      toHaveOffcanvas: function(util, customEqualityTests) {
+        return {
+          compare: function(actual, content?, selector?) {
+            const offcanvasContent = document.querySelector(selector || 'body').querySelector('.offcanvas');
+            let pass = true;
+            let errMsg;
+
+            if (!content) {
+              pass = !!offcanvasContent;
+              errMsg = 'offcanvas open but found none';
+            } else {
+              pass = !!offcanvasContent && offcanvasContent.textContent.trim() === content;
+              errMsg = `offcanvas open with content ${content} but found none`;
+            }
+
+            return {pass: pass, message: `Expected ${actual.outerHTML} to have ${errMsg}`};
+          },
+          negativeCompare: function(actual, selector?) {
+            const openOffcanvas = document.querySelector(selector || 'body').querySelector('ngb-offcanvas-panel');
+
+            return {
+              pass: !openOffcanvas,
+              message: `Expected ${actual.outerHTML} not to have an offcanvas open but found one`
+            };
+          }
+        };
+      }
+    });
+
+    jasmine.addMatchers({
+      toHaveOffcanvasBackdrop: function(util, customEqualityTests) {
+        return {
+          compare: function(actual, selector?) {
+            const backdrop = document.querySelector(selector || 'body').querySelector('ngb-offcanvas-backdrop');
+            return {pass: !!backdrop, message: `Expected ${actual.outerHTML} to have one backdrop element`};
+          },
+          negativeCompare: function(actual, selector?) {
+            const backdrop = document.querySelector(selector || 'body').querySelector('ngb-offcanvas-backdrop');
+            return {pass: !backdrop, message: `Expected ${actual.outerHTML} not to have a backdrop element`};
+          }
+        };
+      }
+    });
+  });
+
+  afterEach(() => {
+    // detect left-over modals and report errors when found
+
+    const remainingOffcanvasPanels = document.querySelectorAll('ngb-offcanvas-panel');
+    if (remainingOffcanvasPanels.length) {
+      fail(`${remainingOffcanvasPanels.length} offcanvas panels were left in the DOM.`);
+    }
+
+    const remainingOffcanvasBackdrops = document.querySelectorAll('ngb-offcanvas-backdrop');
+    if (remainingOffcanvasBackdrops.length) {
+      fail(`${remainingOffcanvasBackdrops.length} offcanvas backdrops were left in the DOM.`);
+    }
+  });
+
+  describe('default configuration', () => {
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({imports: [NgbOffcanvasTestModule]});
+      fixture = TestBed.createComponent(TestComponent);
+    });
+
+    describe('basic functionality', () => {
+
+      it('should open and close offcanvas with default options', () => {
+        const offcanvasInstance = fixture.componentInstance.open('foo');
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas('foo');
+
+        const offcanvasEl = document.querySelector('ngb-offcanvas-panel') as HTMLElement;
+        expect(offcanvasEl).not.toHaveClass('fade');
+        expect(offcanvasEl).toHaveClass('show');
+        expect(offcanvasEl.style.visibility).toBe('visible');
+
+        offcanvasInstance.close('some result');
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+
+      it('should open and close offcanvas from a TemplateRef content', () => {
+        const offcanvasInstance = fixture.componentInstance.openTpl();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas('Hello, World!');
+
+        offcanvasInstance.close('some result');
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+
+      it('should properly destroy TemplateRef content', () => {
+        const spyService = fixture.debugElement.injector.get(SpyService);
+        const offcanvasInstance = fixture.componentInstance.openDestroyableTpl();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas('Some content');
+        expect(spyService.called).toBeFalsy();
+
+        offcanvasInstance.close('some result');
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+        expect(spyService.called).toBeTruthy();
+      });
+
+      it('should open and close offcanvas from a component type', () => {
+        const spyService = fixture.debugElement.injector.get(SpyService);
+        const offcanvasInstance = fixture.componentInstance.openCmpt(DestroyableCmpt);
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas('Some content');
+        expect(spyService.called).toBeFalsy();
+
+        offcanvasInstance.close('some result');
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+        expect(spyService.called).toBeTruthy();
+      });
+
+      it('should inject active offcanvas ref when component is used as content', () => {
+        fixture.componentInstance.openCmpt(WithActiveOffcanvasCmpt);
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas('Close');
+
+        (<HTMLElement>document.querySelector('button.closeFromInside')).click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+
+      it('should expose component used as offcanvas content', () => {
+        const offcanvasInstance = fixture.componentInstance.openCmpt(WithActiveOffcanvasCmpt);
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas('Close');
+        expect(offcanvasInstance.componentInstance instanceof WithActiveOffcanvasCmpt).toBeTruthy();
+
+        offcanvasInstance.close();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+        expect(offcanvasInstance.componentInstance).toBe(undefined);
+      });
+
+      it('should open and close offcanvas from inside', () => {
+        fixture.componentInstance.openTplClose();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas();
+
+        (<HTMLElement>document.querySelector('button#close')).click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+
+      it('should open and dismiss offcanvas from inside', () => {
+        fixture.componentInstance.openTplDismiss().result.catch(NOOP);
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas();
+
+        (<HTMLElement>document.querySelector('button#dismiss')).click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+
+      it('should open and close offcanvas from template implicit context', () => {
+        fixture.componentInstance.openTplImplicitContext();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas();
+
+        (<HTMLElement>document.querySelector('button#close')).click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+
+      it('should open and dismiss offcanvas from template implicit context', () => {
+        fixture.componentInstance.openTplImplicitContext().result.catch(NOOP);
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas();
+
+        (<HTMLElement>document.querySelector('button#dismiss')).click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+
+      it(`should emit 'closed' on close`, () => {
+        const closedSpy = createSpy();
+        fixture.componentInstance.openTplClose().closed.subscribe(closedSpy);
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas();
+
+        (<HTMLElement>document.querySelector('button#close')).click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+
+        expect(closedSpy).toHaveBeenCalledWith('myResult');
+      });
+
+      it(`should emit 'dismissed' on dismissal`, () => {
+        const dismissSpy = createSpy();
+        fixture.componentInstance.openTplDismiss().dismissed.subscribe(dismissSpy);
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas();
+
+        (<HTMLElement>document.querySelector('button#dismiss')).click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+
+        expect(dismissSpy).toHaveBeenCalledWith('myReason');
+      });
+
+      it('should resolve result promise on close', async() => {
+        let resolvedResult;
+        fixture.componentInstance.openTplClose().result.then((result) => resolvedResult = result);
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas();
+
+        (<HTMLElement>document.querySelector('button#close')).click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+
+        await fixture.whenStable();
+        expect(resolvedResult).toBe('myResult');
+      });
+
+      it('should reject result promise on dismiss', async() => {
+        let rejectReason;
+        fixture.componentInstance.openTplDismiss().result.catch((reason) => rejectReason = reason);
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas();
+
+        (<HTMLElement>document.querySelector('button#dismiss')).click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+
+        await fixture.whenStable();
+        expect(rejectReason).toBe('myReason');
+      });
+
+      it(`should emit 'shown' and 'hidden' events`, () => {
+        const shownSpy = createSpy();
+        const hiddenSpy = createSpy();
+        const modalRef = fixture.componentInstance.openTplClose();
+        modalRef.shown.subscribe(shownSpy);
+        modalRef.hidden.subscribe(hiddenSpy);
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas();
+        expect(shownSpy).toHaveBeenCalledWith(undefined);
+
+        (<HTMLElement>document.querySelector('button#close')).click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+        expect(hiddenSpy).toHaveBeenCalledWith(undefined);
+      });
+
+      it('should remove / restore scroll bar when offcanvas is open and closed', fakeAsync(() => {
+           expect(window.getComputedStyle(document.body).overflow).not.toBe('hidden');
+           const offcanvasRef = fixture.componentInstance.open('bar');
+           fixture.detectChanges();
+           expect(window.getComputedStyle(document.body).overflow).toBe('hidden');
+
+           offcanvasRef.close('bar result');
+           fixture.detectChanges();
+           tick();
+
+           expect(window.getComputedStyle(document.body).overflow).not.toBe('hidden');
+         }));
+
+      it('should not throw when close called multiple times', () => {
+        const offcanvasInstance = fixture.componentInstance.open('foo');
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas('foo');
+
+        offcanvasInstance.close('some result');
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+
+        offcanvasInstance.close('some result');
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+
+      it('should dismiss with service dismiss', () => {
+        fixture.componentInstance.open('foo');
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas('foo');
+
+        fixture.componentInstance.dismiss('dismissArg');
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+
+      it('should dismiss with backdrop click', async() => {
+        let rejectReason: any;
+        fixture.componentInstance.open('foo').result.catch((reason) => rejectReason = reason);
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas('foo');
+
+        document.querySelector('ngb-offcanvas-backdrop') ?.dispatchEvent(new Event('click'));
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+        await fixture.whenStable();
+        expect(rejectReason).toBe(OffcanvasDismissReasons.BACKDROP_CLICK);
+      });
+
+      it('should not throw when service dismiss called with no active offcanvas', () => {
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+
+        fixture.componentInstance.dismiss();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+
+      it('should not throw when dismiss called multiple times', () => {
+        const modalRef = fixture.componentInstance.open('foo');
+        modalRef.result.catch(NOOP);
+
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas('foo');
+
+        modalRef.dismiss('some reason');
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+
+        modalRef.dismiss('some reason');
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+
+      it('should indicate if there is an open offcanvas', fakeAsync(() => {
+           fixture.componentInstance.open('foo');
+           fixture.detectChanges();
+           expect(fixture.nativeElement).toHaveOffcanvas('foo');
+           expect(fixture.componentInstance.offcanvasService.hasOpenOffcanvas()).toBeTrue();
+
+           fixture.componentInstance.dismiss();
+           fixture.detectChanges();
+           tick();
+           expect(fixture.nativeElement).not.toHaveOffcanvas();
+           expect(fixture.componentInstance.offcanvasService.hasOpenOffcanvas()).toBeFalse();
+         }));
+    });
+
+    describe('backdrop options', () => {
+
+      it('should have backdrop by default', () => {
+        const offcanvasInstance = fixture.componentInstance.open('foo');
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement).toHaveOffcanvas('foo');
+        expect(fixture.nativeElement).toHaveOffcanvasBackdrop();
+
+        offcanvasInstance.close('some reason');
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+        expect(fixture.nativeElement).not.toHaveOffcanvasBackdrop();
+      });
+
+      it('should open and close offcanvas without backdrop', () => {
+        const offcanvasInstance = fixture.componentInstance.open('foo', {backdrop: false});
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement).toHaveOffcanvas('foo');
+        expect(fixture.nativeElement).not.toHaveOffcanvasBackdrop();
+
+        offcanvasInstance.close('some reason');
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+        expect(fixture.nativeElement).not.toHaveOffcanvasBackdrop();
+      });
+
+      it('should open and close offcanvas without backdrop from template content', () => {
+        const offcanvasInstance = fixture.componentInstance.openTpl({backdrop: false});
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement).toHaveOffcanvas('Hello, World!');
+        expect(fixture.nativeElement).not.toHaveOffcanvasBackdrop();
+
+        offcanvasInstance.close('some reason');
+        fixture.detectChanges();
+
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+        expect(fixture.nativeElement).not.toHaveOffcanvasBackdrop();
+      });
+
+      it('should not dismiss on clicks that result in detached elements', () => {
+        const offcanvasInstance = fixture.componentInstance.openTplIf({});
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas();
+
+        (<HTMLElement>document.querySelector('button#if')).click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas();
+
+        offcanvasInstance.close();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+    });
+
+    describe('beforeDismiss options', () => {
+
+      it('should not dismiss when the callback returns false', () => {
+        const offcanvasInstance = fixture.componentInstance.openTplDismiss({beforeDismiss: () => { return false; }});
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas();
+
+        (<HTMLElement>document.querySelector('button#dismiss')).click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas();
+
+        offcanvasInstance.close();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+
+      it('should dismiss when the callback does not return false', () => {
+        fixture.componentInstance.openTplDismiss(<any>{beforeDismiss: () => {}});
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas();
+
+        (<HTMLElement>document.querySelector('button#dismiss')).click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+
+      it('should not dismiss when the returned promise is resolved with false', fakeAsync(() => {
+           const offcanvasInstance =
+               fixture.componentInstance.openTplDismiss({beforeDismiss: () => Promise.resolve(false)});
+           fixture.detectChanges();
+           expect(fixture.nativeElement).toHaveOffcanvas();
+
+           (<HTMLElement>document.querySelector('button#dismiss')).click();
+           fixture.detectChanges();
+           tick();
+           expect(fixture.nativeElement).toHaveOffcanvas();
+
+           offcanvasInstance.close();
+           fixture.detectChanges();
+           tick();
+           expect(fixture.nativeElement).not.toHaveOffcanvas();
+         }));
+
+      it('should not dismiss when the returned promise is rejected', fakeAsync(() => {
+           const offcanvasInstance =
+               fixture.componentInstance.openTplDismiss({beforeDismiss: () => Promise.reject('error')});
+           fixture.detectChanges();
+           expect(fixture.nativeElement).toHaveOffcanvas();
+
+           (<HTMLElement>document.querySelector('button#dismiss')).click();
+           fixture.detectChanges();
+           tick();
+           expect(fixture.nativeElement).toHaveOffcanvas();
+
+           offcanvasInstance.close();
+           fixture.detectChanges();
+           tick();
+           expect(fixture.nativeElement).not.toHaveOffcanvas();
+         }));
+
+      it('should dismiss when the returned promise is not resolved with false', fakeAsync(() => {
+           fixture.componentInstance.openTplDismiss(<any>{beforeDismiss: () => Promise.resolve()});
+           fixture.detectChanges();
+           expect(fixture.nativeElement).toHaveOffcanvas();
+
+           (<HTMLElement>document.querySelector('button#dismiss')).click();
+           fixture.detectChanges();
+           tick();
+           expect(fixture.nativeElement).not.toHaveOffcanvas();
+         }));
+
+      it('should dismiss when the callback is not defined', () => {
+        fixture.componentInstance.openTplDismiss({});
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas();
+
+        (<HTMLElement>document.querySelector('button#dismiss')).click();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+    });
+
+    describe('container options', () => {
+
+      it('should attach offcanvas and backdrop elements to the specified container', () => {
+        const offcanvasInstance = fixture.componentInstance.open('foo', {container: '#testContainer'});
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas('foo', '#testContainer');
+        expect(fixture.nativeElement).toHaveOffcanvasBackdrop('#testContainer');
+
+        offcanvasInstance.close();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+        expect(fixture.nativeElement).not.toHaveOffcanvasBackdrop();
+      });
+
+      it('should attach offcanvas and backdrop elements to the specified container DOM element', () => {
+        const containerDomEl = document.querySelector('div#testContainer');
+        const offcanvasInstance = fixture.componentInstance.open('foo', {container: containerDomEl as HTMLElement});
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas('foo', '#testContainer');
+        expect(fixture.nativeElement).toHaveOffcanvasBackdrop('#testContainer');
+
+        offcanvasInstance.close();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+        expect(fixture.nativeElement).not.toHaveOffcanvasBackdrop();
+      });
+
+      it('should throw when the specified container element doesn\'t exist', () => {
+        const brokenSelector = '#notInTheDOM';
+        expect(() => {
+          fixture.componentInstance.open('foo', {container: brokenSelector});
+        }).toThrowError(`The specified offcanvas container "${brokenSelector}" was not found in the DOM.`);
+      });
+    });
+
+    describe('position options', () => {
+
+      it('should render offcanvas with specified position', () => {
+        const offcanvasInstance = fixture.componentInstance.open('foo', {position: 'end'});
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas('foo');
+        expect(document.querySelector('ngb-offcanvas-panel')).toHaveCssClass('offcanvas-end');
+
+        offcanvasInstance.close();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+    });
+
+    describe('panel custom class options', () => {
+
+      it('should render offcanvas with the correct panel custom classes', () => {
+        const offcanvasInstance = fixture.componentInstance.open('foo', {panelClass: 'bar'});
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas('foo');
+        expect(document.querySelector('ngb-offcanvas-panel')).toHaveCssClass('bar');
+
+        offcanvasInstance.close();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+
+    });
+
+    describe('backdrop custom class options', () => {
+
+      it('should render offcanvas with the correct backdrop custom classes', () => {
+        const offcanvasInstance = fixture.componentInstance.open('foo', {backdropClass: 'my-fancy-backdrop'});
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas('foo');
+        expect(document.querySelector('ngb-offcanvas-backdrop')).toHaveCssClass('my-fancy-backdrop');
+
+        offcanvasInstance.close();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+
+    });
+
+    describe('custom injector option', () => {
+
+      it('should render offcanvas with a custom injector', () => {
+        const customInjector =
+            Injector.create({providers: [{provide: CustomSpyService, useClass: CustomSpyService, deps: []}]});
+        const offcanvasInstance = fixture.componentInstance.openCmpt(CustomInjectorCmpt, {injector: customInjector});
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas('Some content');
+
+        offcanvasInstance.close();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+
+    });
+
+    describe('focus management', () => {
+
+      describe('initial focus', () => {
+        it('should focus the proper specified element when [ngbAutofocus] is used', () => {
+          fixture.detectChanges();
+          const offcanvasInstance = fixture.componentInstance.openCmpt(WithAutofocusOffcanvasCmpt);
+          fixture.detectChanges();
+
+          expect(document.activeElement).toBe(document.querySelector('button.withNgbAutofocus'));
+          offcanvasInstance.close();
+        });
+
+        it('should focus the first focusable element when [ngbAutofocus] is not used', () => {
+          fixture.detectChanges();
+          const offcanvasInstance = fixture.componentInstance.openCmpt(WithFirstFocusableOffcanvasCmpt);
+          fixture.detectChanges();
+
+          expect(document.activeElement).toBe(document.querySelector('button.firstFocusable'));
+          offcanvasInstance.close();
+          fixture.detectChanges();
+        });
+
+        it('should skip element with tabindex=-1 when finding the first focusable element', () => {
+          fixture.detectChanges();
+          const offcanvasInstance = fixture.componentInstance.openCmpt(WithSkipTabindexFirstFocusableOffcanvasCmpt);
+          fixture.detectChanges();
+
+          expect(document.activeElement).toBe(document.querySelector('button.other'));
+          offcanvasInstance.close();
+          fixture.detectChanges();
+        });
+
+        it('should focus offcanvas panel as a default fallback option', () => {
+          fixture.detectChanges();
+          const offcanvasInstance = fixture.componentInstance.open('content');
+          fixture.detectChanges();
+
+          expect(document.activeElement).toBe(document.querySelector('ngb-offcanvas-panel'));
+          offcanvasInstance.close();
+          fixture.detectChanges();
+        });
+
+      });
+    });
+
+    describe('scrollable document', () => {
+
+      it('should keep the document scrollable', () => {
+        const offcanvasInstance = fixture.componentInstance.open('foo', {scroll: true});
+        fixture.detectChanges();
+        expect(fixture.nativeElement).toHaveOffcanvas('foo');
+        expect(window.getComputedStyle(document.body).overflow).not.toBe('hidden');
+
+        offcanvasInstance.close();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+    });
+
+    describe('accessibility', () => {
+
+      it('should support aria-labelledby', () => {
+        const id = 'aria-labelledby-id';
+
+        const offcanvasInstance = fixture.componentInstance.open('foo', {ariaLabelledBy: id});
+        fixture.detectChanges();
+
+        const modalElement = <HTMLElement>document.querySelector('ngb-offcanvas-panel');
+        expect(modalElement.getAttribute('aria-labelledby')).toBe(id);
+
+        offcanvasInstance.close('some result');
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+
+      it('should support aria-describedby', () => {
+        const id = 'aria-describedby-id';
+
+        const offcanvasInstance = fixture.componentInstance.open('foo', {ariaDescribedBy: id});
+        fixture.detectChanges();
+
+        const modalElement = <HTMLElement>document.querySelector('ngb-offcanvas-panel');
+        expect(modalElement.getAttribute('aria-describedby')).toBe(id);
+
+        offcanvasInstance.close('some result');
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+
+      it('should have aria-modal attribute', () => {
+        const a11yFixture = TestBed.createComponent(TestA11yComponent);
+        const offcanvasInstance = a11yFixture.componentInstance.open();
+        a11yFixture.detectChanges();
+
+        const modalElement = <HTMLElement>document.querySelector('ngb-offcanvas-panel');
+        expect(modalElement.getAttribute('aria-modal')).toBe('true');
+
+        offcanvasInstance.close();
+        fixture.detectChanges();
+        expect(fixture.nativeElement).not.toHaveOffcanvas();
+      });
+
+      // unlike modal, we don't set aria-hidden on siblings: Bootstrap doesn't seem to do it. If we do, then we have to
+      // be careful about the backdrop option: if no backdrop, then the siblings are not really hidden, and we can still
+      // interact with them
+    });
+  });
+
+  describe('custom global configuration', () => {
+
+    beforeEach(() => {
+      TestBed.configureTestingModule(
+          {imports: [NgbOffcanvasTestModule], providers: [{provide: NgbOffcanvasConfig, useValue: {position: 'end'}}]});
+      fixture = TestBed.createComponent(TestComponent);
+    });
+
+    it('should accept global configuration under the NgbOffcanvasConfig token', () => {
+      const offcanvasInstance = fixture.componentInstance.open('foo');
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement).toHaveOffcanvas('foo');
+      expect(document.querySelector('ngb-offcanvas-panel')).toHaveCssClass('offcanvas-end');
+      expect(document.querySelector('ngb-offcanvas-panel')).not.toHaveCssClass('offcanvas-start');
+
+      offcanvasInstance.close('some reason');
+      fixture.detectChanges();
+    });
+
+    it('should override global configuration with local options', () => {
+      const offcanvasInstance = fixture.componentInstance.open('foo', {position: 'top'});
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement).toHaveOffcanvas('foo');
+      expect(document.querySelector('ngb-offcanvas-panel')).toHaveCssClass('offcanvas-top');
+      expect(document.querySelector('ngb-offcanvas-panel')).not.toHaveCssClass('offcanvas-end');
+      expect(document.querySelector('ngb-offcanvas-panel')).not.toHaveCssClass('offcanvas-start');
+
+      offcanvasInstance.close('some reason');
+      fixture.detectChanges();
+    });
+  });
+
+  if (isBrowserVisible('ngb-offcanvas animations')) {
+    describe('ngb-offcanvas animations', () => {
+
+      @Component({
+        template: `
+          <ng-template #content let-close="close" let-dismiss="dismiss">
+            <div id="inside-div">Bla bla</div>
+            <button class="btn btn-primary" id="close" (click)="close('myResult')">Close me</button>
+          </ng-template>
+        `
+      })
+      class TestAnimationComponent {
+        @ViewChild('content', {static: true}) content;
+
+        constructor(private offcanvasService: NgbOffcanvas) {}
+
+        open(backdrop: boolean = true, keyboard = true) {
+          return this.offcanvasService.open(this.content, {backdrop, keyboard});
+        }
+      }
+
+      beforeEach(() => {
+        TestBed.configureTestingModule({
+          declarations: [TestAnimationComponent],
+          imports: [NgbOffcanvasModule],
+          providers: [{provide: NgbConfig, useClass: NgbConfigAnimation}]
+        });
+      });
+
+      afterEach(() => document.body.classList.remove('ngb-reduce-motion'));
+
+      [true, false].forEach(reduceMotion => {
+
+        it(`should run transform transition when opening/closing offcanvas (force-reduced-motion = ${reduceMotion})`,
+           (done) => {
+             if (reduceMotion) {
+               document.body.classList.add('ngb-reduce-motion');
+             }
+             const component = TestBed.createComponent(TestAnimationComponent);
+             component.detectChanges();
+
+             const offcanvasRef = component.componentInstance.open();
+
+             // Ensure that everything works fine after a reflow
+             document.body.getBoundingClientRect();
+
+             let offcanvasEl: HTMLElement | null = null;
+
+             offcanvasRef.shown.subscribe(() => {
+               offcanvasEl = document.querySelector('ngb-offcanvas-panel') as HTMLElement;
+               const closeButton = document.querySelector('button#close') as HTMLButtonElement;
+
+               expect(window.getComputedStyle(offcanvasEl).transform).toBe('none');
+               expect(offcanvasEl).toHaveClass('show');
+               closeButton.click();
+             });
+
+             offcanvasRef.hidden.subscribe(() => {
+               offcanvasEl = document.querySelector('ngb-offcanvas-panel');
+               expect(offcanvasEl).toBeNull();
+               done();
+             });
+
+             component.detectChanges();
+             offcanvasEl = document.querySelector('ngb-offcanvas-panel');
+             // if reducedMotion is true, modal would be opened and closed already at this point
+             if (offcanvasEl) {
+               expect(window.getComputedStyle(offcanvasEl).transform).toMatch(/matrix.*/);
+             }
+           });
+      });
+    });
+  }
+});
+
+
+
+@Component({selector: 'custom-injector-cmpt', template: 'Some content'})
+export class CustomInjectorCmpt implements OnDestroy {
+  constructor(private _spyService: CustomSpyService) {}
+
+  ngOnDestroy(): void { this._spyService.called = true; }
+}
+
+@Component({selector: 'destroyable-cmpt', template: 'Some content'})
+export class DestroyableCmpt implements OnDestroy {
+  constructor(private _spyService: SpyService) {}
+
+  ngOnDestroy(): void { this._spyService.called = true; }
+}
+
+@Component(
+    {selector: 'offcanvas-content-cmpt', template: '<button class="closeFromInside" (click)="close()">Close</button>'})
+export class WithActiveOffcanvasCmpt {
+  constructor(public activeModal: NgbActiveOffcanvas) {}
+
+  close() { this.activeModal.close('from inside'); }
+}
+
+@Component(
+    {selector: 'offcanvas-autofocus-cmpt', template: `<button class="withNgbAutofocus" ngbAutofocus>Click Me</button>`})
+export class WithAutofocusOffcanvasCmpt {
+}
+
+@Component({
+  selector: 'offcanvas-firstfocusable-cmpt',
+  template: `
+  <button class="firstFocusable close">Close</button>
+  <button class="other">Other button</button>
+`
+})
+export class WithFirstFocusableOffcanvasCmpt {
+}
+
+@Component({
+  selector: 'offcanvas-skip-tabindex-firstfocusable-cmpt',
+  template: `
+  <button tabindex="-1" class="firstFocusable close">Close</button>
+  <button class="other">Other button</button>
+`
+})
+export class WithSkipTabindexFirstFocusableOffcanvasCmpt {
+}
+
+@Component({
+  selector: 'test-cmpt',
+  template: `
+    <div id="testContainer"></div>
+    <ng-template #content>Hello, {{name}}!</ng-template>
+    <ng-template #destroyableContent><destroyable-cmpt></destroyable-cmpt></ng-template>
+    <ng-template #contentWithClose let-close="close">
+      <button id="close" (click)="close('myResult')">Close me</button>
+    </ng-template>
+    <ng-template #contentWithDismiss let-dismiss="dismiss">
+      <button id="dismiss" (click)="dismiss('myReason')">Dismiss me</button>
+    </ng-template>
+    <ng-template #contentWithImplicitContext let-offcanvas>
+      <button id="close" (click)="offcanvas.close('myResult')">Close me</button>
+      <button id="dismiss" (click)="offcanvas.dismiss('myReason')">Dismiss me</button>
+    </ng-template>
+    <ng-template #contentWithIf>
+      <ng-template [ngIf]="show">
+        <button id="if" (click)="show = false">Click me</button>
+      </ng-template>
+    </ng-template>
+    <button id="open" (click)="open('from button')">Open</button>
+    <div id="open-no-focus" (click)="open('from non focusable element')">Open</div>
+  `
+})
+class TestComponent {
+  name = 'World';
+  openedModal: NgbOffcanvasRef;
+  show = true;
+  @ViewChild('content', {static: true}) tplContent;
+  @ViewChild('destroyableContent', {static: true}) tplDestroyableContent;
+  @ViewChild('contentWithClose', {static: true}) tplContentWithClose;
+  @ViewChild('contentWithDismiss', {static: true}) tplContentWithDismiss;
+  @ViewChild('contentWithImplicitContext', {static: true}) tplContentWithImplicitContext;
+  @ViewChild('contentWithIf', {static: true}) tplContentWithIf;
+
+  constructor(public offcanvasService: NgbOffcanvas) {}
+
+  open(content: string, options?: NgbOffcanvasOptions) {
+    this.openedModal = this.offcanvasService.open(content, options);
+    return this.openedModal;
+  }
+  close() {
+    if (this.openedModal) {
+      this.openedModal.close('ok');
+    }
+  }
+  dismiss(reason?: any) { this.offcanvasService.dismiss(reason); }
+  openTpl(options?: NgbOffcanvasOptions) { return this.offcanvasService.open(this.tplContent, options); }
+  openCmpt(cmptType: any, options?: NgbOffcanvasOptions) { return this.offcanvasService.open(cmptType, options); }
+  openDestroyableTpl(options?: NgbOffcanvasOptions) {
+    return this.offcanvasService.open(this.tplDestroyableContent, options);
+  }
+  openTplClose(options?: NgbOffcanvasOptions) { return this.offcanvasService.open(this.tplContentWithClose, options); }
+  openTplDismiss(options?: NgbOffcanvasOptions) {
+    return this.offcanvasService.open(this.tplContentWithDismiss, options);
+  }
+  openTplImplicitContext(options?: NgbOffcanvasOptions) {
+    return this.offcanvasService.open(this.tplContentWithImplicitContext, options);
+  }
+  openTplIf(options?: NgbOffcanvasOptions) { return this.offcanvasService.open(this.tplContentWithIf, options); }
+  get activeInstance() { return this.offcanvasService.activeInstance; }
+}
+
+@Component({
+  selector: 'test-a11y-cmpt',
+  template: `
+    <div class="to-hide to-restore-true" aria-hidden="true">
+      <div class="not-to-hide"></div>
+    </div>
+    <div class="not-to-hide">
+      <div class="to-hide">
+        <div class="not-to-hide"></div>
+      </div>
+
+      <div class="not-to-hide" id="container"></div>
+
+      <div class="to-hide">
+        <div class="not-to-hide"></div>
+      </div>
+    </div>
+    <div class="to-hide to-restore-false" aria-hidden="false">
+      <div class="not-to-hide"></div>
+    </div>
+  `
+})
+class TestA11yComponent {
+  constructor(private offcanvasService: NgbOffcanvas) {}
+
+  open(options?: any) { return this.offcanvasService.open('foo', options); }
+}
+
+@NgModule({
+  declarations: [
+    TestComponent, CustomInjectorCmpt, DestroyableCmpt, WithActiveOffcanvasCmpt, WithAutofocusOffcanvasCmpt,
+    WithFirstFocusableOffcanvasCmpt, WithSkipTabindexFirstFocusableOffcanvasCmpt, TestA11yComponent
+  ],
+  exports: [TestComponent, DestroyableCmpt],
+  imports: [CommonModule, NgbOffcanvasModule],
+  providers: [SpyService]
+})
+class NgbOffcanvasTestModule {
+}

--- a/src/offcanvas/offcanvas.ts
+++ b/src/offcanvas/offcanvas.ts
@@ -1,0 +1,26 @@
+import {ComponentFactoryResolver, Injectable, Injector} from '@angular/core';
+import {NgbOffcanvasConfig, NgbOffcanvasOptions} from './offcanvas-config';
+import {NgbOffcanvasRef} from './offcanvas-ref';
+import {NgbOffcanvasStack} from './offcanvas-stack';
+
+@Injectable({providedIn: 'root'})
+export class NgbOffcanvas {
+  constructor(
+      private _moduleCFR: ComponentFactoryResolver, private _injector: Injector,
+      private _offcanvasStack: NgbOffcanvasStack, private _config: NgbOffcanvasConfig) {}
+
+  /**
+   * Opens a new offcanvas panel with the specified content and supplied options.
+   *
+   * Content can be provided as a `TemplateRef` or a component type. If you pass a component type as content,
+   * then instances of those components can be injected with an instance of the `NgbActiveOffcanvas` class. You can then
+   * use `NgbActiveOffcanvas` methods to close / dismiss offcanvas from "inside" of your component.
+   *
+   * Also see the [`NgbOffcanvasOptions`](#/components/offcanvas/api#NgbOffcanvasOptions) for the list of supported
+   * options.
+   */
+  open(content: any, options: NgbOffcanvasOptions = {}): NgbOffcanvasRef {
+    const combinedOptions = {...this._config, animation: this._config.animation, ...options};
+    return this._offcanvasStack.open(this._moduleCFR, this._injector, content, combinedOptions);
+  }
+}

--- a/src/offcanvas/offcanvas.ts
+++ b/src/offcanvas/offcanvas.ts
@@ -23,4 +23,19 @@ export class NgbOffcanvas {
     const combinedOptions = {...this._config, animation: this._config.animation, ...options};
     return this._offcanvasStack.open(this._moduleCFR, this._injector, content, combinedOptions);
   }
+
+  /**
+   * Returns an observable that holds the active offcanvas instance.
+   */
+  get activeInstance() { return this._offcanvasStack.activeInstance; }
+
+  /**
+   * Dismisses the currently displayed offcanvas with the supplied reason.
+   */
+  dismiss(reason?: any) { this._offcanvasStack.dismiss(reason); }
+
+  /**
+   * Indicates if there is currently an open offcanvas in the application.
+   */
+  hasOpenOffcanvas(): boolean { return this._offcanvasStack.hasOpenOffcanvas(); }
 }

--- a/src/test/typings/custom-jasmine.d.ts
+++ b/src/test/typings/custom-jasmine.d.ts
@@ -4,6 +4,8 @@ declare namespace jasmine {
     toHaveCssClass(expected: any): boolean;
     toHaveModal(content?: string | string[], selector?: string): boolean;
     toHaveBackdrop(): boolean;
+    toHaveOffcanvas(content?: string | string[], selector?: string): boolean;
+    toHaveOffcanvasBackdrop(selector?: string): boolean;
     toBeShown(): boolean;
   }
 }


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.

This PR implements the Offcanvas component of Bootstrap 5, in a way that is very similar to the Modal component.

It has a demo showing most of the options in action, but more demos should be added.

The design is very similar to the design of the Modal service and components. There are some notable differences, though:
- Bootstrap doesn't use a window component covering the whole screen as it does for the modal. So I did the same thing as Bootstrap. As a result, the clicks on the backdrop which closes the offcanvas are handled by the backdrop itself
- Only one offcanvas must be opened at once. The code itself doesn't ensure that: it's up the developer to ensure that it's the case. But since most of the time, there should be a backdrop, clicking on two different buttons that both open an offcanvas should be impossible. 
- The scrollbar is restored only after the offcanvas is hidden (i.e. after the animation rather than before). This is especially important when the offcanvas is on the end (right), because otherwise, the scrollbar restoration makes the offcanvas shift to the left before the animation starts. This should also be done on the modal, BTW, which would avoid the shifting bug that we see now when closing a modal.

Pros of the design:
- very flexible
- familiar, because it's similar to the modal design, so developers already using modals should be able to use the offcanvas very easily
- since the code is close to the code of the modal, maintenance should be easy

Cons:
- retains the same historic baggage as the modal
  - a result promise
  - the markup for the offcanvas panel is hidden in the ng-bootstrap component, forcing us to pass various options like aria attributes and css classes
 
