### PR TITLE
fix(tooltip): tooltip created after view destroyed

### DIFF
--- a/src/util/triggers.spec.ts
+++ b/src/util/triggers.spec.ts
@@ -166,6 +166,21 @@ describe('triggers', () => {
 			expect(states).toEqual([true, true]);
 		}));
 
+		it('should clear delay timer if component is destroyed before openFn is called', () => {
+			const delayMs = 5000;
+			const clearTimeoutSpy = spyOn(window, 'clearTimeout');
+			const fakeSetTimeoutResult = setTimeout(() => {}, 0);
+			const setTimeoutSpy = spyOn(window, 'setTimeout');
+			setTimeoutSpy.and.returnValue(fakeSetTimeoutResult);
+
+			cleanupFn = listenToTriggers(div, 'hover', isOpenedFn, openFn, closeFn, delayMs);
+			div.dispatchEvent(new MouseEvent('mouseenter'));
+			cleanupFn();
+
+			expect(setTimeoutSpy).toHaveBeenCalledWith(jasmine.any(Function), delayMs);
+			expect(clearTimeoutSpy).toHaveBeenCalledWith(fakeSetTimeoutResult);
+		});
+
 		afterEach(() => {
 			cleanupFn();
 			openFn.calls.reset();

--- a/src/util/triggers.ts
+++ b/src/util/triggers.ts
@@ -96,5 +96,6 @@ export function listenToTriggers(
 		}
 	}
 
+	cleanupFns.push(() => clearTimeout(timeout));
 	return () => cleanupFns.forEach((cleanupFn) => cleanupFn());
 }


### PR DESCRIPTION
If a popover delays loading for a duration longer than the host component lifecycle, it results in an error:

```
RuntimeError: NG0911: View has already been destroyed.
    at storeLViewOnDestroy (core.mjs:4231:11)
    at NodeInjectorDestroyRef.onDestroy (core.mjs:6471:5)
    at new AfterRenderSequence (core.mjs:19076:44)
    at afterRenderImpl (core.mjs:19125:20)
    at afterNextRender (core.mjs:19104:10)
    at PopupService.open (ng-bootstrap.mjs:9061:5)
    at _NgbTooltip.open (ng-bootstrap.mjs:15430:30)
    at ng-bootstrap.mjs:11922:56
    at sentryWrapped (helpers.js:81:17)
    at timer (zone.js:1752:27)
    at _ZoneDelegate.invokeTask (zone.js:364:171)
    at core.mjs:6714:49
    at AsyncStackTaggingZoneSpec.onInvokeTask (core.mjs:6714:30)
    at _ZoneDelegate.invokeTask (zone.js:364:54)
    at Object.onInvokeTask (core.mjs:7034:25)
    at _ZoneDelegate.invokeTask (zone.js:364:54)
    at ZoneImpl.runTask (zone.js:163:37)
    at invokeTask (zone.js:441:26)
    at ZoneTask.invoke (zone.js:430:38)
    at data.args.<computed> (zone.js:1719:26)
```

Fixed this error by ensuring clearTimeout is called in the cleanup functions. This fix was inspired by this [comment](https://github.com/ng-bootstrap/ng-bootstrap/issues/4657#issuecomment-2011317281). The PR mentioned in that comment didn't fix the issue for me. I've been using this fix in production for a few months via a forked repo.

Fixes #4657 Fixes #4772

---

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
