### PR TITLE
feat(dropdown): replace NgbNavbar usage by DOM call to closest()

### DIFF
--- a/src/dropdown/dropdown.module.ts
+++ b/src/dropdown/dropdown.module.ts
@@ -1,12 +1,5 @@
 import { NgModule } from '@angular/core';
-import {
-	NgbDropdown,
-	NgbDropdownAnchor,
-	NgbDropdownToggle,
-	NgbDropdownMenu,
-	NgbDropdownItem,
-	NgbNavbar,
-} from './dropdown';
+import { NgbDropdown, NgbDropdownAnchor, NgbDropdownToggle, NgbDropdownMenu, NgbDropdownItem } from './dropdown';
 
 export {
 	NgbDropdown,
@@ -14,18 +7,12 @@ export {
 	NgbDropdownToggle,
 	NgbDropdownMenu,
 	NgbDropdownItem,
+	// eslint-disable-next-line deprecation/deprecation
 	NgbNavbar,
 } from './dropdown';
 export { NgbDropdownConfig } from './dropdown-config';
 
-const NGB_DROPDOWN_DIRECTIVES = [
-	NgbDropdown,
-	NgbDropdownAnchor,
-	NgbDropdownToggle,
-	NgbDropdownMenu,
-	NgbDropdownItem,
-	NgbNavbar,
-];
+const NGB_DROPDOWN_DIRECTIVES = [NgbDropdown, NgbDropdownAnchor, NgbDropdownToggle, NgbDropdownMenu, NgbDropdownItem];
 
 @NgModule({
 	imports: NGB_DROPDOWN_DIRECTIVES,

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -12,7 +12,6 @@ import {
 	NgZone,
 	OnChanges,
 	OnDestroy,
-	Optional,
 	Output,
 	QueryList,
 	Renderer2,
@@ -31,6 +30,9 @@ import { Key } from '../util/key';
 import { NgbDropdownConfig } from './dropdown-config';
 import { FOCUSABLE_ELEMENTS_SELECTOR } from '../util/focus-trap';
 
+/**
+ * @deprecated this directive isn't useful anymore. You can remove it from your imports
+ */
 @Directive({ selector: '.navbar', standalone: true })
 export class NgbNavbar {}
 
@@ -249,7 +251,6 @@ export class NgbDropdown implements AfterContentInit, OnChanges, OnDestroy {
 		private _ngZone: NgZone,
 		private _elementRef: ElementRef<HTMLElement>,
 		private _renderer: Renderer2,
-		@Optional() ngbNavbar: NgbNavbar,
 	) {
 		this.placement = config.placement;
 		this.popperOptions = config.popperOptions;
@@ -257,7 +258,7 @@ export class NgbDropdown implements AfterContentInit, OnChanges, OnDestroy {
 		this.autoClose = config.autoClose;
 
 		this._positioning = ngbPositioning();
-		this.display = ngbNavbar ? 'static' : 'dynamic';
+		this.display = this._elementRef.nativeElement.closest('.navbar') ? 'static' : 'dynamic';
 	}
 
 	ngAfterContentInit() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ export {
 	NgbDropdownMenu,
 	NgbDropdownModule,
 	NgbDropdownToggle,
+	// eslint-disable-next-line deprecation/deprecation
 	NgbNavbar,
 } from './dropdown/dropdown.module';
 export {


### PR DESCRIPTION
The NgbNavbar directive is not removed, but simply deprecated, in order to avoid a breaking change for people who have imported it in their modules or standalone components.

fix #4462

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.
