### PR TITLE
fix(collapse): restore previous transition logic

### DIFF
--- a/demo/src/app/components/collapse/demos/horizontal/collapse-horizontal.html
+++ b/demo/src/app/components/collapse/demos/horizontal/collapse-horizontal.html
@@ -5,7 +5,7 @@
   </button>
 </p>
 <div style="min-height: 100px;">
-  <div #collapse="ngbCollapse" [(ngbCollapse)]="isCollapsed" [horizontal]="true">
+  <div #collapse="ngbCollapse" [(ngbCollapse)]="isCollapsed" [horizontal]="true" style="max-width:300px;">
     <div class="card" style="width: 300px;">
       <div class="card-body">
         You can collapse horizontally this card by clicking Toggle

--- a/src/util/transition/ngbCollapseTransition.ts
+++ b/src/util/transition/ngbCollapseTransition.ts
@@ -49,36 +49,26 @@ export const ngbCollapsingTransition: NgbTransitionStartFn<NgbCollapseCtx> =
         return;
       }
 
-      if (direction === 'show') {
-        // Fix the dimension before starting the animation
-        element.style[dimension] = '0px';
+      // No maxHeight -> running the transition for the first time
+      if (!maxSize) {
+        maxSize = measureCollapsingElementDimensionPx(element, dimension);
+        context.maxSize = maxSize;
+
+        // Fix the height before starting the animation
+        element.style[dimension] = direction !== 'show' ? maxSize : '0px';
+
         classList.remove('collapse');
+        classList.remove('collapsing');
+        classList.remove('show');
+
+        reflow(element);
 
         // Start the animation
         classList.add('collapsing');
-
-        const scrollDimension = `scroll${dimension[0].toUpperCase()}${dimension.slice(1)}`;
-        element.style[dimension] = element[scrollDimension] + 'px';
-      } else {
-        // No maxSize -> running the transition for the first time
-        if (!maxSize) {
-          maxSize = measureCollapsingElementDimensionPx(element, dimension);
-          context.maxSize = maxSize;
-
-          // Fix the height before starting the animation
-          element.style[dimension] = maxSize;
-
-          classList.remove('collapse');
-          classList.remove('collapsing');
-          classList.remove('show');
-
-          reflow(element);
-
-          // Start the animation
-          classList.add('collapsing');
-        }
-        element.style[dimension] = '0px';
       }
+
+      // Start or revert the animation
+      element.style[dimension] = direction === 'show' ? maxSize : '0px';
 
       return () => {
         setInitialClasses();


### PR DESCRIPTION
This PR restores the previous collapse transition logic that was changed with #4370.

Without this PR, the show and hide phases are inconsistent: the hide phase is from the full size of the container to `0px`, and the show phase is from `0px` to the `scrollWidth`/`scrollHeight` of the container and then there is a sudden change when the classes are changed at the end of the transition.

Using `scrollWidth` / `scrollHeight` does not feel right for me. We should use whatever size the container will have when changing the classes at the end of the transition, which is what `measureCollapsingElementDimensionPx` measures correctly. I have added `style="max-width:300px;"` on the container in the demo so that the animation matches the visible content.

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
