### PR TITLE
fix(datepicker): export NgbDateStructAdapter

### DIFF
--- a/src/datepicker/datepicker.module.ts
+++ b/src/datepicker/datepicker.module.ts
@@ -26,7 +26,7 @@ export {NgbInputDatepickerConfig} from './datepicker-input-config';
 export {NgbDatepickerI18n, NgbDatepickerI18nDefault} from './datepicker-i18n';
 export {NgbDateStruct} from './ngb-date-struct';
 export {NgbDate} from './ngb-date';
-export {NgbDateAdapter} from './adapters/ngb-date-adapter';
+export {NgbDateAdapter, NgbDateStructAdapter} from './adapters/ngb-date-adapter';
 export {NgbDateNativeAdapter} from './adapters/ngb-date-native-adapter';
 export {NgbDateNativeUTCAdapter} from './adapters/ngb-date-native-utc-adapter';
 export {NgbDateParserFormatter} from './ngb-date-parser-formatter';

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ export {
   NgbCalendarBuddhist,
   NgbDate,
   NgbDateAdapter,
+  NgbDateStructAdapter,
   NgbDateNativeAdapter,
   NgbDateNativeUTCAdapter,
   NgbDateParserFormatter,


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] ~added/updated any applicable tests.~
 - [ ] added/updated any applicable API documentation. -> see notes
 - [x] ~added/updated any applicable demos.~

## Summary
Hi :)
Thanks for building this great lib. 

Currently, we use `NgbDatepicker` and the `NgbDateNativeAdapter ` to track our models as native ES Dates globally across our project.
In a specific module, we wanted override this and use the standard behavior via `NgbDateStructAdapter`. However, this implementation isn't exported and thus, not accessible to us. Trying to import it results in a path like this and won't compile:

`import { NgbDateStructAdapter } from '@ng-bootstrap/ng-bootstrap/datepicker/adapters/ngb-date-adapter';`

I don't see a reason not to export it since it could profit some people (like our project) that want to use it outside of the default behavior.

This PR adds the `NgbDateStructAdapter` to it's modules exports.

## Notes
I didn't update the API docs because the `NgbDateStructAdapter` is already mentioned in the `NgbDateAdapter` section. Let me know if I should make that more explicit.

The same behavior is found with the `NgbDateISOParserFormatter` and `NgbDateParserFormatter` as well as `NgbCalendarGregorian` and `NgbCalendar`. If you agree that these should be available from the outside , I can further add to this PR or make a new one. Just let me know :)

