### PR TITLE
docs(tooltip): replace term popover with tooltip in isOpen() method description.

### DIFF
--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -308,7 +308,7 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 	}
 
 	/**
-	 * Returns `true`, if the popover is currently shown.
+	 * Returns `true`, if the tooltip is currently shown.
 	 */
 	isOpen(): boolean {
 		return this._windowRef != null;


### PR DESCRIPTION
docs(tooltip): replace term `popover` with `tooltip` in `isOpen()` method description.
