### PR TITLE
Use <button> as well as <a> for [ngbNavLink]

### DIFF
--- a/demo/src/app/components/nav/overview/nav-overview.component.html
+++ b/demo/src/app/components/nav/overview/nav-overview.component.html
@@ -25,11 +25,11 @@
 	<ngb-alert type="secondary" [dismissible]="false">
 		<ul ngbNav #nav="ngbNav" class="nav-pills">
 			<li ngbNavItem>
-				<a ngbNavLink>First</a>
+				<button ngbNavLink>First</button>
 				<ng-template ngbNavContent>Content for the first nav</ng-template>
 			</li>
 			<li ngbNavItem>
-				<a ngbNavLink>Second</a>
+				<button ngbNavLink>Second</button>
 				<ng-template ngbNavContent>Content for the second nav</ng-template>
 			</li>
 		</ul>
@@ -105,9 +105,13 @@
 	<h4>Accessibility</h4>
 
 	<p>
-		By default nav sets <code>'tablist'</code>, <code>'tab'</code> and <code>'tabpanel'</code> roles on elements. If you
-		plan to use different ones (ex. if you're using a nav inside the navbar), you can tell it not to generate any roles
-		and add your own. Or you could simply override them by providing <code>role="myRole"</code> where necessary.
+		By default nav sets <code>'tablist'</code>, <code>'tab'</code> and
+		<code>'tabpanel'</code> roles on elements. When using the automatic
+		roles, use <code>&lt;button&rt;</code> instead of <code>&lt;a&rt;</code> for the nav
+		links. If you plan to use different ones (ex. if you're using a nav
+		inside the navbar), you can tell it not to generate any roles and add
+		your own. Or you could simply override them by providing
+		<code>role="myRole"</code> where necessary.
 	</p>
 
 	<ngbd-code [snippet]="ROLES"></ngbd-code>

--- a/src/nav/nav.ts
+++ b/src/nav/nav.ts
@@ -401,7 +401,7 @@ export class NgbNav implements AfterContentInit, OnChanges, OnDestroy {
  * @since 5.2.0
  */
 @Directive({
-	selector: 'a[ngbNavLink]',
+	selector: 'a[ngbNavLink], button[ngbNavLink]',
 	host: {
 		'[id]': 'navItem.domId',
 		'[class.nav-link]': 'true',


### PR DESCRIPTION
Adds `<button>` to the selector list for `[ngbNavLink]`, to fix accessibility testing issues with `role="tab"` used on `<a>` elements.

I have not propagated the change throughout all the demos, only the overview, pending review and feedback.

Fixes #4090, #4204, and #4398.