### PR TITLE
fix(modal): focusable boundary without display none

### DIFF
--- a/src/util/focus-trap.ts
+++ b/src/util/focus-trap.ts
@@ -19,7 +19,7 @@ export const FOCUSABLE_ELEMENTS_SELECTOR = [
 export function getFocusableBoundaryElements(element: HTMLElement): HTMLElement[] {
 	const list: HTMLElement[] = Array.from(
 		element.querySelectorAll(FOCUSABLE_ELEMENTS_SELECTOR) as NodeListOf<HTMLElement>,
-	).filter((el) => el.tabIndex !== -1);
+	).filter((el) => el.tabIndex !== -1 && el.offsetParent !== null);
 	return [list[0], list[list.length - 1]];
 }
 


### PR DESCRIPTION
fix #4630

This will remove `display: none` and `[hidden]` elements from the focusable boudary.
It will note remove `visibility: hidden` or `opacity: 0`.
