### PR TITLE
fix(typeahead): track results by index in NgbTypeahead

### DIFF
--- a/src/typeahead/typeahead-window.ts
+++ b/src/typeahead/typeahead-window.ts
@@ -40,14 +40,14 @@ export interface ResultTemplateContext {
 		<ng-template #rt let-result="result" let-term="term" let-formatter="formatter">
 			<ngb-highlight [result]="formatter(result)" [term]="term" />
 		</ng-template>
-		@for (result of results; track result; let idx = $index) {
+		@for (result of results; track $index) {
 			<button
 				type="button"
 				class="dropdown-item"
 				role="option"
-				[id]="id + '-' + idx"
-				[class.active]="idx === activeIdx"
-				(mouseenter)="markActive(idx)"
+				[id]="id + '-' + $index"
+				[class.active]="$index === activeIdx"
+				(mouseenter)="markActive($index)"
 				(click)="select(result)"
 			>
 				<ng-template


### PR DESCRIPTION
Since the list or results if provided by the user code, we can't ensure that the list doesn't contain duplicates. Tracking by index is a safer default and won't generate a warning or a crash as mentioned in the issue.

fix #4702

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.
