### PR TITLE
feat(datepicker): add live area to announce selected month(s) update

### DIFF
--- a/src/datepicker/datepicker-navigation.spec.ts
+++ b/src/datepicker/datepicker-navigation.spec.ts
@@ -134,6 +134,19 @@ describe('ngb-datepicker-navigation', () => {
 		expect(links[0].getAttribute('title')).toBe('Previous month');
 		expect(links[1].getAttribute('title')).toBe('Next month');
 	});
+
+	it('should have a live-attribute announcing month selection updates', () => {
+		const fixture = createTestComponent(`<ngb-datepicker-navigation [months]="months" />`);
+
+		const monthsAnnouncer = fixture.nativeElement.querySelector(
+			'ngb-datepicker-navigation .visually-hidden[aria-live="polite"]',
+		);
+		expect(monthsAnnouncer).toBeTruthy();
+		expect(monthsAnnouncer.textContent).toBe('August 2016');
+		fixture.componentInstance.months = [{ firstDate: new NgbDate(2016, 9, 1) }];
+		fixture.detectChanges();
+		expect(monthsAnnouncer.textContent).toBe('September 2016');
+	});
 });
 
 @Component({
@@ -147,6 +160,7 @@ class TestComponent {
 	nextDisabled = false;
 	showSelect = true;
 	selectBoxes = { months: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], years: [2015, 2016, 2017, 2018, 2019, 2020] };
+	months = [{ firstDate: new NgbDate(2016, 8, 1) }];
 
 	onNavigate = (event) => {};
 	onSelect = (date) => {};

--- a/src/datepicker/datepicker-navigation.ts
+++ b/src/datepicker/datepicker-navigation.ts
@@ -45,7 +45,7 @@ import { NgbDatepickerNavigationSelect } from './datepicker-navigation-select';
 		}
 
 		@if (!showSelect) {
-			@for (month of months; track month; let i = $index) {
+			@for (month of months; track idMonth(month); let i = $index) {
 				@if (i > 0) {
 					<div class="ngb-dp-arrow"></div>
 				}
@@ -57,6 +57,12 @@ import { NgbDatepickerNavigationSelect } from './datepicker-navigation-select';
 				}
 			}
 		}
+		<div class="visually-hidden" aria-live="polite">
+			@for (month of months; track idMonth(month)) {
+				<span>{{ i18n.getMonthLabel(month.firstDate) }}</span>
+			}
+		</div>
+
 		<div class="ngb-dp-arrow ngb-dp-arrow-next">
 			<button
 				type="button"
@@ -97,5 +103,9 @@ export class NgbDatepickerNavigation {
 	onClickNext(event: MouseEvent) {
 		(event.currentTarget as HTMLElement).focus();
 		this.navigate.emit(this.navigation.NEXT);
+	}
+
+	idMonth(month: MonthViewModel) {
+		return month;
 	}
 }


### PR DESCRIPTION
When using a screen reader, month(s) updates are not announced.
(Especially for previous and next arrow buttons)

This PR solves it by adding a visually hidden live area announcing the month updates.