### PR TITLE
fix(datepicker): Minimum year range will not go below 1

### DIFF
--- a/src/datepicker/datepicker-tools.spec.ts
+++ b/src/datepicker/datepicker-tools.spec.ts
@@ -596,6 +596,14 @@ describe(`datepicker-tools`, () => {
 			// both are not set
 			test(null, new NgbDate(2018, 1, 1), null, range(2008, 2028));
 			test(null, new NgbDate(2000, 1, 1), null, range(1990, 2010));
+
+			// when single digit year set
+			// both 'min' and 'max' are not set
+			test(null, new NgbDate(9, 1, 1), null, range(1, 19));
+			// 'min' is not set
+			test(null, new NgbDate(9, 1, 1), new NgbDate(15, 1, 1), range(1, 15));
+			// 'max' is not set
+			test(new NgbDate(-5, 1, 1), new NgbDate(1, 1, 1), null, range(1, 11));
 		});
 	});
 

--- a/src/datepicker/datepicker-tools.ts
+++ b/src/datepicker/datepicker-tools.ts
@@ -78,7 +78,8 @@ export function generateSelectBoxYears(date: NgbDate, minDate: NgbDate | null, m
 		return [];
 	}
 
-	const start = minDate ? Math.max(minDate.year, date.year - 500) : date.year - 10;
+	// Note: Native HTML input type="date" has year range starting from 1
+	const start = Math.max(1, minDate ? Math.max(minDate.year, date.year - 500) : date.year - 10);
 	const end = maxDate ? Math.min(maxDate.year, date.year + 500) : date.year + 10;
 
 	const length = end - start + 1;


### PR DESCRIPTION
With this change we no longer show negative and/or 0 numbers in year selection.
This behaviour is now more aligned with native browser date input
Ref #4784 
