### PR TITLE
feat(rating): Allow to set tabindex using [tabIndex].

### DIFF
--- a/src/rating/rating-config.spec.ts
+++ b/src/rating/rating-config.spec.ts
@@ -7,5 +7,6 @@ describe('ngb-rating-config', () => {
     expect(config.max).toBe(10);
     expect(config.readonly).toBe(false);
     expect(config.resettable).toBe(false);
+    expect(config.tabindex).toBe(0);
   });
 });

--- a/src/rating/rating-config.ts
+++ b/src/rating/rating-config.ts
@@ -11,4 +11,5 @@ export class NgbRatingConfig {
   max = 10;
   readonly = false;
   resettable = false;
+  tabindex: number | string = 0;
 }

--- a/src/rating/rating.spec.ts
+++ b/src/rating/rating.spec.ts
@@ -1,9 +1,16 @@
-import {TestBed, ComponentFixture, inject, fakeAsync, tick} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
 import {createGenericTestComponent} from '../test/common';
 import {Key} from '../util/key';
 
 import {Component, DebugElement} from '@angular/core';
-import {FormsModule, ReactiveFormsModule, UntypedFormGroup, UntypedFormControl, Validators} from '@angular/forms';
+import {
+  FormControl,
+  FormsModule,
+  ReactiveFormsModule,
+  UntypedFormControl,
+  UntypedFormGroup,
+  Validators
+} from '@angular/forms';
 
 import {NgbRatingModule} from './rating.module';
 import {NgbRating} from './rating';
@@ -450,6 +457,29 @@ describe('ngb-rating', () => {
     });
   });
 
+  it('should allow customizing tabindex', () => {
+    const fixture = createTestComponent(`<ngb-rating [formControl]="formControl" [tabindex]="tabindex"></ngb-rating>`);
+    const element = fixture.debugElement.query(By.directive(NgbRating));
+
+    expect(element.attributes['tabindex']).toBe('3');
+
+    fixture.componentInstance.tabindex = undefined;
+    fixture.detectChanges();
+    expect(element.attributes['tabindex']).toBe('0');
+
+    fixture.componentInstance.tabindex = '2323';
+    fixture.detectChanges();
+    expect(element.attributes['tabindex']).toBe('2323');
+
+    fixture.componentInstance.formControl.disable();
+    fixture.detectChanges();
+    expect(element.attributes['tabindex']).toBe('-1');
+
+    fixture.componentInstance.formControl.enable();
+    fixture.detectChanges();
+    expect(element.attributes['tabindex']).toBe('2323');
+  });
+
   it('should set tabindex to -1 when disabled', () => {
     const fixture = createTestComponent('<ngb-rating></ngb-rating>');
     let ratingEl = fixture.debugElement.query(By.directive(NgbRating));
@@ -784,7 +814,9 @@ describe('ngb-rating', () => {
 class TestComponent {
   changed = false;
   form = new UntypedFormGroup({rating: new UntypedFormControl(null, Validators.required)});
+  formControl = new FormControl(0);
   max = 10;
   model;
   rate = 3;
+  tabindex?: string | number = 3;
 }

--- a/src/rating/rating.ts
+++ b/src/rating/rating.ts
@@ -42,7 +42,7 @@ export interface StarTemplateContext {
   encapsulation: ViewEncapsulation.None,
   host: {
     'class': 'd-inline-flex',
-    '[tabindex]': 'disabled ? -1 : 0',
+    '[tabindex]': 'disabled ? -1 : tabindex',
     'role': 'slider',
     'aria-valuemin': '0',
     '[attr.aria-valuemax]': 'max',
@@ -70,7 +70,6 @@ export class NgbRating implements ControlValueAccessor,
   contexts: StarTemplateContext[] = [];
   disabled = false;
   nextRate: number;
-
 
   /**
    * The maximal rating that can be given.
@@ -101,6 +100,12 @@ export class NgbRating implements ControlValueAccessor,
   @ContentChild(TemplateRef, {static: false}) starTemplateFromContent: TemplateRef<StarTemplateContext>;
 
   /**
+   * Allows setting a custom rating tabindex.
+   * If the component is disabled, `tabindex` will still be set to `-1`.
+   */
+  @Input() tabindex: number | string;
+
+  /**
    * An event emitted when the user is hovering over a given rating.
    *
    * Event payload equals to the rating being hovered over.
@@ -127,6 +132,7 @@ export class NgbRating implements ControlValueAccessor,
   constructor(config: NgbRatingConfig, private _changeDetectorRef: ChangeDetectorRef) {
     this.max = config.max;
     this.readonly = config.readonly;
+    this.tabindex = config.tabindex;
   }
 
   ariaValueText() { return `${this.nextRate} out of ${this.max}`; }


### PR DESCRIPTION
Hi,
I am using the rating control and was unable to set the tabindex on the control. Have I missed something or is this pull request required to be able to set the tabindex of the html element?
The change was tested using the demo-site.

Best regards,
Ashwani Mehlem