### PR TITLE
(docs) pagination: fix misspelled word in pagination usage example

### DIFF
--- a/demo/src/app/components/pagination/overview/pagination-overview.component.html
+++ b/demo/src/app/components/pagination/overview/pagination-overview.component.html
@@ -37,7 +37,7 @@
 	<h4>Filtering and sorting</h4>
 	<p>
 		To add filtering or sorting on top of your pagination, you will have to update the way you split your data
-		collection. As mentionned in
+		collection. As mentioned in
 		<a href="https://angular.io/guide/pipes#appendix-no-filterpipe-or-orderbypipe" rel="no-opener no-referer"
 			>Angular documentation</a
 		>, you don't need to reimplement dedicated pipes for that purpose. Recommendation is to move filtering and sorting


### PR DESCRIPTION
Fixed mistyped word: `mentionned` to correct: `mentioned` in [pagination usage example](https://ng-bootstrap.github.io/#/components/pagination/overview)