### PR TITLE
refactor: remove standalone true statements

### DIFF
--- a/demo/src/app/components/modal/demos/component/modal-component.ts
+++ b/demo/src/app/components/modal/demos/component/modal-component.ts
@@ -3,7 +3,6 @@ import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
 	selector: 'ngbd-modal-content',
-	standalone: true,
 	template: `
 		<div class="modal-header">
 			<h4 class="modal-title">Hi there!</h4>
@@ -25,7 +24,6 @@ export class NgbdModalContent {
 
 @Component({
 	selector: 'ngbd-modal-component',
-	standalone: true,
 	templateUrl: './modal-component.html',
 })
 export class NgbdModalComponent {

--- a/demo/src/app/components/modal/demos/config/modal-config.ts
+++ b/demo/src/app/components/modal/demos/config/modal-config.ts
@@ -3,7 +3,6 @@ import { NgbModal, NgbModalConfig } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
 	selector: 'ngbd-modal-config',
-	standalone: true,
 	templateUrl: './modal-config.html',
 	// add NgbModalConfig and NgbModal to the component providers
 	providers: [NgbModalConfig, NgbModal],

--- a/demo/src/app/components/modal/demos/focus/modal-focus.ts
+++ b/demo/src/app/components/modal/demos/focus/modal-focus.ts
@@ -3,7 +3,6 @@ import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
 	selector: 'ngbd-modal-confirm',
-	standalone: true,
 	template: `
 		<div class="modal-header">
 			<h4 class="modal-title" id="modal-title">Profile deletion</h4>
@@ -35,7 +34,6 @@ export class NgbdModalConfirm {
 
 @Component({
 	selector: 'ngbd-modal-confirm-autofocus',
-	standalone: true,
 	template: `
 		<div class="modal-header">
 			<h4 class="modal-title" id="modal-title">Profile deletion</h4>
@@ -71,7 +69,7 @@ const MODALS: { [name: string]: Type<any> } = {
 	autofocus: NgbdModalConfirmAutofocus,
 };
 
-@Component({ selector: 'ngbd-modal-focus', standalone: true, templateUrl: './modal-focus.html' })
+@Component({ selector: 'ngbd-modal-focus', templateUrl: './modal-focus.html' })
 export class NgbdModalFocus {
 	private modalService = inject(NgbModal);
 

--- a/demo/src/app/components/modal/demos/options/modal-options.ts
+++ b/demo/src/app/components/modal/demos/options/modal-options.ts
@@ -3,7 +3,6 @@ import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
 	selector: 'ngbd-modal-options',
-	standalone: true,
 	templateUrl: './modal-options.html',
 	encapsulation: ViewEncapsulation.None,
 	styles: `

--- a/demo/src/app/components/modal/demos/stacked/modal-stacked.ts
+++ b/demo/src/app/components/modal/demos/stacked/modal-stacked.ts
@@ -4,7 +4,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
 	selector: 'ngbd-modal-stacked',
-	standalone: true,
 	template: `
 		<div class="modal-header">
 			<h4 class="modal-title">Hi there!</h4>
@@ -29,7 +28,6 @@ export class NgbdModal1Content {
 }
 
 @Component({
-	standalone: true,
 	template: `
 		<div class="modal-header">
 			<h4 class="modal-title">Hi there!</h4>
@@ -49,7 +47,6 @@ export class NgbdModal2Content {
 
 @Component({
 	selector: 'ngbd-modal-stacked',
-	standalone: true,
 	templateUrl: './modal-stacked.html',
 })
 export class NgbdModalStacked {

--- a/demo/src/app/components/modal/demos/updatable/modal-updatable-options.ts
+++ b/demo/src/app/components/modal/demos/updatable/modal-updatable-options.ts
@@ -3,7 +3,6 @@ import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
 	selector: 'ngbd-modal-updatable-options',
-	standalone: true,
 	template: `
 		<div class="modal-header">
 			<h4 class="modal-title">Hi there!</h4>
@@ -41,7 +40,6 @@ export class NgbdModalContent {
 
 @Component({
 	selector: 'ngbd-modal-updatable-component',
-	standalone: true,
 	templateUrl: './modal-updatable-options.html',
 })
 export class NgbdModalUpdatableOptions {

--- a/demo/src/app/components/offcanvas/demos/component/offcanvas-component.ts
+++ b/demo/src/app/components/offcanvas/demos/component/offcanvas-component.ts
@@ -3,7 +3,6 @@ import { NgbActiveOffcanvas, NgbOffcanvas } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
 	selector: 'ngbd-offcanvas-content',
-	standalone: true,
 	template: `
 		<div class="offcanvas-header">
 			<h5 class="offcanvas-title">Offcanvas</h5>
@@ -37,7 +36,6 @@ export class NgbdOffcanvasContent {
 
 @Component({
 	selector: 'ngbd-offcanvas-component',
-	standalone: true,
 	templateUrl: './offcanvas-component.html',
 })
 export class NgbdOffcanvasComponent {

--- a/demo/src/app/components/offcanvas/demos/config/offcanvas-config.ts
+++ b/demo/src/app/components/offcanvas/demos/config/offcanvas-config.ts
@@ -3,7 +3,6 @@ import { NgbOffcanvas, NgbOffcanvasConfig } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
 	selector: 'ngbd-offcanvas-config',
-	standalone: true,
 	templateUrl: './offcanvas-config.html',
 	// add NgbOffcanvasConfig and NgbOffcanvas to the component providers
 	providers: [NgbOffcanvasConfig, NgbOffcanvas],

--- a/demo/src/app/components/offcanvas/demos/focus/offcanvas-focus.ts
+++ b/demo/src/app/components/offcanvas/demos/focus/offcanvas-focus.ts
@@ -3,7 +3,6 @@ import { NgbActiveOffcanvas, NgbOffcanvas } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
 	selector: 'ngbd-offcanvas-firstfocus',
-	standalone: true,
 	template: `
 		<div class="offcanvas-header">
 			<h4 class="offcanvas-title">Offcanvas title</h4>
@@ -23,7 +22,6 @@ export class NgbdOffcanvasFirstFocus {
 
 @Component({
 	selector: 'ngbd-offcanvas-autofocus',
-	standalone: true,
 	template: `
 		<div class="offcanvas-header">
 			<h4 class="offcanvas-title">Offcanvas title</h4>
@@ -45,7 +43,6 @@ export class NgbdOffcanvasAutoFocus {
 
 @Component({
 	selector: 'ngbd-offcanvas-focus',
-	standalone: true,
 	templateUrl: './offcanvas-focus.html',
 })
 export class NgbdOffcanvasFocus {

--- a/demo/src/app/components/offcanvas/demos/options/offcanvas-options.ts
+++ b/demo/src/app/components/offcanvas/demos/options/offcanvas-options.ts
@@ -3,7 +3,6 @@ import { NgbOffcanvas } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
 	selector: 'ngbd-offcanvas-options',
-	standalone: true,
 	templateUrl: './offcanvas-options.html',
 	encapsulation: ViewEncapsulation.None,
 })

--- a/demo/src/app/components/table/demos/complete/sortable.directive.ts
+++ b/demo/src/app/components/table/demos/complete/sortable.directive.ts
@@ -12,7 +12,6 @@ export interface SortEvent {
 
 @Directive({
 	selector: 'th[sortable]',
-	standalone: true,
 	host: {
 		'[class.asc]': 'direction === "asc"',
 		'[class.desc]': 'direction === "desc"',

--- a/demo/src/app/components/table/demos/sortable/table-sortable.ts
+++ b/demo/src/app/components/table/demos/sortable/table-sortable.ts
@@ -53,7 +53,6 @@ export interface SortEvent {
 
 @Directive({
 	selector: 'th[sortable]',
-	standalone: true,
 	host: {
 		'[class.asc]': 'direction === "asc"',
 		'[class.desc]': 'direction === "desc"',

--- a/demo/src/app/pages/getting-started/getting-started.page.ts
+++ b/demo/src/app/pages/getting-started/getting-started.page.ts
@@ -109,7 +109,6 @@ export class GettingStartedPage {
 
       @Component({
         selector: 'app-product',
-        standalone: true,
         imports: [NgbAlert],
         templateUrl: './product.component.html'
       })

--- a/demo/src/app/shared/api-docs/api-docs-badge.component.ts
+++ b/demo/src/app/shared/api-docs/api-docs-badge.component.ts
@@ -11,7 +11,6 @@ const BADGES = {
 
 @Component({
 	selector: 'ngbd-api-docs-badge',
-	standalone: true,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	template: `
 		<h5>

--- a/demo/src/app/shared/code.component.ts
+++ b/demo/src/app/shared/code.component.ts
@@ -13,7 +13,6 @@ import { CodeHighlightService } from '../services/code-highlight.service';
 
 @Component({
 	selector: 'ngbd-code',
-	standalone: true,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	template: `
 		<pre class="language-{{ snippet().lang }}"><code #code class="language-{{ snippet().lang }}"></code></pre>

--- a/e2e-app/src/app/modal/role/modal-role.component.ts
+++ b/e2e-app/src/app/modal/role/modal-role.component.ts
@@ -2,7 +2,6 @@ import { Component, inject } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
-	standalone: true,
 	templateUrl: './modal-role.component.html',
 })
 export class ModalRoleComponent {

--- a/e2e-app/src/app/navigation.component.ts
+++ b/e2e-app/src/app/navigation.component.ts
@@ -5,7 +5,6 @@ import { ROUTES } from './app.routes';
 
 @Component({
 	selector: 'app-navigation',
-	standalone: true,
 	template: `
 		<a role="button" class="btn btn-outline-primary ms-3" id="navigate-home" href="#/">Menu</a>
 		<div [hidden]="isHidden">

--- a/src/accordion/accordion.directive.ts
+++ b/src/accordion/accordion.directive.ts
@@ -36,7 +36,6 @@ let nextId = 0;
  */
 @Component({
 	selector: '[ngbAccordionBody]',
-	standalone: true,
 	template: `
 		<ng-container #container />
 		<ng-content />
@@ -95,7 +94,6 @@ export class NgbAccordionBody implements AfterContentChecked, OnDestroy {
  */
 @Directive({
 	exportAs: 'ngbAccordionCollapse',
-	standalone: true,
 	selector: '[ngbAccordionCollapse]',
 	host: {
 		role: 'region',
@@ -120,7 +118,6 @@ export class NgbAccordionCollapse {
  */
 @Directive({
 	selector: '[ngbAccordionToggle]',
-	standalone: true,
 	host: {
 		'[id]': 'item.toggleId',
 		'[class.collapsed]': 'item.collapsed',
@@ -143,7 +140,6 @@ export class NgbAccordionToggle {
  */
 @Directive({
 	selector: 'button[ngbAccordionButton]',
-	standalone: true,
 	host: {
 		'[disabled]': 'item.disabled',
 		class: 'accordion-button',
@@ -162,7 +158,6 @@ export class NgbAccordionButton {
  */
 @Directive({
 	selector: '[ngbAccordionHeader]',
-	standalone: true,
 	host: {
 		role: 'heading',
 		class: 'accordion-header',
@@ -186,7 +181,6 @@ export class NgbAccordionHeader {
 @Directive({
 	selector: '[ngbAccordionItem]',
 	exportAs: 'ngbAccordionItem',
-	standalone: true,
 	host: {
 		'[id]': 'id',
 		class: 'accordion-item',
@@ -384,7 +378,6 @@ export class NgbAccordionItem implements AfterContentInit {
  */
 @Directive({
 	selector: '[ngbAccordion]',
-	standalone: true,
 	exportAs: 'ngbAccordion',
 	host: {
 		class: 'accordion',

--- a/src/alert/alert.ts
+++ b/src/alert/alert.ts
@@ -24,7 +24,6 @@ import { ngbAlertFadingTransition } from './alert-transition';
 @Component({
 	selector: 'ngb-alert',
 	exportAs: 'ngbAlert',
-	standalone: true,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	encapsulation: ViewEncapsulation.None,
 	host: {

--- a/src/carousel/carousel.ts
+++ b/src/carousel/carousel.ts
@@ -42,7 +42,7 @@ let carouselId = 0;
 /**
  * A directive that wraps the individual carousel slide.
  */
-@Directive({ selector: 'ng-template[ngbSlide]', standalone: true })
+@Directive({ selector: 'ng-template[ngbSlide]' })
 export class NgbSlide {
 	templateRef = inject(TemplateRef);
 

--- a/src/collapse/collapse.ts
+++ b/src/collapse/collapse.ts
@@ -10,7 +10,6 @@ import { NgbCollapseConfig } from './collapse-config';
 @Directive({
 	selector: '[ngbCollapse]',
 	exportAs: 'ngbCollapse',
-	standalone: true,
 	host: {
 		'[class.collapse-horizontal]': 'horizontal',
 	},

--- a/src/datepicker/datepicker-day-view.ts
+++ b/src/datepicker/datepicker-day-view.ts
@@ -4,7 +4,6 @@ import { NgbDatepickerI18n } from './datepicker-i18n';
 
 @Component({
 	selector: '[ngbDatepickerDayView]',
-	standalone: true,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	encapsulation: ViewEncapsulation.None,
 	styleUrl: './datepicker-day-view.scss',

--- a/src/datepicker/datepicker-input.ts
+++ b/src/datepicker/datepicker-input.ts
@@ -54,7 +54,6 @@ import { ContentTemplateContext } from './datepicker-content-template-context';
 @Directive({
 	selector: 'input[ngbDatepicker]',
 	exportAs: 'ngbDatepicker',
-	standalone: true,
 	host: {
 		'(input)': 'manualDateChange($event.target.value)',
 		'(change)': 'manualDateChange($event.target.value, true)',

--- a/src/datepicker/datepicker-navigation-select.ts
+++ b/src/datepicker/datepicker-navigation-select.ts
@@ -16,7 +16,6 @@ import { NgbDatepickerI18n } from './datepicker-i18n';
 
 @Component({
 	selector: 'ngb-datepicker-navigation-select',
-	standalone: true,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	encapsulation: ViewEncapsulation.None,
 	styleUrl: './datepicker-navigation-select.scss',

--- a/src/datepicker/datepicker.ts
+++ b/src/datepicker/datepicker.ts
@@ -111,7 +111,7 @@ export interface NgbDatepickerState {
  *
  * @since 5.3.0
  */
-@Directive({ selector: 'ng-template[ngbDatepickerContent]', standalone: true })
+@Directive({ selector: 'ng-template[ngbDatepickerContent]' })
 export class NgbDatepickerContent {
 	templateRef = inject(TemplateRef);
 }

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -41,7 +41,6 @@ import { getActiveElement } from '../util/util';
  */
 @Directive({
 	selector: '[ngbDropdownItem]',
-	standalone: true,
 	host: {
 		class: 'dropdown-item',
 		'[class.disabled]': 'disabled',
@@ -73,7 +72,6 @@ export class NgbDropdownItem {
  */
 @Directive({
 	selector: 'button[ngbDropdownItem]',
-	standalone: true,
 	host: { '[disabled]': 'item.disabled' },
 })
 export class NgbDropdownButtonItem {
@@ -85,7 +83,6 @@ export class NgbDropdownButtonItem {
  */
 @Directive({
 	selector: '[ngbDropdownMenu]',
-	standalone: true,
 	host: {
 		class: 'dropdown-menu',
 		'[class.show]': 'dropdown.isOpen()',
@@ -117,7 +114,6 @@ export class NgbDropdownMenu {
  */
 @Directive({
 	selector: '[ngbDropdownAnchor]',
-	standalone: true,
 	host: {
 		class: 'dropdown-toggle',
 		'[class.show]': 'dropdown.isOpen()',
@@ -136,7 +132,6 @@ export class NgbDropdownAnchor {
  */
 @Directive({
 	selector: '[ngbDropdownToggle]',
-	standalone: true,
 	host: {
 		class: 'dropdown-toggle',
 		'[class.show]': 'dropdown.isOpen()',
@@ -159,7 +154,6 @@ export class NgbDropdownToggle extends NgbDropdownAnchor {}
 @Directive({
 	selector: '[ngbDropdown]',
 	exportAs: 'ngbDropdown',
-	standalone: true,
 	host: { '[class.show]': 'isOpen()' },
 })
 export class NgbDropdown implements OnInit, AfterContentInit, OnChanges, OnDestroy {

--- a/src/modal/modal-backdrop.ts
+++ b/src/modal/modal-backdrop.ts
@@ -17,7 +17,6 @@ import { reflow } from '../util/util';
 
 @Component({
 	selector: 'ngb-modal-backdrop',
-	standalone: true,
 	encapsulation: ViewEncapsulation.None,
 	template: '',
 	host: {

--- a/src/modal/modal-window.ts
+++ b/src/modal/modal-window.ts
@@ -25,7 +25,6 @@ import { isString, reflow } from '../util/util';
 
 @Component({
 	selector: 'ngb-modal-window',
-	standalone: true,
 	host: {
 		'[class]': '"modal d-block" + (windowClass ? " " + windowClass : "")',
 		'[class.fade]': 'animation',

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -1160,7 +1160,6 @@ describe('ngb-modal', () => {
 	if (isBrowserVisible('ngb-modal animations')) {
 		describe('ngb-modal animations', () => {
 			@Component({
-				standalone: true,
 				template: `
 					<ng-template #content let-close="close" let-dismiss="dismiss">
 						<div id="inside-div">Bla bla</div>
@@ -1414,7 +1413,7 @@ describe('ngb-modal', () => {
 	});
 });
 
-@Component({ selector: 'custom-injector-cmpt', standalone: true, template: 'Some content' })
+@Component({ selector: 'custom-injector-cmpt', template: 'Some content' })
 export class CustomInjectorCmpt implements OnDestroy {
 	constructor(private _spyService: CustomSpyService) {}
 
@@ -1423,7 +1422,7 @@ export class CustomInjectorCmpt implements OnDestroy {
 	}
 }
 
-@Component({ selector: 'destroyable-cmpt', standalone: true, template: 'Some content' })
+@Component({ selector: 'destroyable-cmpt', template: 'Some content' })
 export class DestroyableCmpt implements OnDestroy {
 	constructor(private _spyService: SpyService) {}
 
@@ -1434,7 +1433,6 @@ export class DestroyableCmpt implements OnDestroy {
 
 @Component({
 	selector: 'modal-content-cmpt',
-	standalone: true,
 	template: '<button class="closeFromInside" (click)="close()">Close</button>',
 })
 export class WithActiveModalCmpt {
@@ -1447,14 +1445,12 @@ export class WithActiveModalCmpt {
 
 @Component({
 	selector: 'modal-autofocus-cmpt',
-	standalone: true,
 	template: `<button class="withNgbAutofocus" ngbAutofocus>Click Me</button>`,
 })
 export class WithAutofocusModalCmpt {}
 
 @Component({
 	selector: 'modal-firstfocusable-cmpt',
-	standalone: true,
 	template: `
 		<button class="firstFocusable close">Close</button>
 		<button class="other">Other button</button>
@@ -1464,7 +1460,6 @@ export class WithFirstFocusableModalCmpt {}
 
 @Component({
 	selector: 'modal-skip-tabindex-firstfocusable-cmpt',
-	standalone: true,
 	template: `
 		<button tabindex="-1" class="firstFocusable close">Close</button>
 		<button class="other">Other button</button>
@@ -1562,7 +1557,6 @@ class TestComponent {
 
 @Component({
 	selector: 'test-a11y-cmpt',
-	standalone: true,
 	template: `
 		<div class="to-hide to-restore-true" aria-hidden="true">
 			<div class="not-to-hide"></div>

--- a/src/nav/nav-outlet.ts
+++ b/src/nav/nav-outlet.ts
@@ -22,7 +22,6 @@ import { NgTemplateOutlet } from '@angular/common';
 
 @Directive({
 	selector: '[ngbNavPane]',
-	standalone: true,
 	host: {
 		'[id]': 'item.panelDomId',
 		class: 'tab-pane',

--- a/src/nav/nav.ts
+++ b/src/nav/nav.ts
@@ -49,7 +49,7 @@ export interface NgbNavContentContext {
  *
  * @since 5.2.0
  */
-@Directive({ selector: 'ng-template[ngbNavContent]', standalone: true })
+@Directive({ selector: 'ng-template[ngbNavContent]' })
 export class NgbNavContent {
 	templateRef = inject(TemplateRef);
 }
@@ -61,7 +61,6 @@ export class NgbNavContent {
  */
 @Directive({
 	selector: '[ngbNavItem]:not(ng-container)',
-	standalone: true,
 	host: {
 		'[attr.role]': `role ? role : nav.roles ? 'presentation' : undefined`,
 	},
@@ -80,7 +79,7 @@ export class NgbNavItemRole {
 @Directive({
 	selector: '[ngbNavItem]',
 	exportAs: 'ngbNavItem',
-	standalone: true,
+
 	host: {
 		class: 'nav-item',
 	},
@@ -173,7 +172,6 @@ export class NgbNavItem implements OnInit {
 @Directive({
 	selector: '[ngbNav]',
 	exportAs: 'ngbNav',
-	standalone: true,
 	host: {
 		class: 'nav',
 		'[class.flex-column]': `orientation === 'vertical'`,
@@ -405,7 +403,6 @@ export class NgbNav implements AfterContentInit, OnChanges {
 
 @Directive({
 	selector: '[ngbNavLink]',
-	standalone: true,
 	host: {
 		'[id]': 'navItem.domId',
 		class: 'nav-link',
@@ -442,7 +439,6 @@ export class NgbNavLinkBase {
  */
 @Directive({
 	selector: 'button[ngbNavLink]',
-	standalone: true,
 	host: {
 		type: 'button',
 		'[disabled]': 'navItem.disabled',
@@ -458,7 +454,6 @@ export class NgbNavLinkButton extends NgbNavLinkBase {}
  */
 @Directive({
 	selector: 'a[ngbNavLink]',
-	standalone: true,
 	host: {
 		href: '',
 		'(click)': 'nav.click(navItem); $event.preventDefault()',

--- a/src/offcanvas/offcanvas-backdrop.ts
+++ b/src/offcanvas/offcanvas-backdrop.ts
@@ -20,7 +20,6 @@ import { OffcanvasDismissReasons } from './offcanvas-dismiss-reasons';
 
 @Component({
 	selector: 'ngb-offcanvas-backdrop',
-	standalone: true,
 	encapsulation: ViewEncapsulation.None,
 	template: '',
 	host: {

--- a/src/offcanvas/offcanvas-panel.ts
+++ b/src/offcanvas/offcanvas-panel.ts
@@ -24,7 +24,6 @@ import { DOCUMENT } from '@angular/common';
 
 @Component({
 	selector: 'ngb-offcanvas-panel',
-	standalone: true,
 	template: '<ng-content />',
 	encapsulation: ViewEncapsulation.None,
 	host: {

--- a/src/offcanvas/offcanvas.spec.ts
+++ b/src/offcanvas/offcanvas.spec.ts
@@ -772,7 +772,6 @@ describe('ngb-offcanvas', () => {
 	if (isBrowserVisible('ngb-offcanvas animations')) {
 		describe('ngb-offcanvas animations', () => {
 			@Component({
-				standalone: true,
 				template: `
 					<ng-template #content let-close="close" let-dismiss="dismiss">
 						<div id="inside-div">Bla bla</div>
@@ -882,7 +881,7 @@ describe('ngb-offcanvas', () => {
 	}
 });
 
-@Component({ selector: 'custom-injector-cmpt', standalone: true, template: 'Some content' })
+@Component({ selector: 'custom-injector-cmpt', template: 'Some content' })
 export class CustomInjectorCmpt implements OnDestroy {
 	constructor(private _spyService: CustomSpyService) {}
 
@@ -891,7 +890,7 @@ export class CustomInjectorCmpt implements OnDestroy {
 	}
 }
 
-@Component({ selector: 'destroyable-cmpt', standalone: true, template: 'Some content' })
+@Component({ selector: 'destroyable-cmpt', template: 'Some content' })
 export class DestroyableCmpt implements OnDestroy {
 	constructor(private _spyService: SpyService) {}
 
@@ -902,7 +901,6 @@ export class DestroyableCmpt implements OnDestroy {
 
 @Component({
 	selector: 'offcanvas-content-cmpt',
-	standalone: true,
 	template: '<button class="closeFromInside" (click)="close()">Close</button>',
 })
 export class WithActiveOffcanvasCmpt {
@@ -915,14 +913,12 @@ export class WithActiveOffcanvasCmpt {
 
 @Component({
 	selector: 'offcanvas-autofocus-cmpt',
-	standalone: true,
 	template: `<button class="withNgbAutofocus" ngbAutofocus>Click Me</button>`,
 })
 export class WithAutofocusOffcanvasCmpt {}
 
 @Component({
 	selector: 'offcanvas-firstfocusable-cmpt',
-	standalone: true,
 	template: `
 		<button class="firstFocusable close">Close</button>
 		<button class="other">Other button</button>
@@ -932,7 +928,6 @@ export class WithFirstFocusableOffcanvasCmpt {}
 
 @Component({
 	selector: 'offcanvas-skip-tabindex-firstfocusable-cmpt',
-	standalone: true,
 	template: `
 		<button tabindex="-1" class="firstFocusable close">Close</button>
 		<button class="other">Other button</button>
@@ -1019,7 +1014,6 @@ class TestComponent {
 
 @Component({
 	selector: 'test-a11y-cmpt',
-	standalone: true,
 	template: `
 		<div class="to-hide to-restore-true" aria-hidden="true">
 			<div class="not-to-hide"></div>

--- a/src/pagination/pagination.ts
+++ b/src/pagination/pagination.ts
@@ -82,7 +82,7 @@ export interface NgbPaginationPagesContext {
  *
  * @since 4.1.0
  */
-@Directive({ selector: 'ng-template[ngbPaginationEllipsis]', standalone: true })
+@Directive({ selector: 'ng-template[ngbPaginationEllipsis]' })
 export class NgbPaginationEllipsis {
 	templateRef = inject(TemplateRef<NgbPaginationLinkContext>);
 }
@@ -92,7 +92,7 @@ export class NgbPaginationEllipsis {
  *
  * @since 4.1.0
  */
-@Directive({ selector: 'ng-template[ngbPaginationFirst]', standalone: true })
+@Directive({ selector: 'ng-template[ngbPaginationFirst]' })
 export class NgbPaginationFirst {
 	templateRef = inject(TemplateRef<NgbPaginationLinkContext>);
 }
@@ -102,7 +102,7 @@ export class NgbPaginationFirst {
  *
  * @since 4.1.0
  */
-@Directive({ selector: 'ng-template[ngbPaginationLast]', standalone: true })
+@Directive({ selector: 'ng-template[ngbPaginationLast]' })
 export class NgbPaginationLast {
 	templateRef = inject(TemplateRef<NgbPaginationLinkContext>);
 }
@@ -112,7 +112,7 @@ export class NgbPaginationLast {
  *
  * @since 4.1.0
  */
-@Directive({ selector: 'ng-template[ngbPaginationNext]', standalone: true })
+@Directive({ selector: 'ng-template[ngbPaginationNext]' })
 export class NgbPaginationNext {
 	templateRef = inject(TemplateRef<NgbPaginationLinkContext>);
 }
@@ -122,7 +122,7 @@ export class NgbPaginationNext {
  *
  * @since 4.1.0
  */
-@Directive({ selector: 'ng-template[ngbPaginationNumber]', standalone: true })
+@Directive({ selector: 'ng-template[ngbPaginationNumber]' })
 export class NgbPaginationNumber {
 	templateRef = inject(TemplateRef<NgbPaginationNumberContext>);
 }
@@ -132,7 +132,7 @@ export class NgbPaginationNumber {
  *
  * @since 4.1.0
  */
-@Directive({ selector: 'ng-template[ngbPaginationPrevious]', standalone: true })
+@Directive({ selector: 'ng-template[ngbPaginationPrevious]' })
 export class NgbPaginationPrevious {
 	templateRef = inject(TemplateRef<NgbPaginationLinkContext>);
 }
@@ -142,7 +142,7 @@ export class NgbPaginationPrevious {
  *
  * @since 9.1.0
  */
-@Directive({ selector: 'ng-template[ngbPaginationPages]', standalone: true })
+@Directive({ selector: 'ng-template[ngbPaginationPages]' })
 export class NgbPaginationPages {
 	templateRef = inject(TemplateRef<NgbPaginationPagesContext>);
 }

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -1116,7 +1116,7 @@ if (isBrowserVisible('ngb-popover animations')) {
 	});
 }
 
-@Component({ selector: 'destroyable-cmpt', standalone: true, template: 'Some content' })
+@Component({ selector: 'destroyable-cmpt', template: 'Some content' })
 export class DestroyableCmpt implements OnDestroy {
 	constructor(private _spyService: SpyService) {}
 

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -77,7 +77,7 @@ export class NgbPopoverWindow {
 /**
  * A lightweight and extensible directive for fancy popover creation.
  */
-@Directive({ selector: '[ngbPopover]', exportAs: 'ngbPopover', standalone: true })
+@Directive({ selector: '[ngbPopover]', exportAs: 'ngbPopover' })
 export class NgbPopover implements OnInit, OnDestroy, OnChanges {
 	static ngAcceptInputType_autoClose: boolean | string;
 

--- a/src/progressbar/progressbar.ts
+++ b/src/progressbar/progressbar.ts
@@ -132,7 +132,6 @@ export class NgbProgressbar {
  */
 @Component({
 	selector: 'ngb-progressbar-stacked',
-	standalone: true,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	encapsulation: ViewEncapsulation.None,
 	host: {

--- a/src/scrollspy/scrollspy.ts
+++ b/src/scrollspy/scrollspy.ts
@@ -36,7 +36,6 @@ export interface NgbScrollSpyRef {
  */
 @Directive({
 	selector: '[ngbScrollSpyItem]',
-	standalone: true,
 	exportAs: 'ngbScrollSpyItem',
 	host: {
 		'[class.active]': 'isActive()',
@@ -141,7 +140,6 @@ export class NgbScrollSpyItem implements OnInit {
  */
 @Directive({
 	selector: '[ngbScrollSpyMenu]',
-	standalone: true,
 })
 export class NgbScrollSpyMenu implements NgbScrollSpyRef, AfterViewInit {
 	private _scrollSpyRef: NgbScrollSpyRef = inject(NgbScrollSpyService);
@@ -200,7 +198,6 @@ export class NgbScrollSpyMenu implements NgbScrollSpyRef, AfterViewInit {
  */
 @Directive({
 	selector: '[ngbScrollSpy]',
-	standalone: true,
 	exportAs: 'ngbScrollSpy',
 	host: {
 		tabindex: '0',
@@ -306,7 +303,6 @@ export class NgbScrollSpy implements NgbScrollSpyRef, AfterViewInit {
  */
 @Directive({
 	selector: '[ngbScrollSpyFragment]',
-	standalone: true,
 	host: {
 		'[id]': 'id',
 	},

--- a/src/timepicker/timepicker.ts
+++ b/src/timepicker/timepicker.ts
@@ -23,7 +23,6 @@ const FILTER_REGEX = /[^0-9]/g;
 @Component({
 	exportAs: 'ngbTimepicker',
 	selector: 'ngb-timepicker',
-	standalone: true,
 	encapsulation: ViewEncapsulation.None,
 	styleUrl: './timepicker.scss',
 	template: `

--- a/src/toast/toast.ts
+++ b/src/toast/toast.ts
@@ -31,7 +31,7 @@ import { NgTemplateOutlet } from '@angular/common';
  *
  * @since 5.0.0
  */
-@Directive({ selector: '[ngbToastHeader]', standalone: true })
+@Directive({ selector: '[ngbToastHeader]' })
 export class NgbToastHeader {}
 
 /**

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -35,7 +35,6 @@ let nextId = 0;
 
 @Component({
 	selector: 'ngb-tooltip-window',
-	standalone: true,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	encapsulation: ViewEncapsulation.None,
 	host: {
@@ -61,7 +60,7 @@ export class NgbTooltipWindow {
 /**
  * A lightweight and extensible directive for fancy tooltip creation.
  */
-@Directive({ selector: '[ngbTooltip]', standalone: true, exportAs: 'ngbTooltip' })
+@Directive({ selector: '[ngbTooltip]', exportAs: 'ngbTooltip' })
 export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 	static ngAcceptInputType_autoClose: boolean | string;
 

--- a/src/typeahead/highlight.ts
+++ b/src/typeahead/highlight.ts
@@ -11,7 +11,6 @@ import { regExpEscape, removeAccents, toString } from '../util/util';
  */
 @Component({
 	selector: 'ngb-highlight',
-	standalone: true,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	encapsulation: ViewEncapsulation.None,
 	template: `

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -56,7 +56,6 @@ let nextWindowId = 0;
 @Directive({
 	selector: 'input[ngbTypeahead]',
 	exportAs: 'ngbTypeahead',
-	standalone: true,
 	host: {
 		'(blur)': 'handleBlur()',
 		'[class.open]': 'isPopupOpen()',

--- a/ssr-app/src/app/components/modal.component.ts
+++ b/ssr-app/src/app/components/modal.component.ts
@@ -14,7 +14,6 @@ function getDismissReason(reason: any): string {
 
 @Component({
 	selector: 'modal-component',
-	standalone: true,
 	template: `
 		<ng-template #content let-modal>
 			<div class="modal-header">


### PR DESCRIPTION
Removing the remnants of 'standalone: true' for the components that were omitted by Angular automated migration.

Didn't remove `standalone: true` in the ng-add test as it is better to keep explicit value. (https://github.com/ng-bootstrap/ng-bootstrap/blob/master/schematics/ng-add/setup-project.spec.ts#L24)