### PR TITLE
fix(pagination): remove `.visually-hidden` spans

### DIFF
--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -25,7 +25,7 @@ function expectPages(nativeEl: HTMLElement, pagesDef: string[], ellipsis = '...'
 			expect(pages[i]).toHaveCssClass('active');
 			expect(pages[i]).not.toHaveCssClass('disabled');
 			expect(pages[i].getAttribute('aria-current')).toBe('page');
-			expect(textContent).toEqual(pageDef.substring(1) + ' (current)');
+			expect(textContent).toEqual(pageDef.substring(1));
 		} else if (classIndicator === '-') {
 			expect(pages[i]).not.toHaveCssClass('active');
 			expect(pages[i]).toHaveCssClass('disabled');
@@ -682,10 +682,7 @@ describe('ngb-pagination', () => {
           <ng-template ngbPaginationPrevious>P</ng-template>
           <ng-template ngbPaginationNext>N</ng-template>
           <ng-template ngbPaginationEllipsis>E</ng-template>
-          <ng-template ngbPaginationNumber let-page let-currentPage="currentPage">
-            {{ page }}!
-            <span *ngIf="page === currentPage" class="visually-hidden">(current)</span>
-          </ng-template>
+          <ng-template ngbPaginationNumber let-page let-currentPage="currentPage">{{ page }}!</ng-template>
         </ngb-pagination>
       `);
 
@@ -701,7 +698,6 @@ describe('ngb-pagination', () => {
           <ng-template ngbPaginationNext let-disabled="disabled">{{ disabled ? 'dN' : 'N' }}</ng-template>
           <ng-template ngbPaginationNumber let-page let-currentPage="currentPage" let-disabled="disabled">
             {{ disabled ? 'd'+page : page }}
-            <span *ngIf="page === currentPage" class="visually-hidden">(current)</span>
           </ng-template>
         </ngb-pagination>
       `);

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -161,10 +161,7 @@ export class NgbPaginationPages {
 		<ng-template #next><span aria-hidden="true" i18n="@@ngb.pagination.next">&raquo;</span></ng-template>
 		<ng-template #last><span aria-hidden="true" i18n="@@ngb.pagination.last">&raquo;&raquo;</span></ng-template>
 		<ng-template #ellipsis>...</ng-template>
-		<ng-template #defaultNumber let-page let-currentPage="currentPage">
-			{{ page }}
-			<span *ngIf="page === currentPage" class="visually-hidden">(current)</span>
-		</ng-template>
+		<ng-template #defaultNumber let-page let-currentPage="currentPage">{{ page }}</ng-template>
 		<ng-template #defaultPages let-page let-pages="pages" let-disabled="disabled">
 			<li
 				*ngFor="let pageNumber of pages"


### PR DESCRIPTION
Not necessary to have them since `aria-current` was introduced

Fixes #3870