### PR TITLE
fix(modal): remove visual 'twitch' when closing

### DIFF
--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -1005,6 +1005,10 @@ describe('ngb-modal', () => {
 
           let modalEl: HTMLElement | null = null;
 
+          modalRef.result.then(() => { expect(document.body.classList.contains('modal-open')).toBe(true); });
+
+          modalRef.closed.subscribe(() => { expect(document.body.classList.contains('modal-open')).toBe(true); });
+
           modalRef.shown.subscribe(() => {
             modalEl = document.querySelector('ngb-modal-window') as HTMLElement;
             const closeButton = document.querySelector('button#close') as HTMLButtonElement;
@@ -1018,7 +1022,11 @@ describe('ngb-modal', () => {
           modalRef.hidden.subscribe(() => {
             modalEl = document.querySelector('ngb-modal-window');
             expect(modalEl).toBeNull();
-            done();
+            expect(document.body.classList.contains('modal-open')).toBe(true);
+            setTimeout(() => {
+              expect(document.body.classList.contains('modal-open')).toBe(false);
+              done();
+            });
           });
 
           component.detectChanges();


### PR DESCRIPTION
Twitch was caused by removing classes/styles from the `<body>` too early after `result` promise was resolved, but animation was potentially on-going.
Now the cleanup is done only after BOTH `result` promise is resolved and `(hidden)` event was emitted on animation completion.

Fixes #4293