### PR TITLE
fix(modal): provide `NgbModal` at the correct level

### DIFF
--- a/src/modal/modal-lazy-module.spec.ts
+++ b/src/modal/modal-lazy-module.spec.ts
@@ -1,0 +1,40 @@
+import { Component, inject, Injectable, NgModule, OnDestroy } from '@angular/core';
+import { NgbModal } from './modal';
+import { NgbModalModule } from './modal.module';
+import { RouterModule } from '@angular/router';
+
+@Injectable()
+class LazyService {
+	get text() {
+		return 'lazy modal';
+	}
+}
+
+@Component({ template: '{{ lazyService.text }}' })
+class LazyModalContent {
+	constructor(public lazyService: LazyService) {}
+}
+
+@Component({ template: 'child' })
+class LazyComponent implements OnDestroy {
+	private _ref = inject(NgbModal).open(LazyModalContent);
+
+	ngOnDestroy() {
+		this._ref.close();
+	}
+}
+
+@NgModule({
+	declarations: [LazyComponent, LazyModalContent],
+	providers: [LazyService],
+	imports: [
+		NgbModalModule,
+		RouterModule.forChild([
+			{
+				path: '',
+				component: LazyComponent,
+			},
+		]),
+	],
+})
+export default class LazyModule {}

--- a/src/modal/modal.module.ts
+++ b/src/modal/modal.module.ts
@@ -1,9 +1,11 @@
 import { NgModule } from '@angular/core';
 
+import { NgbModal } from './modal';
+
 export { NgbModal } from './modal';
 export { NgbModalConfig, NgbModalOptions } from './modal-config';
 export { NgbModalRef, NgbActiveModal } from './modal-ref';
 export { ModalDismissReasons } from './modal-dismiss-reasons';
 
-@NgModule({})
+@NgModule({ providers: [NgbModal] })
 export class NgbModalModule {}


### PR DESCRIPTION
Provides `NgbModal` at the `NgbModalModule` level as well as at the 'root' level. Provides environment injector based on the `contentInjector` and not the `appRef.injector` when using component as modal content.

Fixes #4447