### PR TITLE
demo: use `provideHttpClient` in stackblitz demos

### DIFF
--- a/misc/stackblitzes-templates/main.ts.ejs
+++ b/misc/stackblitzes-templates/main.ts.ejs
@@ -1,8 +1,13 @@
 import './polyfills';
+import {provideHttpClient, withNoXsrfProtection} from '@angular/common/http';
 import {bootstrapApplication} from '@angular/platform-browser';
 import {<%=className%>} from '<%=tsImportName%>';
 
-bootstrapApplication(<%=className%>)
+bootstrapApplication(<%=className%>, {
+  providers: [
+    provideHttpClient(withNoXsrfProtection()),
+  ],
+})
 .then(ref => {
   // Ensure Angular destroys itself on hot reloads.
   if (window['ngRef']) {


### PR DESCRIPTION
This change provides an HttpClient to all the stackblitz demos to ensure they function like they do on the demo site. Currently the HttpClient is the only provider needed, but the stackblitz template `misc/stackblitzes-templates/main.ts.ejs` should be kept in sync with `demo/src/main.ts` to ensure the individual examples have all their dependencies provided.

The needed providers can also be provided to the demo modules themselves or as context to the template renderer, but that may be more effort than its worth and while providing the dependencies to all the examples is overkill it will ensure they all work correctly.

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.
