### PR TITLE
fix(collapse): solved running transition twice

### DIFF
--- a/demo/src/app/components/collapse/demos/basic/collapse-basic.html
+++ b/demo/src/app/components/collapse/demos/basic/collapse-basic.html
@@ -1,13 +1,17 @@
 <p>
   <button type="button" class="btn btn-outline-primary" (click)="collapse.toggle()" [attr.aria-expanded]="!isCollapsed"
     aria-controls="collapseExample">
-    Toggle
+    Toggle with Function
   </button>
+  <button type="button" class="btn btn-outline-primary ms-2" (click)="isCollapsed = ! isCollapsed" [attr.aria-expanded]="!isCollapsed"
+  aria-controls="collapseExample">
+  Toggle with Two Way Binding
+</button>
 </p>
 <div #collapse="ngbCollapse" [(ngbCollapse)]="isCollapsed">
   <div class="card">
     <div class="card-body">
-      You can collapse this card by clicking Toggle
+      You can collapse this card by clicking one Toggle button
     </div>
   </div>
 </div>

--- a/src/collapse/collapse.ts
+++ b/src/collapse/collapse.ts
@@ -1,14 +1,4 @@
-import {
-  Directive,
-  ElementRef,
-  EventEmitter,
-  Input,
-  NgZone,
-  OnChanges,
-  OnInit,
-  Output,
-  SimpleChanges,
-} from '@angular/core';
+import {Directive, ElementRef, EventEmitter, Input, NgZone, OnInit, Output} from '@angular/core';
 import {ngbRunTransition} from '../util/transition/ngbTransition';
 import {ngbCollapsingTransition} from '../util/transition/ngbCollapseTransition';
 import {NgbCollapseConfig} from './collapse-config';
@@ -18,7 +8,7 @@ import {NgbCollapseConfig} from './collapse-config';
  * page.
  */
 @Directive({selector: '[ngbCollapse]', exportAs: 'ngbCollapse', host: {'[class.collapse-horizontal]': 'horizontal'}})
-export class NgbCollapse implements OnInit, OnChanges {
+export class NgbCollapse implements OnInit {
   /**
    * If `true`, collapse will be animated.
    *
@@ -30,9 +20,25 @@ export class NgbCollapse implements OnInit, OnChanges {
   @Input() animation;
 
   /**
+   * Flag used to track if the collapse setter is invoked during initialization
+   * or not. This distinction is made in order to avoid running the transition during initialization.
+   */
+  private _afterInit = false;
+
+  private _isCollapsed = false;
+
+  /**
    * If `true`, will collapse the element or show it otherwise.
    */
-  @Input('ngbCollapse') collapsed = false;
+  @Input('ngbCollapse')
+  set collapsed(isCollapsed: boolean) {
+    if (this._isCollapsed !== isCollapsed) {
+      this._isCollapsed = isCollapsed;
+      if (this._afterInit) {
+        this._runTransitionWithEvents(isCollapsed, this.animation);
+      }
+    }
+  }
 
   @Output() ngbCollapseChange = new EventEmitter<boolean>();
 
@@ -63,12 +69,9 @@ export class NgbCollapse implements OnInit, OnChanges {
     this.horizontal = config.horizontal;
   }
 
-  ngOnInit() { this._runTransition(this.collapsed, false); }
-
-  ngOnChanges({collapsed}: SimpleChanges) {
-    if (!collapsed.firstChange) {
-      this._runTransitionWithEvents(this.collapsed, this.animation);
-    }
+  ngOnInit() {
+    this._runTransition(this._isCollapsed, false);
+    this._afterInit = true;
   }
 
   /**
@@ -79,10 +82,9 @@ export class NgbCollapse implements OnInit, OnChanges {
    *
    * @since 8.0.0
    */
-  toggle(open: boolean = this.collapsed) {
+  toggle(open: boolean = this._isCollapsed) {
     this.collapsed = !open;
-    this.ngbCollapseChange.next(this.collapsed);
-    this._runTransitionWithEvents(this.collapsed, this.animation);
+    this.ngbCollapseChange.next(this._isCollapsed);
   }
 
   private _runTransition(collapsed: boolean, animation: boolean) {


### PR DESCRIPTION
I have removed the OnChange in the ngbCollapse directive to avoid starting the animation twice.
I have used a setter and a flag. The setter executes the "_runTransitionWithEvents" while the flag is used to avoid running the animation during initialisation. 
