### PR TITLE
Revert "fix(carousel): move 'aria-activedescendant' attribute to indicators"

### DIFF
--- a/src/carousel/carousel.spec.ts
+++ b/src/carousel/carousel.spec.ts
@@ -23,7 +23,7 @@ const getArrowElements = (el: HTMLElement) =>
 function expectActiveSlides(nativeEl: HTMLDivElement, active: boolean[]) {
 	const slideElms = getSlideElements(nativeEl);
 	const indicatorElms = getIndicatorElements(nativeEl);
-	const indicatorContainerElm = nativeEl.querySelector('.carousel-indicators');
+	const carouselElm = nativeEl.querySelector('ngb-carousel');
 
 	expect(slideElms.length).toBe(active.length);
 	expect(indicatorElms.length).toBe(active.length);
@@ -33,7 +33,7 @@ function expectActiveSlides(nativeEl: HTMLDivElement, active: boolean[]) {
 			expect(slideElms[i]).toHaveCssClass('active');
 			expect(indicatorElms[i]).toHaveCssClass('active');
 			expect(indicatorElms[i].getAttribute('aria-selected')).toBe('true');
-			expect(indicatorContainerElm!.getAttribute('aria-activedescendant')).toBe(slideElms[i].id);
+			expect(carouselElm!.getAttribute('aria-activedescendant')).toBe(slideElms[i].id);
 		} else {
 			expect(slideElms[i]).not.toHaveCssClass('active');
 			expect(indicatorElms[i]).not.toHaveCssClass('active');

--- a/src/carousel/carousel.ts
+++ b/src/carousel/carousel.ts
@@ -79,14 +79,10 @@ export class NgbSlide {
 		'(mouseleave)': 'mouseHover = false',
 		'(focusin)': 'focused = true',
 		'(focusout)': 'focused = false',
+		'[attr.aria-activedescendant]': `'slide-' + activeId`,
 	},
 	template: `
-		<div
-			class="carousel-indicators"
-			[class.visually-hidden]="!showNavigationIndicators"
-			role="tablist"
-			[attr.aria-activedescendant]="'slide-' + activeId"
-		>
+		<div class="carousel-indicators" [class.visually-hidden]="!showNavigationIndicators" role="tablist">
 			<button
 				type="button"
 				data-bs-target


### PR DESCRIPTION
Reverts ng-bootstrap/ng-bootstrap#4524

While a11y warnings in question are gone, screen readers actually perform much worse in my manual tests.