### PR TITLE
fix(pagination): put aria-current on link element instead of li for a11y

### DIFF
--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -23,12 +23,12 @@ function expectPages(nativeEl: HTMLElement, pagesDef: string[], ellipsis = '...'
 		if (classIndicator === '+') {
 			expect(pages[i]).toHaveCssClass('active');
 			expect(pages[i]).not.toHaveCssClass('disabled');
-			expect(pages[i].getAttribute('aria-current')).toBe('page');
+			expect(pages[i].querySelector('a')!.getAttribute('aria-current')).toBe('page');
 			expect(textContent).toEqual(pageDef.substring(1));
 		} else if (classIndicator === '-') {
 			expect(pages[i]).not.toHaveCssClass('active');
 			expect(pages[i]).toHaveCssClass('disabled');
-			expect(pages[i].getAttribute('aria-current')).toBeNull();
+			expect(pages[i].querySelector('a')!.getAttribute('aria-current')).toBeNull();
 			expect(textContent).toEqual(pageDef.substring(1));
 		} else if (classIndicator === 'c') {
 			// Custom Pages
@@ -38,7 +38,7 @@ function expectPages(nativeEl: HTMLElement, pagesDef: string[], ellipsis = '...'
 		} else {
 			expect(pages[i]).not.toHaveCssClass('active');
 			expect(pages[i]).not.toHaveCssClass('disabled');
-			expect(pages[i].getAttribute('aria-current')).toBeNull();
+			expect(pages[i].querySelector('a')!.getAttribute('aria-current')).toBeNull();
 			expect(textContent).toEqual(pageDef);
 		}
 
@@ -46,7 +46,7 @@ function expectPages(nativeEl: HTMLElement, pagesDef: string[], ellipsis = '...'
 		if (textContent === ellipsis) {
 			expect(pages[i]).not.toHaveCssClass('active');
 			expect(pages[i]).toHaveCssClass('disabled');
-			expect(pages[i].getAttribute('aria-current')).toBeNull();
+			expect(pages[i].querySelector('a')!.getAttribute('aria-current')).toBeNull();
 			expect(pages[i].querySelector('a')!.getAttribute('tabindex')).toEqual('-1');
 			expect(pages[i].querySelector('a')!.hasAttribute('aria-disabled')).toBeTruthy();
 		}

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -170,7 +170,6 @@ export class NgbPaginationPages {
 					class="page-item"
 					[class.active]="pageNumber === page"
 					[class.disabled]="isEllipsis(pageNumber) || disabled"
-					[attr.aria-current]="pageNumber === page ? 'page' : null"
 				>
 					@if (isEllipsis(pageNumber)) {
 						<a class="page-link" tabindex="-1" aria-disabled="true">
@@ -186,6 +185,7 @@ export class NgbPaginationPages {
 							(click)="selectPage(pageNumber); $event.preventDefault()"
 							[attr.tabindex]="disabled ? '-1' : null"
 							[attr.aria-disabled]="disabled ? 'true' : null"
+							[attr.aria-current]="pageNumber === page ? 'page' : null"
 						>
 							<ng-template
 								[ngTemplateOutlet]="tplNumber?.templateRef || defaultNumber"


### PR DESCRIPTION
Focusable pagination element should be marked with `aria-current` for the SR to read it properly (NVDA works with the attribute set on li but JAWS needs it to be on <a> element). 

reference of the `aria-current` and recommended usage: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current#example