### PR TITLE
fix(datepicker): `startDate` type should accept dates withe days

### DIFF
--- a/src/datepicker/datepicker-config.ts
+++ b/src/datepicker/datepicker-config.ts
@@ -22,6 +22,6 @@ export class NgbDatepickerConfig {
 	navigation: 'select' | 'arrows' | 'none' = 'select';
 	outsideDays: 'visible' | 'collapsed' | 'hidden' = 'visible';
 	showWeekNumbers = false;
-	startDate: { year: number; month: number };
+	startDate: { year: number; month: number; day?: number };
 	weekdays: TranslationWidth | boolean = TranslationWidth.Short;
 }

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -187,6 +187,15 @@ describe('ngb-datepicker', () => {
 		}).not.toThrowError();
 	});
 
+	it(`should accept 'startDate' values containing days`, () => {
+		const fixture = TestBed.createComponent(NgbDatepicker);
+		fixture.componentInstance.startDate = { year: 2016, month: 8, day: 3 };
+		fixture.detectChanges();
+
+		expect(getMonthSelect(fixture.nativeElement).value).toBe('8');
+		expect(getYearSelect(fixture.nativeElement).value).toBe('2016');
+	});
+
 	it('should handle incorrect startDate values', () => {
 		const fixture = createTestComponent(`<ngb-datepicker [startDate]="date"></ngb-datepicker>`);
 		const today = new Date();


### PR DESCRIPTION
Fixes #4616
