### PR TITLE
fix(datepicker): config not applied

### DIFF
--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -26,11 +26,18 @@ function expectSameValues(inputDatepicker: NgbInputDatepicker, config: NgbInputD
 	);
 }
 
+function getWeekdays(element: HTMLElement): string[] {
+	return (<HTMLElement[]>Array.from(element.querySelectorAll('.ngb-dp-weekday')) || []).map((el) =>
+		el.textContent!.trim(),
+	);
+}
+
 function customizeConfig(config: NgbInputDatepickerConfig) {
 	config.autoClose = 'outside';
 	config.container = 'body';
-	config.positionTarget = 'positionTarget';
+	config.positionTarget = '#positionTarget';
 	config.placement = ['bottom-start', 'top-end'];
+	config.firstDayOfWeek = 7;
 }
 
 describe('NgbInputDatepicker', () => {
@@ -94,6 +101,30 @@ describe('NgbInputDatepicker', () => {
 				.query(By.directive(NgbInputDatepicker))
 				.injector.get(NgbInputDatepicker);
 			expectSameValues(inputDatepicker, config);
+		});
+	});
+
+	describe('Custom config as provider', () => {
+		const config = new NgbInputDatepickerConfig();
+		config.firstDayOfWeek = 7;
+
+		beforeEach(() => {
+			TestBed.configureTestingModule({
+				providers: [{ provide: NgbInputDatepickerConfig, useValue: config }],
+			});
+		});
+
+		it('should provide config to child datepicker', () => {
+			const fixture = createTestCmpt(`<input ngbDatepicker>`);
+
+			const inputDatepicker = fixture.debugElement
+				.query(By.directive(NgbInputDatepicker))
+				.injector.get(NgbInputDatepicker);
+			inputDatepicker.open();
+			fixture.detectChanges();
+			const datepicker = fixture.nativeElement.querySelector('ngb-datepicker');
+			expect(datepicker).not.toBeNull();
+			expect(getWeekdays(datepicker)).toEqual(['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']);
 		});
 	});
 

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -6,6 +6,7 @@ import {
 	EventEmitter,
 	forwardRef,
 	inject,
+	Injector,
 	Input,
 	NgZone,
 	OnChanges,
@@ -81,6 +82,7 @@ export class NgbInputDatepicker implements OnChanges, OnDestroy, ControlValueAcc
 	private _document = inject(DOCUMENT);
 	private _changeDetector = inject(ChangeDetectorRef);
 	private _config = inject(NgbInputDatepickerConfig);
+	private _injector = inject(Injector);
 
 	private _cRef: ComponentRef<NgbDatepicker> | null = null;
 	private _disabled = false;
@@ -378,7 +380,7 @@ export class NgbInputDatepicker implements OnChanges, OnDestroy, ControlValueAcc
 	 */
 	open() {
 		if (!this.isOpen()) {
-			this._cRef = this._vcRef.createComponent(NgbDatepicker);
+			this._cRef = this._vcRef.createComponent(NgbDatepicker, { injector: this._injector });
 
 			this._applyPopupStyling(this._cRef.location.nativeElement);
 			this._applyDatepickerInputs(this._cRef);

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -1219,6 +1219,26 @@ describe('ngb-datepicker', () => {
 		});
 	});
 
+	describe('Custom config with startDate', () => {
+		const config = new NgbDatepickerConfig();
+		config.firstDayOfWeek = 2;
+
+		beforeEach(() => {
+			TestBed.configureTestingModule({
+				providers: [{ provide: NgbDatepickerConfig, useValue: config }],
+			});
+		});
+
+		it(`should inherit config even when 'startDate' is set before init`, () => {
+			const fixture = createTestComponent(
+				`<ngb-datepicker [startDate]="{ year: 2016, month: 8, day: 3 }"></ngb-datepicker>`,
+			);
+			fixture.detectChanges();
+
+			expect(getWeekdays(fixture.nativeElement)).toEqual(['Tu', 'We', 'Th', 'Fr', 'Sa', 'Su', 'Mo']);
+		});
+	});
+
 	describe('NgbDatepicker', () => {
 		let mockState: NgbDatepickerState;
 		let dp: NgbDatepicker;

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -306,6 +306,7 @@ export class NgbDatepicker implements AfterViewInit, OnChanges, OnInit, ControlV
 
 	private _controlValue: NgbDate | null = null;
 	private _publicState: NgbDatepickerState = <any>{};
+	private _initialized = false;
 
 	/**
 	 * The reference to a custom content template.
@@ -612,6 +613,7 @@ export class NgbDatepicker implements AfterViewInit, OnChanges, OnInit, ControlV
 		if (!this.dayTemplate) {
 			this.dayTemplate = this._defaultDayTemplate;
 		}
+		this._initialized = true;
 	}
 
 	ngOnChanges(changes: SimpleChanges) {
@@ -631,7 +633,7 @@ export class NgbDatepicker implements AfterViewInit, OnChanges, OnInit, ControlV
 			.forEach((name) => (inputs[name] = this[name]));
 		this._service.set(inputs);
 
-		if ('startDate' in changes) {
+		if ('startDate' in changes && this._initialized) {
 			const { currentValue, previousValue } = changes.startDate;
 			if (isChangedMonth(previousValue, currentValue)) {
 				this.navigateTo(this.startDate);


### PR DESCRIPTION
Note that the proposed fix for #4697 will not resolve the issue when `NgbDatepicker.navigateTo()` is called manually, only when it is called by setting the `[startDate]` input. It seems reasonable to expect users not to call functions on components before they're initialized, so I believe this fix to be sufficient. That said, I'm more than happy to hear any feedback.

Fixes #4697
Fixes #3848 