### PR TITLE
fix(accordion): respect destroyOnHide while OnPush change detection

### DIFF
--- a/src/accordion/accordion.directive.ts
+++ b/src/accordion/accordion.directive.ts
@@ -298,6 +298,7 @@ export class NgbAccordionItem implements AfterContentInit {
 			this._collapseAnimationRunning = false;
 			this.hidden.emit();
 			this._accordion.hidden.emit(this.id);
+			this._cd.detectChanges();
 		});
 		ngbCollapse.shown.pipe(takeUntilDestroyed(this._destroyRef)).subscribe(() => {
 			this.shown.emit();


### PR DESCRIPTION
The documentation says when destroyOnHide is set to true or unset (which by default is true), content of the body should be removed from the DOM, but when using OnPush change detection strategy, content of the body is present to the DOM.

Fixes #4758

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [-] added/updated any applicable tests.
 - [-] added/updated any applicable API documentation.
 - [-] added/updated any applicable demos.
