### PR TITLE
feat(tooltip/popover/dropdown): add custom container support

### DIFF
--- a/demo/src/app/components/dropdown/demos/container/dropdown-container.html
+++ b/demo/src/app/components/dropdown/demos/container/dropdown-container.html
@@ -3,50 +3,87 @@
 	it belongs. This option is useful if the dropdown is defined inside an element that clips its contents (i.e.
 	<code>overflow: hidden</code>).
 </p>
-<table class="table table-striped">
-	<thead>
-		<tr>
-			<th scope="col">#</th>
-			<th scope="col">Items</th>
-			<th scope="col">Actions</th>
-			<th scope="col">Actions</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>1</td>
-			<td>
-				Item
-				<div>
-					<small class="text-muted">Both &ldquo;Actions&rdquo; table cells define an overflow hidden</small>
-				</div>
-			</td>
-			<td class="overflow-hidden">
-				<div ngbDropdown container="body">
-					<button type="button" class="btn btn-outline-primary btn-sm" ngbDropdownToggle>Actions</button>
-					<div ngbDropdownMenu>
-						<button ngbDropdownItem>Edit</button>
-						<button ngbDropdownItem>Duplicate</button>
-						<button ngbDropdownItem>Move</button>
-						<div class="dropdown-divider"></div>
-						<button ngbDropdownItem>Delete</button>
+<div id="dropdown-container" #dropdownContainer>
+	<table class="table table-striped">
+		<thead>
+			<tr>
+				<th scope="col">#</th>
+				<th scope="col">Items</th>
+				<th scope="col">Actions</th>
+				<th scope="col">Actions</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>1</td>
+				<td>
+					Item
+					<div>
+						<small class="text-muted">Both &ldquo;Actions&rdquo; table cells define an overflow hidden</small>
 					</div>
-				</div>
-				<small class="text-muted">Dropdown uses container "body"</small>
-			</td>
-			<td class="overflow-hidden">
-				<div ngbDropdown>
-					<button type="button" class="btn btn-outline-primary btn-sm" ngbDropdownToggle>Actions</button>
-					<div ngbDropdownMenu>
-						<button ngbDropdownItem>Edit</button>
-						<button ngbDropdownItem>Duplicate</button>
-						<button ngbDropdownItem>Move</button>
-						<div class="dropdown-divider"></div>
-						<button ngbDropdownItem>Delete</button>
+				</td>
+				<td class="overflow-hidden">
+					<div ngbDropdown container="body">
+						<button type="button" class="btn btn-outline-primary btn-sm" ngbDropdownToggle>Actions</button>
+						<div ngbDropdownMenu>
+							<button ngbDropdownItem>Edit</button>
+							<button ngbDropdownItem>Duplicate</button>
+							<button ngbDropdownItem>Move</button>
+							<div class="dropdown-divider"></div>
+							<button ngbDropdownItem>Delete</button>
+						</div>
 					</div>
-				</div>
-				<small class="text-muted">Default dropdown</small>
-			</td>
-		</tr>
-	</tbody>
-</table>
+					<small class="text-muted">Dropdown uses container "body"</small>
+				</td>
+				<td class="overflow-hidden">
+					<div ngbDropdown>
+						<button type="button" class="btn btn-outline-primary btn-sm" ngbDropdownToggle>Actions</button>
+						<div ngbDropdownMenu>
+							<button ngbDropdownItem>Edit</button>
+							<button ngbDropdownItem>Duplicate</button>
+							<button ngbDropdownItem>Move</button>
+							<div class="dropdown-divider"></div>
+							<button ngbDropdownItem>Delete</button>
+						</div>
+					</div>
+					<small class="text-muted">Default dropdown</small>
+				</td>
+			</tr>
+			<tr>
+				<td>1</td>
+				<td>
+					Item
+					<div>
+						<small class="text-muted">Both Dropdown's container will be the div</small>
+					</div>
+				</td>
+				<td class="overflow-hidden">
+					<div ngbDropdown container="#dropdown-container">
+						<button type="button" class="btn btn-outline-primary btn-sm" ngbDropdownToggle>Actions</button>
+						<div ngbDropdownMenu>
+							<button ngbDropdownItem>Edit</button>
+							<button ngbDropdownItem>Duplicate</button>
+							<button ngbDropdownItem>Move</button>
+							<div class="dropdown-divider"></div>
+							<button ngbDropdownItem>Delete</button>
+						</div>
+					</div>
+					<small class="text-muted">Dropdown uses container <code>#dropdown-container</code></small>
+				</td>
+				<td class="overflow-hidden">
+					<div ngbDropdown [container]="dropdownContainer">
+						<button type="button" class="btn btn-outline-primary btn-sm" ngbDropdownToggle>Actions</button>
+						<div ngbDropdownMenu>
+							<button ngbDropdownItem>Edit</button>
+							<button ngbDropdownItem>Duplicate</button>
+							<button ngbDropdownItem>Move</button>
+							<div class="dropdown-divider"></div>
+							<button ngbDropdownItem>Delete</button>
+						</div>
+					</div>
+					<small class="text-muted">Dropdown uses container element <code>dropdownContainer</code></small>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+</div>

--- a/demo/src/app/components/popover/demos/container/popover-container.html
+++ b/demo/src/app/components/popover/demos/container/popover-container.html
@@ -17,13 +17,34 @@
 			</button>
 			<button
 				type="button"
-				class="btn btn-outline-secondary"
+				class="btn btn-outline-secondary mb-2"
 				placement="bottom"
 				ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus."
 				container="body"
 			>
 				Popover appended to body
 			</button>
+			<button
+				type="button"
+				class="btn btn-outline-secondary mb-2"
+				placement="bottom"
+				ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus."
+				container="#popver-container"
+			>
+				Popover appended to container by id
+			</button>
+			<button
+				type="button"
+				class="btn btn-outline-secondary"
+				placement="bottom"
+				ngbPopover="Vivamus sagittis lacus vel augue laoreet rutrum faucibus."
+				[container]="popoverContainer"
+			>
+				Popover appended to container
+			</button>
 		</div>
+	</div>
+	<div class="col-auto">
+		<div class="card px-1 py-5 overflow-visible" id="popver-container" #popoverContainer>Popover custom container</div>
 	</div>
 </div>

--- a/demo/src/app/components/tooltip/demos/container/tooltip-container.html
+++ b/demo/src/app/components/tooltip/demos/container/tooltip-container.html
@@ -17,13 +17,36 @@
 			</button>
 			<button
 				type="button"
-				class="btn btn-outline-secondary"
+				class="btn btn-outline-secondary mb-2"
 				placement="bottom"
 				ngbTooltip="Vivamus sagittis lacus vel augue laoreet rutrum faucibus."
 				container="body"
 			>
 				Tooltip appended to body
 			</button>
+			<button
+				type="button"
+				class="btn btn-outline-secondary mb-2"
+				placement="top"
+				container="#tooltip-custom-container"
+				ngbTooltip="Vivamus sagittis lacus vel augue laoreet rutrum faucibus."
+			>
+				Tooltip append to container id
+			</button>
+			<button
+				type="button"
+				class="btn btn-outline-secondary mb-2"
+				placement="top"
+				[container]="tooltipContainer"
+				ngbTooltip="Vivamus sagittis lacus vel augue laoreet rutrum faucibus."
+			>
+				Tooltip append to container
+			</button>
+		</div>
+	</div>
+	<div class="col-auto">
+		<div class="card px-1 py-5 overflow-visible" id="tooltip-custom-container" #tooltipContainer>
+			Tooltip custom container
 		</div>
 	</div>
 </div>

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -30,7 +30,7 @@ import { Key } from '../util/key';
 
 import { NgbDropdownConfig } from './dropdown-config';
 import { FOCUSABLE_ELEMENTS_SELECTOR } from '../util/focus-trap';
-import { getActiveElement } from '../util/util';
+import { appendContainerChild, getActiveElement } from '../util/util';
 
 /**
  * @deprecated 14.2.0 this directive isn't useful anymore. You can remove it from your imports
@@ -225,7 +225,7 @@ export class NgbDropdown implements OnInit, AfterContentInit, OnChanges, OnDestr
 	 *
 	 * @since 4.1.0
 	 */
-	@Input() container: null | 'body';
+	@Input() container: null | 'body' | HTMLElement;
 
 	/**
 	 * Enable or disable the dynamic positioning. The default value is dynamic unless the dropdown is used
@@ -528,15 +528,16 @@ export class NgbDropdown implements OnInit, AfterContentInit, OnChanges, OnDestr
 
 			renderer.appendChild(dropdownElement, dropdownMenuElement);
 		}
-		if (this._bodyContainer) {
-			renderer.removeChild(this._document.body, this._bodyContainer);
+		if (this._bodyContainer?.parentElement) {
+			renderer.removeChild(this._bodyContainer.parentElement, this._bodyContainer);
 			this._bodyContainer = null;
 		}
 	}
 
-	private _applyContainer(container: null | 'body' = null) {
+	private _applyContainer(container: null | 'body' | HTMLElement = null) {
 		this._resetContainer();
-		if (container === 'body') {
+		if (container) {
+			console.log(container);
 			const renderer = this._renderer;
 			const dropdownMenuElement = this._menu.nativeElement;
 			const bodyContainer = (this._bodyContainer = this._bodyContainer || renderer.createElement('div'));
@@ -547,7 +548,7 @@ export class NgbDropdown implements OnInit, AfterContentInit, OnChanges, OnDestr
 			renderer.setStyle(bodyContainer, 'z-index', '1055');
 
 			renderer.appendChild(bodyContainer, dropdownMenuElement);
-			renderer.appendChild(this._document.body, bodyContainer);
+			appendContainerChild(this._document, bodyContainer, container);
 		}
 
 		this._applyCustomDropdownClass(this.dropdownClass);

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -220,8 +220,7 @@ export class NgbDropdown implements OnInit, AfterContentInit, OnChanges, OnDestr
 	@Input() popperOptions: (options: Partial<Options>) => Partial<Options>;
 
 	/**
-	 * A selector specifying the element the dropdown should be appended to.
-	 * Currently only supports "body".
+	 * A selector or HTMLElement specifying the element the dropdown should be appended to.
 	 *
 	 * @since 4.1.0
 	 */

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -27,7 +27,7 @@ import { listenToTriggers } from '../util/triggers';
 import { ngbAutoClose } from '../util/autoclose';
 import { ngbPositioning, PlacementArray } from '../util/positioning';
 import { PopupService } from '../util/popup';
-import { isString } from '../util/util';
+import { appendContainerChild, isString } from '../util/util';
 
 import { NgbPopoverConfig } from './popover-config';
 import { Options } from '@popperjs/core';
@@ -151,7 +151,7 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
 	 *
 	 * Currently only supports `body`.
 	 */
-	@Input() container: string;
+	@Input() container: string | HTMLElement;
 
 	/**
 	 * If `true`, popover is disabled and won't be displayed.
@@ -271,9 +271,7 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
 
 			this._renderer.setAttribute(this._getPositionTargetElement(), 'aria-describedby', this._ngbPopoverWindowId);
 
-			if (this.container === 'body') {
-				this._document.querySelector(this.container).appendChild(this._windowRef.location.nativeElement);
-			}
+			appendContainerChild(this._document, this._windowRef.location.nativeElement, this.container);
 
 			// We need to detect changes, because we don't know where .open() might be called from.
 			// Ex. opening popover from one of lifecycle hooks that run after the CD
@@ -293,7 +291,7 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
 					hostElement: this._getPositionTargetElement(),
 					targetElement: this._windowRef!.location.nativeElement,
 					placement: this.placement,
-					appendToBody: this.container === 'body',
+					appendToBody: this.container === 'body' || this.container === this._document.body,
 					baseClass: 'bs-popover',
 					updatePopperOptions: (options) => this.popperOptions(addPopperOffset([0, 8])(options)),
 				});

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -147,9 +147,8 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
 	@Input() positionTarget?: string | HTMLElement;
 
 	/**
-	 * A selector specifying the element the popover should be appended to.
+	 * A selector or HTMLElement specifying the element the popover should be appended to.
 	 *
-	 * Currently only supports `body`.
 	 */
 	@Input() container: string | HTMLElement;
 

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -117,9 +117,8 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 	@Input() positionTarget?: string | HTMLElement;
 
 	/**
-	 * A selector specifying the element the tooltip should be appended to.
+	 * A selector or HTMLElement specifying the element the tooltip should be appended to.
 	 *
-	 * Currently only supports `"body"`.
 	 */
 	@Input() container: string | HTMLElement;
 

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -28,7 +28,7 @@ import { ngbAutoClose } from '../util/autoclose';
 import { ngbPositioning, PlacementArray } from '../util/positioning';
 import { PopupService } from '../util/popup';
 import { Options } from '@popperjs/core';
-import { isString } from '../util/util';
+import { appendContainerChild, isString } from '../util/util';
 
 import { NgbTooltipConfig } from './tooltip-config';
 import { Subscription } from 'rxjs';
@@ -121,7 +121,7 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 	 *
 	 * Currently only supports `"body"`.
 	 */
-	@Input() container: string;
+	@Input() container: string | HTMLElement;
 
 	/**
 	 * If `true`, tooltip is disabled and won't be displayed.
@@ -245,9 +245,7 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 
 			this._renderer.setAttribute(this._getPositionTargetElement(), 'aria-describedby', this._ngbTooltipWindowId);
 
-			if (this.container === 'body') {
-				this._document.querySelector(this.container).appendChild(this._windowRef.location.nativeElement);
-			}
+			appendContainerChild(this._document, this._windowRef.location.nativeElement, this.container);
 
 			// We need to detect changes, because we don't know where .open() might be called from.
 			// Ex. opening tooltip from one of lifecycle hooks that run after the CD
@@ -267,7 +265,7 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 					hostElement: this._getPositionTargetElement(),
 					targetElement: this._windowRef!.location.nativeElement,
 					placement: this.placement,
-					appendToBody: this.container === 'body',
+					appendToBody: this.container === 'body' || this.container === this._document.body,
 					baseClass: 'bs-tooltip',
 					updatePopperOptions: (options) => this.popperOptions(options),
 				});

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -113,3 +113,18 @@ export function getActiveElement(root: Document | ShadowRoot = document): Elemen
 
 	return activeEl.shadowRoot ? getActiveElement(activeEl.shadowRoot) : activeEl;
 }
+
+/**
+ * Append child element to container
+ */
+export function appendContainerChild(
+	document: Document,
+	element: HTMLElement,
+	container?: string | HTMLElement | null,
+) {
+	if (container instanceof HTMLElement) {
+		container.appendChild(element);
+	} else if (container) {
+		(document.querySelector(container) ?? document.body).appendChild(element);
+	}
+}


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.

Currently in ng-bootstrap, there is no way of setting the container of tooltip/popover/dropdown to other values, the only accepted values are null and `body`, which is not enough. For example, I have something like 
```
<body>
  <app-root>
      <div id="screen"></div>
  </app-root>
</body>
```

or somthing like above, then if I need to make `#screen` div fullscreen, then all tooltip/popover/dropdown with `container=body` will not work, without the `container=body` the actual container must not be `overflow: hidden`, this is huge restriction. And my special case has much more problem, I have a something in table, the outer component also need to be fullscreen, in the cells of this table, I have dropdown as actions menu, have tooltip on some elements, and also the popover on some elements, without this custom container support, my use case will only work without the component fullscreen.

So I've changed the `container` input, which accept an valid css selector or a `HTMLElement`, then tooltip/popover/dropdown will use this container element as the real container. this will solve the many problems.

and I don't think there will be any new test, because the `body` string value in `container` is a valid CSS selector. so the old tests works fine.

And I believe this will also fix #1884 and #870 .