### PR TITLE
fix(datepicker): generate weekday labels in correct order

### DIFF
--- a/src/datepicker/datepicker-i18n.ts
+++ b/src/datepicker/datepicker-i18n.ts
@@ -116,7 +116,9 @@ export class NgbDatepickerI18nDefault extends NgbDatepickerI18n {
 		width: Exclude<Intl.DateTimeFormatOptions['weekday'], undefined> = 'narrow',
 	): string {
 		const weekdaysStartingOnSunday = [...Array(7).keys()].map((day) =>
-			Intl.DateTimeFormat(this._locale, { weekday: width }).format(new Date(Date.UTC(2021, 5, day - 1))),
+			Intl.DateTimeFormat(this._locale, { weekday: width, timeZone: 'UTC' }).format(
+				new Date(Date.UTC(2021, 5, day - 1)),
+			),
 		);
 		const weekdays = weekdaysStartingOnSunday.map((day, index) => weekdaysStartingOnSunday[(index + 1) % 7]);
 		return weekdays[weekday - 1] || '';

--- a/src/datepicker/datepicker-i18n.ts
+++ b/src/datepicker/datepicker-i18n.ts
@@ -105,10 +105,10 @@ export class NgbDatepickerI18nDefault extends NgbDatepickerI18n {
 	private _locale = inject(LOCALE_ID);
 
 	private _monthsShort = [...Array(12).keys()].map((month) =>
-		Intl.DateTimeFormat(this._locale, { month: 'short' }).format(new Date(2000, month)),
+		Intl.DateTimeFormat(this._locale, { month: 'short', timeZone: 'UTC' }).format(new Date(2000, month, 15)),
 	);
 	private _monthsFull = [...Array(12).keys()].map((month) =>
-		Intl.DateTimeFormat(this._locale, { month: 'long' }).format(new Date(2000, month)),
+		Intl.DateTimeFormat(this._locale, { month: 'long', timeZone: 'UTC' }).format(new Date(2000, month, 15)),
 	);
 
 	getWeekdayLabel(


### PR DESCRIPTION
`timeZone` defaults to the user's timezone, which means that the week names might be returned in an unexpected order:

```
> TZ=Europe/Copenhagen node --eval "console.log([...Array(7).keys()].map((day) => Intl.DateTimeFormat('en', { weekday: 'narrow' }).format(new Date(Date.UTC(2021, 5, day - 1)))))"
[
  'S', 'M', 'T',
  'W', 'T', 'F',
  'S'
]

> TZ=America/New_York  node --eval "console.log([...Array(7).keys()].map((day) => Intl.DateTimeFormat('en', { weekday: 'narrow' }).format(new Date(Date.UTC(2021, 5, day - 1)))))"
[
  'S', 'S', 'M',
  'T', 'W', 'T',
  'F'
]
```

This would have been caught if the unit tests were run in different timezones (presumably they are run with `TZ=UTC` in CI?), as they are currently either passing or failing, depending on the timezone they are run in:

```
> TZ=UTC npm run test
...
TOTAL: 1579 SUCCESS
...

> TZ=America/New_York npm run test
...
TOTAL: 11 FAILED, 1568 SUCCESS
...
```

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#timezone

Closes https://github.com/ng-bootstrap/ng-bootstrap/issues/4729.

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
