### PR TITLE
fix: set the value of typeahead's control to null instead of undefined

### DIFF
--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -633,7 +633,7 @@ describe('ngb-typeahead', () => {
 			fixture.detectChanges();
 			expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
 			expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
-			expect(fixture.componentInstance.model).toBeUndefined();
+			expect(fixture.componentInstance.model).toBeNull();
 
 			const event = createKeyDownEvent('Enter');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
@@ -659,7 +659,7 @@ describe('ngb-typeahead', () => {
 			fixture.detectChanges();
 			expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
 			expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
-			expect(fixture.componentInstance.model).toBeUndefined();
+			expect(fixture.componentInstance.model).toBeNull();
 
 			const event = createKeyDownEvent('Enter');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
@@ -672,7 +672,7 @@ describe('ngb-typeahead', () => {
 			fixture.detectChanges();
 			expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
 			expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
-			expect(fixture.componentInstance.model).toBeUndefined();
+			expect(fixture.componentInstance.model).toBeNull();
 		}));
 
 		it('should clear model on user input when the editable option is on and no search was triggered', fakeAsync(() => {
@@ -691,7 +691,7 @@ describe('ngb-typeahead', () => {
 			fixture.detectChanges();
 			expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
 			expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
-			expect(fixture.componentInstance.model).toBeUndefined();
+			expect(fixture.componentInstance.model).toBeNull();
 
 			const event = createKeyDownEvent('Enter');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
@@ -704,8 +704,25 @@ describe('ngb-typeahead', () => {
 			fixture.detectChanges();
 			expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
 			expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
-			expect(fixture.componentInstance.model).toBeUndefined();
+			expect(fixture.componentInstance.model).toBeNull();
 		}));
+
+		it('should use null and not undefined as value to make sure the form group value is valid (issue 4777)', () => {
+			const html = `
+           <form [formGroup]="form">
+             <input type="text" formControlName="control" [ngbTypeahead]="findObjects" [editable]="false" />
+           </form>`;
+			const fixture = createTestComponent(html);
+			const compiled = fixture.nativeElement;
+
+			changeInput(compiled, 'o');
+			fixture.detectChanges();
+
+			const formValue = fixture.componentInstance.form.getRawValue();
+			expect(formValue.control).toBeNull();
+
+			expect(() => fixture.componentInstance.form.setValue(formValue)).not.toThrow();
+		});
 	});
 
 	describe('select event', () => {
@@ -1086,7 +1103,7 @@ describe('ngb-typeahead', () => {
 			changeInput(compiled, 'one mor');
 			fixture.detectChanges();
 			expectWindowResults(compiled, ['+one more']);
-			expect(fixture.componentInstance.form.controls.control.value).toBeUndefined();
+			expect(fixture.componentInstance.form.controls.control.value).toBeNull();
 			expect(fixture.componentInstance.form.controls.control.valid).toBeFalse();
 		}));
 	});

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -409,7 +409,7 @@ export class NgbTypeahead implements ControlValueAccessor, OnInit, OnChanges, On
 			tap((value) => {
 				this._inputValueBackup = this.showHint ? value : null;
 				this._inputValueForSelectOnExact = this.selectOnExact ? value : null;
-				this._onChange(this.editable ? value : undefined);
+				this._onChange(this.editable ? value : null);
 			}),
 			this.ngbTypeahead ? this.ngbTypeahead : () => of([]),
 		);


### PR DESCRIPTION
fix #4777

BREAKING CHANGE:
When typing into a non-editable typeahead and not selecting any value, the associated form control value is set to null instead of undefined.

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.
