### PR TITLE
fix wrong import for rxjs > 6.6.6

### DIFF
--- a/src/offcanvas/offcanvas-stack.ts
+++ b/src/offcanvas/offcanvas-stack.ts
@@ -10,7 +10,8 @@ import {
   NgZone,
   TemplateRef
 } from '@angular/core';
-import {finalize, Subject} from 'rxjs';
+import {finalize} from 'rxjs/operators';
+import {Subject} from 'rxjs';
 
 import {ngbFocusTrap} from '../util/focus-trap';
 import {ContentRef} from '../util/popup';


### PR DESCRIPTION
this may fix https://github.com/ng-bootstrap/ng-bootstrap/issues/4316 but I didn't test it.