### PR TITLE
test(offcanvas): fix animation timings for tests

### DIFF
--- a/src/test/test-styles.css
+++ b/src/test/test-styles.css
@@ -23,6 +23,12 @@
   transition: transform 0.01s ease-out,-webkit-transform 0.01s ease-out !important;
 }
 
+.offcanvas {
+  transition: -webkit-transform 0.01s ease-out !important;
+  transition: transform 1s ease-out !important;
+  transition: transform 0.01s ease-out,-webkit-transform 0.01s ease-out !important;
+}
+
 .carousel-item {
   transition: -webkit-transform 0.01s ease-out !important;
   transition: transform 0.01s ease-out !important;
@@ -32,6 +38,7 @@
 .ngb-reduce-motion .fade,
 .ngb-reduce-motion .collapsing,
 .ngb-reduce-motion .modal.fade .modal-dialog,
+.ngb-reduce-motion .offcanvas,
 .ngb-reduce-motion .carousel-item {
   transition: none !important;
 }


### PR DESCRIPTION
Reduces animation timing for offcanvas tests.

@jnizet FYI, I've also completely forgot about `reduce-motion` in tests as well as animation timing.