### PR TITLE
fix(offcanvas): provide NgbOffcanvas at the correct level

### DIFF
--- a/src/offcanvas/offcanvas.module.ts
+++ b/src/offcanvas/offcanvas.module.ts
@@ -1,9 +1,11 @@
 import { NgModule } from '@angular/core';
 
+import { NgbOffcanvas } from './offcanvas';
+
 export { NgbOffcanvas } from './offcanvas';
 export { NgbOffcanvasConfig, NgbOffcanvasOptions } from './offcanvas-config';
 export { NgbOffcanvasRef, NgbActiveOffcanvas } from './offcanvas-ref';
 export { OffcanvasDismissReasons } from './offcanvas-dismiss-reasons';
 
-@NgModule({})
+@NgModule({ providers: [NgbOffcanvas] })
 export class NgbOffcanvasModule {}


### PR DESCRIPTION
Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [ ] added/updated any applicable tests.
 - [ ] added/updated any applicable API documentation.
 - [ ] added/updated any applicable demos.

Provides `NgbOffcanvas` at the `NgbOffcanvasModule` level as well as at the `root` level. Provides environment injector based on the contentInjector and not the `_applicationRef.injector` when using component as content.

Already fixed for `NgbModal` by #4464 

Fixes #4857 #4720 