### PR TITLE
fix(highlight): Change highlight to track by index

### DIFF
--- a/src/typeahead/highlight.ts
+++ b/src/typeahead/highlight.ts
@@ -15,7 +15,7 @@ import { regExpEscape, removeAccents, toString } from '../util/util';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	encapsulation: ViewEncapsulation.None,
 	template: `
-		@for (part of parts; track part; let odd = $odd) {
+		@for (part of parts; track $index; let odd = $odd) {
 			@if (odd) {
 				<span class="{{ highlightClass }}">{{ part }}</span>
 			} @else {


### PR DESCRIPTION
Change track statement in `highlight.ts` to use `$index` instead of `part`. 

The current statement causes performance issues and even browser crashes when running a large number of strings with the same characters repeated in a typeahead.