### PR TITLE
feat(modal): add windowRole option

### DIFF
--- a/src/modal/modal-config.spec.ts
+++ b/src/modal/modal-config.spec.ts
@@ -22,6 +22,7 @@ describe('NgbModalConfig', () => {
 			expect(config.scrollable).toBeUndefined();
 			expect(config.size).toBeUndefined();
 			expect(config.windowClass).toBeUndefined();
+			expect(config.windowRole).toBe('dialog');
 		},
 	));
 });

--- a/src/modal/modal-config.ts
+++ b/src/modal/modal-config.ts
@@ -119,6 +119,13 @@ export interface NgbModalOptions {
 	 * @since 1.1.0
 	 */
 	backdropClass?: string;
+
+	/**
+	 * Role attribute for the modal window.
+	 *
+	 * Default value is `'dialog'`.
+	 */
+	windowRole?: 'dialog' | 'alertdialog';
 }
 
 /**
@@ -165,6 +172,7 @@ export class NgbModalConfig implements Required<NgbModalOptions> {
 	windowClass: string;
 	modalDialogClass: string;
 	backdropClass: string;
+	windowRole: 'dialog' | 'alertdialog' = 'dialog';
 
 	get animation(): boolean {
 		return this._animation ?? this._ngbConfig.animation;

--- a/src/modal/modal-ref.ts
+++ b/src/modal/modal-ref.ts
@@ -51,6 +51,7 @@ const WINDOW_ATTRIBUTES: string[] = [
 	'size',
 	'windowClass',
 	'modalDialogClass',
+	'windowRole',
 ];
 const BACKDROP_ATTRIBUTES: string[] = ['animation', 'backdropClass'];
 

--- a/src/modal/modal-window.spec.ts
+++ b/src/modal/modal-window.spec.ts
@@ -59,6 +59,9 @@ describe('ngb-modal-dialog', () => {
 			const dialogEl: Element = fixture.nativeElement.querySelector('.modal-dialog');
 
 			expect(fixture.nativeElement.getAttribute('role')).toBe('dialog');
+			fixture.componentInstance.windowRole = 'alertdialog';
+			fixture.detectChanges();
+			expect(fixture.nativeElement.getAttribute('role')).toBe('alertdialog');
 			expect(dialogEl.getAttribute('role')).toBe('document');
 		});
 

--- a/src/modal/modal-window.ts
+++ b/src/modal/modal-window.ts
@@ -27,7 +27,7 @@ import { isString, reflow } from '../util/util';
 	host: {
 		'[class]': '"modal d-block" + (windowClass ? " " + windowClass : "")',
 		'[class.fade]': 'animation',
-		role: 'dialog',
+		'[attr.role]': 'windowRole',
 		tabindex: '-1',
 		'[attr.aria-modal]': 'true',
 		'[attr.aria-labelledby]': 'ariaLabelledBy',
@@ -73,6 +73,7 @@ export class NgbModalWindow implements OnInit, OnDestroy {
 	@Input() size: string;
 	@Input() windowClass: string;
 	@Input() modalDialogClass: string;
+	@Input() windowRole: 'dialog' | 'alertdialog' = 'dialog';
 
 	@Output('dismiss') dismissEvent = new EventEmitter();
 


### PR DESCRIPTION
Currently the role attribute on the modal window is hard coded to 'dialog', this adds the ability to set alertdialog to improve accessibility. It does not affect current code as it defaults to 'dialog'.

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
