### PR TITLE
fix(modal): remove inline styles from backdrop for CSP compliance

### DIFF
--- a/src/modal/modal-backdrop.ts
+++ b/src/modal/modal-backdrop.ts
@@ -23,11 +23,11 @@ const BACKDROP_ATTRIBUTES: string[] = ['animation', 'backdropClass'];
 	selector: 'ngb-modal-backdrop',
 	encapsulation: ViewEncapsulation.None,
 	template: '',
+	styleUrls: ['./modal.scss'],
 	host: {
 		'[class]': '"modal-backdrop" + (backdropClass ? " " + backdropClass : "")',
 		'[class.show]': '!animation',
 		'[class.fade]': 'animation',
-		style: 'z-index: 1055',
 	},
 })
 export class NgbModalBackdrop implements OnInit {

--- a/src/modal/modal-backdrop.ts
+++ b/src/modal/modal-backdrop.ts
@@ -23,11 +23,11 @@ const BACKDROP_ATTRIBUTES: string[] = ['animation', 'backdropClass'];
 	selector: 'ngb-modal-backdrop',
 	encapsulation: ViewEncapsulation.None,
 	template: '',
-	styleUrls: ['./modal.scss'],
 	host: {
 		'[class]': '"modal-backdrop" + (backdropClass ? " " + backdropClass : "")',
 		'[class.show]': '!animation',
 		'[class.fade]': 'animation',
+		'[style.z-index]': '1055',
 	},
 })
 export class NgbModalBackdrop implements OnInit {

--- a/src/modal/modal.scss
+++ b/src/modal/modal.scss
@@ -5,7 +5,3 @@ ngb-modal-window {
 		overflow: hidden;
 	}
 }
-
-ngb-modal-backdrop {
-	z-index: 1055;
-}

--- a/src/modal/modal.scss
+++ b/src/modal/modal.scss
@@ -5,3 +5,7 @@ ngb-modal-window {
 		overflow: hidden;
 	}
 }
+
+ngb-modal-backdrop {
+	z-index: 1055;
+}

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -47,7 +47,7 @@ let nextId = 0;
 		'[class.fade]': 'animation',
 		role: 'tooltip',
 		'[id]': 'id',
-		style: 'position: absolute;',
+		'[style.position]': '"absolute"',
 		'(mouseenter)': 'onMouseEnter()',
 		'(mouseleave)': 'onMouseLeave()',
 	},

--- a/src/scrollspy/scrollspy.ts
+++ b/src/scrollspy/scrollspy.ts
@@ -201,7 +201,7 @@ export class NgbScrollSpyMenu implements NgbScrollSpyRef, AfterViewInit {
 	exportAs: 'ngbScrollSpy',
 	host: {
 		tabindex: '0',
-		style: 'overflow-y: auto',
+		'[style.overflow-y]': '"auto"',
 	},
 	providers: [NgbScrollSpyService],
 })


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
NgbModalBackdrop component uses inline styles (z-index: 1055) which violates Content Security Policy when strict CSP is enabled with 'unsafe-inline' disallowed.

## What is the new behavior?
The z-index styling has been moved from inline host binding to the external modal.scss stylesheet, making the component CSP-compliant.

## Changes Made:
- Removed `style: 'z-index: 1055'` from NgbModalBackdrop host binding
- Added `ngb-modal-backdrop { z-index: 1055; }` rule to modal.scss
- Added `styleUrls: ['./modal.scss']` to component decorator

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
This change maintains the same visual behavior while resolving CSP compliance issues for applications using strict Content Security Policy settings.