### PR TITLE
(docs) scrollspy: fix misspelled word in scrollspy overview docs

### DIFF
--- a/demo/src/app/components/scrollspy/overview/scrollspy-overview.component.html
+++ b/demo/src/app/components/scrollspy/overview/scrollspy-overview.component.html
@@ -20,7 +20,7 @@
 		container should be watched. Fragments are identified by unique <code>id</code> attributes.
 	</p>
 
-	<p>Fpr example, if you want to watch for the document scroll changes, you need to do at least the following:</p>
+	<p>For example, if you want to watch for the document scroll changes, you need to do at least the following:</p>
 
 	<ngbd-code [snippet]="SERVICE"></ngbd-code>
 


### PR DESCRIPTION
Fixed mistyped word: `Fpr` to correct: `For` in [scrollspy overview](https://ng-bootstrap.github.io/#/components/scrollspy/overview)