### PR TITLE
fix(typeahead): remove aria-multiline attribute

### DIFF
--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -796,7 +796,6 @@ describe('ngb-typeahead', () => {
 			fixture.detectChanges();
 
 			expect(input.getAttribute('role')).toBe('combobox');
-			expect(input.getAttribute('aria-multiline')).toBe('false');
 			expect(input.getAttribute('aria-autocomplete')).toBe('list');
 			expect(input.getAttribute('aria-expanded')).toBe('false');
 			expect(input.getAttribute('aria-owns')).toBeNull();

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -68,7 +68,6 @@ let nextWindowId = 0;
 		autocapitalize: 'off',
 		autocorrect: 'off',
 		role: 'combobox',
-		'aria-multiline': 'false',
 		'[attr.aria-autocomplete]': 'showHint ? "both" : "list"',
 		'[attr.aria-activedescendant]': 'activeDescendant',
 		'[attr.aria-owns]': 'isPopupOpen() ? popupId : null',


### PR DESCRIPTION
Removes `aria-multiline="false"`, which is invalid on comboboxes.

Fixes #4181