### PR TITLE
docs(modal): typo in component title

### DIFF
--- a/demo/src/app/components/modal/modal.routes.ts
+++ b/demo/src/app/components/modal/modal.routes.ts
@@ -68,7 +68,7 @@ export const ROUTES: Routes = [
 		path: '',
 		component: ComponentWrapper,
 		data: {
-			name: 'Dropdown',
+			name: 'Modal',
 			bootstrap: 'https://getbootstrap.com/docs/%version%/components/modal/',
 		},
 		children: [


### PR DESCRIPTION
When  navigating to the info page for the Modal-Component, the page title is `Dropdown` instead of `Modal`.  
Same applies to the link directing to the Bootstrap docs.

fixes #4648  
fixes #4661 