### PR TITLE
fix(typeahead): add aria-controls for accessibility

### DIFF
--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -799,7 +799,7 @@ describe('ngb-typeahead', () => {
 			expect(input.getAttribute('role')).toBe('combobox');
 			expect(input.getAttribute('aria-autocomplete')).toBe('list');
 			expect(input.getAttribute('aria-expanded')).toBe('false');
-			expect(input.getAttribute('aria-owns')).toBeNull();
+			expect(input.getAttribute('aria-controls')).toBeNull();
 			expect(input.getAttribute('aria-autocomplete')).toBe('list');
 			expect(input.getAttribute('aria-activedescendant')).toBeNull();
 		});
@@ -823,7 +823,7 @@ describe('ngb-typeahead', () => {
 			fixture.detectChanges();
 			expectWindowResults(compiled, ['+one', 'one more']);
 			expect(input.getAttribute('aria-expanded')).toBe('true');
-			expect(input.getAttribute('aria-owns')).toMatch(/ngb-typeahead-[0-9]+/);
+			expect(input.getAttribute('aria-controls')).toMatch(/ngb-typeahead-[0-9]+/);
 			expect(input.getAttribute('aria-activedescendant')).toMatch(/ngb-typeahead-[0-9]+-0/);
 
 			let event = createKeyDownEvent('ArrowDown');
@@ -835,7 +835,7 @@ describe('ngb-typeahead', () => {
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
 			fixture.detectChanges();
 			expect(input.getAttribute('aria-expanded')).toBe('false');
-			expect(input.getAttribute('aria-owns')).toBeNull();
+			expect(input.getAttribute('aria-controls')).toBeNull();
 			expect(input.getAttribute('aria-activedescendant')).toBeNull();
 		}));
 	});

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -66,7 +66,7 @@ let nextWindowId = 0;
 		role: 'combobox',
 		'[attr.aria-autocomplete]': 'showHint ? "both" : "list"',
 		'[attr.aria-activedescendant]': 'activeDescendant',
-		'[attr.aria-owns]': 'isPopupOpen() ? popupId : null',
+		'[attr.aria-controls]': 'isPopupOpen() ? popupId : null',
 		'[attr.aria-expanded]': 'isPopupOpen()',
 	},
 	providers: [{ provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => NgbTypeahead), multi: true }],


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
 
 `combobox` needs `aria-controls` to be specified:
 https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/combobox_role
