### PR TITLE
feat(datepicker): export DayTemplateContext

### DIFF
--- a/src/datepicker/datepicker.module.ts
+++ b/src/datepicker/datepicker.module.ts
@@ -28,6 +28,7 @@ export { NgbDateNativeAdapter } from './adapters/ngb-date-native-adapter';
 export { NgbDateNativeUTCAdapter } from './adapters/ngb-date-native-utc-adapter';
 export { NgbDateParserFormatter } from './ngb-date-parser-formatter';
 export { NgbDatepickerKeyboardService } from './datepicker-keyboard-service';
+export { DayTemplateContext } from './datepicker-day-template-context';
 
 const NGB_DATEPICKER_DIRECTIVES = [NgbDatepicker, NgbDatepickerContent, NgbInputDatepicker, NgbDatepickerMonth];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ export {
 	NgbDateStruct,
 	NgbInputDatepicker,
 	NgbPeriod,
+	DayTemplateContext,
 } from './datepicker/datepicker.module';
 export {
 	NgbDropdown,


### PR DESCRIPTION
`DayTemplateContext` is now exported from the ng-bootstrap public API.
DayTemplateContext is referenced in the official documentation as the type for the `[dayTemplate]` input of the datepicker component. [https://ng-bootstrap.github.io/#/components/datepicker/api#DayTemplateContext](https://ng-bootstrap.github.io/#/components/datepicker/api#DayTemplateContext)
This change makes DayTemplateContext available for import, enabling consumers to define type-safe properties and templates that interact with the datepicker’s day template context, as described in the documentation.

### Code Example
```typescript
import { DayTemplateContext, NgbDatepickerConfig } from '@ng-bootstrap/ng-bootstrap';

...
  @Input() customTemplate: TemplateRef<DayTemplateContext> | undefined;
  
  constructor(
    public config: NgbDatepickerConfig
    ) {
    ...

  getDayTemplate() {
    if (this.customTemplate !== undefined) {
      return this.customTemplate;
    } else {
      return this.config.dayTemplate;
    }
  }
...
```

```html
...
<input #ctrl [attr.id]="componentId" class="form-control" [formControl]="formControl" 
    ngbDatepicker
    [dayTemplate]="getDayTemplate()">
...
```
