### PR TITLE
refactor(toast): update toast transitions to Bootstrap 5.2

### DIFF
--- a/src/toast/toast-transition.ts
+++ b/src/toast/toast-transition.ts
@@ -4,24 +4,24 @@ import { reflow } from '../util/util';
 export const ngbToastFadeInTransition: NgbTransitionStartFn = (element: HTMLElement, animation: true) => {
 	const { classList } = element;
 
-	if (!animation) {
+	if (animation) {
+		classList.add('fade');
+	} else {
 		classList.add('show');
 		return;
 	}
 
-	classList.remove('hide');
 	reflow(element);
-	classList.add('showing');
+	classList.add('show', 'showing');
 
 	return () => {
 		classList.remove('showing');
-		classList.add('show');
 	};
 };
 
 export const ngbToastFadeOutTransition: NgbTransitionStartFn = ({ classList }: HTMLElement) => {
-	classList.remove('show');
+	classList.add('showing');
 	return () => {
-		classList.add('hide');
+		classList.remove('show', 'showing');
 	};
 };

--- a/src/toast/toast.spec.ts
+++ b/src/toast/toast.spec.ts
@@ -160,7 +160,7 @@ if (isBrowserVisible('ngb-toast animations')) {
 					expect(toastEl).toHaveCssClass('show');
 				} else {
 					expect(window.getComputedStyle(toastEl).opacity).toBe('0');
-					expect(toastEl).not.toHaveCssClass('show');
+					expect(toastEl).toHaveCssClass('show');
 					expect(toastEl).toHaveCssClass('showing');
 				}
 			});
@@ -185,7 +185,6 @@ if (isBrowserVisible('ngb-toast animations')) {
 					expect(window.getComputedStyle(toastEl).opacity).toBe('0');
 					expect(toastEl).not.toHaveCssClass('show');
 					expect(toastEl).toHaveCssClass('fade');
-					expect(toastEl).toHaveCssClass('hide');
 				});
 			});
 		});


### PR DESCRIPTION
Toast animations have been broken since the update to Bootstrap v5.2, which changed it's internal api for transitions. This PR mimics the behavior of the logic in bootstrap.js and removes the use of the deprecated class `hide`.
