### PR TITLE
docs(modal): replace incorrect header(Dropdown) with correct (Modal)

### DIFF
--- a/demo/src/app/components/modal/modal.routes.ts
+++ b/demo/src/app/components/modal/modal.routes.ts
@@ -68,7 +68,7 @@ export const ROUTES: Routes = [
 		path: '',
 		component: ComponentWrapper,
 		data: {
-			name: 'Dropdown',
+			name: 'Modal',
 			bootstrap: 'https://getbootstrap.com/docs/%version%/components/modal/',
 		},
 		children: [


### PR DESCRIPTION
in modal page in demo application header has incorrect value(Dropdown).