### PR TITLE
Fix NgbAlert dismissable mentions 'close' output instead of 'closed'

### DIFF
--- a/src/alert/alert.ts
+++ b/src/alert/alert.ts
@@ -62,7 +62,7 @@ export class NgbAlert implements OnInit, OnChanges {
 	 * If `true`, alert can be dismissed by the user.
 	 *
 	 * The close button (×) will be displayed and you can be notified
-	 * of the event with the `(close)` output.
+	 * of the event with the `(closed)` output.
 	 */
 	@Input() dismissible: boolean;
 


### PR DESCRIPTION
Fix #4553