### PR TITLE
Refactor/avoid ng zone

### DIFF
--- a/src/carousel/carousel.ts
+++ b/src/carousel/carousel.ts
@@ -1,6 +1,8 @@
 import {
 	AfterContentChecked,
 	AfterContentInit,
+	afterNextRender,
+	AfterRenderPhase,
 	AfterViewInit,
 	ChangeDetectionStrategy,
 	ChangeDetectorRef,
@@ -11,6 +13,7 @@ import {
 	ElementRef,
 	EventEmitter,
 	inject,
+	Injector,
 	Input,
 	NgZone,
 	Output,
@@ -139,6 +142,7 @@ export class NgbCarousel implements AfterContentChecked, AfterContentInit, After
 	private _cd = inject(ChangeDetectorRef);
 	private _container = inject(ElementRef);
 	private _destroyRef = inject(DestroyRef);
+	private _injector = inject(Injector);
 
 	private _interval$ = new BehaviorSubject(this._config.interval);
 	private _mouseHover$ = new BehaviorSubject(false);
@@ -340,16 +344,19 @@ export class NgbCarousel implements AfterContentChecked, AfterContentInit, After
 
 			// The following code need to be done asynchronously, after the dom becomes stable,
 			// otherwise all changes will be undone.
-			this._ngZone.onStable.pipe(take(1)).subscribe(() => {
-				for (const { id } of this.slides) {
-					const element = this._getSlideElement(id);
-					if (id === this.activeId) {
-						element.classList.add('active');
-					} else {
-						element.classList.remove('active');
+			afterNextRender(
+				() => {
+					for (const { id } of this.slides) {
+						const element = this._getSlideElement(id);
+						if (id === this.activeId) {
+							element.classList.add('active');
+						} else {
+							element.classList.remove('active');
+						}
 					}
-				}
-			});
+				},
+				{ phase: AfterRenderPhase.MixedReadWrite, injector: this._injector },
+			);
 		});
 	}
 

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -1,6 +1,8 @@
 import { fromEvent, merge } from 'rxjs';
-import { filter, take } from 'rxjs/operators';
+import { filter } from 'rxjs/operators';
 import {
+	afterNextRender,
+	AfterRenderPhase,
 	AfterViewInit,
 	ChangeDetectionStrategy,
 	ChangeDetectorRef,
@@ -303,6 +305,7 @@ export class NgbDatepicker implements AfterViewInit, OnChanges, OnInit, ControlV
 	private _ngbDateAdapter = inject(NgbDateAdapter<any>);
 	private _ngZone = inject(NgZone);
 	private _destroyRef = inject(DestroyRef);
+	private _injector = inject(Injector);
 
 	private _controlValue: NgbDate | null = null;
 	private _publicState: NgbDatepickerState = <any>{};
@@ -547,10 +550,12 @@ export class NgbDatepicker implements AfterViewInit, OnChanges, OnInit, ControlV
 	}
 
 	focus() {
-		this._ngZone.onStable
-			.asObservable()
-			.pipe(take(1))
-			.subscribe(() => this._nativeElement.querySelector<HTMLElement>('div.ngb-dp-day[tabindex="0"]')?.focus());
+		afterNextRender(
+			() => {
+				this._nativeElement.querySelector<HTMLElement>('div.ngb-dp-day[tabindex="0"]')?.focus();
+			},
+			{ phase: AfterRenderPhase.Read, injector: this._injector },
+		);
 	}
 
 	/**

--- a/src/modal/modal-backdrop.ts
+++ b/src/modal/modal-backdrop.ts
@@ -1,7 +1,17 @@
-import { Component, ElementRef, inject, Input, NgZone, OnInit, ViewEncapsulation } from '@angular/core';
+import {
+	afterNextRender,
+	AfterRenderPhase,
+	Component,
+	ElementRef,
+	inject,
+	Injector,
+	Input,
+	NgZone,
+	OnInit,
+	ViewEncapsulation,
+} from '@angular/core';
 
 import { Observable } from 'rxjs';
-import { take } from 'rxjs/operators';
 
 import { ngbRunTransition } from '../util/transition/ngbTransition';
 import { reflow } from '../util/util';
@@ -21,15 +31,14 @@ import { reflow } from '../util/util';
 export class NgbModalBackdrop implements OnInit {
 	private _nativeElement = inject(ElementRef).nativeElement as HTMLElement;
 	private _zone = inject(NgZone);
+	private _injector = inject(Injector);
 
 	@Input() animation: boolean;
 	@Input() backdropClass: string;
 
 	ngOnInit() {
-		this._zone.onStable
-			.asObservable()
-			.pipe(take(1))
-			.subscribe(() => {
+		afterNextRender(
+			() =>
 				ngbRunTransition(
 					this._zone,
 					this._nativeElement,
@@ -40,8 +49,9 @@ export class NgbModalBackdrop implements OnInit {
 						element.classList.add('show');
 					},
 					{ animation: this.animation, runningTransition: 'continue' },
-				);
-			});
+				),
+			{ injector: this._injector, phase: AfterRenderPhase.MixedReadWrite },
+		);
 	}
 
 	hide(): Observable<void> {

--- a/src/modal/modal-window.ts
+++ b/src/modal/modal-window.ts
@@ -1,9 +1,12 @@
 import { DOCUMENT } from '@angular/common';
 import {
+	afterNextRender,
+	AfterRenderPhase,
 	Component,
 	ElementRef,
 	EventEmitter,
 	inject,
+	Injector,
 	Input,
 	NgZone,
 	OnDestroy,
@@ -56,6 +59,7 @@ export class NgbModalWindow implements OnInit, OnDestroy {
 	private _document = inject(DOCUMENT);
 	private _elRef = inject(ElementRef<HTMLElement>);
 	private _zone = inject(NgZone);
+	private _injector = inject(Injector);
 
 	private _closed$ = new Subject<void>();
 	private _elWithFocus: Element | null = null; // element that is focused prior to modal opening
@@ -93,12 +97,7 @@ export class NgbModalWindow implements OnInit, OnDestroy {
 
 	ngOnInit() {
 		this._elWithFocus = this._document.activeElement;
-		this._zone.onStable
-			.asObservable()
-			.pipe(take(1))
-			.subscribe(() => {
-				this._show();
-			});
+		afterNextRender(() => this._show(), { injector: this._injector, phase: AfterRenderPhase.MixedReadWrite });
 	}
 
 	ngOnDestroy() {

--- a/src/offcanvas/offcanvas-panel.ts
+++ b/src/offcanvas/offcanvas-panel.ts
@@ -1,8 +1,11 @@
 import {
+	afterNextRender,
+	AfterRenderPhase,
 	Component,
 	ElementRef,
 	EventEmitter,
 	inject,
+	Injector,
 	Input,
 	NgZone,
 	OnDestroy,
@@ -12,7 +15,7 @@ import {
 } from '@angular/core';
 
 import { fromEvent, Observable, Subject } from 'rxjs';
-import { filter, take, takeUntil } from 'rxjs/operators';
+import { filter, takeUntil } from 'rxjs/operators';
 
 import { getFocusableBoundaryElements } from '../util/focus-trap';
 import { OffcanvasDismissReasons } from './offcanvas-dismiss-reasons';
@@ -38,6 +41,7 @@ export class NgbOffcanvasPanel implements OnInit, OnDestroy {
 	private _document = inject(DOCUMENT);
 	private _elRef = inject(ElementRef<HTMLElement>);
 	private _zone = inject(NgZone);
+	private _injector = inject(Injector);
 
 	private _closed$ = new Subject<void>();
 	private _elWithFocus: Element | null = null; // element that is focused prior to offcanvas opening
@@ -60,12 +64,7 @@ export class NgbOffcanvasPanel implements OnInit, OnDestroy {
 
 	ngOnInit() {
 		this._elWithFocus = this._document.activeElement;
-		this._zone.onStable
-			.asObservable()
-			.pipe(take(1))
-			.subscribe(() => {
-				this._show();
-			});
+		afterNextRender(() => this._show(), { injector: this._injector, phase: AfterRenderPhase.MixedReadWrite });
 	}
 
 	ngOnDestroy() {

--- a/src/toast/toast.ts
+++ b/src/toast/toast.ts
@@ -1,5 +1,7 @@
 import {
 	AfterContentInit,
+	afterNextRender,
+	AfterRenderPhase,
 	Attribute,
 	Component,
 	ContentChild,
@@ -7,6 +9,7 @@ import {
 	ElementRef,
 	EventEmitter,
 	inject,
+	Injector,
 	Input,
 	NgZone,
 	OnChanges,
@@ -17,7 +20,6 @@ import {
 } from '@angular/core';
 
 import { Observable } from 'rxjs';
-import { take } from 'rxjs/operators';
 
 import { NgbToastConfig } from './toast-config';
 import { ngbRunTransition } from '../util/transition/ngbTransition';
@@ -78,6 +80,7 @@ export class NgbToastHeader {}
 export class NgbToast implements AfterContentInit, OnChanges {
 	private _config = inject(NgbToastConfig);
 	private _zone = inject(NgZone);
+	private _injector = inject(Injector);
 	private _element = inject(ElementRef);
 
 	private _timeoutID;
@@ -140,13 +143,13 @@ export class NgbToast implements AfterContentInit, OnChanges {
 	}
 
 	ngAfterContentInit() {
-		this._zone.onStable
-			.asObservable()
-			.pipe(take(1))
-			.subscribe(() => {
+		afterNextRender(
+			() => {
 				this._init();
 				this.show();
-			});
+			},
+			{ phase: AfterRenderPhase.MixedReadWrite, injector: this._injector },
+		);
 	}
 
 	ngOnChanges(changes: SimpleChanges) {


### PR DESCRIPTION
This replaces a few usages of NgZone.onStable, which is not zoneless-compatible, with calls to afterRender or afterNextRender.
I'm not absolutely sure they behave exactly the same way, but the tests pass, and that's the recommended way of avoiding this method.
 
 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.
