### PR TITLE
fix(tooltip): close tooltip/popover when anchor element becomes hidden

### DIFF
--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -632,6 +632,28 @@ describe('ngb-popover', () => {
 			fixture.detectChanges();
 			expect(getWindow(document.querySelector(selector))).toBeNull();
 		});
+
+		it('should close popover when the anchor element becomes hidden', async () => {
+			const fixture = createTestComponent(`
+				<div id="wrapper">
+					<div ngbPopover="Great tip!" container="body" triggers="manual"></div>
+				</div>
+			`);
+			const directive = fixture.debugElement.query(By.directive(NgbPopover));
+			const popover = directive.injector.get(NgbPopover);
+
+			popover.open();
+			fixture.detectChanges();
+			await fixture.whenStable();
+			expect(getWindow(document.body)).not.toBeNull();
+
+			// Hide the wrapper, simulating a dropdown closing
+			fixture.nativeElement.querySelector('#wrapper').style.display = 'none';
+			fixture.detectChanges();
+			await fixture.whenStable();
+
+			expect(getWindow(document.body)).toBeNull();
+		});
 	});
 
 	describe('visibility', () => {

--- a/src/popover/popover.ts
+++ b/src/popover/popover.ts
@@ -296,6 +296,11 @@ export class NgbPopover implements OnInit, OnDestroy, OnChanges {
 				this._afterRenderRef = afterEveryRender(
 					{
 						mixedReadWrite: () => {
+							const hostEl = this._getPositionTargetElement();
+							if (!hostEl.isConnected || (hostEl.offsetParent === null && hostEl.offsetWidth === 0)) {
+								this._ngZone.run(() => this.close());
+								return;
+							}
 							this._positioning.update();
 						},
 					},

--- a/src/tooltip/tooltip.spec.ts
+++ b/src/tooltip/tooltip.spec.ts
@@ -649,6 +649,28 @@ describe('ngb-tooltip', () => {
 			fixture.detectChanges();
 			expect(getWindow(document.querySelector(selector))).toBeNull();
 		});
+
+		it('should close tooltip when the anchor element becomes hidden', async () => {
+			const fixture = createTestComponent(`
+				<div id="wrapper">
+					<div ngbTooltip="Great tip!" container="body" triggers="manual"></div>
+				</div>
+			`);
+			const directive = fixture.debugElement.query(By.directive(NgbTooltip));
+			const tooltip = directive.injector.get(NgbTooltip);
+
+			tooltip.open();
+			fixture.detectChanges();
+			await fixture.whenStable();
+			expect(getWindow(document.body)).not.toBeNull();
+
+			// Hide the wrapper, simulating a dropdown closing
+			fixture.nativeElement.querySelector('#wrapper').style.display = 'none';
+			fixture.detectChanges();
+			await fixture.whenStable();
+
+			expect(getWindow(document.body)).toBeNull();
+		});
 	});
 
 	describe('visibility', () => {

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -277,6 +277,11 @@ export class NgbTooltip implements OnInit, OnDestroy, OnChanges {
 				this._afterRenderRef = afterEveryRender(
 					{
 						mixedReadWrite: () => {
+							const hostEl = this._getPositionTargetElement();
+							if (!hostEl.isConnected || (hostEl.offsetParent === null && hostEl.offsetWidth === 0)) {
+								this._ngZone.run(() => this.close());
+								return;
+							}
 							this._positioning.update();
 						},
 					},


### PR DESCRIPTION
When a tooltip/popover with container="body" is inside a dropdown item, clicking the item closes the dropdown but the tooltip remains open and jumps to the top-left corner. This happens because no mouseleave event fires when the anchor disappears programmatically, and Popper positions against a zero-rect hidden element.

Added a visibility check in afterEveryRender to close the tooltip/popover when its anchor is detached from the DOM or hidden via display:none.

Fixes #4906

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) and [DEVELOPER.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/DEVELOPER.md) guide.
 - [x] built and tested the changes locally.
 - [x] added/updated any applicable tests.
 - [x] added/updated any applicable API documentation.
 - [x] added/updated any applicable demos.
