### PR TITLE
feat: Add a color mode handler script into service

### DIFF
--- a/demo/src/app/shared/theme-picker.component.ts
+++ b/demo/src/app/shared/theme-picker.component.ts
@@ -1,13 +1,11 @@
-import { ChangeDetectionStrategy, Component, computed, effect, signal } from '@angular/core';
-import { NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { ColorMode, ColorModeService, NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
 
 interface Theme {
-	id: 'auto' | 'light' | 'dark';
+	id: ColorMode;
 	name: string;
 	icon: string;
 }
-
-const PREFERS_COLOR_SCHEME_DARK = window.matchMedia('(prefers-color-scheme: dark)');
 
 const THEMES: Theme[] = [
 	{ id: 'auto', name: 'Auto', icon: 'bi-circle-half' },
@@ -26,7 +24,7 @@ const THEMES: Theme[] = [
 			</a>
 			<div ngbDropdownMenu aria-labelledby="demo-site-theme" class="dropdown-menu dropdown-menu-end">
 				@for (theme of themes(); track theme) {
-					<button ngbDropdownItem [class.active]="theme.id === current().id" (click)="preferred.set(theme.id)">
+					<button ngbDropdownItem [class.active]="theme.id === current().id" (click)="setColorMode(theme.id)">
 						<span class="bi {{ theme.icon }} me-2"></span>{{ theme.name }}
 					</button>
 				}
@@ -35,22 +33,14 @@ const THEMES: Theme[] = [
 	`,
 })
 export class ThemePickerComponent {
+	private colorModeService = inject(ColorModeService);
+
 	themes = signal(THEMES).asReadonly();
-	preferred = signal(localStorage.getItem('theme') || this.themes()[0].id);
-	current = computed(() => this.themes().find((t) => t.id === this.preferred()) || this.themes()[0]);
-	systemTheme = signal(PREFERS_COLOR_SCHEME_DARK.matches ? 'dark' : 'light');
-	dataBsTheme = computed(() => (this.current().id === 'auto' ? this.systemTheme()! : this.current().id));
 
-	constructor() {
-		// save preferred theme in local storage when it changes
-		effect(() => localStorage.setItem('theme', this.preferred()));
-
-		// updating current theme in DOM
-		effect(() => document.documentElement.setAttribute('data-bs-theme', this.dataBsTheme()));
-
-		// listening to system theme changes, could be done with RxJS, but this is simpler
-		PREFERS_COLOR_SCHEME_DARK.addEventListener('change', (event) =>
-			this.systemTheme.set(event.matches ? 'dark' : 'light'),
-		);
+	current = computed(
+		() => this.themes().find((t) => t.id === this.colorModeService.currentColorMode()) ?? this.themes[0],
+	);
+	setColorMode(themeId: Theme['id']) {
+		this.colorModeService.setColorMode(themeId);
 	}
 }

--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -1,7 +1,8 @@
 /// <reference types="@angular/localize" />
 
+import { provideHttpClient, withNoXsrfProtection } from '@angular/common/http';
+import { inject, provideAppInitializer, provideExperimentalZonelessChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
-import { AppComponent } from './app/app.component';
 import {
 	PreloadAllModules,
 	provideRouter,
@@ -10,9 +11,10 @@ import {
 	withInMemoryScrolling,
 	withPreloading,
 } from '@angular/router';
+import { provideColorMode } from '@ng-bootstrap/ng-bootstrap';
+
+import { AppComponent } from './app/app.component';
 import { ROUTES } from './app/routes';
-import { provideHttpClient, withNoXsrfProtection } from '@angular/common/http';
-import { inject, provideAppInitializer, provideExperimentalZonelessChangeDetection } from '@angular/core';
 import { AnalyticsService } from './app/services/analytics.service';
 
 bootstrapApplication(AppComponent, {
@@ -30,5 +32,6 @@ bootstrapApplication(AppComponent, {
 		provideHttpClient(withNoXsrfProtection()),
 		provideExperimentalZonelessChangeDetection(),
 		provideAppInitializer(() => inject(AnalyticsService).start()),
+		provideColorMode(),
 	],
 }).catch((err) => console.error(err));

--- a/src/color-mode/color-mode.module.ts
+++ b/src/color-mode/color-mode.module.ts
@@ -1,0 +1,46 @@
+import { ModuleWithProviders, NgModule } from '@angular/core';
+
+import { provideColorMode } from './color-mode.provider';
+import { ColorModeConfig } from './color-mode.service';
+
+/**
+ * The `ColorModeModule` is an Angular module that provides color mode configuration and services.
+ *
+ * This module can be imported into your Angular application to enable color mode functionality.
+ *
+ * @example
+ * // Importing the module in your application
+ * import { ColorModeModule } from './color-mode/color-mode.module';
+ *
+ * @NgModule({
+ *   imports: [
+ *     ColorModeModule,
+ *   ],
+ * })
+ *
+ * or with configurations
+ *
+ * @NgModule({
+ *   imports: [
+ *     ColorModeModule.forRoot({
+ *       	defaultColorMode: 'auto',
+ *				saveToLocalStorage: true,
+ *				localStorageKey: 'bs_preferred_color_mode',
+ *     }),
+ *   ],
+ * })
+ * export class AppModule {}
+ *
+ * @module
+ */
+@NgModule({
+	providers: provideColorMode(),
+})
+export class ColorModeModule {
+	static forRoot(options?: Partial<ColorModeConfig>): ModuleWithProviders<ColorModeModule> {
+		return {
+			ngModule: ColorModeModule,
+			providers: provideColorMode(options),
+		};
+	}
+}

--- a/src/color-mode/color-mode.provider.ts
+++ b/src/color-mode/color-mode.provider.ts
@@ -1,0 +1,35 @@
+import { EnvironmentProviders, inject, makeEnvironmentProviders, provideAppInitializer } from '@angular/core';
+
+import {
+	ColorModeConfig,
+	ColorModeConfigDefaults,
+	NG_COLORMODE_CONFIG,
+	NgbColorModeService,
+} from './color-mode.service';
+
+/**
+ * Provides the color mode configuration for the application.
+ *
+ * This function sets up the necessary providers for the color mode configuration
+ * and initializes the color mode service.
+ *
+ * @param options - An optional partial configuration object to override the default color mode settings.
+ * @returns An array of environment providers required for the color mode configuration.
+ */
+export function provideColorMode(options?: Partial<ColorModeConfig>): EnvironmentProviders[] {
+	return [
+		makeEnvironmentProviders([
+			{
+				provide: NG_COLORMODE_CONFIG,
+				useValue: {
+					...ColorModeConfigDefaults,
+					...options,
+				},
+			},
+		]),
+		provideAppInitializer(() => {
+			const colorModeService = inject(NgbColorModeService);
+			return colorModeService.initialize();
+		}),
+	];
+}

--- a/src/color-mode/color-mode.service.spec.ts
+++ b/src/color-mode/color-mode.service.spec.ts
@@ -1,0 +1,26 @@
+import { inject } from '@angular/core/testing';
+
+import { NgbColorModeService } from './color-mode.service';
+
+describe('ColorModeService', () => {
+	let service: NgbColorModeService;
+
+	beforeEach(inject([NgbColorModeService], (s: NgbColorModeService) => {
+		service = s;
+	}));
+
+	it('should get colorMode value', () => {
+		spyOn(localStorage, 'getItem').and.returnValue(null);
+
+		service.initialize();
+
+		const colorMode = service.currentColorMode;
+		expect(colorMode()).toBe('auto');
+
+		service.setColorMode('dark');
+		expect(colorMode()).toBe('dark');
+
+		service.setColorMode('light');
+		expect(colorMode()).toBe('light');
+	});
+});

--- a/src/color-mode/color-mode.service.ts
+++ b/src/color-mode/color-mode.service.ts
@@ -1,0 +1,95 @@
+import { DOCUMENT } from '@angular/common';
+import { computed, inject, Injectable, InjectionToken, signal } from '@angular/core';
+
+export type ColorMode = 'light' | 'dark' | 'auto';
+
+export type ColorModeConfig = {
+	defaultColorMode: ColorMode;
+	saveToLocalStorage: boolean;
+	localStorageKey: string;
+};
+
+export const ColorModeConfigDefaults: ColorModeConfig = {
+	defaultColorMode: 'auto',
+	saveToLocalStorage: true,
+	localStorageKey: 'bs_preferred_color_mode',
+};
+
+export const NG_COLORMODE_CONFIG = new InjectionToken<ColorModeConfig>('Color mode settings', {
+	factory: () => ColorModeConfigDefaults,
+});
+
+/**
+ * Service to manage the color mode (light, dark, auto) of the application.
+ * It provides methods to initialize and set the color mode, and handles
+ * storing the preference in local storage if configured.
+ *
+ * @example
+ * Inject the service via provideColorMode() in the app.config file or import the ColorModeModule in main AppModule
+ *
+ * // inject ColorModeService
+ * private colorModeService = inject(ColorModeService)
+ *
+ * // Set the color mode manually to dark
+ * this.colorModeService.setColorMode('dark');
+ *
+ * // Obtain the current color mode (signal based)
+ * currentColorMode = this.colorModeService.colorMode
+ *
+ * @providedIn 'root'
+ */
+@Injectable({
+	providedIn: 'root',
+})
+export class NgbColorModeService {
+	private document = inject(DOCUMENT);
+	private settings = inject(NG_COLORMODE_CONFIG);
+
+	private systemPreffersColorScheme = signal<ColorMode>(
+		window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light',
+	);
+	private defaultColorMode: ColorMode = 'auto';
+	private colorMode = signal<ColorMode>('auto');
+
+	currentColorMode = computed(() => this.colorMode());
+
+	private getColorModeLS(): string | null {
+		return localStorage.getItem(this.settings.localStorageKey);
+	}
+
+	private setColorModeLS(colorMode: ColorMode) {
+		localStorage.setItem(this.settings.localStorageKey, colorMode);
+	}
+
+	/**
+	 * Initialize the color mode. Service should be initialized during the APP Initialization
+	 */
+	initialize() {
+		const colorMode = this.getColorModeLS() ?? this.defaultColorMode;
+		this.setColorMode(colorMode as ColorMode);
+
+		this.document.defaultView?.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+			this.systemPreffersColorScheme.set(e.matches ? 'dark' : 'light');
+			this.setColorMode();
+		});
+	}
+
+	/**
+	 * Set the color mode to an 'html' element and set the local storage with the preference of the color mode
+	 * @param mode
+	 */
+	setColorMode(colorMode?: ColorMode): void {
+		if (colorMode) {
+			this.colorMode.set(colorMode);
+			if (this.settings.saveToLocalStorage) {
+				this.setColorModeLS(colorMode);
+			}
+		}
+
+		const bsDomeTheme = this.currentColorMode() === 'auto' ? this.systemPreffersColorScheme() : this.currentColorMode();
+		const documentElement = this.document.documentElement;
+		if (documentElement) {
+			documentElement.setAttribute('data-bs-theme', bsDomeTheme);
+		}
+	}
+}

--- a/src/color-mode/index.ts
+++ b/src/color-mode/index.ts
@@ -1,0 +1,8 @@
+export * from './color-mode.module';
+export * from './color-mode.provider';
+export {
+	NG_COLORMODE_CONFIG,
+	ColorMode,
+	ColorModeConfig,
+	NgbColorModeService as ColorModeService,
+} from './color-mode.service';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { NgbDatepickerModule } from './datepicker/datepicker.module';
 import { NgbDropdownModule } from './dropdown/dropdown.module';
 import { NgbModalModule } from './modal/modal.module';
 import { NgbNavModule } from './nav/nav.module';
+import { NgbOffcanvasModule } from './offcanvas/offcanvas.module';
 import { NgbPaginationModule } from './pagination/pagination.module';
 import { NgbPopoverModule } from './popover/popover.module';
 import { NgbProgressbarModule } from './progressbar/progressbar.module';
@@ -17,7 +18,6 @@ import { NgbTimepickerModule } from './timepicker/timepicker.module';
 import { NgbToastModule } from './toast/toast.module';
 import { NgbTooltipModule } from './tooltip/tooltip.module';
 import { NgbTypeaheadModule } from './typeahead/typeahead.module';
-import { NgbOffcanvasModule } from './offcanvas/offcanvas.module';
 
 export {
 	NgbAccordionDirective,
@@ -42,6 +42,7 @@ export {
 	NgbSlideEventSource,
 } from './carousel/carousel.module';
 export { NgbCollapse, NgbCollapseConfig, NgbCollapseModule } from './collapse/collapse.module';
+export * from './color-mode';
 export {
 	NgbCalendar,
 	NgbCalendarEthiopian,


### PR DESCRIPTION
- Add a new service to manage the color mode (light, dark, auto) of the application, according to demo and bootstrap.
- Exposed provideColorMode() and ColorModeModule to easily include it in application (standalone or module based application).
```
bootstrapApplication(AppComponent, {
	providers: [
		provideColorMode(),
		...
	]
});
```

```
@NgModule({
     imports: [
         ColorModeModule,
     ],
 })
```
