### PR TITLE
demo(toast): clear toasts from the service when the demo is destroyed

### DIFF
--- a/demo/src/app/components/toast/demos/howto-global/toast-global.component.ts
+++ b/demo/src/app/components/toast/demos/howto-global/toast-global.component.ts
@@ -1,9 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 
 import { ToastService } from './toast-service';
 
 @Component({ selector: 'ngbd-toast-global', templateUrl: './toast-global.component.html' })
-export class NgbdToastGlobal {
+export class NgbdToastGlobal implements OnDestroy {
   constructor(public toastService: ToastService) {}
 
   showStandard() {
@@ -16,5 +16,9 @@ export class NgbdToastGlobal {
 
   showDanger(dangerTpl) {
     this.toastService.show(dangerTpl, { classname: 'bg-danger text-light', delay: 15000 });
+  }
+
+  ngOnDestroy(): void {
+    this.toastService.clear();
   }
 }

--- a/demo/src/app/components/toast/demos/howto-global/toast-service.ts
+++ b/demo/src/app/components/toast/demos/howto-global/toast-service.ts
@@ -11,4 +11,8 @@ export class ToastService {
   remove(toast) {
     this.toasts = this.toasts.filter(t => t !== toast);
   }
+
+  clear() {
+    this.toasts.splice(0, this.toasts.length);
+  }
 }


### PR DESCRIPTION
This avoids the toasts to reappear when leaving the demo page while toasts are open and then coming back.

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
