### PR TITLE
fix(accordion): ensure items are expanded by default and update docs

### DIFF
--- a/demo/src/app/components/accordion/overview/accordion-overview.component.ts
+++ b/demo/src/app/components/accordion/overview/accordion-overview.component.ts
@@ -19,7 +19,7 @@ export class NgbdAccordionOverviewComponent extends NgbdOverviewPage {
 	BASIC_ACCORDION = Snippet({
 		lang: 'html',
 		code: `
-      <div ngbAccordion>
+      <div ngbAccordion [collapsed]="true">
         <div ngbAccordionItem>
           <h2 ngbAccordionHeader>
             <button ngbAccordionButton>First</button>

--- a/demo/src/app/components/accordion/overview/demo/accordion-overview-demo.component.ts
+++ b/demo/src/app/components/accordion/overview/demo/accordion-overview-demo.component.ts
@@ -7,7 +7,7 @@ import { NgbAccordionDirective, NgbAccordionModule } from '@ng-bootstrap/ng-boot
 	imports: [NgbAccordionModule, NgbAccordionDirective],
 	template: `
 		<div ngbAccordion [closeOthers]="true">
-			<div ngbAccordionItem>
+			<div ngbAccordionItem [collapsed]="true">
 				<h2 ngbAccordionHeader>
 					<button ngbAccordionButton>First</button>
 				</h2>
@@ -18,7 +18,7 @@ import { NgbAccordionDirective, NgbAccordionModule } from '@ng-bootstrap/ng-boot
 				</div>
 			</div>
 
-			<div ngbAccordionItem>
+			<div ngbAccordionItem [collapsed]="true">
 				<h2 ngbAccordionHeader>
 					<button ngbAccordionButton>Second</button>
 				</h2>

--- a/src/accordion/accordion.directive.ts
+++ b/src/accordion/accordion.directive.ts
@@ -191,7 +191,7 @@ export class NgbAccordionItem implements AfterContentInit {
 	private _cd = inject(ChangeDetectorRef);
 	private _destroyRef = inject(DestroyRef);
 
-	private _collapsed = true;
+	private _collapsed = false;
 	private _id = `ngb-accordion-item-${nextId++}`;
 	private _destroyOnHide: boolean | undefined;
 


### PR DESCRIPTION
Accordion items were incorrectly collapsed by default when the `collapsed` property was omitted.
Now, items are expanded by default as intended.

Documentation has been updated to explicitly use `[collapsed]="false"` so that the demo accordion example reflects the correct behavior.

---

### Changes

* Fixed default value for `collapsed` in `NgbAccordionItem` component.
* Updated documentation example in `Accordion` section to use `[collapsed]="false"`.

---

### Verification

1. Run the demo app:

   ```bash
   yarn demo
   ```

   * Navigate to the Accordion example; items should be expanded by default.
2. Confirm that `[collapsed]="false"` in the docs demo works as expected.
---

### Related Issue

* Fixes #4848

---

