### PR TITLE
fix(carousel): move 'aria-activedescendant' attribute to indicators

### DIFF
--- a/src/carousel/carousel.spec.ts
+++ b/src/carousel/carousel.spec.ts
@@ -23,7 +23,7 @@ const getArrowElements = (el: HTMLElement) =>
 function expectActiveSlides(nativeEl: HTMLDivElement, active: boolean[]) {
 	const slideElms = getSlideElements(nativeEl);
 	const indicatorElms = getIndicatorElements(nativeEl);
-	const carouselElm = nativeEl.querySelector('ngb-carousel');
+	const indicatorContainerElm = nativeEl.querySelector('.carousel-indicators');
 
 	expect(slideElms.length).toBe(active.length);
 	expect(indicatorElms.length).toBe(active.length);
@@ -33,7 +33,7 @@ function expectActiveSlides(nativeEl: HTMLDivElement, active: boolean[]) {
 			expect(slideElms[i]).toHaveCssClass('active');
 			expect(indicatorElms[i]).toHaveCssClass('active');
 			expect(indicatorElms[i].getAttribute('aria-selected')).toBe('true');
-			expect(carouselElm!.getAttribute('aria-activedescendant')).toBe(slideElms[i].id);
+			expect(indicatorContainerElm!.getAttribute('aria-activedescendant')).toBe(slideElms[i].id);
 		} else {
 			expect(slideElms[i]).not.toHaveCssClass('active');
 			expect(indicatorElms[i]).not.toHaveCssClass('active');

--- a/src/carousel/carousel.ts
+++ b/src/carousel/carousel.ts
@@ -79,10 +79,14 @@ export class NgbSlide {
 		'(mouseleave)': 'mouseHover = false',
 		'(focusin)': 'focused = true',
 		'(focusout)': 'focused = false',
-		'[attr.aria-activedescendant]': `'slide-' + activeId`,
 	},
 	template: `
-		<div class="carousel-indicators" [class.visually-hidden]="!showNavigationIndicators" role="tablist">
+		<div
+			class="carousel-indicators"
+			[class.visually-hidden]="!showNavigationIndicators"
+			role="tablist"
+			[attr.aria-activedescendant]="'slide-' + activeId"
+		>
 			<button
 				type="button"
 				data-bs-target


### PR DESCRIPTION
Moves the aria-activedescendant attribute from the root element to the '.carousel-indicators' element which has a compatible 'tablist' role. Checked with lighthouse and axe devtools, both don't show the role mismatch warning on carousels.

Fixes #4416

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
