### PR TITLE
fix(core): restore popper default preventOverflow function

### DIFF
--- a/src/util/positioning.ts
+++ b/src/util/positioning.ts
@@ -162,12 +162,6 @@ export function getPopperOptions({ placement, baseClass }: PositioningOptions, r
 					fallbackPlacements: popperPlacements,
 				},
 			},
-			{
-				enabled: true,
-				name: 'preventOverflow',
-				phase: 'main',
-				fn: function () {},
-			},
 		],
 	};
 }


### PR DESCRIPTION
While investigating https://github.com/ng-bootstrap/ng-bootstrap/issues/4678 I discovered that ng-bootstrap seems to override popper's native `preventOverflow` function, which so far as I can tell seems un-helpful. I also note that in the original PR which added this, maxokorokov noted that it is probably not necessary (I see no response to the comment and the change was left in): https://github.com/ng-bootstrap/ng-bootstrap/pull/4129#discussion_r704246424

I'm unsure whether you guys would consider this breaking, from my perspective its sort of the opposite, but given its been this way for literally a couple of years I dont want to understate the potential ramifications. Certainly all tests pass and my suspicion is the majority of users will see no changes from this (if someone is adding their own `preventOverflow.fn` it will continue to work, etc)

Closes #4678

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - ~~[ ] added/updated any applicable tests.~~
 - ~~[ ] added/updated any applicable API documentation.~~
 - ~~[ ] added/updated any applicable demos.~~