### PR TITLE
demo: migrate nav and sidenav to offcanvas

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -77,7 +77,7 @@ The most useful commands are:
 
 #### `yarn demo`
 
-Serves the demo site locally in dev mode at [http://localhost:4200/](http://localhost:4200/). You can optionally add `--prod` argument to serve demo in production mode or `--aot` to serve demo in dev mode, but with AOT
+Serves the demo site locally in dev mode at [http://localhost:4200/](http://localhost:4200/). You can optionally add `--configuration=production` argument to serve demo in production mode or `--aot` to serve demo in dev mode, but with AOT
 
 #### `yarn build`
 

--- a/demo/src/app/app.component.html
+++ b/demo/src/app/app.component.html
@@ -1,153 +1,38 @@
-<header class="navbar navbar-expand navbar-dark px-4 flex-column flex-md-row">
-  <a
-    class="navbar-brand me-md-2 me-0"
-    routerLink="/"
-    aria-label="NG Bootstrap"
-    (click)="navbarCollapsed = true"
-  >
-    <svg
-      class="align-middle"
-      xmlns="http://www.w3.org/2000/svg"
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-      width="36"
-      height="36"
-      viewBox="0 0 512 512"
-    >
-      <defs>
-        <linearGradient id="a">
-          <stop offset="0" stop-color="#0143a3" />
-          <stop offset="1" stop-color="#0273d4" />
-        </linearGradient>
-        <linearGradient
-          xlink:href="#a"
-          id="b"
-          gradientUnits="userSpaceOnUse"
-          gradientTransform="matrix(1.33396 0 0 1.33396 404.049 -265.9)"
-          x1="-111"
-          y1="967.862"
-          x2="-110.5"
-          y2="617.362"
-        />
-      </defs>
-      <path
-        d="M255.71 558.533l207.07 81.226-20.02 272.853-185.907 113.26-187.05-114.404L50.356 640.33z"
-        fill="url(#b)"
-        fill-rule="evenodd"
-        transform="translate(0 -540.362)"
-        stroke="#fff"
-        stroke-width="20"
-      />
-      <path
-        d="M255.142 18.01l1.716 467.404 185.675-113.635 19.725-272.724z"
-        fill-rule="evenodd"
-        fill-opacity=".098"
-      />
-      <path
-        d="M220.151 247.738v77.444h45.872q23.078 0 34.12-9.485 11.186-9.628 11.186-29.308 0-19.82-11.185-29.165-11.043-9.486-34.12-9.486H220.15zm0-86.93v63.71h42.333q20.953 0 31.147-7.786 10.336-7.929 10.336-24.069 0-15.998-10.336-23.927-10.194-7.928-31.147-7.928H220.15zm-28.6-23.503h73.056q32.705 0 50.403 13.592 17.697 13.592 17.697 38.651 0 19.397-9.06 30.865-9.062 11.468-26.618 14.3 21.096 4.53 32.705 18.971 11.751 14.3 11.751 35.82 0 28.316-19.255 43.749-19.254 15.432-54.791 15.432h-75.887v-211.38z"
-        fill="#fff"
-      />
-    </svg>
-    <span class="ms-2 d-xl-none d-lg-none d-md-none d-inline"
-      >ng-bootstrap</span
-    >
-  </a>
-
-  <div class="navbar-nav-scroll">
-    <ul class="navbar-nav flex-row">
-      <li class="nav-item">
-        <a
-          class="nav-link"
-          [routerLinkActive]="['active']"
-          [routerLink]="['/home']"
-          (click)="navbarCollapsed = true"
-          >Home</a
-        >
-      </li>
-      <li class="nav-item">
-        <a
-          class="nav-link"
-          [routerLinkActive]="['active']"
-          [routerLink]="['/getting-started']"
-          (click)="navbarCollapsed = true"
-          >Getting Started</a
-        >
-      </li>
-      <li class="nav-item">
-        <a
-          class="nav-link"
-          [routerLinkActive]="['active']"
-          [routerLink]="['/guides']"
-          (click)="navbarCollapsed = true"
-          >Guides</a
-        >
-      </li>
-      <li class="nav-item">
-        <a
-          class="nav-link"
-          [routerLinkActive]="['active']"
-          [routerLink]="['/components']"
-          (click)="navbarCollapsed = true"
-          >Components</a
-        >
-      </li>
-    </ul>
-  </div>
-
-  <div class="demo-site-versions navbar-nav flex-row ms-md-auto me-4">
-    <ngbd-demo-versions></ngbd-demo-versions>
-  </div>
-
-  <ul
-    class="social-buttons navbar-nav flex-row d-none d-md-flex align-items-center"
-  >
-    <li>
-      <a
-        href="https://www.npmjs.com/package/@ng-bootstrap/ng-bootstrap"
-        rel="nofollow noopener noreferrer"
-        target="_blank"
-        [title]="downloadCount + ' downloads over the last 30 days on Npm'"
-        class="d-flex flex-column align-items-center"
-      >
-        <!-- hide the text from a screen reader so that it uses title attribute for the announcement and navigation  -->
-        <span aria-hidden="true">{{ downloadCount }}</span>
-        <svg viewBox="0 0 780 250" width="40" height="13">
-          <path
-            d="M240,250h100v-50h100V0H240V250z M340,50h50v100h-50V50z M480,0v200h100V50h50v150h50V50h50v150h50V0H480z M0,200h100V50h50v150h50V0H0V200z"
-          ></path>
+<header class="navbar navbar-expand-lg navbar-dark bd-navbar sticky-top">
+  <nav class="container-xxl bd-gutter flex-wrap flex-lg-nowrap " aria-label="Main navigation">
+    <button class="navbar-toggler p-2" type="button"
+            aria-controls="doc-nav"
+            [attr.aria-expanded]="!sidebarCollapsed"
+            aria-label="Toggle documentation navigation" (click)="openSidenavbar()">
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" class="bi" fill="currentColor" viewBox="0 0 16 16">
+        <path fill-rule="evenodd"
+              d="M2.5 11.5A.5.5 0 0 1 3 11h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4A.5.5 0 0 1 3 7h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4A.5.5 0 0 1 3 3h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"></path>
         </svg>
-      </a>
-    </li>
-    <li class="ms-3">
-      <a
-        href="https://github.com/ng-bootstrap/ng-bootstrap"
-        rel="nofollow noopener noreferrer"
-        target="_blank"
-        title="Open ng-bootstrap/ng-bootstrap on GitHub"
-        ><svg:svg aria-hidden="true" ngbdIcon="github"></svg:svg
-      ></a>
-    </li>
-    <li class="ms-3">
-      <a
-        href="https://twitter.com/intent/tweet?text=I&#39;m+checking+out+&#23;ng-bootstrap,+THE+Angular+UI+framework+for+Bootstrap+CSS&url=https%3A%2F%2Fng-bootstrap.github.io%2F&hashtags=ng-bootstrap,angular,bootstrap"
-        rel="nofollow noopener noreferrer"
-        target="_blank"
-        title="Tweet #ngbootstrap"
-        ><svg:svg aria-hidden="true" ngbdIcon="twitter"></svg:svg
-      ></a>
-    </li>
-  </ul>
+      <span class="d-none fs-6 pe-1">Browse</span>
+    </button>
 
-  <button
-    class="navbar-toggler navbar-toggler-right"
-    type="button"
-    (click)="navbarCollapsed = !navbarCollapsed"
-    [attr.aria-expanded]="!navbarCollapsed"
-    aria-controls="navbarContent"
-    aria-expanded="false"
-    aria-label="Toggle navigation"
-  >
-    <span class="navbar-toggler-icon"></span>
-  </button>
+    <!-- If we dont use the sidenav toggler -->
+    <!--    <div class="d-lg-none" style="width: 1.5rem;"></div>-->
+
+
+    <a class="navbar-brand p-0 me-0 me-lg-2" href="/" aria-label="Bootstrap">
+      <img src="/img/ngb-logo.png" width="36" height="36">
+    </a>
+
+    <div class="d-flex">
+      <button class="navbar-toggler d-flex d-lg-none order-3 p-2" type="button" aria-controls="bdNavbar"
+              aria-label="Toggle navigation"
+              (click)="openNavbar()">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-three-dots"
+             viewBox="0 0 16 16">
+          <path
+            d="M3 9.5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3zm5 0a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3z"/>
+        </svg>
+      </button>
+    </div>
+
+    <app-nav class="d-none d-lg-block flex-grow-1"></app-nav>
+  </nav>
 </header>
 
 <div>
@@ -162,14 +47,14 @@
         href="https://github.com/orgs/ng-bootstrap/people"
         rel="noopener"
         target="_blank"
-        >ng-bootstrap team
+      >ng-bootstrap team
       </a>
       with the help of our
       <a
         href="https://github.com/ng-bootstrap/ng-bootstrap/graphs/contributors"
         rel="noopener"
         target="_blank"
-        >contributors</a
+      >contributors</a
       >.
     </p>
     <p>
@@ -178,22 +63,22 @@
         href="https://raw.githubusercontent.com/ng-bootstrap/ng-bootstrap/master/LICENSE"
         rel="noopener"
         target="_blank"
-        >MIT license conditions.</a
+      >MIT license conditions.</a
       >
     </p>
     <p>
       Documentation licensed under
       <a href="https://creativecommons.org/licenses/by/3.0/" target="_blank"
-        >CC BY 3.0</a
+      >CC BY 3.0</a
       >. Design and content of the documentation site heavily inspired by the
       <a href="https://getbootstrap.com/" rel="noopener" target="_blank"
-        >original Bootstrap design</a
+      >original Bootstrap design</a
       >.
     </p>
     <p>
       Icons made by
       <a href="https://iconmonstr.com/" rel="noopener" target="_blank"
-        >Iconmonstr</a
+      >Iconmonstr</a
       >
     </p>
   </div>

--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -1,34 +1,50 @@
 import {ViewportScroller} from '@angular/common';
-import {HttpClient} from '@angular/common/http';
 import {Component, NgZone, OnInit} from '@angular/core';
 import {ActivatedRoute} from '@angular/router';
-import {filter, map} from 'rxjs/operators';
+import {filter} from 'rxjs/operators';
 
-import {environment} from '../environments/environment';
+
 import {componentsList} from './shared';
 import {Analytics} from './shared/analytics/analytics';
-import {of} from 'rxjs';
+import {NavOffcanvasComponent} from "./nav/nav-offcanvas.component";
+import {SideNavOffcanvasComponent} from "./shared/side-nav/side-nav-offcanvas.component";
+import {NgbOffcanvas} from "@ng-bootstrap/ng-bootstrap";
 
 
 @Component({selector: 'ngbd-app', templateUrl: './app.component.html'})
 export class AppComponent implements OnInit {
-  downloadCount = '';
   navbarCollapsed = true;
+  sidebarCollapsed = true;
 
   components = componentsList;
 
   constructor(
-      private _analytics: Analytics, route: ActivatedRoute, vps: ViewportScroller, zone: NgZone,
-      httpClient: HttpClient) {
+    private _analytics: Analytics, private offcanvasService: NgbOffcanvas, route: ActivatedRoute, vps: ViewportScroller, zone: NgZone) {
     route.fragment.pipe(filter(fragment => !!fragment))
-        .subscribe((fragment: string) => zone.runOutsideAngular(() => requestAnimationFrame(() => vps.scrollToAnchor(fragment))));
-
-    if (environment.production) {
-      httpClient.get<{downloads: string}>('https://api.npmjs.org/downloads/point/last-month/@ng-bootstrap/ng-bootstrap')
-          .pipe(map(data => data?.downloads))
-          .subscribe({next: count => this.downloadCount = count.toLocaleString(), error: () => of('')});
-    }
+      .subscribe((fragment: string) => zone.runOutsideAngular(() => requestAnimationFrame(() => vps.scrollToAnchor(fragment))));
   }
 
-  ngOnInit(): void { this._analytics.trackPageViews(); }
+  ngOnInit(): void {
+    this._analytics.trackPageViews();
+  }
+
+  openSidenavbar() {
+    this.offcanvasService.open(SideNavOffcanvasComponent, {
+      ariaLabelledBy: 'bdSidebarOffcanvasLabel',
+      panelClass: 'd-lg-none',
+      backdropClass: 'd-lg-none',
+      scroll: true,
+      position: 'start'
+    });
+  }
+
+  openNavbar() {
+    this.offcanvasService.open(NavOffcanvasComponent, {
+      ariaLabelledBy: 'bdNavbarOffcanvasLabel',
+      panelClass: 'bdNavbarBody d-lg-none',
+      backdropClass: 'd-lg-none',
+      scroll: true,
+      position: 'end'
+    });
+  }
 }

--- a/demo/src/app/app.module.ts
+++ b/demo/src/app/app.module.ts
@@ -3,6 +3,7 @@ import {BrowserModule} from '@angular/platform-browser';
 import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 
 import {AppComponent} from './app.component';
+import {NavComponent} from "./nav/nav.component";
 import {routing} from './app.routing';
 import {NgbdAccordionModule} from './components/accordion/accordion.module';
 import {NgbdAlertModule} from './components/alert/alert.module';
@@ -29,7 +30,9 @@ import {PositioningPage} from './pages/positioning/positioning.component';
 import {NgbdSharedModule} from './shared';
 import {NgbdDemoVersionsComponent} from './demo-versions.component';
 import {NgbdOffcanvasModule} from './components/offcanvas/offcanvas.module';
+import {NavOffcanvasComponent} from "./nav/nav-offcanvas.component";
 import {NgbdComponentsSharedModule} from './components/shared';
+
 
 
 const DEMOS = [
@@ -42,7 +45,7 @@ const DEMOS = [
 const PAGES = [GettingStartedPage, AnimationsPage, I18nPage, PositioningPage];
 
 @NgModule({
-  declarations: [AppComponent, DefaultComponent, NgbdDemoVersionsComponent, ...PAGES],
+  declarations: [AppComponent, DefaultComponent, NgbdDemoVersionsComponent, NavComponent, NavOffcanvasComponent, ...PAGES],
     imports: [BrowserModule, routing, NgbModule, NgbdSharedModule, ...DEMOS, NgbdComponentsSharedModule],
   bootstrap: [AppComponent]
 })

--- a/demo/src/app/demo-versions.component.ts
+++ b/demo/src/app/demo-versions.component.ts
@@ -13,14 +13,14 @@ interface Version {
   selector: 'ngbd-demo-versions',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="nav-item" ngbDropdown>
+    <li ngbDropdown class="nav-item col-6 col-lg-auto">
       <a class="nav-link" ngbDropdownToggle id="demo-site-versions" role="button">
-        ng-bootstrap v{{ current }}
+        <span class="d-lg-none">ng-bootstrap</span> v{{ current }}
       </a>
       <div ngbDropdownMenu aria-labelledby="demo-site-versions" class="dropdown-menu dropdown-menu-end">
-        <a ngbDropdownItem *ngFor="let version of versions$ | async" href="{{ version.url }}#{{ routerUrl }}">{{ version.text }}</a>
+        <a ngbDropdownItem *ngFor="let version of versions$ | async" [style.font-weight]="version.text.toLowerCase().includes('latest') ? '500' : '400'" href="{{ version.url }}#{{ routerUrl }}">{{ version.text }}</a>
       </div>
-    </div>
+    </li>
   `
 })
 

--- a/demo/src/app/nav/nav-offcanvas.component.ts
+++ b/demo/src/app/nav/nav-offcanvas.component.ts
@@ -1,0 +1,17 @@
+import {Component} from "@angular/core";
+import {NgbActiveOffcanvas} from "../../../../src";
+import {HttpClient} from "@angular/common/http";
+import {NavComponent} from "./nav.component";
+
+@Component({
+  selector: 'app-nav-offcanvas',
+  templateUrl: './nav.component.html'
+})
+export class NavOffcanvasComponent extends NavComponent {
+  constructor(
+    activeOffcanvas: NgbActiveOffcanvas,
+    httpClient: HttpClient) {
+    super(httpClient);
+    this.activeOffcanvas = activeOffcanvas;
+  }
+}

--- a/demo/src/app/nav/nav.component.html
+++ b/demo/src/app/nav/nav.component.html
@@ -1,0 +1,102 @@
+<div tabindex="-1" id="bdNavbar">
+  <div class="offcanvas-header d-lg-none">
+    <h5 class="offcanvas-title text-white" id="bdNavbarOffcanvasLabel">ng-bootstrap</h5>
+    <button type="button" class="btn-close btn-close-white" aria-label="Close"
+            (click)="activeOffcanvas?.dismiss()"></button>
+  </div>
+
+  <div class="p-4 pt-0 p-lg-0 text-white-50 d-lg-flex flex-lg-row" [class.offcanvas-body]="activeOffcanvas">
+    <hr class="d-lg-none text-white-50">
+    <ul class="navbar-nav flex-row flex-wrap bd-navbar-nav align-items-center">
+      <li class="nav-item col-6 col-lg-auto">
+        <a
+          class="nav-link py-2 px-0 px-lg-2"
+          [routerLinkActive]="['active']"
+          [routerLink]="['/home']"
+          (click)="onLinkClick()"
+        >Home</a
+        >
+      </li>
+      <li class="nav-item col-6 col-lg-auto">
+        <a
+          class="nav-link py-2 px-0 px-lg-2"
+          [routerLinkActive]="['active']"
+          [routerLink]="['/getting-started']"
+          (click)="onLinkClick()"
+        >Getting Started</a
+        >
+      </li>
+      <li class="nav-item col-6 col-lg-auto">
+        <a
+          class="nav-link py-2 px-0 px-lg-2"
+          [routerLinkActive]="['active']"
+          [routerLink]="['/guides']"
+          (click)="onLinkClick()"
+        >Guides</a
+        >
+      </li>
+      <li class="nav-item col-6 col-lg-auto">
+        <a
+          class="nav-link py-2 px-0 px-lg-2"
+          [routerLinkActive]="['active']"
+          [routerLink]="['/components']"
+          (click)="onLinkClick()"
+        >Components</a
+        >
+      </li>
+    </ul>
+
+    <hr class="d-lg-none text-white-50">
+
+    <ul class="navbar-nav flex-row flex-wrap ms-md-auto align-items-lg-center gap-lg-2">
+      <li class="nav-item col-6 col-lg-auto">
+        <a href="https://github.com/ng-bootstrap/ng-bootstrap"
+           class="nav-link py-2 px-0 px-lg-2" target="_blank" rel="nofollow noopener noreferrer"
+           title="Open ng-bootstrap/ng-bootstrap on GitHub">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-github"
+               viewBox="0 0 16 16">
+            <path
+              d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+          </svg>
+          <small class="d-lg-none ms-2">GitHub</small>
+        </a>
+      </li>
+
+      <li class="nav-item col-6 col-lg-auto">
+        <a
+          href="https://twitter.com/intent/tweet?text=I&#39;m+checking+out+&#23;ng-bootstrap,+THE+Angular+UI+framework+for+Bootstrap+CSS&url=https%3A%2F%2Fng-bootstrap.github.io%2F&hashtags=ng-bootstrap,angular,bootstrap"
+          class="nav-link py-2 px-0 px-lg-2" target="_blank" rel="nofollow noopener noreferrer"
+          title="Tweet #ngbootstrap">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-twitter"
+               viewBox="0 0 16 16">
+            <path
+              d="M5.026 15c6.038 0 9.341-5.003 9.341-9.334 0-.14 0-.282-.006-.422A6.685 6.685 0 0 0 16 3.542a6.658 6.658 0 0 1-1.889.518 3.301 3.301 0 0 0 1.447-1.817 6.533 6.533 0 0 1-2.087.793A3.286 3.286 0 0 0 7.875 6.03a9.325 9.325 0 0 1-6.767-3.429 3.289 3.289 0 0 0 1.018 4.382A3.323 3.323 0 0 1 .64 6.575v.045a3.288 3.288 0 0 0 2.632 3.218 3.203 3.203 0 0 1-.865.115 3.23 3.23 0 0 1-.614-.057 3.283 3.283 0 0 0 3.067 2.277A6.588 6.588 0 0 1 .78 13.58a6.32 6.32 0 0 1-.78-.045A9.344 9.344 0 0 0 5.026 15z"/>
+          </svg>
+          <small class="d-lg-none ms-2">Twitter</small>
+        </a>
+      </li>
+
+      <li class="nav-item col-3 col-lg-auto">
+        <a href="https://www.npmjs.com/package/@ng-bootstrap/ng-bootstrap"
+           [title]="downloadCount + ' downloads over the last 30 days on Npm'"
+           class="nav-link py-2 px-0 px-lg-2" target="_blank" rel="nofollow noopener noreferrer">
+          <div class="d-flex flex-column align-items-center">
+            <span aria-hidden="true">{{ downloadCount }}</span>
+            <svg viewBox="0 0 780 250" width="40" height="13" fill="#fff">
+              <path
+                d="M240,250h100v-50h100V0H240V250z M340,50h50v100h-50V50z M480,0v200h100V50h50v150h50V50h50v150h50V0H480z M0,200h100V50h50v150h50V0H0V200z"
+              ></path>
+            </svg>
+          </div>
+        </a>
+      </li>
+
+      <li class="nav-item py-1 col-12 col-lg-auto">
+        <div class="vr d-none d-lg-flex h-100 mx-lg-2 text-white"></div>
+        <hr class="d-lg-none text-white-50">
+      </li>
+
+      <ngbd-demo-versions></ngbd-demo-versions>
+    </ul>
+  </div>
+</div>

--- a/demo/src/app/nav/nav.component.ts
+++ b/demo/src/app/nav/nav.component.ts
@@ -1,0 +1,30 @@
+import {Component} from "@angular/core";
+import {HttpClient} from "@angular/common/http";
+import {map} from "rxjs/operators";
+import {environment} from "../../environments/environment";
+import {of} from "rxjs";
+import {NgbActiveOffcanvas} from "@ng-bootstrap/ng-bootstrap";
+
+@Component({
+  selector: 'app-nav',
+  templateUrl: './nav.component.html'
+})
+export class NavComponent {
+  downloadCount = '';
+
+  public activeOffcanvas: NgbActiveOffcanvas | undefined;
+
+  constructor(
+    httpClient: HttpClient) {
+    if (environment.production) {
+      httpClient.get<{ downloads: string }>('https://api.npmjs.org/downloads/point/last-month/@ng-bootstrap/ng-bootstrap')
+        .pipe(map(data => data?.downloads))
+        .subscribe({next: count => this.downloadCount = count.toLocaleString(), error: () => of('')});
+    }
+  }
+
+  onLinkClick(): void {
+    this.activeOffcanvas?.close();
+  }
+
+}

--- a/demo/src/app/shared/component-wrapper/component-wrapper.component.html
+++ b/demo/src/app/shared/component-wrapper/component-wrapper.component.html
@@ -1,99 +1,71 @@
-<div class="container-fluid">
-  <div class="row flex-xl-nowrap">
-    <div class="col-12 col-lg-2" style="border-right: 1px solid rgba(0, 0, 0, 0.1)">
-      <div class="d-lg-none d-flex py-2 px-4 align-items-center text-body sidebar-collapsed"
-        (click)="sidebarCollapsed = !sidebarCollapsed" role="button">
-        <span class="me-auto">Menu</span>
-        <button class="btn btn-link p-0" aria-controls="doc-nav" [attr.aria-expanded]="!sidebarCollapsed"
-          aria-label="Toggle documentation navigation">
-          <svg class="align-middle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="30" height="30"
-            focusable="false">
-            <title>Menu</title>
-            <path stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10"
-              d="M4 7h22M4 15h22M4 23h22"></path>
-          </svg>
-        </button>
-      </div>
-      <ngbd-side-nav
-        id="doc-nav"
-        [ngbCollapse]="sidebarCollapsed"
-        class="d-lg-block py-3 collapse sidebar"
-      ></ngbd-side-nav>
-    </div>
+<div class="container-xxl bd-gutter mt-3 my-md-4 bd-layout">
+  <aside class="bd-sidebar">
+    <ngbd-side-nav
+      id="doc-nav"
+      class="d-none  d-lg-block py-3 collapse"
+    ></ngbd-side-nav>
+  </aside>
 
-    <div class="col-12 col-lg-10">
-      <header class="bg-light pt-4 pb-md-5 px-4 px-lg-5 d-flex d-md-block align-items-center title">
-        <h1 class="mb-4 me-auto me-md-none">{{ component | titlecase }}</h1>
+  <main class="bd-main order-1">
+    <div class="bd-intro pt-2 ps-lg-2">
+      <h1 class="mt-0">{{ component | titlecase }}</h1>
 
+      <header class="my-4 d-flex d-md-block align-items-center">
         <ul ngbNav [activeId]="this.activeTab"
-          class="nav-tabs px-4 px-lg-5 content-tabset justify-content-md-start justify-content-end">
-
+            class="nav-tabs px-2 justify-content-md-start justify-content-end">
           <li [ngbNavItem]="childRoute.path" *ngFor="let childRoute of route.routeConfig!.children">
             <a ngbNavLink [routerLink]="['.', childRoute.path]">
               {{ childRoute.path || '' | titlecase }}
             </a>
           </li>
-
-          <li ngbNavItem ngbDropdown placement="bottom-right"
-            class="align-self-center ms-0 ms-md-auto navigation-dropdown"
-            *ngIf="tableOfContents.length && isLargeScreenOrLess">
-            <span ngbDropdownToggle class="nav-link" title="Table of content">
-              <span class="visually-hidden">Table of content</span>
-              <svg aria-hidden="true" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
-                <path fill="currentColor"
-                  d="M464 32H48C21.49 32 0 53.49 0 80v352c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V80c0-26.51-21.49-48-48-48zm-6 400H54a6 6 0 0 1-6-6V86a6 6 0 0 1 6-6h404a6 6 0 0 1 6 6v340a6 6 0 0 1-6 6zm-42-92v24c0 6.627-5.373 12-12 12H204c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h200c6.627 0 12 5.373 12 12zm0-96v24c0 6.627-5.373 12-12 12H204c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h200c6.627 0 12 5.373 12 12zm0-96v24c0 6.627-5.373 12-12 12H204c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h200c6.627 0 12 5.373 12 12zm-252 12c0 19.882-16.118 36-36 36s-36-16.118-36-36 16.118-36 36-36 36 16.118 36 36zm0 96c0 19.882-16.118 36-36 36s-36-16.118-36-36 16.118-36 36-36 36 16.118 36 36zm0 96c0 19.882-16.118 36-36 36s-36-16.118-36-36 16.118-36 36-36 36 16.118 36 36z">
-                </path>
-              </svg>
-            </span>
-
-            <div class="dropdown-menu-end" ngbDropdownMenu>
-              <ng-template ngFor [ngForOf]="tableOfContents" let-topic>
-                <a *ngIf="topic.title else divider" class="dropdown-item" [routerLink]="['.', this.activeTab]"
-                  [fragment]="topic.fragment">{{topic.title}}</a>
-              </ng-template>
-              <ng-template #divider>
-                <div class="dropdown-divider"></div>
-              </ng-template>
-              <ng-container *ngIf="(bootstrapUrl$ | async) as boostrapUrl">
-                <div class="dropdown-divider"></div>
-                <a class="dropdown-item d-flex align-items-center" [href]="boostrapUrl" target="_blank" rel="nofollow noopener noreferrer">
-                  <svg:svg class="me-2" width="16" height="16" fill="currentColor" ngbdIcon="bootstrap" />
-                  {{ component | titlecase }} in Bootstrap
-                </a>
-              </ng-container>
-            </div>
-          </li>
         </ul>
       </header>
+    </div>
 
-      <section class="row py-5 px-2 px-md-4 px-lg-5">
-        <div class="col-12 col-xl-9 px-md-0 pe-xl-4">
-          <ng-template [ngComponentOutlet]="(headerComponentType$ | async)!"></ng-template>
-          <router-outlet (activate)="updateNavigation($event)"></router-outlet>
-        </div>
-
-        <div class="col-12 col-xl-3 d-none d-xl-block contextual-nav" *ngIf="!isLargeScreenOrLess">
-          <ul class="nav flex-column text-muted pt-4">
-            <li *ngFor="let topic of tableOfContents" class="nav-item">
-              <a *ngIf="topic.title else divider" class="nav-link" [routerLink]="['.', this.activeTab]"
-                [fragment]="topic.fragment">{{topic.title}}</a>
+    <div class="bd-toc mb-5 my-lg-0 ps-xl-3 mb-lg-5 text-muted">
+      <button class="btn btn-link link-dark p-md-0 mb-2 mb-md-0 text-decoration-none bd-toc-toggle d-md-none"
+              type="button" (click)="collapse.toggle()" aria-controls="tocContents">
+        On this page
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+             class="bi bi-chevron-expand ms-2" viewBox="0 0 16 16">
+          <path fill-rule="evenodd"
+                d="M3.646 9.146a.5.5 0 0 1 .708 0L8 12.793l3.646-3.647a.5.5 0 0 1 .708.708l-4 4a.5.5 0 0 1-.708 0l-4-4a.5.5 0 0 1 0-.708zm0-2.292a.5.5 0 0 0 .708 0L8 3.207l3.646 3.647a.5.5 0 0 0 .708-.708l-4-4a.5.5 0 0 0-.708 0l-4 4a.5.5 0 0 0 0 .708z"/>
+        </svg>
+      </button>
+      <strong class="d-none d-md-block h6 my-2">On this page</strong>
+      <hr class="d-none d-md-block my-2">
+      <div class="bd-toc-collapse" #collapse="ngbCollapse" [ngbCollapse]="false" id="tocContents">
+        <nav id="TableOfContents">
+          <ul>
+            <li *ngFor="let topic of tableOfContents">
+              <a *ngIf="topic.title else divider" [routerLink]="['.', this.activeTab]"
+                 [fragment]="topic.fragment">{{topic.title}}</a>
             </li>
-            <ng-template #divider>&nbsp;</ng-template>
+            <ng-template #divider>
+              <li>
+                <hr class="dropdown-divider">
+              </li>
+            </ng-template>
             <ng-container *ngIf="(bootstrapUrl$ | async) as boostrapUrl">
-              <li class="nav-item">
-                <a class="nav-link mt-3 mx-3 border-top pt-4 px-0 d-flex align-items-center" [href]="boostrapUrl"
-                  target="_blank" rel="nofollow noopener noreferrer"
-                  [attr.title]="'See ' + component + ' component on getbootstrap.com'"
-                >
-                  <svg:svg class="me-2" width="16" height="16" fill="currentColor" ngbdIcon="bootstrap" />
+              <li>
+                <hr class="d-none d-md-block my-4">
+              </li>
+              <li>
+                <a class="dropdown-item d-flex align-items-center" [href]="boostrapUrl" target="_blank"
+                   rel="nofollow noopener noreferrer">
+                  <svg:svg class="me-2" width="16" height="16" fill="currentColor" ngbdIcon="bootstrap"/>
                   {{ component | titlecase }} in Bootstrap
                 </a>
               </li>
             </ng-container>
           </ul>
-        </div>
-      </section>
-
+        </nav>
+      </div>
     </div>
-  </div>
+
+    <div class="bd-content ps-lg-2">
+      <ng-template [ngComponentOutlet]="(headerComponentType$ | async)!"></ng-template>
+      <router-outlet (activate)="updateNavigation($event)"></router-outlet>
+    </div>
+  </main>
 </div>

--- a/demo/src/app/shared/component-wrapper/component-wrapper.component.ts
+++ b/demo/src/app/shared/component-wrapper/component-wrapper.component.ts
@@ -1,14 +1,14 @@
-import {Component, NgZone, OnDestroy, Type} from '@angular/core';
-import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import {Component, OnDestroy, Type} from '@angular/core';
+import {ActivatedRoute, NavigationEnd, Router} from '@angular/router';
 import {Observable, Subscription} from 'rxjs';
-import { filter, map } from 'rxjs/operators';
+import {filter, map} from 'rxjs/operators';
 
-import { NgbdApiPage } from '../../components/shared/api-page/api.component';
-import { NgbdExamplesPage } from '../../components/shared/examples-page/examples.component';
+import {NgbdApiPage} from '../../components/shared/api-page/api.component';
+import {NgbdExamplesPage} from '../../components/shared/examples-page/examples.component';
 
-import { environment } from '../../../environments/environment';
+import {environment} from '../../../environments/environment';
 
-export type TableOfContents = {fragment: string, title: string}[];
+export type TableOfContents = { fragment: string, title: string }[];
 
 @Component({
   selector: 'component-wrapper',
@@ -25,14 +25,9 @@ export class ComponentWrapper implements OnDestroy {
   headerComponentType$: Observable<Type<any>>;
   bootstrapUrl$: Observable<string>;
 
-  isLargeScreenOrLess: boolean;
-  isSmallScreenOrLess: boolean;
-
-  sidebarCollapsed = true;
-
   tableOfContents: TableOfContents = [];
 
-  constructor(public route: ActivatedRoute, private _router: Router, ngZone: NgZone) {
+  constructor(public route: ActivatedRoute, private _router: Router) {
     // This component is used in route definition 'components'
     // So next child route will always be ':componentType' & next one will always be ':pageType' (or tab)
 
@@ -48,18 +43,6 @@ export class ComponentWrapper implements OnDestroy {
 
     this.headerComponentType$ = this.route.data.pipe(map(data => data?.header));
     this.bootstrapUrl$ = this.route.data.pipe(map(data => data?.bootstrap?.replace('%version%', environment.bootstrap)));
-
-    // information extracted from https://getbootstrap.com/docs/4.1/layout/overview/
-    // TODO: we should implements our own mediamatcher, according to bootstrap layout.
-    const smallScreenQL = matchMedia('(max-width: 767.98px)');
-    // eslint-disable-next-line deprecation/deprecation
-    smallScreenQL.addListener((event) => ngZone.run(() => this.isSmallScreenOrLess = event.matches));
-    this.isSmallScreenOrLess = smallScreenQL.matches;
-
-    const largeScreenQL = matchMedia('(max-width: 1199.98px)');
-    this.isLargeScreenOrLess = largeScreenQL.matches;
-    // eslint-disable-next-line deprecation/deprecation
-    largeScreenQL.addListener((event) => ngZone.run(() => this.isLargeScreenOrLess = event.matches));
   }
 
   ngOnDestroy() {
@@ -86,12 +69,12 @@ export class ComponentWrapper implements OnDestroy {
 
       if (component.classes.length > 0) {
         const klasses = getLinks(component.classes);
-        toc = toc.concat(toc.length > 0  ? [<any>{}, ...klasses] : klasses);
+        toc = toc.concat(toc.length > 0 ? [<any>{}, ...klasses] : klasses);
       }
 
       if (component.configs.length > 0) {
         const configs = getLinks(component.configs);
-        toc = toc.concat(toc.length > 0  ? [<any>{}, ...configs] : configs);
+        toc = toc.concat(toc.length > 0 ? [<any>{}, ...configs] : configs);
       }
 
       this.tableOfContents = toc;

--- a/demo/src/app/shared/index.ts
+++ b/demo/src/app/shared/index.ts
@@ -14,17 +14,18 @@ import {NgbdIcons} from './icons/icons.component';
 import {NgbdPageHeaderComponent} from './page-wrapper/page-header.component';
 import {PageWrapper} from './page-wrapper/page-wrapper.component';
 import {SideNavComponent} from './side-nav/side-nav.component';
+import {SideNavOffcanvasComponent} from "./side-nav/side-nav-offcanvas.component";
 
 export {componentsList} from './side-nav/side-nav.component';
 
 @NgModule({
   imports: [CommonModule, RouterModule, NgbModule],
   exports: [
-    CommonModule, RouterModule, ComponentWrapper, PageWrapper, NgbdPageHeaderComponent, NgbdFragment, SideNavComponent,
+    CommonModule, RouterModule, ComponentWrapper, PageWrapper, NgbdPageHeaderComponent, NgbdFragment, SideNavComponent, SideNavOffcanvasComponent,
     NgbdCodeComponent, NgbModule, FormsModule, ReactiveFormsModule, HttpClientModule, NgbdIcons
   ],
   declarations: [
-    ComponentWrapper, PageWrapper, NgbdPageHeaderComponent, NgbdFragment, SideNavComponent, NgbdCodeComponent, NgbdIcons
+    ComponentWrapper, PageWrapper, NgbdPageHeaderComponent, NgbdFragment, SideNavComponent, SideNavOffcanvasComponent, NgbdCodeComponent, NgbdIcons
   ],
   providers: [Analytics, CodeHighlightService]
 })

--- a/demo/src/app/shared/page-wrapper/page-wrapper.component.html
+++ b/demo/src/app/shared/page-wrapper/page-wrapper.component.html
@@ -1,66 +1,38 @@
-<div class="container-fluid">
-  <div class="row flex-xl-nowrap">
-    <div class="col-12 col-lg-2"
-       style="border-right: 1px solid rgba(0, 0, 0, 0.1)">
-      <div
-        class="d-lg-none d-flex py-2 px-4 align-items-center text-body sidebar-collapsed"
-        (click)="sidebarCollapsed = !sidebarCollapsed"
-        role="button"
-      >
-        <span class="me-auto">Menu</span>
-        <button
-          class="btn btn-link p-0"
-          aria-controls="doc-nav"
-          [attr.aria-expanded]="!sidebarCollapsed"
-          aria-label="Toggle documentation navigation"
-        >
-          <svg class="align-middle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" width="30" height="30" focusable="false"><title>Menu</title><path stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-miterlimit="10" d="M4 7h22M4 15h22M4 23h22"></path></svg>
-        </button>
-      </div>
-      <ngbd-side-nav
-        id="doc-nav"
-        [ngbCollapse]="sidebarCollapsed"
-        class="d-lg-block my-3 collapse sidebar"
-      ></ngbd-side-nav>
+<div class="container-xxl bd-gutter mt-3 my-md-4 bd-layout">
+  <aside class="bd-sidebar">
+    <ngbd-side-nav
+      id="doc-nav"
+      class="d-none d-lg-block my-3"
+    ></ngbd-side-nav>
+  </aside>
+
+  <main class="bd-main order-1">
+    <div class="bd-intro pt-2 ps-lg-2">
+      <h1 class="mt-0">{{ pageTitle }}</h1>
     </div>
-
-    <div class="col-12 col-lg-10">
-      <header class="bg-light pt-4 pb-md-5 px-4 px-lg-5 d-flex d-md-block align-items-center title">
-        <h1 class="mt-0">{{ pageTitle }}</h1>
-
-        <ul class="nav nav-tabs px-4 px-lg-5 content-tabset justify-content-md-start justify-content-end">
-
-          <li
-            ngbDropdown placement="bottom-right"
-            class="nav-item align-self-center ms-0 ms-md-auto navigation-dropdown"
-            *ngIf="tableOfContents.length && isLargeScreenOrLess"
-          >
-            <span ngbDropdownToggle class="nav-link" title="Table of contents">
-              <span class="visually-hidden">Table of content</span>
-              <svg aria-hidden="true" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M464 32H48C21.49 32 0 53.49 0 80v352c0 26.51 21.49 48 48 48h416c26.51 0 48-21.49 48-48V80c0-26.51-21.49-48-48-48zm-6 400H54a6 6 0 0 1-6-6V86a6 6 0 0 1 6-6h404a6 6 0 0 1 6 6v340a6 6 0 0 1-6 6zm-42-92v24c0 6.627-5.373 12-12 12H204c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h200c6.627 0 12 5.373 12 12zm0-96v24c0 6.627-5.373 12-12 12H204c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h200c6.627 0 12 5.373 12 12zm0-96v24c0 6.627-5.373 12-12 12H204c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h200c6.627 0 12 5.373 12 12zm-252 12c0 19.882-16.118 36-36 36s-36-16.118-36-36 16.118-36 36-36 36 16.118 36 36zm0 96c0 19.882-16.118 36-36 36s-36-16.118-36-36 16.118-36 36-36 36 16.118 36 36zm0 96c0 19.882-16.118 36-36 36s-36-16.118-36-36 16.118-36 36-36 36 16.118 36 36z"></path></svg>
-            </span>
-
-            <div class="dropdown-menu-end" ngbDropdownMenu>
-              <a *ngFor="let topic of tableOfContents"
-                 class="dropdown-item" routerLink="." [fragment]="topic.fragment">{{topic.title}}</a>
-            </div>
-          </li>
-        </ul>
-      </header>
-
-      <section class="row py-5 px-2 px-md-4 px-lg-5">
-        <div class="col-12 col-xl-9 px-md-0 pe-xl-4">
-          <ng-content></ng-content>
-        </div>
-
-        <div class="col-12 col-xl-3 d-none d-xl-block contextual-nav">
-          <ul class="nav flex-column text-muted pt-4">
-            <li *ngFor="let topic of tableOfContents" class="nav-item">
-              <a [id]="topic.fragment" class="nav-link" routerLink="." [fragment]="topic.fragment">{{topic.title}}</a>
+    <div class="bd-toc mb-5 my-lg-0 ps-xl-3 mb-lg-5 text-muted">
+      <button class="btn btn-link link-dark p-md-0 mb-2 mb-md-0 text-decoration-none bd-toc-toggle d-md-none"
+              type="button" (click)="collapse.toggle()" aria-controls="tocContents">
+        On this page
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-expand ms-2" viewBox="0 0 16 16">
+          <path fill-rule="evenodd" d="M3.646 9.146a.5.5 0 0 1 .708 0L8 12.793l3.646-3.647a.5.5 0 0 1 .708.708l-4 4a.5.5 0 0 1-.708 0l-4-4a.5.5 0 0 1 0-.708zm0-2.292a.5.5 0 0 0 .708 0L8 3.207l3.646 3.647a.5.5 0 0 0 .708-.708l-4-4a.5.5 0 0 0-.708 0l-4 4a.5.5 0 0 0 0 .708z"/>
+        </svg>
+      </button>
+      <strong class="d-none d-md-block h6 my-2">On this page</strong>
+      <hr class="d-none d-md-block my-2">
+      <div class="bd-toc-collapse" #collapse="ngbCollapse" [ngbCollapse]="false" id="tocContents">
+        <nav id="TableOfContents">
+          <ul>
+            <li *ngFor="let topic of tableOfContents">
+              <a routerLink="." [fragment]="topic.fragment">{{topic.title}}</a>
             </li>
           </ul>
-        </div>
-      </section>
+        </nav>
+      </div>
     </div>
-  </div>
+
+    <div class="bd-content ps-lg-2">
+      <ng-content></ng-content>
+    </div>
+  </main>
 </div>

--- a/demo/src/app/shared/page-wrapper/page-wrapper.component.ts
+++ b/demo/src/app/shared/page-wrapper/page-wrapper.component.ts
@@ -1,4 +1,4 @@
-import {Component, ContentChildren, Input, NgZone, QueryList} from '@angular/core';
+import {Component, ContentChildren, Input, QueryList} from '@angular/core';
 import {NgbdPageHeaderComponent} from './page-header.component';
 import {TableOfContents} from '../component-wrapper/component-wrapper.component';
 
@@ -10,16 +10,6 @@ export class PageWrapper {
   @Input() pageTitle: string;
 
   @ContentChildren(NgbdPageHeaderComponent) private _tableOfContents: QueryList<NgbdPageHeaderComponent>;
-
-  sidebarCollapsed = true;
-  isLargeScreenOrLess: boolean;
-
-  constructor(ngZone: NgZone) {
-    const largeScreenQL = matchMedia('(max-width: 1199.98px)');
-    this.isLargeScreenOrLess = largeScreenQL.matches;
-    // eslint-disable-next-line deprecation/deprecation
-    largeScreenQL.addListener((event) => ngZone.run(() => this.isLargeScreenOrLess = event.matches));
-  }
 
   get tableOfContents(): TableOfContents {
     return this._tableOfContents ? this._tableOfContents.toArray() : [];

--- a/demo/src/app/shared/side-nav/side-nav-offcanvas.component.ts
+++ b/demo/src/app/shared/side-nav/side-nav-offcanvas.component.ts
@@ -1,0 +1,17 @@
+import {Component} from '@angular/core';
+import {Router} from '@angular/router';
+import {NgbActiveOffcanvas} from "@ng-bootstrap/ng-bootstrap";
+import {SideNavComponent} from "./side-nav.component";
+
+@Component({
+  selector: 'ngbd-side-nav-offcanvas',
+  templateUrl: './side-nav.component.html',
+})
+export class SideNavOffcanvasComponent extends SideNavComponent {
+  public activeOffcanvas: NgbActiveOffcanvas | undefined;
+
+  constructor(router: Router, activeOffcanvas: NgbActiveOffcanvas) {
+    super(router);
+    this.activeOffcanvas = activeOffcanvas;
+  }
+}

--- a/demo/src/app/shared/side-nav/side-nav.component.html
+++ b/demo/src/app/shared/side-nav/side-nav.component.html
@@ -1,35 +1,89 @@
-<nav class="toc py-3">
-  <div class="toc-item mb-2" [class.active]="isActive(['/getting-started'])">
-    <a class="toc-link" routerLink="/getting-started">Getting Started</a>
+<div tabindex="-1" id="bdSideNav" class="offcanvas-lg offcanvas-start show" aria-labelledby="bdSidebarOffcanvasLabel"
+     aria-modal="true" role="dialog">
+  <div class="offcanvas-header pb-2 d-lg-none border-bottom">
+    <h5 class="offcanvas-title text-black" id="bdSidebarOffcanvasLabel">Browse docs</h5>
+    <button type="button" class="btn-close btn-close" aria-label="Close"
+            (click)="activeOffcanvas?.dismiss()"></button>
   </div>
 
-  <div class="toc-item mb-2" [class.active]="isActive(['/guides'])">
-    <a class="toc-link" [routerLink]="['/animations']">Guides</a>
-    <ul [ngbCollapse]="!isActive(['/guides'])" class="nav flex-column">
-      <li [class.active]="isActive(['/guides', 'animations'])">
-        <a class="toc-link d-inline-flex align-items-center" routerLink="/guides/animations">Animations</a>
-      </li>
-      <li [class.active]="isActive(['/guides', 'i18n'])">
-        <a class="toc-link" routerLink="/guides/i18n">Internationalization</a>
-      </li>
-      <li [class.active]="isActive(['/guides', 'positioning'])">
-        <a class="toc-link" routerLink="/guides/positioning">Positioning</a>
-      </li>
-    </ul>
+  <div [class.offcanvas-body]="activeOffcanvas">
+    <nav class="bd-links w-100" id="bd-docs-nav" aria-label="Docs navigation">
+      <ul class="bd-links-nav list-unstyled mb-0 pb-3 pb-md-2 pe-lg-2">
+        <li class="bd-links-group py-2">
+          <strong class="bd-links-heading d-flex w-100 align-items-center fw-semibold">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+                 class="bi bi-play-circle-fill me-2" viewBox="0 0 16 16" style="color: var(--bs-indigo);">
+              <path
+                d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM6.79 5.093A.5.5 0 0 0 6 5.5v5a.5.5 0 0 0 .79.407l3.5-2.5a.5.5 0 0 0 0-.814l-3.5-2.5z"/>
+            </svg>
+            <a class="d-inline-block rounded text-decoration-none text-black" routerLink="/getting-started"
+               (click)="onLinkClick()">Getting
+              Started</a>
+          </strong>
+
+          <ul class="list-unstyled fw-normal pb-2 small" [ngbCollapse]="!isActive(['/getting-started'])">
+            <li>
+              <a class="bd-links-link d-inline-block rounded" [class.active]="isActive(['/getting-started'])"
+                 routerLink="/getting-started" (click)="onLinkClick()">Introduction</a>
+            </li>
+          </ul>
+        </li>
+
+        <li class="bd-links-group py-2">
+          <strong class="bd-links-heading d-flex w-100 align-items-center fw-semibold">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+                 class="bi bi-book-half me-2"
+                 viewBox="0 0 16 16">
+              <path
+                d="M8.5 2.687c.654-.689 1.782-.886 3.112-.752 1.234.124 2.503.523 3.388.893v9.923c-.918-.35-2.107-.692-3.287-.81-1.094-.111-2.278-.039-3.213.492V2.687zM8 1.783C7.015.936 5.587.81 4.287.94c-1.514.153-3.042.672-3.994 1.105A.5.5 0 0 0 0 2.5v11a.5.5 0 0 0 .707.455c.882-.4 2.303-.881 3.68-1.02 1.409-.142 2.59.087 3.223.877a.5.5 0 0 0 .78 0c.633-.79 1.814-1.019 3.222-.877 1.378.139 2.8.62 3.681 1.02A.5.5 0 0 0 16 13.5v-11a.5.5 0 0 0-.293-.455c-.952-.433-2.48-.952-3.994-1.105C10.413.809 8.985.936 8 1.783z"/>
+            </svg>
+            <a class="d-inline-block rounded text-decoration-none text-black" routerLink="/guides/animations"
+               (click)="onLinkClick()">Guides</a>
+          </strong>
+
+          <ul class="list-unstyled fw-normal pb-2 small" [ngbCollapse]="!isActive(['/guides'])">
+            <li>
+              <a class="bd-links-link d-inline-block rounded" [class.active]="isActive(['/guides', 'animations'])"
+                 routerLink="/guides/animations" (click)="onLinkClick()">Animations</a>
+            </li>
+            <li>
+              <a class="bd-links-link d-inline-block rounded" [class.active]="isActive(['/guides', 'i18n'])"
+                 routerLink="/guides/i18n" (click)="onLinkClick()">Internationalization</a>
+            </li>
+            <li>
+              <a class="bd-links-link d-inline-block rounded" [class.active]="isActive(['/guides', 'positioning'])"
+                 routerLink="/guides/positioning" (click)="onLinkClick()">Positioning</a>
+            </li>
+          </ul>
+        </li>
+
+        <li class="bd-links-group py-2">
+          <strong class="bd-links-heading d-flex w-100 align-items-center fw-semibold">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+                 class="bi bi-grid-1x2-fill me-2" viewBox="0 0 16 16" style="color: var(--bs-indigo);">
+              <path
+                d="M0 1a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1V1zm9 0a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1h-5a1 1 0 0 1-1-1V1zm0 9a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1h-5a1 1 0 0 1-1-1v-5z"/>
+            </svg>
+            <a class="d-inline-block rounded text-decoration-none text-black" routerLink="/components"
+               (click)="onLinkClick()">Components</a>
+          </strong>
+
+          <ul class="list-unstyled fw-normal pb-2 small" [ngbCollapse]="!isActive(['/components'])">
+            <li *ngFor="let component of components">
+              <a class="bd-links-link d-inline-block rounded"
+                 [class.active]="isActive(['/components', component.toLowerCase()])"
+                 [routerLink]="['/components', component.toLowerCase()]" (click)="onLinkClick()">{{ component }}</a>
+            </li>
+            <li *ngFor="let component of deprecatedComponents">
+              <a class="bd-links-link d-inline-block rounded"
+                 [class.active]="isActive(['/components', component.toLowerCase()])"
+                 [routerLink]="['/components', component.toLowerCase()]" (click)="onLinkClick()">{{ component }}</a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </nav>
   </div>
 
-  <div class="toc-item mb-2" [class.active]="isActive(['/components'])">
-    <a class="toc-link" [routerLink]="['/components']">Components</a>
-    <ul [ngbCollapse]="!isActive(['/components'])" class="nav flex-column">
-      <li *ngFor="let component of components"
-        [class.active]="isActive(['/components', component.toLowerCase()])">
-        <a class="toc-link" [routerLink]="['/components', component.toLowerCase()]">{{ component }}</a>
-      </li>
-      <li *ngFor="let component of deprecatedComponents"
-          [class.active]="isActive(['/components', component.toLowerCase()])">
-        <a class="toc-link deprecated" [routerLink]="['/components', component.toLowerCase()]">{{ component }}</a>
-      </li>
-    </ul>
-  </div>
+</div>
 
-</nav>

--- a/demo/src/app/shared/side-nav/side-nav.component.ts
+++ b/demo/src/app/shared/side-nav/side-nav.component.ts
@@ -1,5 +1,6 @@
 import {Component} from '@angular/core';
 import {Router} from '@angular/router';
+import {NgbActiveOffcanvas} from "@ng-bootstrap/ng-bootstrap";
 
 export const componentsList = [
   'Accordion', 'Alert', 'Carousel', 'Collapse', 'Datepicker', 'Dropdown', 'Modal', 'Nav', 'Offcanvas', 'Pagination',
@@ -16,6 +17,8 @@ export class SideNavComponent {
   components = componentsList;
   deprecatedComponents = deprecatedComponentList;
 
+  public activeOffcanvas: NgbActiveOffcanvas | undefined;
+
   constructor(private router: Router) {}
 
   isActive(currentRoute: any[]): boolean {
@@ -25,5 +28,9 @@ export class SideNavComponent {
       fragment: 'ignored',
       matrixParams: 'ignored'
     });
+  }
+
+  onLinkClick(): void {
+    this.activeOffcanvas?.close();
   }
 }

--- a/demo/src/style/app.scss
+++ b/demo/src/style/app.scss
@@ -1,7 +1,20 @@
 // styles in src/style directory are applied to the whole page
 
-header.navbar {
+@import "node_modules/bootstrap/scss/_functions.scss";
+@import "node_modules/bootstrap/scss/_variables.scss";
+@import "node_modules/bootstrap/scss/_mixins.scss";
+
+// Load docs components
+@import "variables";
+@import "navbar";
+@import "content";
+@import "sidebar";
+@import "layout";
+@import "toc";
+
+.bdNavbarBody {
   background: linear-gradient(135deg, #0143a3, #0273d4);
+  border-left: 0;
 }
 
 .masthead-followup {
@@ -24,160 +37,6 @@ header.navbar {
     font-weight: 500;
     color: #000;
     text-decoration: underline;
-  }
-}
-
-.social-buttons {
-  font-size: x-small;
-  a {
-    color: #fff;
-    text-decoration: none;
-  }
-
-  svg {
-    fill: currentColor;
-  }
-}
-
-.sidebar-collapsed {
-  margin-left: calc(var(--bs-gutter-x) * -0.5);
-  margin-right: calc(var(--bs-gutter-x) * -0.5);
-  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-}
-
-.sidebar {
-  position: sticky;
-  top: 1rem;
-  max-height: calc(100vh - 4rem);
-  margin-right: calc(var(--bs-gutter-x) * -0.5);
-  overflow-x: hidden;
-  overflow-y: auto;
-  z-index: 1;
-
-  a {
-    text-decoration: none;
-  }
-}
-
-header.title {
-  margin-left: calc(var(--bs-gutter-x) * -0.5);
-  margin-right: calc(var(--bs-gutter-x) * -0.5);
-  position: relative;
-
-  .content-tabset {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-
-    .nav-link {
-      border-style: solid;
-      border-width: 3px 1px 1px;
-      border-radius: 3px 3px 0 0;
-    }
-
-    .nav-link:not(.active):hover {
-      border-color: transparent;
-    }
-
-    .active {
-      border-top-color: #28a745;
-    }
-
-    .navigation-dropdown {
-      cursor: pointer;
-
-      .nav-link {
-        padding-right: 0.3rem;
-        line-height: 1em;
-        border-color: transparent;
-        background: none;
-        color: #007bff;
-        &:hover {
-          color: #0056b3;
-        }
-      }
-
-      .dropdown-toggle:after {
-        display: none;
-      }
-
-      .dropdown-menu {
-        border-color: #d9d9d9;
-      }
-
-      svg {
-        width: 22px;
-        height: 22px;
-      }
-
-      &.show {
-        .nav-link {
-          color: #0056b3;
-        }
-      }
-    }
-  }
-}
-
-.toc {
-  margin-left: 15px;
-//   margin-right: -15px;
-  font-size: 1.1rem;
-
-  .toc-item {
-    .toc-link {
-//       display: block;
-//       padding: 0.25rem 1.5rem;
-      color: rgba(0, 0, 0, 0.65);
-
-      &.deprecated {
-        text-decoration: line-through !important;
-
-        &:first-child {
-          margin-top: 0.5rem;
-        }
-      }
-    }
-
-    .nav > li > a {
-      font-size: 0.85em;
-      display: inline-block;
-
-      &:hover,
-      &:focus {
-        text-decoration: none;
-        margin-left: -0.5rem;
-        padding: 0 0.5rem;
-        background-color: #f8f9fa;
-        border-radius: 3px;
-      }
-    }
-
-    .nav > li.active > a {
-      font-weight: 500;
-      color: rgba(0, 0, 0, 0.85);
-    }
-
-    &.active > .toc-link {
-      font-weight: 500;
-      color: rgba(0, 0, 0, 0.85);
-    }
-  }
-}
-
-.contextual-nav .nav {
-  position: sticky;
-  top: 0;
-
-  a {
-    color: inherit;
-    font-size: 90%;
-    padding: 0.25rem 1rem;
-  }
-
-  a:hover {
-    color: #0275d8;
   }
 }
 
@@ -220,6 +79,7 @@ div.api-doc-component,
       .github-link {
         opacity: 1;
       }
+
       & > .title-fragment {
         opacity: 1;
       }
@@ -229,6 +89,7 @@ div.api-doc-component,
   section,
   ngbd-overview-section {
     margin-top: 3rem;
+
     h4 {
       margin-top: 2rem;
       margin-bottom: 1rem;
@@ -237,6 +98,7 @@ div.api-doc-component,
     .meta {
       font-size: 0.8rem;
       margin-bottom: 1rem;
+
       > div {
         margin-bottom: 0.5rem;
       }
@@ -276,6 +138,7 @@ a.title-fragment:focus {
 
 div.component-demo {
   margin-bottom: 3rem;
+
   h2 {
     display: flex;
     margin-bottom: 1rem;
@@ -320,6 +183,7 @@ div.component-demo {
 
       .nav-link:not(.active) {
         color: #999;
+
         &:hover {
           color: #666;
         }

--- a/demo/src/style/content.scss
+++ b/demo/src/style/content.scss
@@ -1,0 +1,73 @@
+/*!
+ * Bootstrap  v5.2.0 (https://getbootstrap.com/)
+ * Copyright 2011-2022 The Bootstrap Authors
+ * Copyright 2011-2022 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
+ */
+
+.bd-content {
+  // Offset content from fixed navbar when jumping to headings
+  > :target {
+    padding-top: 5rem;
+    margin-top: -5rem;
+  }
+
+  > h2:not(:first-child) {
+    margin-top: 3rem;
+  }
+
+  > h3 {
+    margin-top: 2rem;
+  }
+
+  > ul li,
+  > ol li {
+    margin-bottom: .25rem;
+
+    // stylelint-disable selector-max-type, selector-max-compound-selectors
+    > p ~ ul {
+      margin-top: -.5rem;
+      margin-bottom: 1rem;
+    }
+    // stylelint-enable selector-max-type, selector-max-compound-selectors
+  }
+}
+
+.bd-title {
+  @include font-size(3rem);
+}
+
+.bd-lead {
+  @include font-size(1.5rem);
+  font-weight: 300;
+}
+
+.bd-bg-violet {
+  background-color: $bd-violet;
+}
+
+.bi {
+  width: 1em;
+  height: 1em;
+  fill: currentcolor;
+}
+
+.icon-link {
+  display: flex;
+  align-items: center;
+  text-decoration-color: rgba($primary, .5);
+  text-underline-offset: .5rem;
+  backface-visibility: hidden;
+
+  .bi {
+    width: 1.5em;
+    height: 1.5em;
+    transition: .2s ease-in-out transform; // stylelint-disable-line property-disallowed-list
+  }
+
+  &:hover {
+    .bi {
+      transform: translate3d(5px, 0, 0);
+    }
+  }
+}

--- a/demo/src/style/layout.scss
+++ b/demo/src/style/layout.scss
@@ -1,0 +1,64 @@
+/*!
+ * Bootstrap  v5.2.0 (https://getbootstrap.com/)
+ * Copyright 2011-2022 The Bootstrap Authors
+ * Copyright 2011-2022 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
+ */
+
+.bd-gutter {
+  --bs-gutter-x: #{$bd-gutter-x};
+}
+
+.bd-layout {
+
+  @include media-breakpoint-up(lg) {
+    display: grid;
+    grid-template-areas: "sidebar main";
+    grid-template-columns: 1fr 5fr;
+    gap: $grid-gutter-width;
+  }
+}
+
+.bd-sidebar {
+  grid-area: sidebar;
+}
+
+.bd-main {
+  grid-area: main;
+
+  @include media-breakpoint-down(lg) {
+    max-width: 760px;
+    margin-inline: auto;
+  }
+
+  @include media-breakpoint-up(md) {
+    display: grid;
+    grid-template-areas:
+      "intro"
+      "toc"
+      "content";
+    grid-template-rows: auto auto 1fr;
+    gap: inherit;
+  }
+
+  @include media-breakpoint-up(lg) {
+    grid-template-areas:
+      "intro   toc"
+      "content toc";
+    grid-template-rows: auto 1fr;
+    grid-template-columns: 4fr 1fr;
+  }
+}
+
+.bd-intro {
+  grid-area: intro;
+}
+
+.bd-toc {
+  grid-area: toc;
+}
+
+.bd-content {
+  grid-area: content;
+  min-width: 1px; // Fix width when bd-content contains a `<pre>` https://github.com/twbs/bootstrap/issues/25410
+}

--- a/demo/src/style/navbar.scss
+++ b/demo/src/style/navbar.scss
@@ -1,0 +1,97 @@
+/*!
+ * Bootstrap  v5.2.0 (https://getbootstrap.com/)
+ * Copyright 2011-2022 The Bootstrap Authors
+ * Copyright 2011-2022 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
+ */
+
+.bd-navbar {
+  padding: .75rem 0;
+  background: transparent linear-gradient(135deg, #0143a3, #0273d4);
+  box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .15), inset 0 -1px 0 rgba(0, 0, 0, .15);
+
+  .bd-navbar-toggle {
+    @include media-breakpoint-down(lg) {
+      width: 4.25rem;
+    }
+  }
+
+  .navbar-toggler {
+    padding: 0;
+    margin-right: -.5rem;
+    border: 0;
+
+    &:first-child {
+      margin-left: -.5rem;
+    }
+
+    .bi {
+      width: 1.5rem;
+      height: 1.5rem;
+    }
+
+    &:focus {
+      box-shadow: none;
+    }
+  }
+
+  .navbar-brand {
+    transition: .2s ease-in-out transform; // stylelint-disable-line property-disallowed-list
+
+    &:hover {
+      transform: rotate(+5deg) scale(1.1);
+    }
+  }
+
+  .navbar-toggler,
+  .nav-link {
+    padding-right: $spacer * .25;
+    padding-left: $spacer * .25;
+    color: rgba($white, .85);
+
+    &:hover,
+    &:focus {
+      color: $white;
+    }
+
+    &.active {
+      font-weight: 600;
+      color: $white;
+    }
+  }
+
+  .navbar-nav-svg {
+    display: inline-block;
+    vertical-align: -.125rem;
+  }
+
+  .offcanvas-lg {
+    background-color: var(--bd-violet);
+    border-left: 0;
+
+    @include media-breakpoint-down(lg) {
+      box-shadow: $box-shadow-lg;
+    }
+  }
+
+  .dropdown-toggle {
+    &:focus:not(:focus-visible) {
+      outline: 0;
+    }
+  }
+
+  .dropdown-menu {
+    --#{$prefix}dropdown-min-width: 12rem;
+    --#{$prefix}dropdown-link-hover-bg: rgba(var(--bd-violet-rgb), .1);
+    @include rfs(.875rem, --#{$prefix}dropdown-font-size);
+    box-shadow: $dropdown-box-shadow;
+  }
+
+  .dropdown-item.current {
+    font-weight: 600;
+    background-image: escape-svg($dropdown-active-icon);
+    background-repeat: no-repeat;
+    background-position: right $dropdown-item-padding-x top .6rem;
+    background-size: .75rem .75rem;
+  }
+}

--- a/demo/src/style/sidebar.scss
+++ b/demo/src/style/sidebar.scss
@@ -1,0 +1,60 @@
+/*!
+ * Bootstrap  v5.2.0 (https://getbootstrap.com/)
+ * Copyright 2011-2022 The Bootstrap Authors
+ * Copyright 2011-2022 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
+ */
+
+.bd-sidebar {
+  @include media-breakpoint-up(lg) {
+    position: sticky;
+    top: 5rem;
+    // Override collapse behaviors
+    // stylelint-disable-next-line declaration-no-important
+    display: block !important;
+    height: subtract(100vh, 6rem);
+    // Prevent focus styles to be cut off:
+    padding-left: .25rem;
+    margin-left: -.25rem;
+    overflow-y: auto;
+  }
+}
+
+.bd-links-nav {
+  @include media-breakpoint-down(lg) {
+    font-size: .875rem;
+  }
+
+  @include media-breakpoint-between(xs, lg) {
+    column-count: 1;
+    column-gap: 1.5rem;
+
+    .bd-links-group {
+      break-inside: avoid;
+    }
+
+    .bd-links-span-all {
+      column-span: all;
+    }
+  }
+}
+
+.bd-links-link {
+  padding: .1875rem .5rem;
+  margin-top: .125rem;
+  margin-left: 1rem;
+  color: rgba($black, .65);
+  text-decoration: if($link-decoration == none, null, none);
+
+  &:hover,
+  &:focus,
+  &.active {
+    color: rgba($black, .85);
+    text-decoration: if($link-hover-decoration == underline, none, null);
+    background-color: rgba(var(--bd-violet-rgb), .1);
+  }
+
+  &.active {
+    font-weight: 600;
+  }
+}

--- a/demo/src/style/toc.scss
+++ b/demo/src/style/toc.scss
@@ -1,0 +1,92 @@
+/*!
+ * Bootstrap  v5.2.0 (https://getbootstrap.com/)
+ * Copyright 2011-2022 The Bootstrap Authors
+ * Copyright 2011-2022 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
+ */
+
+.bd-toc {
+  @include media-breakpoint-up(lg) {
+    position: sticky;
+    top: 5rem;
+    right: 0;
+    z-index: 2;
+    height: subtract(100vh, 7rem);
+    overflow-y: auto;
+  }
+
+  nav {
+    @include font-size(.875rem);
+
+    ul {
+      padding-left: 0;
+      margin-bottom: 0;
+      list-style: none;
+
+      ul {
+        padding-left: 1rem;
+        margin-top: .25rem;
+      }
+    }
+
+    li {
+      margin-bottom: .35rem;
+    }
+
+    a {
+      color: inherit;
+
+      &:not(:hover) {
+        text-decoration: none;
+      }
+
+      code {
+        font: inherit;
+      }
+    }
+  }
+}
+
+.bd-toc-toggle {
+  display: flex;
+  align-items: center;
+
+  @include media-breakpoint-down(sm) {
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  @include media-breakpoint-down(md) {
+    border: 1px solid $border-color;
+    @include border-radius(.4rem);
+
+    &:hover,
+    &:focus,
+    &:active,
+    &[aria-expanded="true"] {
+      color: var(--bd-violet);
+      background-color: $white;
+      border-color: var(--bd-violet);
+    }
+
+    &:focus,
+    &[aria-expanded="true"] {
+      box-shadow: 0 0 0 3px rgba(var(--bd-violet-rgb), .25);
+    }
+  }
+}
+
+.bd-toc-collapse {
+  @include media-breakpoint-down(md) {
+    nav {
+      padding: 1.25rem;
+      background-color: var(--bs-gray-100);
+      border: 1px solid $border-color;
+      @include border-radius(.25rem);
+    }
+  }
+
+  @include media-breakpoint-up(md) {
+    display: block !important; // stylelint-disable-line declaration-no-important
+  }
+}

--- a/demo/src/style/variables.scss
+++ b/demo/src/style/variables.scss
@@ -1,0 +1,23 @@
+/*!
+ * Bootstrap  v5.2.0 (https://getbootstrap.com/)
+ * Copyright 2011-2022 The Bootstrap Authors
+ * Copyright 2011-2022 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
+ */
+
+// Local docs variables
+$bd-purple:        #0259b9;
+$bd-violet:        lighten(saturate($bd-purple, 5%), 15%); // stylelint-disable-line function-disallowed-list
+$bd-purple-light:  lighten(saturate($bd-purple, 5%), 45%); // stylelint-disable-line function-disallowed-list
+$bd-accent:       #ffe484;
+$dropdown-active-icon: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'><path fill='#292b2c' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/></svg>");
+
+$bd-gutter-x: 3rem;
+
+:root {
+  --bd-purple: #{$bd-purple};
+  --bd-violet: #{$bd-violet};
+  --bd-accent: #{$bd-accent};
+  --bd-violet-rgb: #{to-rgb($bd-violet)};
+  --bd-accent-rgb: #{to-rgb($bd-accent)};
+}


### PR DESCRIPTION
Hello!

I've updated the ng-bootstrap demo page to a more modern look and to be more similar to the new bootstrap docs design.

The pr is mostly restructuring work and implementing bootstrap docs scss.
I hope this isn't frowned upon.

Would be glad for feedback or suggestions! Also if this isn't needed or wanted, no worries.

Sreenshots:
![image](https://user-images.githubusercontent.com/16242839/185106256-3250947d-d6dd-43b5-b9dc-5c1ec0b27dac.png)

![image](https://user-images.githubusercontent.com/16242839/185106330-3ef2f92c-79de-4e6d-b5c9-42faa2dde2fb.png)

![image](https://user-images.githubusercontent.com/16242839/185106407-d34b3af0-4fdb-46d7-9f7b-0919dfa37b78.png)

![image](https://user-images.githubusercontent.com/16242839/185106497-11a3f9bb-e1ef-4ebf-813b-014a1c9b5ff6.png)

![image](https://user-images.githubusercontent.com/16242839/185107892-677795b2-f5ff-425e-a565-fd7fff40ee28.png)

![image](https://user-images.githubusercontent.com/16242839/185107954-7ad5f6a2-eb95-434f-96d5-2c3c26d380db.png)

![image](https://user-images.githubusercontent.com/16242839/185107984-df21de59-5122-4316-acdc-d55c081952de.png)

![image](https://user-images.githubusercontent.com/16242839/185110111-13895e85-8469-45bb-956a-235911c94bef.png)

![image](https://user-images.githubusercontent.com/16242839/185107791-7e44ee99-cdd5-4c95-9dbb-7568d4188c9b.png)
