### PR TITLE
fix(tooltip,popover): keep tooltip/popover open when it is hovered

### DIFF
--- a/demo/src/app/components/popover/demos/delay/popover-delay.html
+++ b/demo/src/app/components/popover/demos/delay/popover-delay.html
@@ -3,6 +3,14 @@
 	<code>openDelay</code> and <code>closeDelay</code> properties. Note that the <code>autoClose</code> feature does not
 	use the close delay, it closes the popover immediately.
 </p>
+<p>
+	When using the <code>hover</code> trigger with a <code>closeDelay</code>, the popover will remain open if the mouse
+	enters it before the close delay is over. This is important for accessibility as it allows users of screen magnifiers
+	to move the cursor over the popover so they can magnify and read it without it disappearing. (See
+	<a href="https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html#hoverable"
+		>WCAG Success Criterion 1.4.13</a
+	>.)
+</p>
 
 <div class="buttons">
 	<button

--- a/demo/src/app/components/tooltip/demos/delay/tooltip-delay.html
+++ b/demo/src/app/components/tooltip/demos/delay/tooltip-delay.html
@@ -3,6 +3,14 @@
 	<code>openDelay</code> and <code>closeDelay</code> properties. Note that the <code>autoClose</code> feature does not
 	use the close delay, it closes the tooltip immediately.
 </p>
+<p>
+	When using the <code>hover</code> trigger with a <code>closeDelay</code>, the tooltip will remain open if the mouse
+	enters it before the close delay is over. This is important for accessibility as it allows users of screen magnifiers
+	to move the cursor over the tooltip so they can magnify and read it without it disappearing. (See
+	<a href="https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html#hoverable"
+		>WCAG Success Criterion 1.4.13</a
+	>.)
+</p>
 
 <div class="buttons">
 	<button

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -633,6 +633,27 @@ describe('ngb-popover', () => {
 	});
 
 	describe('visibility', () => {
+		it('should stay open if the popover is hovered before the closeDelay times out', fakeAsync(() => {
+			const fixture = createTestComponent(
+				`<div ngbPopover="Great tip!" triggers="hover" [closeDelay]="200" style="margin-top: 110px;"></div>`,
+			);
+			const directive = fixture.debugElement.query(By.directive(NgbPopover));
+
+			triggerEvent(directive, 'mouseenter');
+			tick();
+			expect(getWindow(fixture.nativeElement)).toBeTruthy();
+
+			triggerEvent(directive, 'mouseleave');
+			tick(100);
+			triggerEvent(getWindow(fixture.nativeElement), 'mouseenter');
+			tick(300);
+			expect(getWindow(fixture.nativeElement)).toBeTruthy();
+
+			triggerEvent(getWindow(fixture.nativeElement), 'mouseleave');
+			tick(300);
+			expect(getWindow(fixture.nativeElement)).toBeFalsy();
+		}));
+
 		it('should emit events when showing and hiding popover', () => {
 			const fixture = createTestComponent(
 				`<div ngbPopover="Great tip!" triggers="click" (shown)="shown()" (hidden)="hidden()"></div>`,

--- a/src/tooltip/tooltip.spec.ts
+++ b/src/tooltip/tooltip.spec.ts
@@ -646,6 +646,27 @@ describe('ngb-tooltip', () => {
 	});
 
 	describe('visibility', () => {
+		it('should stay open if the tooltip is hovered before the closeDelay times out', fakeAsync(() => {
+			const fixture = createTestComponent(
+				`<div ngbTooltip="Great tip!" triggers="hover" [closeDelay]="200" style="margin-top: 110px;"></div>`,
+			);
+			const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+
+			triggerEvent(directive, 'mouseenter');
+			tick();
+			expect(getWindow(fixture.nativeElement)).toBeTruthy();
+
+			triggerEvent(directive, 'mouseleave');
+			tick(100);
+			triggerEvent(getWindow(fixture.nativeElement), 'mouseenter');
+			tick(300);
+			expect(getWindow(fixture.nativeElement)).toBeTruthy();
+
+			triggerEvent(getWindow(fixture.nativeElement), 'mouseleave');
+			tick(300);
+			expect(getWindow(fixture.nativeElement)).toBeFalsy();
+		}));
+
 		it('should emit events when showing and hiding tooltip', () => {
 			const fixture = createTestComponent(
 				`<div ngbTooltip="Great tip!" triggers="click" (shown)="shown()" (hidden)="hidden()"></div>`,

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -8,7 +8,6 @@ import {
 	Directive,
 	ElementRef,
 	EventEmitter,
-	HostListener,
 	inject,
 	Injector,
 	Input,
@@ -30,8 +29,9 @@ import { PopupService } from '../util/popup';
 import { isString } from '../util/util';
 
 import { NgbTooltipConfig } from './tooltip-config';
-import { Subject } from 'rxjs';
 import { addPopperOffset } from '../util/positioning-util';
+import { Subject } from 'rxjs';
+import { ngbCompleteTransition } from '../util/transition/ngbTransition';
 
 let nextId = 0;
 
@@ -45,6 +45,8 @@ let nextId = 0;
 		'[class.fade]': 'animation',
 		role: 'tooltip',
 		'[id]': 'id',
+		'(mouseenter)': 'onMouseEnter()',
+		'(mouseleave)': 'onMouseLeave()',
 	},
 	styleUrl: './tooltip.scss',
 	template: `
@@ -58,18 +60,8 @@ export class NgbTooltipWindow {
 	@Input() animation: boolean;
 	@Input() id: string;
 	@Input() tooltipClass: string;
-	@Input() readonly mouseEnter: Subject<void>;
-	@Input() readonly mouseLeave: Subject<void>;
-
-	@HostListener('mouseenter')
-	onMouseEnter() {
-		this.mouseEnter?.next();
-	}
-
-	@HostListener('mouseleave')
-	onMouseLeave() {
-		this.mouseLeave?.next();
-	}
+	@Input() onMouseEnter: () => void;
+	@Input() onMouseLeave: () => void;
 }
 
 /**
@@ -203,6 +195,9 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 	private _mouseEnterTooltip = new Subject<void>();
 	private _mouseLeaveTooltip = new Subject<void>();
 
+	private _opening = true;
+	private _transitioning = false;
+
 	/**
 	 * The string content or a `TemplateRef` for the content to be displayed in the tooltip.
 	 *
@@ -227,18 +222,24 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 	 * The `context` is an optional value to be injected into the tooltip template when it is created.
 	 */
 	open(context?: any) {
+		if (!this._opening && this._transitioning) {
+			this._transitioning = false;
+			ngbCompleteTransition(this._windowRef!.location.nativeElement);
+		}
 		if (!this._windowRef && this._ngbTooltip && !this.disableTooltip) {
 			const { windowRef, transition$ } = this._popupService.open(
 				this._ngbTooltip,
 				context ?? this.tooltipContext,
 				this.animation,
 			);
+			this._opening = true;
+			this._transitioning = true;
 			this._windowRef = windowRef;
 			this._windowRef.setInput('animation', this.animation);
 			this._windowRef.setInput('tooltipClass', this.tooltipClass);
 			this._windowRef.setInput('id', this._ngbTooltipWindowId);
-			this._windowRef.setInput('mouseEnter', this._mouseEnterTooltip);
-			this._windowRef.setInput('mouseLeave', this._mouseLeaveTooltip);
+			this._windowRef.setInput('onMouseEnter', () => this._mouseEnterTooltip.next());
+			this._windowRef.setInput('onMouseLeave', () => this._mouseLeaveTooltip.next());
 
 			this._getPositionTargetElement().setAttribute('aria-describedby', this._ngbTooltipWindowId);
 
@@ -292,7 +293,12 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 				[this._nativeElement],
 			);
 
-			transition$.subscribe(() => this.shown.emit());
+			transition$.subscribe(() => {
+				if (this._transitioning) {
+					this._transitioning = false;
+					this.shown.emit();
+				}
+			});
 		}
 	}
 
@@ -302,13 +308,22 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 	 * This is considered to be a "manual" triggering of the tooltip.
 	 */
 	close(animation = this.animation): void {
+		if (this._opening && this._transitioning) {
+			this._transitioning = false;
+			ngbCompleteTransition(this._windowRef!.location.nativeElement);
+		}
 		if (this._windowRef != null) {
 			this._getPositionTargetElement().removeAttribute('aria-describedby');
+			this._opening = false;
+			this._transitioning = true;
 			this._popupService.close(animation).subscribe(() => {
 				this._windowRef = null;
 				this._positioning.destroy();
 				this._afterRenderRef?.destroy();
-				this.hidden.emit();
+				if (this._transitioning) {
+					this._transitioning = false;
+					this.hidden.emit();
+				}
 				this._changeDetector.markForCheck();
 			});
 		}
@@ -356,8 +371,6 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 
 	ngOnDestroy() {
 		this.close(false);
-		this._mouseEnterTooltip.complete();
-		this._mouseLeaveTooltip.complete();
 		// This check is necessary because it's possible that ngOnDestroy could be invoked before ngOnInit.
 		// under certain conditions, see: https://github.com/ng-bootstrap/ng-bootstrap/issues/2199
 		this._unregisterListenersFn?.();

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -8,6 +8,7 @@ import {
 	Directive,
 	ElementRef,
 	EventEmitter,
+	HostListener,
 	inject,
 	Injector,
 	Input,
@@ -29,6 +30,7 @@ import { PopupService } from '../util/popup';
 import { isString } from '../util/util';
 
 import { NgbTooltipConfig } from './tooltip-config';
+import { Subject } from 'rxjs';
 import { addPopperOffset } from '../util/positioning-util';
 
 let nextId = 0;
@@ -56,6 +58,18 @@ export class NgbTooltipWindow {
 	@Input() animation: boolean;
 	@Input() id: string;
 	@Input() tooltipClass: string;
+	@Input() readonly mouseEnter: Subject<void>;
+	@Input() readonly mouseLeave: Subject<void>;
+
+	@HostListener('mouseenter')
+	onMouseEnter() {
+		this.mouseEnter?.next();
+	}
+
+	@HostListener('mouseleave')
+	onMouseLeave() {
+		this.mouseLeave?.next();
+	}
 }
 
 /**
@@ -186,6 +200,9 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 	private _positioning = ngbPositioning();
 	private _afterRenderRef: AfterRenderRef | undefined;
 
+	private _mouseEnterTooltip = new Subject<void>();
+	private _mouseLeaveTooltip = new Subject<void>();
+
 	/**
 	 * The string content or a `TemplateRef` for the content to be displayed in the tooltip.
 	 *
@@ -220,6 +237,8 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 			this._windowRef.setInput('animation', this.animation);
 			this._windowRef.setInput('tooltipClass', this.tooltipClass);
 			this._windowRef.setInput('id', this._ngbTooltipWindowId);
+			this._windowRef.setInput('mouseEnter', this._mouseEnterTooltip);
+			this._windowRef.setInput('mouseLeave', this._mouseLeaveTooltip);
 
 			this._getPositionTargetElement().setAttribute('aria-describedby', this._ngbTooltipWindowId);
 
@@ -324,6 +343,8 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 			this.close.bind(this),
 			+this.openDelay,
 			+this.closeDelay,
+			this._mouseEnterTooltip,
+			this._mouseLeaveTooltip,
 		);
 	}
 
@@ -335,6 +356,8 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 
 	ngOnDestroy() {
 		this.close(false);
+		this._mouseEnterTooltip.complete();
+		this._mouseLeaveTooltip.complete();
 		// This check is necessary because it's possible that ngOnDestroy could be invoked before ngOnInit.
 		// under certain conditions, see: https://github.com/ng-bootstrap/ng-bootstrap/issues/2199
 		this._unregisterListenersFn?.();

--- a/src/util/triggers.ts
+++ b/src/util/triggers.ts
@@ -1,3 +1,5 @@
+import { Observable, EMPTY } from 'rxjs';
+
 const ALIASES = {
 	hover: ['mouseenter', 'mouseleave'],
 	focus: ['focusin', 'focusout'],
@@ -36,6 +38,8 @@ export function listenToTriggers(
 	closeFn: () => void,
 	openDelayMs = 0,
 	closeDelayMs = 0,
+	enterPopover: Observable<void> = EMPTY,
+	leavePopover: Observable<void> = EMPTY,
 ) {
 	const parsedTriggers = parseTriggers(triggers);
 
@@ -72,6 +76,17 @@ export function listenToTriggers(
 				withDelay(() => activeOpenTriggers.size > 0 && openFn(), openDelayMs);
 			});
 			addEventListener(closeTrigger, () => {
+				activeOpenTriggers.delete(openTrigger);
+				withDelay(() => activeOpenTriggers.size === 0 && closeFn(), closeDelayMs);
+			});
+		}
+
+		if (openTrigger === 'mouseenter' && closeTrigger === 'mouseleave' && closeDelayMs > 0) {
+			enterPopover.subscribe(() => {
+				activeOpenTriggers.add(openTrigger);
+				clearTimeout(timeout);
+			});
+			leavePopover.subscribe(() => {
 				activeOpenTriggers.delete(openTrigger);
 				withDelay(() => activeOpenTriggers.size === 0 && closeFn(), closeDelayMs);
 			});

--- a/src/util/triggers.ts
+++ b/src/util/triggers.ts
@@ -38,8 +38,8 @@ export function listenToTriggers(
 	closeFn: () => void,
 	openDelayMs = 0,
 	closeDelayMs = 0,
-	enterPopover: Observable<void> = EMPTY,
-	leavePopover: Observable<void> = EMPTY,
+	enterContent: Observable<void> = EMPTY,
+	leaveContent: Observable<void> = EMPTY,
 ) {
 	const parsedTriggers = parseTriggers(triggers);
 
@@ -80,16 +80,19 @@ export function listenToTriggers(
 				withDelay(() => activeOpenTriggers.size === 0 && closeFn(), closeDelayMs);
 			});
 		}
-
 		if (openTrigger === 'mouseenter' && closeTrigger === 'mouseleave' && closeDelayMs > 0) {
-			enterPopover.subscribe(() => {
-				activeOpenTriggers.add(openTrigger);
+			const enterContentSub = enterContent.subscribe(() => {
+				activeOpenTriggers.delete(openTrigger);
 				clearTimeout(timeout);
 			});
-			leavePopover.subscribe(() => {
+			const leaveContentSub = leaveContent.subscribe(() => {
 				activeOpenTriggers.delete(openTrigger);
 				withDelay(() => activeOpenTriggers.size === 0 && closeFn(), closeDelayMs);
 			});
+			cleanupFns.push(
+				() => enterContentSub.unsubscribe(),
+				() => leaveContentSub.unsubscribe(),
+			);
 		}
 	}
 


### PR DESCRIPTION
When using a hover trigger and a close delay, tooltips/popovers will be kept open if the mouse leaves the trigger element and enters the tooltip/popover element before the close delay times out.

Fixes #4168

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
