### PR TITLE
fix(timepicker): wrong auto-setting of hour value

### DIFF
--- a/src/timepicker/timepicker.ts
+++ b/src/timepicker/timepicker.ts
@@ -381,7 +381,7 @@ export class NgbTimepicker implements ControlValueAccessor, OnChanges {
 	}
 
 	toggleMeridian() {
-		if (this.meridian) {
+		if (this.model && isNumber(this.model.hour) && this.meridian) {
 			this.changeHour(12);
 		}
 	}


### PR DESCRIPTION
Toggling the meridian option with empty model wrongly sets the hour without any user input on it.

Fixes #4797
