### PR TITLE
test(dropdown): make the dropdown test zoneless

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -33,7 +33,7 @@
 						"coverageReporters": ["lcov"],
 						"browsers": ["ChromiumHeadless"],
 						"runnerConfig": "src/vitest.config.ts",
-						"include": ["src/(accordion|alert|collapse|nav)/**/*.spec.ts"]
+						"include": ["src/(accordion|alert|collapse|dropdown|nav)/**/*.spec.ts"]
 					},
 					"configurations": {
 						"other-browsers": {
@@ -41,12 +41,12 @@
 						},
 						"zone": {
 							"setupFiles": ["src/setup-zone-test.ts"],
-							"include": ["src/!(accordion|alert|collapse|nav)/**/*.spec.ts"]
+							"include": ["src/!(accordion|alert|collapse|dropdown|nav)/**/*.spec.ts"]
 						},
 						"zone-other-browsers": {
 							"browsers": ["FirefoxHeadless", "WebkitHeadless"],
 							"setupFiles": ["src/setup-zone-test.ts"],
-							"include": ["src/!(accordion|alert|collapse|nav)/**/*.spec.ts"]
+							"include": ["src/!(accordion|alert|collapse|dropdown|nav)/**/*.spec.ts"]
 						}
 					}
 				},

--- a/src/dropdown/dropdown.ts
+++ b/src/dropdown/dropdown.ts
@@ -336,6 +336,7 @@ export class NgbDropdown implements OnInit, AfterContentInit, OnChanges, OnDestr
 					});
 				}
 			}
+			this._changeDetector.markForCheck();
 		}
 	}
 


### PR DESCRIPTION
and refactor it to benefit from vitest's locators and assertions

This allowed finding a bug: when `open()` is called programmatically on a dropdown, it changes the value of its `_open` input (yikes), but since this isn't a signal and since markForCheck wasn't called, the template wasn't updated in zoneless.

On top of #4883
ref #4879 