### PR TITLE
clean up eager cds

### DIFF
--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { VersionPickerComponent } from './shared/version-picker.component';
 import { ThemePickerComponent } from './shared/theme-picker.component';
@@ -10,7 +10,6 @@ import { NPM_VIEWS } from './tokens';
 @Component({
 	selector: 'ngbd-app',
 	templateUrl: './app.component.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	imports: [RouterLink, RouterLinkActive, RouterOutlet, VersionPickerComponent, ThemePickerComponent, AsyncPipe],
 })
 export class AppComponent {

--- a/demo/src/app/components/accordion/demos/basic/accordion-basic.ts
+++ b/demo/src/app/components/accordion/demos/basic/accordion-basic.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbAccordionButton,
 	NgbAccordionDirective,
@@ -20,7 +20,6 @@ import {
 		NgbAccordionBody,
 		NgbAccordionCollapse,
 	],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './accordion-basic.html',
 })
 export class NgbdAccordionBasic {}

--- a/demo/src/app/components/accordion/demos/config/accordion-config.ts
+++ b/demo/src/app/components/accordion/demos/config/accordion-config.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbAccordionConfig,
 	NgbAccordionButton,
@@ -22,7 +22,6 @@ import {
 		NgbAccordionCollapse,
 	],
 	templateUrl: './accordion-config.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [NgbAccordionConfig],
 })
 export class NgbdAccordionConfig {

--- a/demo/src/app/components/accordion/demos/header/accordion-header.ts
+++ b/demo/src/app/components/accordion/demos/header/accordion-header.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 import {
 	NgbAccordionDirective,
 	NgbAccordionItem,
@@ -20,7 +20,6 @@ import {
 	],
 	templateUrl: './accordion-header.html',
 	encapsulation: ViewEncapsulation.None,
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		.custom-header::after {
 			content: none;

--- a/demo/src/app/components/accordion/demos/keep-content/accordion-keep-content.ts
+++ b/demo/src/app/components/accordion/demos/keep-content/accordion-keep-content.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbAlert } from '@ng-bootstrap/ng-bootstrap/alert';
 import {
 	NgbAccordionButton,
@@ -22,7 +22,6 @@ import {
 		NgbAccordionCollapse,
 		NgbAlert,
 	],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './accordion-keep-content.html',
 })
 export class NgbdAccordionKeepContent {

--- a/demo/src/app/components/accordion/demos/static/accordion-static.ts
+++ b/demo/src/app/components/accordion/demos/static/accordion-static.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbAccordionButton,
 	NgbAccordionDirective,
@@ -20,7 +20,6 @@ import {
 		NgbAccordionBody,
 		NgbAccordionCollapse,
 	],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './accordion-static.html',
 })
 export class NgbdAccordionStatic {

--- a/demo/src/app/components/accordion/demos/toggle/accordion-toggle.ts
+++ b/demo/src/app/components/accordion/demos/toggle/accordion-toggle.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbAccordionButton,
 	NgbAccordionDirective,
@@ -20,7 +20,6 @@ import {
 		NgbAccordionBody,
 		NgbAccordionCollapse,
 	],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './accordion-toggle.html',
 })
 export class NgbdAccordionToggle {}

--- a/demo/src/app/components/alert/demos/basic/alert-basic.ts
+++ b/demo/src/app/components/alert/demos/basic/alert-basic.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbAlert } from '@ng-bootstrap/ng-bootstrap/alert';
 
 @Component({
 	selector: 'ngbd-alert-basic',
 	imports: [NgbAlert],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './alert-basic.html',
 })
 export class NgbdAlertBasic {}

--- a/demo/src/app/components/alert/demos/closeable/alert-closeable.ts
+++ b/demo/src/app/components/alert/demos/closeable/alert-closeable.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbAlert } from '@ng-bootstrap/ng-bootstrap/alert';
 
 interface Alert {
@@ -44,7 +44,6 @@ const ALERTS: Alert[] = [
 @Component({
 	selector: 'ngbd-alert-closeable',
 	imports: [NgbAlert],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './alert-closeable.html',
 })
 export class NgbdAlertCloseable {

--- a/demo/src/app/components/alert/demos/config/alert-config.ts
+++ b/demo/src/app/components/alert/demos/config/alert-config.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbAlertConfig, NgbAlert } from '@ng-bootstrap/ng-bootstrap/alert';
 
 @Component({
@@ -6,7 +6,6 @@ import { NgbAlertConfig, NgbAlert } from '@ng-bootstrap/ng-bootstrap/alert';
 	imports: [NgbAlert],
 	templateUrl: './alert-config.html',
 	// add NgbAlertConfig  to the component providers
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [NgbAlertConfig],
 })
 export class NgbdAlertConfig {

--- a/demo/src/app/components/alert/demos/custom/alert-custom.ts
+++ b/demo/src/app/components/alert/demos/custom/alert-custom.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbAlert } from '@ng-bootstrap/ng-bootstrap/alert';
 
 @Component({
 	selector: 'ngbd-alert-custom',
 	imports: [NgbAlert],
 	templateUrl: './alert-custom.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		.alert-custom {
 			color: #99004d;

--- a/demo/src/app/components/alert/demos/selfclosing/alert-selfclosing.ts
+++ b/demo/src/app/components/alert/demos/selfclosing/alert-selfclosing.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { Subject } from 'rxjs';
 import { debounceTime, tap } from 'rxjs/operators';
 import { NgbAlert } from '@ng-bootstrap/ng-bootstrap/alert';
@@ -7,7 +7,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 @Component({
 	selector: 'ngbd-alert-selfclosing',
 	imports: [NgbAlert],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './alert-selfclosing.html',
 })
 export class NgbdAlertSelfclosing {

--- a/demo/src/app/components/carousel/demos/basic/carousel-basic.ts
+++ b/demo/src/app/components/carousel/demos/basic/carousel-basic.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbCarousel, NgbSlide } from '@ng-bootstrap/ng-bootstrap/carousel';
 
 @Component({
 	selector: 'ngbd-carousel-basic',
 	imports: [NgbCarousel, NgbSlide],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './carousel-basic.html',
 })
 export class NgbdCarouselBasic {

--- a/demo/src/app/components/carousel/demos/config/carousel-config.ts
+++ b/demo/src/app/components/carousel/demos/config/carousel-config.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbCarouselConfig, NgbCarousel, NgbSlide } from '@ng-bootstrap/ng-bootstrap/carousel';
 
 @Component({
 	selector: 'ngbd-carousel-config',
 	imports: [NgbCarousel, NgbSlide],
 	templateUrl: './carousel-config.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [NgbCarouselConfig],
 })
 export class NgbdCarouselConfig {

--- a/demo/src/app/components/carousel/demos/navigation/carousel-navigation.ts
+++ b/demo/src/app/components/carousel/demos/navigation/carousel-navigation.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbCarouselConfig, NgbCarousel, NgbSlide } from '@ng-bootstrap/ng-bootstrap/carousel';
 
 @Component({
 	selector: 'ngbd-carousel-navigation',
 	imports: [NgbCarousel, NgbSlide],
 	templateUrl: './carousel-navigation.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [NgbCarouselConfig],
 })
 export class NgbdCarouselNavigation {

--- a/demo/src/app/components/carousel/demos/pause/carousel-pause.ts
+++ b/demo/src/app/components/carousel/demos/pause/carousel-pause.ts
@@ -1,11 +1,10 @@
-import { Component, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { NgbCarousel, NgbSlide, NgbSlideEvent, NgbSlideEventSource } from '@ng-bootstrap/ng-bootstrap/carousel';
 import { FormsModule } from '@angular/forms';
 
 @Component({
 	selector: 'ngbd-carousel-pause',
 	imports: [NgbCarousel, NgbSlide, FormsModule],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './carousel-pause.html',
 })
 export class NgbdCarouselPause {

--- a/demo/src/app/components/collapse/demos/basic/collapse-basic.ts
+++ b/demo/src/app/components/collapse/demos/basic/collapse-basic.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap/collapse';
 
 @Component({
 	selector: 'ngbd-collapse-basic',
 	imports: [NgbCollapse],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './collapse-basic.html',
 })
 export class NgbdCollapseBasic {

--- a/demo/src/app/components/collapse/demos/horizontal/collapse-horizontal.ts
+++ b/demo/src/app/components/collapse/demos/horizontal/collapse-horizontal.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap/collapse';
 
 @Component({
 	selector: 'ngbd-collapse-horizontal',
 	imports: [NgbCollapse],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './collapse-horizontal.html',
 })
 export class NgbdCollapseHorizontal {

--- a/demo/src/app/components/collapse/demos/navbar/collapse-navbar.ts
+++ b/demo/src/app/components/collapse/demos/navbar/collapse-navbar.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap/collapse';
 import { RouterLink } from '@angular/router';
 
 @Component({
 	selector: 'ngbd-collapse-navbar',
 	imports: [NgbCollapse, RouterLink],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './collapse-navbar.html',
 })
 export class NgbdCollapseNavbar {

--- a/demo/src/app/components/datepicker/calendars/datepicker-calendars.component.ts
+++ b/demo/src/app/components/datepicker/calendars/datepicker-calendars.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 
 import { Snippet } from '../../../services/snippet';
 import { NgbdDatepickerHebrew } from '../demos/hebrew/datepicker-hebrew';
@@ -62,7 +62,6 @@ const DEMOS: Demo[] = [
 @Component({
 	selector: 'ngbd-datepicker-calendars',
 	imports: [NgbAlert, CodeComponent, NgbdWidgetDemoComponent, NgComponentOutlet],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<p>
 			Datepicker relies on <code>NgbCalendar</code> abstract class for calendar-related calculations. Default

--- a/demo/src/app/components/datepicker/demos/adapter/datepicker-adapter.ts
+++ b/demo/src/app/components/datepicker/demos/adapter/datepicker-adapter.ts
@@ -1,4 +1,4 @@
-import { Component, Injectable, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Injectable } from '@angular/core';
 import {
 	NgbCalendar,
 	NgbDateAdapter,
@@ -64,7 +64,6 @@ export class CustomDateParserFormatter extends NgbDateParserFormatter {
 	templateUrl: './datepicker-adapter.html',
 	// NOTE: For this example we are only providing current component, but probably
 	// NOTE: you will want to provide your main App Module
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [
 		{ provide: NgbDateAdapter, useClass: CustomAdapter },
 		{ provide: NgbDateParserFormatter, useClass: CustomDateParserFormatter },

--- a/demo/src/app/components/datepicker/demos/basic/datepicker-basic.ts
+++ b/demo/src/app/components/datepicker/demos/basic/datepicker-basic.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { NgbCalendar, NgbDatepicker, NgbDateStruct } from '@ng-bootstrap/ng-bootstrap/datepicker';
 import { FormsModule } from '@angular/forms';
 import { JsonPipe } from '@angular/common';
@@ -6,7 +6,6 @@ import { JsonPipe } from '@angular/common';
 @Component({
 	selector: 'ngbd-datepicker-basic',
 	imports: [NgbDatepicker, FormsModule, JsonPipe],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './datepicker-basic.html',
 })
 export class NgbdDatepickerBasic {

--- a/demo/src/app/components/datepicker/demos/buddhist/datepicker-buddhist.ts
+++ b/demo/src/app/components/datepicker/demos/buddhist/datepicker-buddhist.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Injectable, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, Injectable } from '@angular/core';
 import {
 	NgbCalendar,
 	NgbCalendarBuddhist,
@@ -61,7 +61,6 @@ export class NgbDatepickerI18nBuddhist extends NgbDatepickerI18n {
 	selector: 'ngbd-datepicker-buddhist',
 	imports: [NgbDatepicker, FormsModule, JsonPipe],
 	templateUrl: './datepicker-buddhist.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [
 		{ provide: NgbCalendar, useClass: NgbCalendarBuddhist },
 		{ provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nBuddhist },

--- a/demo/src/app/components/datepicker/demos/config/datepicker-config.ts
+++ b/demo/src/app/components/datepicker/demos/config/datepicker-config.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbCalendar,
 	NgbDate,
@@ -12,7 +12,6 @@ import { FormsModule } from '@angular/forms';
 	selector: 'ngbd-datepicker-config',
 	imports: [NgbInputDatepicker, FormsModule],
 	templateUrl: './datepicker-config.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [NgbInputDatepickerConfig],
 })
 export class NgbdDatepickerConfig {

--- a/demo/src/app/components/datepicker/demos/customday/datepicker-customday.ts
+++ b/demo/src/app/components/datepicker/demos/customday/datepicker-customday.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { NgbCalendar, NgbDate, NgbInputDatepicker, NgbDateStruct } from '@ng-bootstrap/ng-bootstrap/datepicker';
 import { FormsModule } from '@angular/forms';
 
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 	selector: 'ngbd-datepicker-customday',
 	imports: [NgbInputDatepicker, FormsModule],
 	templateUrl: './datepicker-customday.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		.custom-day {
 			text-align: center;

--- a/demo/src/app/components/datepicker/demos/custommonth/datepicker-custommonth.ts
+++ b/demo/src/app/components/datepicker/demos/custommonth/datepicker-custommonth.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 import { NgbDatepicker, NgbInputDatepicker, NgbDatepickerMonth } from '@ng-bootstrap/ng-bootstrap/datepicker';
 
 @Component({
@@ -6,7 +6,6 @@ import { NgbDatepicker, NgbInputDatepicker, NgbDatepickerMonth } from '@ng-boots
 	imports: [NgbDatepicker, NgbInputDatepicker, NgbDatepickerMonth],
 	templateUrl: './datepicker-custommonth.html',
 	encapsulation: ViewEncapsulation.None,
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		.no-header-padding .ngb-dp-header {
 			padding: 0;

--- a/demo/src/app/components/datepicker/demos/disabled/datepicker-disabled.ts
+++ b/demo/src/app/components/datepicker/demos/disabled/datepicker-disabled.ts
@@ -1,11 +1,10 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { NgbCalendar, NgbDatepicker } from '@ng-bootstrap/ng-bootstrap/datepicker';
 import { FormsModule } from '@angular/forms';
 
 @Component({
 	selector: 'ngbd-datepicker-disabled',
 	imports: [NgbDatepicker, FormsModule],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './datepicker-disabled.html',
 })
 export class NgbdDatepickerDisabled {

--- a/demo/src/app/components/datepicker/demos/ethiopian/datepicker-ethiopian.ts
+++ b/demo/src/app/components/datepicker/demos/ethiopian/datepicker-ethiopian.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, ViewEncapsulation } from '@angular/core';
 import {
 	NgbCalendar,
 	NgbCalendarEthiopian,
@@ -21,7 +21,6 @@ import { FormsModule } from '@angular/forms';
 			overflow: hidden;
 		}
 	`,
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [
 		{ provide: NgbCalendar, useClass: NgbCalendarEthiopian },
 		{ provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nAmharic },

--- a/demo/src/app/components/datepicker/demos/footertemplate/datepicker-footertemplate.ts
+++ b/demo/src/app/components/datepicker/demos/footertemplate/datepicker-footertemplate.ts
@@ -1,11 +1,10 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { NgbCalendar, NgbInputDatepicker, NgbDateStruct } from '@ng-bootstrap/ng-bootstrap/datepicker';
 import { FormsModule } from '@angular/forms';
 
 @Component({
 	selector: 'ngbd-datepicker-footertemplate',
 	imports: [NgbInputDatepicker, FormsModule],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './datepicker-footertemplate.html',
 })
 export class NgbdDatepickerFootertemplate {

--- a/demo/src/app/components/datepicker/demos/hebrew/datepicker-hebrew.ts
+++ b/demo/src/app/components/datepicker/demos/hebrew/datepicker-hebrew.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import {
 	NgbCalendar,
 	NgbCalendarHebrew,
@@ -40,7 +40,6 @@ import { JsonPipe } from '@angular/common';
 			direction: ltr;
 		}
 	`,
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [
 		{ provide: NgbCalendar, useClass: NgbCalendarHebrew },
 		{ provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nHebrew },

--- a/demo/src/app/components/datepicker/demos/i18n/datepicker-i18n.ts
+++ b/demo/src/app/components/datepicker/demos/i18n/datepicker-i18n.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Injectable, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, Injectable } from '@angular/core';
 import { NgbDatepickerI18n, NgbDatepicker, NgbDateStruct } from '@ng-bootstrap/ng-bootstrap/datepicker';
 import { FormsModule } from '@angular/forms';
 import { NgbAlert } from '@ng-bootstrap/ng-bootstrap/alert';
@@ -45,7 +45,6 @@ export class CustomDatepickerI18n extends NgbDatepickerI18n {
 	selector: 'ngbd-datepicker-i18n',
 	imports: [NgbDatepicker, NgbAlert, FormsModule],
 	templateUrl: './datepicker-i18n.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [I18n, { provide: NgbDatepickerI18n, useClass: CustomDatepickerI18n }],
 })
 export class NgbdDatepickerI18n {

--- a/demo/src/app/components/datepicker/demos/islamiccivil/datepicker-islamiccivil.ts
+++ b/demo/src/app/components/datepicker/demos/islamiccivil/datepicker-islamiccivil.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Injectable, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, Injectable } from '@angular/core';
 import {
 	NgbCalendar,
 	NgbCalendarIslamicCivil,
@@ -48,7 +48,6 @@ export class IslamicI18n extends NgbDatepickerI18n {
 	selector: 'ngbd-datepicker-islamiccivil',
 	imports: [NgbDatepicker, FormsModule, JsonPipe],
 	templateUrl: './datepicker-islamiccivil.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [
 		{ provide: NgbCalendar, useClass: NgbCalendarIslamicCivil },
 		{ provide: NgbDatepickerI18n, useClass: IslamicI18n },

--- a/demo/src/app/components/datepicker/demos/islamicumalqura/datepicker-islamicumalqura.ts
+++ b/demo/src/app/components/datepicker/demos/islamicumalqura/datepicker-islamicumalqura.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Injectable, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, Injectable } from '@angular/core';
 import {
 	NgbCalendar,
 	NgbCalendarIslamicUmalqura,
@@ -48,7 +48,6 @@ export class IslamicI18n extends NgbDatepickerI18n {
 	selector: 'ngbd-datepicker-islamicumalqura',
 	imports: [NgbDatepicker, FormsModule, JsonPipe],
 	templateUrl: './datepicker-islamicumalqura.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [
 		{ provide: NgbCalendar, useClass: NgbCalendarIslamicUmalqura },
 		{ provide: NgbDatepickerI18n, useClass: IslamicI18n },

--- a/demo/src/app/components/datepicker/demos/jalali/datepicker-jalali.ts
+++ b/demo/src/app/components/datepicker/demos/jalali/datepicker-jalali.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Injectable, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, Injectable } from '@angular/core';
 import {
 	NgbCalendar,
 	NgbCalendarPersian,
@@ -32,7 +32,6 @@ export class NgbDatepickerI18nPersian extends NgbDatepickerI18n {
 	selector: 'ngbd-datepicker-jalali',
 	imports: [NgbDatepicker, FormsModule, JsonPipe],
 	templateUrl: './datepicker-jalali.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [
 		{ provide: NgbCalendar, useClass: NgbCalendarPersian },
 		{ provide: NgbDatepickerI18n, useClass: NgbDatepickerI18nPersian },

--- a/demo/src/app/components/datepicker/demos/keyboard/datepicker-keyboard.ts
+++ b/demo/src/app/components/datepicker/demos/keyboard/datepicker-keyboard.ts
@@ -1,4 +1,4 @@
-import { Component, Injectable, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Injectable } from '@angular/core';
 import { NgbDatepicker, NgbDatepickerKeyboardService, NgbDateStruct } from '@ng-bootstrap/ng-bootstrap/datepicker';
 import { FormsModule } from '@angular/forms';
 
@@ -39,7 +39,6 @@ export class CustomKeyboardService extends NgbDatepickerKeyboardService {
 	selector: 'ngbd-datepicker-keyboard',
 	imports: [NgbDatepicker, FormsModule],
 	templateUrl: './datepicker-keyboard.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [{ provide: NgbDatepickerKeyboardService, useClass: CustomKeyboardService }],
 })
 export class NgbdDatepickerKeyboard {

--- a/demo/src/app/components/datepicker/demos/multiple/datepicker-multiple.ts
+++ b/demo/src/app/components/datepicker/demos/multiple/datepicker-multiple.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { NgbDatepicker, NgbInputDatepicker } from '@ng-bootstrap/ng-bootstrap/datepicker';
 
@@ -6,7 +6,6 @@ import { NgbDatepicker, NgbInputDatepicker } from '@ng-bootstrap/ng-bootstrap/da
 	selector: 'ngbd-datepicker-multiple',
 	imports: [NgbDatepicker, NgbInputDatepicker, FormsModule],
 	templateUrl: './datepicker-multiple.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		select.form-select {
 			margin: 0.5rem 0.5rem 0 0;

--- a/demo/src/app/components/datepicker/demos/popup/datepicker-popup.ts
+++ b/demo/src/app/components/datepicker/demos/popup/datepicker-popup.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbAlert } from '@ng-bootstrap/ng-bootstrap/alert';
 import { NgbInputDatepicker, NgbDateStruct } from '@ng-bootstrap/ng-bootstrap/datepicker';
 import { FormsModule } from '@angular/forms';
@@ -7,7 +7,6 @@ import { JsonPipe } from '@angular/common';
 @Component({
 	selector: 'ngbd-datepicker-popup',
 	imports: [NgbInputDatepicker, NgbAlert, FormsModule, JsonPipe],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './datepicker-popup.html',
 })
 export class NgbdDatepickerPopup {

--- a/demo/src/app/components/datepicker/demos/positiontarget/datepicker-positiontarget.ts
+++ b/demo/src/app/components/datepicker/demos/positiontarget/datepicker-positiontarget.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbInputDatepicker, NgbDateStruct } from '@ng-bootstrap/ng-bootstrap/datepicker';
 import { FormsModule } from '@angular/forms';
 
 @Component({
 	selector: 'ngbd-datepicker-positiontarget',
 	imports: [NgbInputDatepicker, FormsModule],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './datepicker-positiontarget.html',
 })
 export class NgbdDatepickerPositiontarget {

--- a/demo/src/app/components/datepicker/demos/range-popup/datepicker-range-popup.ts
+++ b/demo/src/app/components/datepicker/demos/range-popup/datepicker-range-popup.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import {
 	NgbCalendar,
 	NgbDate,
@@ -12,7 +12,6 @@ import { JsonPipe } from '@angular/common';
 	selector: 'ngbd-datepicker-range-popup',
 	imports: [NgbInputDatepicker, FormsModule, JsonPipe],
 	templateUrl: './datepicker-range-popup.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		.dp-hidden {
 			width: 0;

--- a/demo/src/app/components/datepicker/demos/range/datepicker-range.ts
+++ b/demo/src/app/components/datepicker/demos/range/datepicker-range.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { NgbCalendar, NgbDate, NgbDatepicker } from '@ng-bootstrap/ng-bootstrap/datepicker';
 import { FormsModule } from '@angular/forms';
 import { JsonPipe } from '@angular/common';
@@ -7,7 +7,6 @@ import { JsonPipe } from '@angular/common';
 	selector: 'ngbd-datepicker-range',
 	imports: [NgbDatepicker, FormsModule, JsonPipe],
 	templateUrl: './datepicker-range.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		.custom-day {
 			text-align: center;

--- a/demo/src/app/components/dropdown/demos/basic/dropdown-basic.ts
+++ b/demo/src/app/components/dropdown/demos/basic/dropdown-basic.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbDropdown,
 	NgbDropdownToggle,
@@ -10,7 +10,6 @@ import {
 @Component({
 	selector: 'ngbd-dropdown-basic',
 	imports: [NgbDropdown, NgbDropdownToggle, NgbDropdownMenu, NgbDropdownItem, NgbDropdownButtonItem],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './dropdown-basic.html',
 })
 export class NgbdDropdownBasic {}

--- a/demo/src/app/components/dropdown/demos/config/dropdown-config.ts
+++ b/demo/src/app/components/dropdown/demos/config/dropdown-config.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbDropdownConfig,
 	NgbDropdown,
@@ -12,7 +12,6 @@ import {
 	selector: 'ngbd-dropdown-config',
 	imports: [NgbDropdown, NgbDropdownToggle, NgbDropdownMenu, NgbDropdownItem, NgbDropdownButtonItem],
 	templateUrl: './dropdown-config.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [NgbDropdownConfig],
 })
 export class NgbdDropdownConfig {

--- a/demo/src/app/components/dropdown/demos/container/dropdown-container.ts
+++ b/demo/src/app/components/dropdown/demos/container/dropdown-container.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbDropdown,
 	NgbDropdownToggle,
@@ -10,7 +10,6 @@ import {
 @Component({
 	selector: 'ngbd-dropdown-container',
 	imports: [NgbDropdown, NgbDropdownToggle, NgbDropdownMenu, NgbDropdownItem, NgbDropdownButtonItem],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './dropdown-container.html',
 })
 export class NgbdDropdownContainer {}

--- a/demo/src/app/components/dropdown/demos/disabled/dropdown-disabled.ts
+++ b/demo/src/app/components/dropdown/demos/disabled/dropdown-disabled.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbDropdown,
 	NgbDropdownToggle,
@@ -10,7 +10,6 @@ import {
 @Component({
 	selector: 'ngbd-dropdown-disabled',
 	imports: [NgbDropdown, NgbDropdownToggle, NgbDropdownMenu, NgbDropdownItem, NgbDropdownButtonItem],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './dropdown-disabled.html',
 })
 export class NgbdDropdownDisabled {}

--- a/demo/src/app/components/dropdown/demos/form/dropdown-form.ts
+++ b/demo/src/app/components/dropdown/demos/form/dropdown-form.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbDropdown,
 	NgbDropdownToggle,
@@ -10,7 +10,6 @@ import {
 @Component({
 	selector: 'ngbd-dropdown-form',
 	imports: [NgbDropdown, NgbDropdownToggle, NgbDropdownMenu, NgbDropdownItem, NgbDropdownButtonItem],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './dropdown-form.html',
 })
 export class NgbdDropdownForm {}

--- a/demo/src/app/components/dropdown/demos/manual/dropdown-manual.ts
+++ b/demo/src/app/components/dropdown/demos/manual/dropdown-manual.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbDropdown,
 	NgbDropdownAnchor,
@@ -10,7 +10,6 @@ import {
 @Component({
 	selector: 'ngbd-dropdown-manual',
 	imports: [NgbDropdown, NgbDropdownAnchor, NgbDropdownMenu, NgbDropdownItem, NgbDropdownButtonItem],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './dropdown-manual.html',
 })
 export class NgbdDropdownManual {}

--- a/demo/src/app/components/dropdown/demos/navbar/dropdown-navbar.ts
+++ b/demo/src/app/components/dropdown/demos/navbar/dropdown-navbar.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbDropdown, NgbDropdownToggle, NgbDropdownMenu, NgbDropdownItem } from '@ng-bootstrap/ng-bootstrap/dropdown';
 
 @Component({
 	selector: 'ngbd-dropdown-navbar',
 	imports: [NgbDropdown, NgbDropdownToggle, NgbDropdownMenu, NgbDropdownItem],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './dropdown-navbar.html',
 })
 export class NgbdDropdownNavbar {

--- a/demo/src/app/components/dropdown/demos/split/dropdown-split.ts
+++ b/demo/src/app/components/dropdown/demos/split/dropdown-split.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbDropdown,
 	NgbDropdownToggle,
@@ -10,7 +10,6 @@ import {
 @Component({
 	selector: 'ngbd-dropdown-split',
 	imports: [NgbDropdown, NgbDropdownToggle, NgbDropdownMenu, NgbDropdownItem, NgbDropdownButtonItem],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './dropdown-split.html',
 })
 export class NgbdDropdownSplit {}

--- a/demo/src/app/components/modal/demos/basic/modal-basic.ts
+++ b/demo/src/app/components/modal/demos/basic/modal-basic.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, TemplateRef, WritableSignal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, signal, TemplateRef, WritableSignal } from '@angular/core';
 
 import { ModalDismissReasons, NgbModal } from '@ng-bootstrap/ng-bootstrap/modal';
 import { NgbInputDatepicker } from '@ng-bootstrap/ng-bootstrap/datepicker';
@@ -6,7 +6,6 @@ import { NgbInputDatepicker } from '@ng-bootstrap/ng-bootstrap/datepicker';
 @Component({
 	selector: 'ngbd-modal-basic',
 	imports: [NgbInputDatepicker],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './modal-basic.html',
 })
 export class NgbdModalBasic {

--- a/demo/src/app/components/modal/demos/component/modal-component.ts
+++ b/demo/src/app/components/modal/demos/component/modal-component.ts
@@ -1,9 +1,8 @@
-import { Component, inject, Input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, Input } from '@angular/core';
 import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap/modal';
 
 @Component({
 	selector: 'ngbd-modal-content',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<div class="modal-header">
 			<h4 class="modal-title">Hi there!</h4>
@@ -25,7 +24,6 @@ export class NgbdModalContent {
 
 @Component({
 	selector: 'ngbd-modal-component',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './modal-component.html',
 })
 export class NgbdModalComponent {

--- a/demo/src/app/components/modal/demos/config/modal-config.ts
+++ b/demo/src/app/components/modal/demos/config/modal-config.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbModal, NgbModalConfig } from '@ng-bootstrap/ng-bootstrap/modal';
 
 @Component({
 	selector: 'ngbd-modal-config',
 	templateUrl: './modal-config.html',
 	// add NgbModalConfig and NgbModal to the component providers
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [NgbModalConfig, NgbModal],
 })
 export class NgbdModalConfig {

--- a/demo/src/app/components/modal/demos/focus/modal-focus.ts
+++ b/demo/src/app/components/modal/demos/focus/modal-focus.ts
@@ -1,9 +1,8 @@
-import { Component, inject, Type, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, Type } from '@angular/core';
 import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap/modal';
 
 @Component({
 	selector: 'ngbd-modal-confirm',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<div class="modal-header">
 			<h4 class="modal-title" id="modal-title">Profile deletion</h4>
@@ -35,7 +34,6 @@ export class NgbdModalConfirm {
 
 @Component({
 	selector: 'ngbd-modal-confirm-autofocus',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<div class="modal-header">
 			<h4 class="modal-title" id="modal-title">Profile deletion</h4>
@@ -73,7 +71,6 @@ const MODALS: { [name: string]: Type<any> } = {
 
 @Component({
 	selector: 'ngbd-modal-focus',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './modal-focus.html',
 })
 export class NgbdModalFocus {

--- a/demo/src/app/components/modal/demos/options/modal-options.ts
+++ b/demo/src/app/components/modal/demos/options/modal-options.ts
@@ -1,11 +1,10 @@
-import { Component, inject, TemplateRef, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, TemplateRef, ViewEncapsulation } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap/modal';
 
 @Component({
 	selector: 'ngbd-modal-options',
 	templateUrl: './modal-options.html',
 	encapsulation: ViewEncapsulation.None,
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		.dark-modal .modal-content {
 			background-color: #292b2c;

--- a/demo/src/app/components/modal/demos/stacked/modal-stacked.ts
+++ b/demo/src/app/components/modal/demos/stacked/modal-stacked.ts
@@ -1,10 +1,9 @@
-import { Component, inject, signal, WritableSignal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, signal, WritableSignal } from '@angular/core';
 import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap/modal';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
 	selector: 'ngbd-modal-stacked',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<div class="modal-header">
 			<h4 class="modal-title">Hi there!</h4>
@@ -29,7 +28,6 @@ export class NgbdModal1Content {
 }
 
 @Component({
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<div class="modal-header">
 			<h4 class="modal-title">Hi there!</h4>
@@ -49,7 +47,6 @@ export class NgbdModal2Content {
 
 @Component({
 	selector: 'ngbd-modal-stacked',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './modal-stacked.html',
 })
 export class NgbdModalStacked {

--- a/demo/src/app/components/modal/demos/updatable/modal-updatable-options.ts
+++ b/demo/src/app/components/modal/demos/updatable/modal-updatable-options.ts
@@ -1,9 +1,8 @@
-import { Component, inject, Input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, Input } from '@angular/core';
 import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap/modal';
 
 @Component({
 	selector: 'ngbd-modal-updatable-options',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<div class="modal-header">
 			<h4 class="modal-title">Hi there!</h4>
@@ -41,7 +40,6 @@ export class NgbdModalContent {
 
 @Component({
 	selector: 'ngbd-modal-updatable-component',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './modal-updatable-options.html',
 })
 export class NgbdModalUpdatableOptions {

--- a/demo/src/app/components/nav/demos/basic/nav-basic.ts
+++ b/demo/src/app/components/nav/demos/basic/nav-basic.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbNavContent,
 	NgbNav,
@@ -12,7 +12,6 @@ import {
 @Component({
 	selector: 'ngbd-nav-basic',
 	imports: [NgbNavContent, NgbNav, NgbNavItem, NgbNavItemRole, NgbNavLinkButton, NgbNavLinkBase, NgbNavOutlet],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './nav-basic.html',
 })
 export class NgbdNavBasic {

--- a/demo/src/app/components/nav/demos/config/nav-config.ts
+++ b/demo/src/app/components/nav/demos/config/nav-config.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbNavConfig,
 	NgbNavContent,
@@ -14,7 +14,6 @@ import {
 	selector: 'ngbd-nav-config',
 	imports: [NgbNavContent, NgbNav, NgbNavItem, NgbNavItemRole, NgbNavLink, NgbNavLinkBase, NgbNavOutlet],
 	templateUrl: './nav-config.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [NgbNavConfig],
 })
 export class NgbdNavConfig {

--- a/demo/src/app/components/nav/demos/custom-style/nav-custom-style.ts
+++ b/demo/src/app/components/nav/demos/custom-style/nav-custom-style.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbDropdown,
 	NgbDropdownToggle,
@@ -32,7 +32,6 @@ import {
 		NgbDropdownItem,
 		NgbDropdownButtonItem,
 	],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './nav-custom-style.html',
 })
 export class NgbdNavCustomStyle {}

--- a/demo/src/app/components/nav/demos/dynamic/nav-dynamic.ts
+++ b/demo/src/app/components/nav/demos/dynamic/nav-dynamic.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbNavContent,
 	NgbNav,
@@ -13,7 +13,6 @@ import {
 	selector: 'ngbd-nav-dynamic',
 	imports: [NgbNavContent, NgbNav, NgbNavItem, NgbNavItemRole, NgbNavLinkButton, NgbNavLinkBase, NgbNavOutlet],
 	templateUrl: './nav-dynamic.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		.close {
 			font-size: 1.4rem;

--- a/demo/src/app/components/nav/demos/keep-content/nav-keep-content.ts
+++ b/demo/src/app/components/nav/demos/keep-content/nav-keep-content.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbAlert } from '@ng-bootstrap/ng-bootstrap/alert';
 import {
 	NgbNavContent,
@@ -22,7 +22,6 @@ import {
 		NgbNavOutlet,
 		NgbAlert,
 	],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './nav-keep-content.html',
 })
 export class NgbdNavKeep {

--- a/demo/src/app/components/nav/demos/markup/nav-markup.ts
+++ b/demo/src/app/components/nav/demos/markup/nav-markup.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbNavContent,
 	NgbNav,
@@ -12,7 +12,6 @@ import {
 @Component({
 	selector: 'ngbd-nav-markup',
 	imports: [NgbNavContent, NgbNav, NgbNavItem, NgbNavLink, NgbNavLinkButton, NgbNavLinkBase, NgbNavOutlet],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './nav-markup.html',
 })
 export class NgbdNavMarkup {}

--- a/demo/src/app/components/nav/demos/selection/nav-selection.ts
+++ b/demo/src/app/components/nav/demos/selection/nav-selection.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbNavChangeEvent,
 	NgbNavContent,
@@ -13,7 +13,6 @@ import {
 @Component({
 	selector: 'ngbd-nav-selection',
 	imports: [NgbNavContent, NgbNav, NgbNavItem, NgbNavItemRole, NgbNavLinkButton, NgbNavLinkBase, NgbNavOutlet],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './nav-selection.html',
 })
 export class NgbdNavSelection {

--- a/demo/src/app/components/nav/demos/vertical/nav-vertical.ts
+++ b/demo/src/app/components/nav/demos/vertical/nav-vertical.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbNavContent,
 	NgbNav,
@@ -24,7 +24,6 @@ import {
 		NgbNavLinkBase,
 		NgbNavOutlet,
 	],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './nav-vertical.html',
 })
 export class NgbdNavVertical {

--- a/demo/src/app/components/nav/overview/nav-overview.component.ts
+++ b/demo/src/app/components/nav/overview/nav-overview.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 
 import { Snippet } from '../../../services/snippet';
 import { NgbAlert } from '@ng-bootstrap/ng-bootstrap/alert';
@@ -34,7 +34,6 @@ import { NgbdOverviewPage } from '../../../shared/overview-page/overview-page.cl
 		PageHeaderComponent,
 	],
 	templateUrl: './nav-overview.component.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	host: { '[class.overview]': 'true' },
 })
 export class NgbdNavOverviewComponent extends NgbdOverviewPage {

--- a/demo/src/app/components/offcanvas/demos/basic/offcanvas-basic.ts
+++ b/demo/src/app/components/offcanvas/demos/basic/offcanvas-basic.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, TemplateRef, WritableSignal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, signal, TemplateRef, WritableSignal } from '@angular/core';
 
 import { NgbInputDatepicker } from '@ng-bootstrap/ng-bootstrap/datepicker';
 import { NgbOffcanvas, OffcanvasDismissReasons } from '@ng-bootstrap/ng-bootstrap/offcanvas';
@@ -6,7 +6,6 @@ import { NgbOffcanvas, OffcanvasDismissReasons } from '@ng-bootstrap/ng-bootstra
 @Component({
 	selector: 'ngbd-offcanvas-basic',
 	imports: [NgbInputDatepicker],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './offcanvas-basic.html',
 })
 export class NgbdOffcanvasBasic {

--- a/demo/src/app/components/offcanvas/demos/component/offcanvas-component.ts
+++ b/demo/src/app/components/offcanvas/demos/component/offcanvas-component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, Input } from '@angular/core';
 import { NgbActiveOffcanvas, NgbOffcanvas } from '@ng-bootstrap/ng-bootstrap/offcanvas';
 
 @Component({
@@ -20,7 +20,6 @@ import { NgbActiveOffcanvas, NgbOffcanvas } from '@ng-bootstrap/ng-bootstrap/off
 			</button>
 		</div>
 	`,
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		/* Opening offcanvas as a component requires this style in order to scroll */
 		:host {
@@ -37,7 +36,6 @@ export class NgbdOffcanvasContent {
 
 @Component({
 	selector: 'ngbd-offcanvas-component',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './offcanvas-component.html',
 })
 export class NgbdOffcanvasComponent {

--- a/demo/src/app/components/offcanvas/demos/config/offcanvas-config.ts
+++ b/demo/src/app/components/offcanvas/demos/config/offcanvas-config.ts
@@ -1,11 +1,10 @@
-import { Component, TemplateRef, ChangeDetectionStrategy } from '@angular/core';
+import { Component, TemplateRef } from '@angular/core';
 import { NgbOffcanvas, NgbOffcanvasConfig } from '@ng-bootstrap/ng-bootstrap/offcanvas';
 
 @Component({
 	selector: 'ngbd-offcanvas-config',
 	templateUrl: './offcanvas-config.html',
 	// add NgbOffcanvasConfig and NgbOffcanvas to the component providers
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [NgbOffcanvasConfig, NgbOffcanvas],
 })
 export class NgbdOffcanvasConfig {

--- a/demo/src/app/components/offcanvas/demos/focus/offcanvas-focus.ts
+++ b/demo/src/app/components/offcanvas/demos/focus/offcanvas-focus.ts
@@ -1,9 +1,8 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { NgbActiveOffcanvas, NgbOffcanvas } from '@ng-bootstrap/ng-bootstrap/offcanvas';
 
 @Component({
 	selector: 'ngbd-offcanvas-firstfocus',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<div class="offcanvas-header">
 			<h4 class="offcanvas-title">Offcanvas title</h4>
@@ -23,7 +22,6 @@ export class NgbdOffcanvasFirstFocus {
 
 @Component({
 	selector: 'ngbd-offcanvas-autofocus',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<div class="offcanvas-header">
 			<h4 class="offcanvas-title">Offcanvas title</h4>
@@ -45,7 +43,6 @@ export class NgbdOffcanvasAutoFocus {
 
 @Component({
 	selector: 'ngbd-offcanvas-focus',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './offcanvas-focus.html',
 })
 export class NgbdOffcanvasFocus {

--- a/demo/src/app/components/offcanvas/demos/options/offcanvas-options.ts
+++ b/demo/src/app/components/offcanvas/demos/options/offcanvas-options.ts
@@ -1,10 +1,9 @@
-import { Component, inject, TemplateRef, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, TemplateRef, ViewEncapsulation } from '@angular/core';
 import { NgbOffcanvas } from '@ng-bootstrap/ng-bootstrap/offcanvas';
 
 @Component({
 	selector: 'ngbd-offcanvas-options',
 	templateUrl: './offcanvas-options.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	encapsulation: ViewEncapsulation.None,
 })
 export class NgbdOffcanvasOptions {

--- a/demo/src/app/components/pagination/demos/advanced/pagination-advanced.ts
+++ b/demo/src/app/components/pagination/demos/advanced/pagination-advanced.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbPagination } from '@ng-bootstrap/ng-bootstrap/pagination';
 
 @Component({
 	selector: 'ngbd-pagination-advanced',
 	imports: [NgbPagination],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './pagination-advanced.html',
 })
 export class NgbdPaginationAdvanced {

--- a/demo/src/app/components/pagination/demos/basic/pagination-basic.ts
+++ b/demo/src/app/components/pagination/demos/basic/pagination-basic.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbPagination } from '@ng-bootstrap/ng-bootstrap/pagination';
 
 @Component({
 	selector: 'ngbd-pagination-basic',
 	imports: [NgbPagination],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './pagination-basic.html',
 })
 export class NgbdPaginationBasic {

--- a/demo/src/app/components/pagination/demos/config/pagination-config.ts
+++ b/demo/src/app/components/pagination/demos/config/pagination-config.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbPaginationConfig, NgbPagination } from '@ng-bootstrap/ng-bootstrap/pagination';
 
 @Component({
 	selector: 'ngbd-pagination-config',
 	imports: [NgbPagination],
 	templateUrl: './pagination-config.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [NgbPaginationConfig],
 })
 export class NgbdPaginationConfig {

--- a/demo/src/app/components/pagination/demos/customization/pagination-customization.ts
+++ b/demo/src/app/components/pagination/demos/customization/pagination-customization.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbPagination,
 	NgbPaginationNext,
@@ -12,7 +12,6 @@ const FILTER_PAG_REGEX = /[^0-9]/g;
 @Component({
 	selector: 'ngbd-pagination-customization',
 	imports: [NgbPagination, NgbPaginationNext, NgbPaginationNumber, NgbPaginationPrevious, NgbPaginationPages],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './pagination-customization.html',
 })
 export class NgbdPaginationCustomization {

--- a/demo/src/app/components/pagination/demos/disabled/pagination-disabled.ts
+++ b/demo/src/app/components/pagination/demos/disabled/pagination-disabled.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbPagination } from '@ng-bootstrap/ng-bootstrap/pagination';
 
 @Component({
 	selector: 'ngbd-pagination-disabled',
 	imports: [NgbPagination],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './pagination-disabled.html',
 })
 export class NgbdPaginationDisabled {

--- a/demo/src/app/components/pagination/demos/justify/pagination-justify.ts
+++ b/demo/src/app/components/pagination/demos/justify/pagination-justify.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbPagination } from '@ng-bootstrap/ng-bootstrap/pagination';
 
 @Component({
 	selector: 'ngbd-pagination-justify',
 	imports: [NgbPagination],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './pagination-justify.html',
 })
 export class NgbdPaginationJustify {

--- a/demo/src/app/components/pagination/demos/size/pagination-size.ts
+++ b/demo/src/app/components/pagination/demos/size/pagination-size.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbPagination } from '@ng-bootstrap/ng-bootstrap/pagination';
 
 @Component({
 	selector: 'ngbd-pagination-size',
 	imports: [NgbPagination],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './pagination-size.html',
 })
 export class NgbdPaginationSize {

--- a/demo/src/app/components/popover/demos/autoclose/popover-autoclose.ts
+++ b/demo/src/app/components/popover/demos/autoclose/popover-autoclose.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbPopover } from '@ng-bootstrap/ng-bootstrap/popover';
 
 @Component({
 	selector: 'ngbd-popover-autoclose',
 	imports: [NgbPopover],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './popover-autoclose.html',
 })
 export class NgbdPopoverAutoclose {}

--- a/demo/src/app/components/popover/demos/basic/popover-basic.ts
+++ b/demo/src/app/components/popover/demos/basic/popover-basic.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbPopover } from '@ng-bootstrap/ng-bootstrap/popover';
 
 @Component({
 	selector: 'ngbd-popover-basic',
 	imports: [NgbPopover],
 	templateUrl: './popover-basic.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	host: { class: 'd-block' },
 })
 export class NgbdPopoverBasic {}

--- a/demo/src/app/components/popover/demos/config/popover-config.ts
+++ b/demo/src/app/components/popover/demos/config/popover-config.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbPopoverConfig, NgbPopover } from '@ng-bootstrap/ng-bootstrap/popover';
 
 @Component({
 	selector: 'ngbd-popover-config',
 	imports: [NgbPopover],
 	templateUrl: './popover-config.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [NgbPopoverConfig],
 })
 export class NgbdPopoverConfig {

--- a/demo/src/app/components/popover/demos/container/popover-container.ts
+++ b/demo/src/app/components/popover/demos/container/popover-container.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbPopover } from '@ng-bootstrap/ng-bootstrap/popover';
 
 @Component({
 	selector: 'ngbd-popover-container',
 	imports: [NgbPopover],
 	templateUrl: './popover-container.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		.card {
 			overflow: hidden;

--- a/demo/src/app/components/popover/demos/custom-target/popover-target.ts
+++ b/demo/src/app/components/popover/demos/custom-target/popover-target.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbPopover } from '@ng-bootstrap/ng-bootstrap/popover';
 
 @Component({
 	selector: 'ngbd-popover-target',
 	imports: [NgbPopover],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './popover-target.html',
 })
 export class NgbdPopoverTarget {}

--- a/demo/src/app/components/popover/demos/customclass/popover-customclass.ts
+++ b/demo/src/app/components/popover/demos/customclass/popover-customclass.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 import { NgbPopover } from '@ng-bootstrap/ng-bootstrap/popover';
 
 @Component({
@@ -6,7 +6,6 @@ import { NgbPopover } from '@ng-bootstrap/ng-bootstrap/popover';
 	imports: [NgbPopover],
 	templateUrl: './popover-customclass.html',
 	encapsulation: ViewEncapsulation.None,
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		.my-custom-class {
 			background: aliceblue;

--- a/demo/src/app/components/popover/demos/delay/popover-delay.ts
+++ b/demo/src/app/components/popover/demos/delay/popover-delay.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbPopover } from '@ng-bootstrap/ng-bootstrap/popover';
 
 @Component({
 	selector: 'ngbd-popover-delay',
 	imports: [NgbPopover],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './popover-delay.html',
 })
 export class NgbdPopoverDelay {}

--- a/demo/src/app/components/popover/demos/options/popover-options.ts
+++ b/demo/src/app/components/popover/demos/options/popover-options.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbPopover } from '@ng-bootstrap/ng-bootstrap/popover';
 import { Options } from '@popperjs/core';
 
 @Component({
 	selector: 'ngbd-popover-options',
 	imports: [NgbPopover],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './popover-options.html',
 })
 export class NgbdPopoverOptions {

--- a/demo/src/app/components/popover/demos/tplcontent/popover-tplcontent.ts
+++ b/demo/src/app/components/popover/demos/tplcontent/popover-tplcontent.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbPopover } from '@ng-bootstrap/ng-bootstrap/popover';
 
 @Component({
 	selector: 'ngbd-popover-tplcontent',
 	imports: [NgbPopover],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './popover-tplcontent.html',
 })
 export class NgbdPopoverTplcontent {

--- a/demo/src/app/components/popover/demos/tplwithcontext/popover-tplwithcontext.ts
+++ b/demo/src/app/components/popover/demos/tplwithcontext/popover-tplwithcontext.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbPopover } from '@ng-bootstrap/ng-bootstrap/popover';
 
 @Component({
 	selector: 'ngbd-popover-tplwithcontext',
 	imports: [NgbPopover],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './popover-tplwithcontext.html',
 })
 export class NgbdPopoverTplwithcontext {

--- a/demo/src/app/components/popover/demos/triggers/popover-triggers.ts
+++ b/demo/src/app/components/popover/demos/triggers/popover-triggers.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbPopover } from '@ng-bootstrap/ng-bootstrap/popover';
 
 @Component({
 	selector: 'ngbd-popover-triggers',
 	imports: [NgbPopover],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './popover-triggers.html',
 })
 export class NgbdPopoverTriggers {}

--- a/demo/src/app/components/popover/demos/visibility/popover-visibility.ts
+++ b/demo/src/app/components/popover/demos/visibility/popover-visibility.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbPopover } from '@ng-bootstrap/ng-bootstrap/popover';
 import { DatePipe } from '@angular/common';
 
 @Component({
 	selector: 'ngbd-popover-visibility',
 	imports: [NgbPopover, DatePipe],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './popover-visibility.html',
 })
 export class NgbdPopoverVisibility {

--- a/demo/src/app/components/progressbar/demos/basic/progressbar-basic.ts
+++ b/demo/src/app/components/progressbar/demos/basic/progressbar-basic.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbProgressbar } from '@ng-bootstrap/ng-bootstrap/progressbar';
 
 @Component({
 	selector: 'ngbd-progressbar-basic',
 	imports: [NgbProgressbar],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './progressbar-basic.html',
 })
 export class NgbdProgressbarBasic {}

--- a/demo/src/app/components/progressbar/demos/config/progressbar-config.ts
+++ b/demo/src/app/components/progressbar/demos/config/progressbar-config.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbProgressbarConfig, NgbProgressbar } from '@ng-bootstrap/ng-bootstrap/progressbar';
 
 @Component({
 	selector: 'ngbd-progressbar-config',
 	imports: [NgbProgressbar],
 	templateUrl: './progressbar-config.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [NgbProgressbarConfig],
 })
 export class NgbdProgressbarConfig {

--- a/demo/src/app/components/progressbar/demos/height/progressbar-height.ts
+++ b/demo/src/app/components/progressbar/demos/height/progressbar-height.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbProgressbar } from '@ng-bootstrap/ng-bootstrap/progressbar';
 
 @Component({
 	selector: 'ngbd-progressbar-height',
 	imports: [NgbProgressbar],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './progressbar-height.html',
 })
 export class NgbdProgressbarHeight {

--- a/demo/src/app/components/progressbar/demos/labels/progressbar-labels.ts
+++ b/demo/src/app/components/progressbar/demos/labels/progressbar-labels.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbProgressbar } from '@ng-bootstrap/ng-bootstrap/progressbar';
 
 @Component({
 	selector: 'ngbd-progressbar-labels',
 	imports: [NgbProgressbar],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './progressbar-labels.html',
 })
 export class NgbdProgressbarLabels {}

--- a/demo/src/app/components/progressbar/demos/showvalue/progressbar-showvalue.ts
+++ b/demo/src/app/components/progressbar/demos/showvalue/progressbar-showvalue.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbProgressbar } from '@ng-bootstrap/ng-bootstrap/progressbar';
 
 @Component({
 	selector: 'ngbd-progressbar-showvalue',
 	imports: [NgbProgressbar],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './progressbar-showvalue.html',
 })
 export class NgbdProgressbarShowvalue {}

--- a/demo/src/app/components/progressbar/demos/stacked/progressbar-stacked.ts
+++ b/demo/src/app/components/progressbar/demos/stacked/progressbar-stacked.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbProgressbar, NgbProgressbarStacked } from '@ng-bootstrap/ng-bootstrap/progressbar';
 
 @Component({
 	selector: 'ngbd-progressbar-stacked',
 	imports: [NgbProgressbar, NgbProgressbarStacked],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './progressbar-stacked.html',
 })
 export class NgbdProgressbarStacked {}

--- a/demo/src/app/components/progressbar/demos/striped/progressbar-striped.ts
+++ b/demo/src/app/components/progressbar/demos/striped/progressbar-striped.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbProgressbar } from '@ng-bootstrap/ng-bootstrap/progressbar';
 
 @Component({
 	selector: 'ngbd-progressbar-striped',
 	imports: [NgbProgressbar],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './progressbar-striped.html',
 })
 export class NgbdProgressbarStriped {}

--- a/demo/src/app/components/progressbar/demos/texttypes/progressbar-texttypes.ts
+++ b/demo/src/app/components/progressbar/demos/texttypes/progressbar-texttypes.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbProgressbar } from '@ng-bootstrap/ng-bootstrap/progressbar';
 
 @Component({
 	selector: 'ngbd-progressbar-texttypes',
 	imports: [NgbProgressbar],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './progressbar-texttypes.html',
 })
 export class NgbdProgressbarTextTypes {}

--- a/demo/src/app/components/rating/demos/basic/rating-basic.ts
+++ b/demo/src/app/components/rating/demos/basic/rating-basic.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbRating } from '@ng-bootstrap/ng-bootstrap/rating';
 
 @Component({
 	selector: 'ngbd-rating-basic',
 	imports: [NgbRating],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './rating-basic.html',
 })
 export class NgbdRatingBasic {

--- a/demo/src/app/components/rating/demos/config/rating-config.ts
+++ b/demo/src/app/components/rating/demos/config/rating-config.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbRatingConfig, NgbRating } from '@ng-bootstrap/ng-bootstrap/rating';
 
 @Component({
 	selector: 'ngbd-rating-config',
 	imports: [NgbRating],
 	templateUrl: './rating-config.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [NgbRatingConfig],
 })
 export class NgbdRatingConfig {

--- a/demo/src/app/components/rating/demos/decimal/rating-decimal.ts
+++ b/demo/src/app/components/rating/demos/decimal/rating-decimal.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbRating } from '@ng-bootstrap/ng-bootstrap/rating';
 
 @Component({
 	selector: 'ngbd-rating-decimal',
 	imports: [NgbRating],
 	templateUrl: './rating-decimal.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		i {
 			position: relative;

--- a/demo/src/app/components/rating/demos/events/rating-events.ts
+++ b/demo/src/app/components/rating/demos/events/rating-events.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbRating } from '@ng-bootstrap/ng-bootstrap/rating';
 
 @Component({
 	selector: 'ngbd-rating-events',
 	imports: [NgbRating],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './rating-events.html',
 })
 export class NgbdRatingEvents {

--- a/demo/src/app/components/rating/demos/form/rating-form.ts
+++ b/demo/src/app/components/rating/demos/form/rating-form.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { NgbRating } from '@ng-bootstrap/ng-bootstrap/rating';
 
 @Component({
 	selector: 'ngbd-rating-form',
 	imports: [NgbRating, ReactiveFormsModule],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './rating-form.html',
 })
 export class NgbdRatingForm {

--- a/demo/src/app/components/rating/demos/template/rating-template.ts
+++ b/demo/src/app/components/rating/demos/template/rating-template.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbRating } from '@ng-bootstrap/ng-bootstrap/rating';
 
 @Component({
 	selector: 'ngbd-rating-template',
 	imports: [NgbRating],
 	templateUrl: './rating-template.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		i {
 			font-size: 1.5rem;

--- a/demo/src/app/components/scrollspy/demos/basic/scrollspy-basic.ts
+++ b/demo/src/app/components/scrollspy/demos/basic/scrollspy-basic.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbScrollSpy, NgbScrollSpyFragment } from '@ng-bootstrap/ng-bootstrap/scrollspy';
 import { FormsModule } from '@angular/forms';
 
 @Component({
 	selector: 'ngbd-scrollspy-basic',
 	imports: [NgbScrollSpy, NgbScrollSpyFragment, FormsModule],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './scrollspy-basic.html',
 })
 export class NgbdScrollSpyBasic {}

--- a/demo/src/app/components/scrollspy/demos/items/scrollspy-items.ts
+++ b/demo/src/app/components/scrollspy/demos/items/scrollspy-items.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbScrollSpy, NgbScrollSpyItem, NgbScrollSpyFragment } from '@ng-bootstrap/ng-bootstrap/scrollspy';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
@@ -6,7 +6,6 @@ import { RouterLink } from '@angular/router';
 @Component({
 	selector: 'ngbd-scrollspy-items',
 	imports: [NgbScrollSpy, NgbScrollSpyItem, NgbScrollSpyFragment, FormsModule, RouterLink],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './scrollspy-items.html',
 })
 export class NgbdScrollSpyItems {}

--- a/demo/src/app/components/scrollspy/demos/navbar/scrollspy-navbar.ts
+++ b/demo/src/app/components/scrollspy/demos/navbar/scrollspy-navbar.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbDropdown,
 	NgbDropdownToggle,
@@ -26,7 +26,6 @@ import {
 		NgbDropdownItem,
 		NgbDropdownButtonItem,
 	],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './scrollspy-navbar.html',
 })
 export class NgbdScrollSpyNavbar {}

--- a/demo/src/app/components/scrollspy/demos/nested/scrollspy-nested.ts
+++ b/demo/src/app/components/scrollspy/demos/nested/scrollspy-nested.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbScrollSpy,
 	NgbScrollSpyItem,
@@ -9,7 +9,6 @@ import {
 @Component({
 	selector: 'ngbd-scrollspy-nested',
 	imports: [NgbScrollSpy, NgbScrollSpyItem, NgbScrollSpyFragment, NgbScrollSpyMenu],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './scrollspy-nested.html',
 })
 export class NgbdScrollSpyNested {}

--- a/demo/src/app/components/scrollspy/demos/service/scrollspy-service.ts
+++ b/demo/src/app/components/scrollspy/demos/service/scrollspy-service.ts
@@ -1,10 +1,9 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { NgbScrollSpyService } from '@ng-bootstrap/ng-bootstrap/scrollspy';
 
 @Component({
 	selector: 'ngbd-scrollspy-service',
 	templateUrl: './scrollspy-service.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [NgbScrollSpyService],
 })
 export class NgbdScrollSpyService {

--- a/demo/src/app/components/scrollspy/overview/scrollspy-overview.component.ts
+++ b/demo/src/app/components/scrollspy/overview/scrollspy-overview.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 
 import { Snippet } from '../../../services/snippet';
 import { CodeComponent } from '../../../shared/code.component';
@@ -10,7 +10,6 @@ import { NgbdOverviewPage } from '../../../shared/overview-page/overview-page.cl
 	selector: 'ngbd-scrollspy-overview',
 	imports: [CodeComponent, RouterLink, PageHeaderComponent],
 	templateUrl: './scrollspy-overview.component.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	host: { '[class.overview]': 'true' },
 })
 export class NgbdScrollSpyOverviewComponent extends NgbdOverviewPage {

--- a/demo/src/app/components/table/demos/basic/table-basic.ts
+++ b/demo/src/app/components/table/demos/basic/table-basic.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 
 interface Country {
@@ -38,7 +38,6 @@ const COUNTRIES: Country[] = [
 @Component({
 	selector: 'ngbd-table-basic',
 	imports: [DecimalPipe],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './table-basic.html',
 })
 export class NgbdTableBasic {

--- a/demo/src/app/components/table/demos/complete/table-complete.ts
+++ b/demo/src/app/components/table/demos/complete/table-complete.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe, DecimalPipe } from '@angular/common';
-import { Component, QueryList, ViewChildren, ChangeDetectionStrategy } from '@angular/core';
+import { Component, QueryList, ViewChildren } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { Country } from './country';
@@ -13,7 +13,6 @@ import { NgbPagination } from '@ng-bootstrap/ng-bootstrap/pagination';
 	selector: 'ngbd-table-complete',
 	imports: [DecimalPipe, FormsModule, AsyncPipe, NgbHighlight, NgbdSortableHeader, NgbPagination],
 	templateUrl: './table-complete.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [CountryService, DecimalPipe],
 })
 export class NgbdTableComplete {

--- a/demo/src/app/components/table/demos/filtering/table-filtering.ts
+++ b/demo/src/app/components/table/demos/filtering/table-filtering.ts
@@ -1,4 +1,4 @@
-import { Component, PipeTransform, ChangeDetectionStrategy } from '@angular/core';
+import { Component, PipeTransform } from '@angular/core';
 import { AsyncPipe, DecimalPipe } from '@angular/common';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
@@ -55,7 +55,6 @@ function search(text: string, pipe: PipeTransform): Country[] {
 	selector: 'ngbd-table-filtering',
 	imports: [DecimalPipe, AsyncPipe, ReactiveFormsModule, NgbHighlight],
 	templateUrl: './table-filtering.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [DecimalPipe],
 })
 export class NgbdTableFiltering {

--- a/demo/src/app/components/table/demos/pagination/table-pagination.ts
+++ b/demo/src/app/components/table/demos/pagination/table-pagination.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgbPagination } from '@ng-bootstrap/ng-bootstrap/pagination';
@@ -95,7 +95,6 @@ const COUNTRIES: Country[] = [
 @Component({
 	selector: 'ngbd-table-pagination',
 	imports: [DecimalPipe, FormsModule, NgbPagination],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './table-pagination.html',
 })
 export class NgbdTablePagination {

--- a/demo/src/app/components/table/demos/sortable/table-sortable.ts
+++ b/demo/src/app/components/table/demos/sortable/table-sortable.ts
@@ -1,13 +1,4 @@
-import {
-	Component,
-	Directive,
-	EventEmitter,
-	Input,
-	Output,
-	QueryList,
-	ViewChildren,
-	ChangeDetectionStrategy,
-} from '@angular/core';
+import { Component, Directive, EventEmitter, Input, Output, QueryList, ViewChildren } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 
 interface Country {
@@ -82,7 +73,6 @@ export class NgbdSortableHeader {
 @Component({
 	selector: 'ngbd-table-sortable',
 	imports: [DecimalPipe, NgbdSortableHeader],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './table-sortable.html',
 })
 export class NgbdTableSortable {

--- a/demo/src/app/components/table/overview/demo/table-overview-demo.component.ts
+++ b/demo/src/app/components/table/overview/demo/table-overview-demo.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 
 interface Country {
@@ -11,7 +11,6 @@ interface Country {
 @Component({
 	selector: 'ngbd-table-overview-demo',
 	imports: [DecimalPipe],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<table class="table table-striped">
 			<thead>

--- a/demo/src/app/components/timepicker/demos/adapter/timepicker-adapter.ts
+++ b/demo/src/app/components/timepicker/demos/adapter/timepicker-adapter.ts
@@ -1,4 +1,4 @@
-import { Component, Injectable, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Injectable } from '@angular/core';
 import { NgbTimeStruct, NgbTimeAdapter, NgbTimepicker } from '@ng-bootstrap/ng-bootstrap/timepicker';
 import { FormsModule } from '@angular/forms';
 
@@ -32,7 +32,6 @@ export class NgbTimeStringAdapter extends NgbTimeAdapter<string> {
 	templateUrl: './timepicker-adapter.html',
 	// NOTE: For this example we are only providing current component, but probably
 	// NOTE: you will want to provide your main App Module
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [{ provide: NgbTimeAdapter, useClass: NgbTimeStringAdapter }],
 })
 export class NgbdTimepickerAdapter {

--- a/demo/src/app/components/timepicker/demos/basic/timepicker-basic.ts
+++ b/demo/src/app/components/timepicker/demos/basic/timepicker-basic.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { JsonPipe } from '@angular/common';
 import { NgbTimepicker } from '@ng-bootstrap/ng-bootstrap/timepicker';
@@ -6,7 +6,6 @@ import { NgbTimepicker } from '@ng-bootstrap/ng-bootstrap/timepicker';
 @Component({
 	selector: 'ngbd-timepicker-basic',
 	imports: [NgbTimepicker, FormsModule, JsonPipe],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './timepicker-basic.html',
 })
 export class NgbdTimepickerBasic {

--- a/demo/src/app/components/timepicker/demos/config/timepicker-config.ts
+++ b/demo/src/app/components/timepicker/demos/config/timepicker-config.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbTimepickerConfig, NgbTimepicker } from '@ng-bootstrap/ng-bootstrap/timepicker';
 import { NgbTimeStruct } from '@ng-bootstrap/ng-bootstrap/timepicker';
 import { FormsModule } from '@angular/forms';
@@ -7,7 +7,6 @@ import { FormsModule } from '@angular/forms';
 	selector: 'ngbd-timepicker-config',
 	imports: [NgbTimepicker, FormsModule],
 	templateUrl: './timepicker-config.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [NgbTimepickerConfig],
 })
 export class NgbdTimepickerConfig {

--- a/demo/src/app/components/timepicker/demos/i18n/timepicker-i18n.ts
+++ b/demo/src/app/components/timepicker/demos/i18n/timepicker-i18n.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Injectable, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, Injectable } from '@angular/core';
 import { NgbAlert } from '@ng-bootstrap/ng-bootstrap/alert';
 import { NgbTimepickerI18n, NgbTimepicker } from '@ng-bootstrap/ng-bootstrap/timepicker';
 import { FormsModule } from '@angular/forms';
@@ -33,7 +33,6 @@ export class CustomTimepickerI18n extends NgbTimepickerI18n {
 	selector: 'ngbd-timepicker-i18n',
 	imports: [NgbTimepicker, NgbAlert, FormsModule],
 	templateUrl: './timepicker-i18n.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [
 		I18n,
 		{

--- a/demo/src/app/components/timepicker/demos/meridian/timepicker-meridian.ts
+++ b/demo/src/app/components/timepicker/demos/meridian/timepicker-meridian.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { NgbTimepicker } from '@ng-bootstrap/ng-bootstrap/timepicker';
 import { JsonPipe } from '@angular/common';
@@ -6,7 +6,6 @@ import { JsonPipe } from '@angular/common';
 @Component({
 	selector: 'ngbd-timepicker-meridian',
 	imports: [NgbTimepicker, FormsModule, JsonPipe],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './timepicker-meridian.html',
 })
 export class NgbdTimepickerMeridian {

--- a/demo/src/app/components/timepicker/demos/seconds/timepicker-seconds.ts
+++ b/demo/src/app/components/timepicker/demos/seconds/timepicker-seconds.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbTimepicker, NgbTimeStruct } from '@ng-bootstrap/ng-bootstrap/timepicker';
 import { FormsModule } from '@angular/forms';
 import { JsonPipe } from '@angular/common';
@@ -6,7 +6,6 @@ import { JsonPipe } from '@angular/common';
 @Component({
 	selector: 'ngbd-timepicker-seconds',
 	imports: [NgbTimepicker, FormsModule, JsonPipe],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './timepicker-seconds.html',
 })
 export class NgbdTimepickerSeconds {

--- a/demo/src/app/components/timepicker/demos/spinners/timepicker-spinners.ts
+++ b/demo/src/app/components/timepicker/demos/spinners/timepicker-spinners.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { NgbTimepicker } from '@ng-bootstrap/ng-bootstrap/timepicker';
 
 @Component({
 	selector: 'ngbd-timepicker-spinners',
 	imports: [NgbTimepicker, FormsModule],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './timepicker-spinners.html',
 })
 export class NgbdTimepickerSpinners {

--- a/demo/src/app/components/timepicker/demos/steps/timepicker-steps.ts
+++ b/demo/src/app/components/timepicker/demos/steps/timepicker-steps.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbTimepicker, NgbTimeStruct } from '@ng-bootstrap/ng-bootstrap/timepicker';
 import { FormsModule } from '@angular/forms';
 import { JsonPipe } from '@angular/common';
@@ -6,7 +6,6 @@ import { JsonPipe } from '@angular/common';
 @Component({
 	selector: 'ngbd-timepicker-steps',
 	imports: [NgbTimepicker, FormsModule, JsonPipe],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './timepicker-steps.html',
 })
 export class NgbdTimepickerSteps {

--- a/demo/src/app/components/timepicker/demos/validation/timepicker-validation.ts
+++ b/demo/src/app/components/timepicker/demos/validation/timepicker-validation.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { NgbTimepicker, NgbTimeStruct } from '@ng-bootstrap/ng-bootstrap/timepicker';
 import { JsonPipe } from '@angular/common';
@@ -6,7 +6,6 @@ import { JsonPipe } from '@angular/common';
 @Component({
 	selector: 'ngbd-timepicker-validation',
 	imports: [NgbTimepicker, ReactiveFormsModule, JsonPipe],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './timepicker-validation.html',
 })
 export class NgbdTimepickerValidation {

--- a/demo/src/app/components/toast/demos/closeable/toast-closeable.ts
+++ b/demo/src/app/components/toast/demos/closeable/toast-closeable.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbToast } from '@ng-bootstrap/ng-bootstrap/toast';
 
 @Component({
 	selector: 'ngbd-toast-closeable',
 	imports: [NgbToast],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './toast-closeable.html',
 })
 export class NgbdToastCloseable {

--- a/demo/src/app/components/toast/demos/custom-header/toast-custom-header.ts
+++ b/demo/src/app/components/toast/demos/custom-header/toast-custom-header.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbToast, NgbToastHeader } from '@ng-bootstrap/ng-bootstrap/toast';
 
 @Component({
 	selector: 'ngbd-toast-customheader',
 	imports: [NgbToast, NgbToastHeader],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './toast-custom-header.html',
 })
 export class NgbdToastCustomHeader {

--- a/demo/src/app/components/toast/demos/howto-global/toast-global.component.ts
+++ b/demo/src/app/components/toast/demos/howto-global/toast-global.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnDestroy, TemplateRef, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, OnDestroy, TemplateRef } from '@angular/core';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap/tooltip';
 
 import { ToastService } from './toast-service';
@@ -7,7 +7,6 @@ import { ToastsContainer } from './toasts-container.component';
 @Component({
 	selector: 'ngbd-toast-global',
 	imports: [NgbTooltip, ToastsContainer],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './toast-global.component.html',
 })
 export class NgbdToastGlobal implements OnDestroy {

--- a/demo/src/app/components/toast/demos/howto-global/toasts-container.component.ts
+++ b/demo/src/app/components/toast/demos/howto-global/toasts-container.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 
 import { ToastService } from './toast-service';
 import { NgTemplateOutlet } from '@angular/common';
@@ -19,7 +19,6 @@ import { NgbToast } from '@ng-bootstrap/ng-bootstrap/toast';
 			</ngb-toast>
 		}
 	`,
-	changeDetection: ChangeDetectionStrategy.Eager,
 	host: { class: 'toast-container position-fixed top-0 end-0 p-3', style: 'z-index: 1200' },
 })
 export class ToastsContainer {

--- a/demo/src/app/components/toast/demos/inline/toast-inline.ts
+++ b/demo/src/app/components/toast/demos/inline/toast-inline.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbToast } from '@ng-bootstrap/ng-bootstrap/toast';
 
 @Component({
 	selector: 'ngbd-toast-inline',
 	imports: [NgbToast],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './toast-inline.html',
 })
 export class NgbdToastInline {

--- a/demo/src/app/components/toast/demos/prevent-autohide/toast-prevent-autohide.ts
+++ b/demo/src/app/components/toast/demos/prevent-autohide/toast-prevent-autohide.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbToast } from '@ng-bootstrap/ng-bootstrap/toast';
 
 @Component({
 	selector: 'ngbd-toast-prevent-autohide',
 	imports: [NgbToast],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './toast-prevent-autohide.html',
 })
 export class NgbdToastPreventAutohide {

--- a/demo/src/app/components/tooltip/demos/autoclose/tooltip-autoclose.ts
+++ b/demo/src/app/components/tooltip/demos/autoclose/tooltip-autoclose.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap/tooltip';
 
 @Component({
 	selector: 'ngbd-tooltip-autoclose',
 	imports: [NgbTooltip],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './tooltip-autoclose.html',
 })
 export class NgbdTooltipAutoclose {}

--- a/demo/src/app/components/tooltip/demos/basic/tooltip-basic.ts
+++ b/demo/src/app/components/tooltip/demos/basic/tooltip-basic.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap/tooltip';
 
 @Component({
 	selector: 'ngbd-tooltip-basic',
 	imports: [NgbTooltip],
 	templateUrl: './tooltip-basic.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	host: { class: 'd-block' },
 })
 export class NgbdTooltipBasic {}

--- a/demo/src/app/components/tooltip/demos/config/tooltip-config.ts
+++ b/demo/src/app/components/tooltip/demos/config/tooltip-config.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbTooltipConfig, NgbTooltip } from '@ng-bootstrap/ng-bootstrap/tooltip';
 
 @Component({
 	selector: 'ngbd-tooltip-config',
 	imports: [NgbTooltip],
 	templateUrl: './tooltip-config.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [NgbTooltipConfig],
 })
 export class NgbdTooltipConfig {

--- a/demo/src/app/components/tooltip/demos/container/tooltip-container.ts
+++ b/demo/src/app/components/tooltip/demos/container/tooltip-container.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap/tooltip';
 
 @Component({
 	selector: 'ngbd-tooltip-container',
 	imports: [NgbTooltip],
 	templateUrl: './tooltip-container.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: '.card { overflow:hidden }',
 })
 export class NgbdTooltipContainer {}

--- a/demo/src/app/components/tooltip/demos/custom-target/tooltip-target.ts
+++ b/demo/src/app/components/tooltip/demos/custom-target/tooltip-target.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap/tooltip';
 
 @Component({
 	selector: 'ngbd-tooltip-target',
 	imports: [NgbTooltip],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './tooltip-target.html',
 })
 export class NgbdTooltipTarget {}

--- a/demo/src/app/components/tooltip/demos/customclass/tooltip-customclass.ts
+++ b/demo/src/app/components/tooltip/demos/customclass/tooltip-customclass.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap/tooltip';
 
 @Component({
@@ -6,7 +6,6 @@ import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap/tooltip';
 	imports: [NgbTooltip],
 	templateUrl: './tooltip-customclass.html',
 	encapsulation: ViewEncapsulation.None,
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		.my-custom-class .tooltip-inner {
 			background-color: darkgreen;

--- a/demo/src/app/components/tooltip/demos/delay/tooltip-delay.ts
+++ b/demo/src/app/components/tooltip/demos/delay/tooltip-delay.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap/tooltip';
 
 @Component({
 	selector: 'ngbd-tooltip-delay',
 	imports: [NgbTooltip],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './tooltip-delay.html',
 })
 export class NgbdTooltipDelay {}

--- a/demo/src/app/components/tooltip/demos/tplcontent/tooltip-tplcontent.ts
+++ b/demo/src/app/components/tooltip/demos/tplcontent/tooltip-tplcontent.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap/tooltip';
 
 @Component({
 	selector: 'ngbd-tooltip-tplcontent',
 	imports: [NgbTooltip],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './tooltip-tplcontent.html',
 })
 export class NgbdTooltipTplcontent {

--- a/demo/src/app/components/tooltip/demos/tplwithcontext/tooltip-tplwithcontext.ts
+++ b/demo/src/app/components/tooltip/demos/tplwithcontext/tooltip-tplwithcontext.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap/tooltip';
 
 @Component({
 	selector: 'ngbd-tooltip-tplwithcontext',
 	imports: [NgbTooltip],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './tooltip-tplwithcontext.html',
 })
 export class NgbdTooltipTplwithcontext {

--- a/demo/src/app/components/tooltip/demos/triggers/tooltip-triggers.ts
+++ b/demo/src/app/components/tooltip/demos/triggers/tooltip-triggers.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap/tooltip';
 
 @Component({
 	selector: 'ngbd-tooltip-triggers',
 	imports: [NgbTooltip],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './tooltip-triggers.html',
 })
 export class NgbdTooltipTriggers {}

--- a/demo/src/app/components/typeahead/demos/basic/typeahead-basic.ts
+++ b/demo/src/app/components/typeahead/demos/basic/typeahead-basic.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbTypeahead } from '@ng-bootstrap/ng-bootstrap/typeahead';
 import { Observable, OperatorFunction } from 'rxjs';
 import { debounceTime, distinctUntilChanged, map } from 'rxjs/operators';
@@ -71,7 +71,6 @@ const states = [
 	selector: 'ngbd-typeahead-basic',
 	imports: [NgbTypeahead, FormsModule, JsonPipe],
 	templateUrl: './typeahead-basic.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		.form-control {
 			width: 300px;

--- a/demo/src/app/components/typeahead/demos/config/typeahead-config.ts
+++ b/demo/src/app/components/typeahead/demos/config/typeahead-config.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { Observable } from 'rxjs';
 import { NgbTypeaheadConfig, NgbTypeahead } from '@ng-bootstrap/ng-bootstrap/typeahead';
 import { debounceTime, distinctUntilChanged, map } from 'rxjs/operators';
@@ -75,7 +75,6 @@ const states = [
 			width: 300px;
 		}
 	`,
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [NgbTypeaheadConfig],
 })
 export class NgbdTypeaheadConfig {

--- a/demo/src/app/components/typeahead/demos/focus/typeahead-focus.ts
+++ b/demo/src/app/components/typeahead/demos/focus/typeahead-focus.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { NgbTypeahead } from '@ng-bootstrap/ng-bootstrap/typeahead';
 import { Observable, Subject, merge, OperatorFunction } from 'rxjs';
 import { debounceTime, distinctUntilChanged, filter, map } from 'rxjs/operators';
@@ -71,7 +71,6 @@ const states = [
 	selector: 'ngbd-typeahead-focus',
 	imports: [NgbTypeahead, FormsModule, JsonPipe],
 	templateUrl: './typeahead-focus.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		.form-control {
 			width: 300px;

--- a/demo/src/app/components/typeahead/demos/format/typeahead-format.ts
+++ b/demo/src/app/components/typeahead/demos/format/typeahead-format.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbTypeahead } from '@ng-bootstrap/ng-bootstrap/typeahead';
 import { Observable, OperatorFunction } from 'rxjs';
 import { debounceTime, distinctUntilChanged, map } from 'rxjs/operators';
@@ -71,7 +71,6 @@ const states = [
 	selector: 'ngbd-typeahead-format',
 	imports: [NgbTypeahead, FormsModule, JsonPipe],
 	templateUrl: './typeahead-format.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		.form-control {
 			width: 300px;

--- a/demo/src/app/components/typeahead/demos/http/typeahead-http.ts
+++ b/demo/src/app/components/typeahead/demos/http/typeahead-http.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Injectable, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, of, OperatorFunction } from 'rxjs';
 import { catchError, debounceTime, distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators';
@@ -35,7 +35,6 @@ export class WikipediaService {
 	imports: [NgbTypeahead, FormsModule, JsonPipe],
 	templateUrl: './typeahead-http.html',
 	providers: [WikipediaService],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		.form-control {
 			width: 300px;

--- a/demo/src/app/components/typeahead/demos/prevent-manual-entry/typeahead-prevent-manual-entry.ts
+++ b/demo/src/app/components/typeahead/demos/prevent-manual-entry/typeahead-prevent-manual-entry.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbTypeahead } from '@ng-bootstrap/ng-bootstrap/typeahead';
 import { Observable, OperatorFunction } from 'rxjs';
 import { debounceTime, distinctUntilChanged, map, filter } from 'rxjs/operators';
@@ -73,7 +73,6 @@ const states: State[] = [
 	selector: 'ngbd-typeahead-prevent-manual-entry',
 	imports: [NgbTypeahead, FormsModule, JsonPipe],
 	templateUrl: './typeahead-prevent-manual-entry.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		.form-control {
 			width: 300px;

--- a/demo/src/app/components/typeahead/demos/select-on-exact/typeahead-select-on-exact.ts
+++ b/demo/src/app/components/typeahead/demos/select-on-exact/typeahead-select-on-exact.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbTypeahead } from '@ng-bootstrap/ng-bootstrap/typeahead';
 import { Observable, OperatorFunction } from 'rxjs';
 import { debounceTime, map } from 'rxjs/operators';
@@ -62,7 +62,6 @@ const states: { name: string }[] = [
 	selector: 'ngbd-typeahead-select-on-exact',
 	imports: [NgbTypeahead, FormsModule, JsonPipe],
 	templateUrl: './typeahead-select-on-exact.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		.form-control {
 			width: 300px;

--- a/demo/src/app/components/typeahead/demos/template/typeahead-template.ts
+++ b/demo/src/app/components/typeahead/demos/template/typeahead-template.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbHighlight, NgbTypeahead } from '@ng-bootstrap/ng-bootstrap/typeahead';
 import { Observable, OperatorFunction } from 'rxjs';
 import { debounceTime, map } from 'rxjs/operators';
@@ -65,7 +65,6 @@ const statesWithFlags: { name: string; flag: string }[] = [
 	selector: 'ngbd-typeahead-template',
 	imports: [NgbHighlight, NgbTypeahead, FormsModule, JsonPipe],
 	templateUrl: './typeahead-template.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	styles: `
 		.form-control {
 			width: 300px;

--- a/demo/src/app/pages/animations/animations.page.ts
+++ b/demo/src/app/pages/animations/animations.page.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { Snippet } from '../../services/snippet';
 import { LIB_VERSIONS } from '../../tokens';
 import { CodeComponent } from '../../shared/code.component';
@@ -8,7 +8,6 @@ import { NgbdPageWrapper } from '../../shared/page-wrapper/page-wrapper.componen
 
 @Component({
 	imports: [CodeComponent, RouterLink, PageHeaderComponent, NgbdPageWrapper],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './animations.page.html',
 })
 export class AnimationsPage {

--- a/demo/src/app/shared/examples-page/demo.component.html
+++ b/demo/src/app/shared/examples-page/demo.component.html
@@ -54,13 +54,13 @@
 					} @else {
 						<li ngbNavItem="{{ component() }}-{{ fragment() }}-html">
 							<a ngbNavLink>
-								<span class="ms-2">{{ component() | lowercase }}-{{ fragment() }}.html</span>
+								<span>{{ component() | lowercase }}-{{ fragment() }}.html</span>
 							</a>
 							<ngbd-code *ngbNavContent [snippet]="markupSnippet()"></ngbd-code>
 						</li>
 						<li ngbNavItem="{{ component() }}-{{ fragment() }}-typescript">
 							<a ngbNavLink>
-								<span class="ms-2">{{ component() | lowercase }}-{{ fragment() }}.ts</span>
+								<span>{{ component() | lowercase }}-{{ fragment() }}.ts</span>
 							</a>
 							<ngbd-code *ngbNavContent [snippet]="codeSnippet()"></ngbd-code>
 						</li>

--- a/e2e-app/src/app/app.component.ts
+++ b/e2e-app/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbConfig } from '@ng-bootstrap/ng-bootstrap/config';
 import { RouterOutlet } from '@angular/router';
 import { NavigationComponent } from './navigation.component';
@@ -6,7 +6,6 @@ import { NavigationComponent } from './navigation.component';
 @Component({
 	selector: 'app-root',
 	imports: [NavigationComponent, RouterOutlet],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<div class="container-fluid">
 			<h1>ng-bootstrap e2e test application</h1>

--- a/e2e-app/src/app/datepicker/container/datepicker-container.component.ts
+++ b/e2e-app/src/app/datepicker/container/datepicker-container.component.ts
@@ -1,11 +1,10 @@
-import { Component, inject, TemplateRef, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, TemplateRef } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap/modal';
 import { NgbInputDatepicker } from '@ng-bootstrap/ng-bootstrap/datepicker';
 import { FormsModule } from '@angular/forms';
 
 @Component({
 	templateUrl: './datepicker-container.component.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	imports: [FormsModule, NgbInputDatepicker],
 })
 export class DatepickerContainerComponent {

--- a/e2e-app/src/app/datepicker/focus/datepicker-focus.component.ts
+++ b/e2e-app/src/app/datepicker/focus/datepicker-focus.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { JsonPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgbInputDatepicker } from '@ng-bootstrap/ng-bootstrap/datepicker';
@@ -6,7 +6,6 @@ import { NgbDropdown, NgbDropdownMenu, NgbDropdownToggle } from '@ng-bootstrap/n
 
 @Component({
 	imports: [FormsModule, NgbInputDatepicker, NgbDropdownMenu, NgbDropdown, NgbDropdownToggle, JsonPipe],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './datepicker-focus.component.html',
 })
 export class DatepickerFocusComponent {

--- a/e2e-app/src/app/datepicker/multiple/datepicker-multiple.component.ts
+++ b/e2e-app/src/app/datepicker/multiple/datepicker-multiple.component.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { JsonPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgbDatepicker } from '@ng-bootstrap/ng-bootstrap/datepicker';
 
 @Component({
 	imports: [FormsModule, NgbDatepicker, JsonPipe],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './datepicker-multiple.component.html',
 })
 export class DatepickerMultipleComponent {

--- a/e2e-app/src/app/dropdown/click/dropdown-click.component.ts
+++ b/e2e-app/src/app/dropdown/click/dropdown-click.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import {
 	NgbDropdown,
@@ -10,7 +10,6 @@ import {
 
 @Component({
 	imports: [FormsModule, NgbDropdown, NgbDropdownToggle, NgbDropdownMenu, NgbDropdownItem, NgbDropdownButtonItem],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<h3>Dropdown click tests</h3>
 		<form>

--- a/e2e-app/src/app/dropdown/focus/dropdown-focus.component.ts
+++ b/e2e-app/src/app/dropdown/focus/dropdown-focus.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import {
 	NgbDropdown,
@@ -10,7 +10,6 @@ import {
 
 @Component({
 	imports: [FormsModule, NgbDropdown, NgbDropdownToggle, NgbDropdownMenu, NgbDropdownItem, NgbDropdownButtonItem],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './dropdown-focus.component.html',
 })
 export class DropdownFocusComponent {

--- a/e2e-app/src/app/dropdown/position/dropdown-position.component.ts
+++ b/e2e-app/src/app/dropdown/position/dropdown-position.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import {
 	NgbDropdown,
@@ -10,7 +10,6 @@ import {
 
 @Component({
 	imports: [FormsModule, NgbDropdown, NgbDropdownToggle, NgbDropdownMenu, NgbDropdownItem, NgbDropdownButtonItem],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './dropdown-position.component.html',
 })
 export class DropdownPositionComponent {

--- a/e2e-app/src/app/dropdown/shadow/dropdown-shadow.component.ts
+++ b/e2e-app/src/app/dropdown/shadow/dropdown-shadow.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import {
 	NgbDropdown,
@@ -11,7 +11,6 @@ import {
 @Component({
 	imports: [FormsModule, NgbDropdown, NgbDropdownToggle, NgbDropdownMenu, NgbDropdownItem, NgbDropdownButtonItem],
 	templateUrl: './dropdown-shadow.component.html',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	encapsulation: ViewEncapsulation.ShadowDom,
 })
 export class DropdownShadowComponent {}

--- a/e2e-app/src/app/modal/focus/modal-focus.component.ts
+++ b/e2e-app/src/app/modal/focus/modal-focus.component.ts
@@ -1,10 +1,9 @@
-import { Component, TemplateRef, ChangeDetectionStrategy } from '@angular/core';
+import { Component, TemplateRef } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap/modal';
 import { FormsModule } from '@angular/forms';
 
 @Component({
 	imports: [FormsModule],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './modal-focus.component.html',
 })
 export class ModalFocusComponent {

--- a/e2e-app/src/app/modal/nesting/modal-nesting.component.ts
+++ b/e2e-app/src/app/modal/nesting/modal-nesting.component.ts
@@ -1,4 +1,4 @@
-import { Component, TemplateRef, ChangeDetectionStrategy } from '@angular/core';
+import { Component, TemplateRef } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap/modal';
 import { NgbInputDatepicker } from '@ng-bootstrap/ng-bootstrap/datepicker';
 import {
@@ -30,7 +30,6 @@ import { FormsModule } from '@angular/forms';
 		NgbTooltip,
 		NgbPopover,
 	],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './modal-nesting.component.html',
 })
 export class ModalNestingComponent {

--- a/e2e-app/src/app/modal/role/modal-role.component.ts
+++ b/e2e-app/src/app/modal/role/modal-role.component.ts
@@ -1,8 +1,7 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap/modal';
 
 @Component({
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './modal-role.component.html',
 })
 export class ModalRoleComponent {

--- a/e2e-app/src/app/modal/stack-confirmation/modal-stack-confirmation.component.ts
+++ b/e2e-app/src/app/modal/stack-confirmation/modal-stack-confirmation.component.ts
@@ -1,8 +1,7 @@
-import { Component, TemplateRef, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { Component, TemplateRef, ViewChild } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap/modal';
 
 @Component({
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './modal-stack-confirmation.component.html',
 })
 export class ModalStackConfirmationComponent {

--- a/e2e-app/src/app/modal/stack/modal-stack.component.ts
+++ b/e2e-app/src/app/modal/stack/modal-stack.component.ts
@@ -1,8 +1,7 @@
-import { Component, TemplateRef, ChangeDetectionStrategy } from '@angular/core';
+import { Component, TemplateRef } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap/modal';
 
 @Component({
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './modal-stack.component.html',
 })
 export class ModalStackComponent {

--- a/e2e-app/src/app/nav/focus/nav-focus.component.ts
+++ b/e2e-app/src/app/nav/focus/nav-focus.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbDropdown,
 	NgbDropdownItem,
@@ -36,7 +36,6 @@ import {
 		NgbNavModule,
 		NgbNavOutlet,
 	],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './nav-focus.component.html',
 })
 export class NavFocusComponent {

--- a/e2e-app/src/app/navigation.component.ts
+++ b/e2e-app/src/app/navigation.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 
 import { ROUTES } from './app.routes';
@@ -7,7 +7,7 @@ import { ROUTES } from './app.routes';
 	selector: 'app-navigation',
 	template: `
 		<a role="button" class="btn btn-outline-primary ms-3" id="navigate-home" href="#/">Menu</a>
-		<div [hidden]="isHidden">
+		<div [hidden]="isHidden()">
 			@for (route of routes; track route) {
 				<div class="card m-1 d-inline-block" style="width: 290px;">
 					<div class="card-header">{{ route.path }}</div>
@@ -30,14 +30,14 @@ import { ROUTES } from './app.routes';
 })
 export class NavigationComponent {
 	routes;
-	isHidden = false;
+	readonly isHidden = signal(false);
 
 	constructor(public router: Router) {
 		this.routes = ROUTES;
 
 		router.events.subscribe((evt) => {
 			if (evt instanceof NavigationEnd) {
-				this.isHidden = evt.url !== '/';
+				this.isHidden.set(evt.url !== '/');
 			}
 		});
 	}

--- a/e2e-app/src/app/navigation.component.ts
+++ b/e2e-app/src/app/navigation.component.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 
 import { ROUTES } from './app.routes';
 
 @Component({
 	selector: 'app-navigation',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<a role="button" class="btn btn-outline-primary ms-3" id="navigate-home" href="#/">Menu</a>
 		<div [hidden]="isHidden">

--- a/e2e-app/src/app/offcanvas/focus/offcanvas-focus.component.ts
+++ b/e2e-app/src/app/offcanvas/focus/offcanvas-focus.component.ts
@@ -1,10 +1,9 @@
-import { Component, TemplateRef, ChangeDetectionStrategy } from '@angular/core';
+import { Component, TemplateRef } from '@angular/core';
 import { NgbOffcanvas } from '@ng-bootstrap/ng-bootstrap/offcanvas';
 import { FormsModule } from '@angular/forms';
 
 @Component({
 	imports: [FormsModule],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './offcanvas-focus.component.html',
 })
 export class OffcanvasFocusComponent {

--- a/e2e-app/src/app/offcanvas/nesting/offcanvas-nesting.component.ts
+++ b/e2e-app/src/app/offcanvas/nesting/offcanvas-nesting.component.ts
@@ -1,4 +1,4 @@
-import { Component, TemplateRef, ChangeDetectionStrategy } from '@angular/core';
+import { Component, TemplateRef } from '@angular/core';
 import { NgbOffcanvas } from '@ng-bootstrap/ng-bootstrap/offcanvas';
 import { NgbInputDatepicker } from '@ng-bootstrap/ng-bootstrap/datepicker';
 import {
@@ -26,7 +26,6 @@ import { FormsModule } from '@angular/forms';
 		NgbDropdownToggle,
 		NgbTypeahead,
 	],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './offcanvas-nesting.component.html',
 })
 export class OffcanvasNestingComponent {

--- a/e2e-app/src/app/offcanvas/stack-confirmation/offcanvas-stack-confirmation.component.ts
+++ b/e2e-app/src/app/offcanvas/stack-confirmation/offcanvas-stack-confirmation.component.ts
@@ -1,9 +1,8 @@
-import { Component, TemplateRef, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { Component, TemplateRef, ViewChild } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap/modal';
 import { NgbOffcanvas } from '@ng-bootstrap/ng-bootstrap/offcanvas';
 
 @Component({
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './offcanvas-stack-confirmation.component.html',
 })
 export class OffcanvasStackConfirmationComponent {

--- a/e2e-app/src/app/timepicker/filter/timepicker-filter.component.ts
+++ b/e2e-app/src/app/timepicker/filter/timepicker-filter.component.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { NgbTimepicker } from '@ng-bootstrap/ng-bootstrap/timepicker';
 
 @Component({
 	imports: [NgbTimepicker, FormsModule],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './timepicker-filter.component.html',
 })
 export class TimepickerFilterComponent {

--- a/e2e-app/src/app/timepicker/navigation/timepicker-navigation.component.ts
+++ b/e2e-app/src/app/timepicker/navigation/timepicker-navigation.component.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { NgbTimepicker } from '@ng-bootstrap/ng-bootstrap/timepicker';
 
 @Component({
 	imports: [NgbTimepicker, FormsModule],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './timepicker-navigation.component.html',
 })
 export class TimepickerNavigationComponent {

--- a/e2e-app/src/app/tooltip/focus/tooltip-focus.component.ts
+++ b/e2e-app/src/app/tooltip/focus/tooltip-focus.component.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap/tooltip';
 
 @Component({
 	imports: [FormsModule, NgbTooltip],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './tooltip-focus.component.html',
 })
 export class TooltipFocusComponent {}

--- a/e2e-app/src/app/tooltip/position/tooltip-position.component.ts
+++ b/e2e-app/src/app/tooltip/position/tooltip-position.component.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgStyle } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap/tooltip';
 
 @Component({
 	imports: [FormsModule, NgbTooltip, NgStyle],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './tooltip-position.component.html',
 })
 export class TooltipPositionComponent {

--- a/e2e-app/src/app/typeahead/focus/typeahead-focus.component.ts
+++ b/e2e-app/src/app/typeahead/focus/typeahead-focus.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { NgbTypeahead } from '@ng-bootstrap/ng-bootstrap/typeahead';
 import { merge, Observable, Subject } from 'rxjs';
 import { delay, distinctUntilChanged, filter, map } from 'rxjs/operators';
@@ -68,7 +68,6 @@ const states = [
 
 @Component({
 	imports: [FormsModule, NgbTypeahead],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './typeahead-focus.component.html',
 })
 export class TypeaheadFocusComponent {

--- a/e2e-app/src/app/typeahead/validation/typeahead-validation.component.ts
+++ b/e2e-app/src/app/typeahead/validation/typeahead-validation.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { NgbTypeahead } from '@ng-bootstrap/ng-bootstrap/typeahead';
 import { merge, Observable, Subject } from 'rxjs';
 import { distinctUntilChanged, filter, map } from 'rxjs/operators';
@@ -68,7 +68,6 @@ const states = [
 
 @Component({
 	imports: [FormsModule, NgbTypeahead, ReactiveFormsModule],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	templateUrl: './typeahead-validation.component.html',
 })
 export class TypeaheadValidationComponent {

--- a/src/carousel/carousel.spec.ts
+++ b/src/carousel/carousel.spec.ts
@@ -2,7 +2,7 @@ import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { createGenericTestComponent, isBrowserVisible } from '../test/common';
 
 import { By } from '@angular/platform-browser';
-import { ChangeDetectionStrategy, Component, provideZoneChangeDetection } from '@angular/core';
+import { Component, provideZoneChangeDetection } from '@angular/core';
 
 import { NgbCarousel, NgbSlideEvent, NgbSlideEventSource, NgbSingleSlideEvent, NgbSlide } from './carousel';
 import { NgbCarouselConfig } from './carousel-config';
@@ -1112,7 +1112,6 @@ class TestComponentOnPush {}
 @Component({
 	selector: 'test-cmp',
 	imports: [NgbCarousel, NgbSlide, TestComponentOnPush],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: '',
 })
 class TestComponent {

--- a/src/datepicker/datepicker-day-view.spec.ts
+++ b/src/datepicker/datepicker-day-view.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 
-import { Component, provideZoneChangeDetection, ChangeDetectionStrategy } from '@angular/core';
+import { Component, provideZoneChangeDetection, signal } from '@angular/core';
 import { NgbDate, NgbDatepickerDayView } from './datepicker.module';
 import { beforeEach, describe, expect, it } from 'vitest';
 
@@ -20,7 +20,7 @@ describe('ngbDatepickerDayView', () => {
 		const el = getElement(fixture.nativeElement);
 		expect(el.innerText).toBe('22');
 
-		fixture.componentInstance.date = new NgbDate(2016, 7, 25);
+		fixture.componentInstance.date.set(new NgbDate(2016, 7, 25));
 		fixture.detectChanges();
 		expect(el.innerText).toBe('25');
 	});
@@ -32,7 +32,7 @@ describe('ngbDatepickerDayView', () => {
 		const el = getElement(fixture.nativeElement);
 		expect(el).not.toHaveCssClass('text-muted');
 
-		fixture.componentInstance.disabled = true;
+		fixture.componentInstance.disabled.set(true);
 		fixture.detectChanges();
 		expect(el).toHaveCssClass('text-muted');
 	});
@@ -45,7 +45,7 @@ describe('ngbDatepickerDayView', () => {
 		expect(el).not.toHaveCssClass('text-muted');
 		expect(el).not.toHaveCssClass('outside');
 
-		fixture.componentInstance.date = new NgbDate(2016, 8, 22);
+		fixture.componentInstance.date.set(new NgbDate(2016, 8, 22));
 		fixture.detectChanges();
 		expect(el).toHaveCssClass('text-muted');
 		expect(el).toHaveCssClass('outside');
@@ -59,7 +59,7 @@ describe('ngbDatepickerDayView', () => {
 		expect(el).not.toHaveCssClass('text-white');
 		expect(el).not.toHaveCssClass('bg-primary');
 
-		fixture.componentInstance.selected = true;
+		fixture.componentInstance.selected.set(true);
 		fixture.detectChanges();
 		expect(el).toHaveCssClass('text-white');
 		expect(el).toHaveCssClass('bg-primary');
@@ -67,8 +67,8 @@ describe('ngbDatepickerDayView', () => {
 
 	it('should not apply muted style if disabled but selected', () => {
 		const fixture = TestBed.createComponent(TestComponent);
-		fixture.componentInstance.disabled = true;
-		fixture.componentInstance.selected = true;
+		fixture.componentInstance.disabled.set(true);
+		fixture.componentInstance.selected.set(true);
 		fixture.detectChanges();
 
 		const el = getElement(fixture.nativeElement);
@@ -80,13 +80,12 @@ describe('ngbDatepickerDayView', () => {
 @Component({
 	selector: 'test-cmp',
 	imports: [NgbDatepickerDayView],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template:
-		'<div ngbDatepickerDayView [date]="date" [currentMonth]="currentMonth" [selected]="selected" [disabled]="disabled"></div>',
+		'<div ngbDatepickerDayView [date]="date()" [currentMonth]="currentMonth()" [selected]="selected()" [disabled]="disabled()"></div>',
 })
 class TestComponent {
-	currentMonth = 7;
-	date: NgbDate = new NgbDate(2016, 7, 22);
-	disabled = false;
-	selected = false;
+	readonly currentMonth = signal(7);
+	readonly date = signal(new NgbDate(2016, 7, 22));
+	readonly disabled = signal(false);
+	readonly selected = signal(false);
 }

--- a/src/datepicker/datepicker-input.spec.ts
+++ b/src/datepicker/datepicker-input.spec.ts
@@ -2,7 +2,7 @@ import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { createGenericTestComponent } from '../test/common';
 
-import { Component, Injectable, provideZoneChangeDetection, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Injectable, provideZoneChangeDetection } from '@angular/core';
 import { FormsModule, NgForm } from '@angular/forms';
 
 import {
@@ -1254,7 +1254,6 @@ class NgbDateNativeAdapter extends NgbDateAdapter<Date> {
 @Component({
 	selector: 'test-native-cmp',
 	imports: [NgbDatepicker, NgbDatepickerContent, NgbInputDatepicker, NgbDatepickerMonth, FormsModule],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: '',
 })
 class TestNativeComponent {
@@ -1264,7 +1263,6 @@ class TestNativeComponent {
 @Component({
 	selector: 'test-cmp',
 	imports: [NgbDatepicker, NgbDatepickerContent, NgbInputDatepicker, NgbDatepickerMonth, FormsModule],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: '',
 })
 class TestComponent {

--- a/src/datepicker/datepicker-integration.spec.ts
+++ b/src/datepicker/datepicker-integration.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, Injectable, Type, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Injectable, Type } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import {
 	NgbDatepicker,
@@ -267,7 +267,6 @@ describe('ngb-datepicker integration', () => {
 @Component({
 	selector: 'test-cmp',
 	imports: [NgbDatepicker, NgbDatepickerContent, NgbInputDatepicker, NgbDatepickerMonth],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: '',
 })
 class TestComponent {}

--- a/src/datepicker/datepicker-month.spec.ts
+++ b/src/datepicker/datepicker-month.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { createGenericTestComponent } from '../test/common';
 
-import { Component, Injectable, provideZoneChangeDetection, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Injectable, provideZoneChangeDetection } from '@angular/core';
 
 import { NgbDatepicker, NgbDatepickerContent, NgbInputDatepicker, NgbDatepickerMonth } from './datepicker.module';
 import { NgbDatepickerKeyboardService } from './datepicker-keyboard-service';
@@ -402,7 +402,6 @@ describe('ngb-datepicker-month', () => {
 @Component({
 	selector: 'test-cmp',
 	imports: [NgbDatepicker, NgbDatepickerContent, NgbInputDatepicker, NgbDatepickerMonth],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: '',
 })
 class TestComponent {

--- a/src/datepicker/datepicker-navigation-select.spec.ts
+++ b/src/datepicker/datepicker-navigation-select.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { createGenericTestComponent, ignoreTrackWarnings, triggerEvent } from '../test/common';
 import { getMonthSelect, getYearSelect } from '../test/datepicker/common';
 
-import { Component, provideZoneChangeDetection, ChangeDetectionStrategy } from '@angular/core';
+import { Component, provideZoneChangeDetection } from '@angular/core';
 
 import { NgbDatepickerNavigationSelect } from './datepicker-navigation-select';
 import { NgbDate } from './ngb-date';
@@ -144,7 +144,6 @@ describe('ngb-datepicker-navigation-select', () => {
 @Component({
 	selector: 'test-cmp',
 	imports: [NgbDatepickerNavigationSelect],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: '',
 })
 class TestComponent {

--- a/src/datepicker/datepicker-navigation.spec.ts
+++ b/src/datepicker/datepicker-navigation.spec.ts
@@ -3,7 +3,7 @@ import { By } from '@angular/platform-browser';
 import { createGenericTestComponent, triggerEvent } from '../test/common';
 import { getMonthSelect, getNavigationLinks, getYearSelect } from '../test/datepicker/common';
 
-import { Component, provideZoneChangeDetection, ChangeDetectionStrategy } from '@angular/core';
+import { Component, provideZoneChangeDetection } from '@angular/core';
 
 import { NavigationEvent } from './datepicker-view-model';
 import { NgbDatepickerNavigation } from './datepicker-navigation';
@@ -157,7 +157,6 @@ describe('ngb-datepicker-navigation', () => {
 @Component({
 	selector: 'test-cmp',
 	imports: [NgbDatepickerNavigation],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: '',
 })
 class TestComponent {

--- a/src/datepicker/datepicker.spec.ts
+++ b/src/datepicker/datepicker.spec.ts
@@ -2,13 +2,7 @@ import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { createGenericTestComponent, ignoreTrackWarnings, triggerEvent } from '../test/common';
 import { getMonthSelect, getYearSelect, getNavigationLinks } from '../test/datepicker/common';
 
-import {
-	Component,
-	TemplateRef,
-	DebugElement,
-	provideZoneChangeDetection,
-	ChangeDetectionStrategy,
-} from '@angular/core';
+import { Component, TemplateRef, DebugElement, provideZoneChangeDetection } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { FormsModule, ReactiveFormsModule, UntypedFormGroup, UntypedFormControl, Validators } from '@angular/forms';
 
@@ -1361,7 +1355,6 @@ describe('ngb-datepicker', () => {
 		FormsModule,
 		ReactiveFormsModule,
 	],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: '',
 })
 class TestComponent {

--- a/src/modal/modal.spec.ts
+++ b/src/modal/modal.spec.ts
@@ -1,4 +1,4 @@
-import { Component, Injectable, Injector, OnDestroy, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Injectable, Injector, OnDestroy, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router, RouterModule, RouterOutlet } from '@angular/router';
 import { NgbModalConfig, NgbModalOptions, NgbModalUpdatableOptions } from './modal-config';
@@ -1331,7 +1331,6 @@ describe('ngb-modal', () => {
 
 @Component({
 	selector: 'custom-injector-cmpt',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: 'Some content',
 })
 export class CustomInjectorCmpt implements OnDestroy {
@@ -1342,7 +1341,7 @@ export class CustomInjectorCmpt implements OnDestroy {
 	}
 }
 
-@Component({ selector: 'destroyable-cmpt', changeDetection: ChangeDetectionStrategy.Eager, template: 'Some content' })
+@Component({ selector: 'destroyable-cmpt', template: 'Some content' })
 export class DestroyableCmpt implements OnDestroy {
 	constructor(private _spyService: SpyService) {}
 
@@ -1353,7 +1352,6 @@ export class DestroyableCmpt implements OnDestroy {
 
 @Component({
 	selector: 'modal-content-cmpt',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: '<button class="closeFromInside" (click)="close()">Close</button>',
 })
 export class WithActiveModalCmpt {
@@ -1366,14 +1364,12 @@ export class WithActiveModalCmpt {
 
 @Component({
 	selector: 'modal-autofocus-cmpt',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `<button class="withNgbAutofocus" ngbAutofocus>Click Me</button>`,
 })
 export class WithAutofocusModalCmpt {}
 
 @Component({
 	selector: 'modal-firstfocusable-cmpt',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<button class="firstFocusable close">Close</button>
 		<button class="other">Other button</button>
@@ -1383,7 +1379,6 @@ export class WithFirstFocusableModalCmpt {}
 
 @Component({
 	selector: 'modal-skip-tabindex-firstfocusable-cmpt',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<button tabindex="-1" class="firstFocusable close">Close</button>
 		<button class="other">Other button</button>
@@ -1394,7 +1389,6 @@ export class WithSkipTabindexFirstFocusableModalCmpt {}
 @Component({
 	selector: 'test-cmpt',
 	imports: [DestroyableCmpt],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<div id="testContainer"></div>
 		<ng-template #content>Hello, {{ name }}!</ng-template>
@@ -1488,7 +1482,6 @@ class TestComponent {
 
 @Component({
 	selector: 'test-a11y-cmpt',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<div class="to-hide to-restore-true" aria-hidden="true">
 			<div class="not-to-hide"></div>

--- a/src/offcanvas/offcanvas.spec.ts
+++ b/src/offcanvas/offcanvas.spec.ts
@@ -1,4 +1,4 @@
-import { Component, Injectable, Injector, OnDestroy, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Injectable, Injector, OnDestroy, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NgbOffcanvasConfig, NgbOffcanvasOptions } from './offcanvas-config';
 import { NgbActiveOffcanvas, NgbOffcanvas, NgbOffcanvasRef, OffcanvasDismissReasons } from './offcanvas.module';
@@ -880,7 +880,6 @@ describe('ngb-offcanvas', () => {
 
 @Component({
 	selector: 'custom-injector-cmpt',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: 'Some content',
 })
 export class CustomInjectorCmpt implements OnDestroy {
@@ -891,7 +890,7 @@ export class CustomInjectorCmpt implements OnDestroy {
 	}
 }
 
-@Component({ selector: 'destroyable-cmpt', changeDetection: ChangeDetectionStrategy.Eager, template: 'Some content' })
+@Component({ selector: 'destroyable-cmpt', template: 'Some content' })
 export class DestroyableCmpt implements OnDestroy {
 	constructor(private _spyService: SpyService) {}
 
@@ -902,7 +901,6 @@ export class DestroyableCmpt implements OnDestroy {
 
 @Component({
 	selector: 'offcanvas-content-cmpt',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: '<button class="closeFromInside" (click)="close()">Close</button>',
 })
 export class WithActiveOffcanvasCmpt {
@@ -915,14 +913,12 @@ export class WithActiveOffcanvasCmpt {
 
 @Component({
 	selector: 'offcanvas-autofocus-cmpt',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `<button class="withNgbAutofocus" ngbAutofocus>Click Me</button>`,
 })
 export class WithAutofocusOffcanvasCmpt {}
 
 @Component({
 	selector: 'offcanvas-firstfocusable-cmpt',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<button class="firstFocusable close">Close</button>
 		<button class="other">Other button</button>
@@ -932,7 +928,6 @@ export class WithFirstFocusableOffcanvasCmpt {}
 
 @Component({
 	selector: 'offcanvas-skip-tabindex-firstfocusable-cmpt',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<button tabindex="-1" class="firstFocusable close">Close</button>
 		<button class="other">Other button</button>
@@ -943,7 +938,6 @@ export class WithSkipTabindexFirstFocusableOffcanvasCmpt {}
 @Component({
 	selector: 'test-cmpt',
 	imports: [DestroyableCmpt],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<div id="testContainer"></div>
 		<ng-template #content>Hello, {{ name }}!</ng-template>
@@ -1026,7 +1020,6 @@ class TestComponent {
 
 @Component({
 	selector: 'test-a11y-cmpt',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<div class="to-hide to-restore-true" aria-hidden="true">
 			<div class="not-to-hide"></div>

--- a/src/pagination/pagination.spec.ts
+++ b/src/pagination/pagination.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { createGenericTestComponent } from '../test/common';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { Component, inputBinding, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inputBinding, signal } from '@angular/core';
 
 import {
 	NgbPagination,
@@ -897,7 +897,6 @@ describe('ngb-pagination', () => {
 		NgbPaginationPrevious,
 		NgbPaginationPages,
 	],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: '',
 })
 class TestComponent {

--- a/src/popover/popover.spec.ts
+++ b/src/popover/popover.spec.ts
@@ -7,7 +7,6 @@ import { By } from '@angular/platform-browser';
 import {
 	Component,
 	ViewChild,
-	ChangeDetectionStrategy,
 	Injectable,
 	OnDestroy,
 	TemplateRef,
@@ -1153,7 +1152,7 @@ if (isBrowserVisible('ngb-popover animations')) {
 	});
 }
 
-@Component({ selector: 'destroyable-cmpt', changeDetection: ChangeDetectionStrategy.Eager, template: 'Some content' })
+@Component({ selector: 'destroyable-cmpt', template: 'Some content' })
 export class DestroyableCmpt implements OnDestroy {
 	constructor(private _spyService: SpyService) {}
 
@@ -1165,7 +1164,6 @@ export class DestroyableCmpt implements OnDestroy {
 @Component({
 	selector: 'test-cmpt',
 	imports: [NgbPopover, NgbTooltip, DestroyableCmpt],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: ``,
 })
 export class TestComponent {
@@ -1203,7 +1201,6 @@ export class TestOnPushComponent {}
 @Component({
 	selector: 'test-hooks',
 	imports: [NgbPopover],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `<div ngbPopover="popover"></div>`,
 })
 export class TestHooksComponent implements AfterViewInit {

--- a/src/scrollspy/scrollspy.spec.ts
+++ b/src/scrollspy/scrollspy.spec.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { ComponentFixture } from '@angular/core/testing';
 import {
 	NgbScrollSpy,
@@ -515,7 +515,6 @@ if (isBrowserVisible('ScrollSpy directives')) {
 
 @Component({
 	imports: [NgbScrollSpy, NgbScrollSpyItem, NgbScrollSpyFragment, NgbScrollSpyMenu, AsyncPipe],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: ``,
 })
 class TestComponent {

--- a/src/test/modal-lazy-module.ts
+++ b/src/test/modal-lazy-module.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Injectable, NgModule, OnDestroy, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, Injectable, NgModule, OnDestroy } from '@angular/core';
 import { NgbModal } from '../modal/modal';
 import { NgbModalModule } from '../modal/modal.module';
 import { RouterModule } from '@angular/router';
@@ -11,7 +11,6 @@ class LazyService {
 }
 
 @Component({
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: '{{ lazyService.text }}',
 })
 class LazyModalContent {
@@ -19,7 +18,6 @@ class LazyModalContent {
 }
 
 @Component({
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: 'child',
 })
 class LazyComponent implements OnDestroy {

--- a/src/test/offcanvas-lazy-component.ts
+++ b/src/test/offcanvas-lazy-component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Injectable, Injector, OnDestroy, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, Injectable, Injector, OnDestroy } from '@angular/core';
 import { NgbOffcanvas } from '../offcanvas/offcanvas';
 
 @Injectable()
@@ -9,7 +9,6 @@ class LazyService {
 }
 
 @Component({
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: '{{ lazyService.text }}',
 })
 class LazyOffCanvasContent {
@@ -18,7 +17,6 @@ class LazyOffCanvasContent {
 
 @Component({
 	template: 'child',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	providers: [LazyService],
 })
 export default class LazyComponent implements OnDestroy {

--- a/src/timepicker/timepicker.spec.ts
+++ b/src/timepicker/timepicker.spec.ts
@@ -1,13 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { createGenericTestComponent } from '../test/common';
 
-import {
-	ChangeDetectionStrategy,
-	Component,
-	DebugElement,
-	Injectable,
-	provideZoneChangeDetection,
-} from '@angular/core';
+import { Component, DebugElement, Injectable, provideZoneChangeDetection } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { UntypedFormControl, UntypedFormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 
@@ -1633,7 +1627,6 @@ describe('ngb-timepicker', () => {
 @Component({
 	selector: 'test-cmp',
 	imports: [NgbTimepicker, FormsModule, ReactiveFormsModule],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: '',
 })
 class TestComponent {

--- a/src/toast/toast.spec.ts
+++ b/src/toast/toast.spec.ts
@@ -1,4 +1,4 @@
-import { Component, provideZoneChangeDetection, ChangeDetectionStrategy } from '@angular/core';
+import { Component, provideZoneChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { createGenericTestComponent, isBrowserVisible } from '../test/common';
@@ -215,7 +215,6 @@ if (isBrowserVisible('ngb-toast animations')) {
 @Component({
 	selector: 'test-cmp',
 	imports: [NgbToast, NgbToastHeader],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: '',
 })
 export class TestComponent {

--- a/src/tooltip/tooltip.spec.ts
+++ b/src/tooltip/tooltip.spec.ts
@@ -6,7 +6,6 @@ import { environment } from '../utils/transition/ngbTransition';
 import { By } from '@angular/platform-browser';
 import {
 	AfterViewInit,
-	ChangeDetectionStrategy,
 	Component,
 	NgZone,
 	provideZoneChangeDetection,
@@ -1055,7 +1054,6 @@ if (isBrowserVisible('ngb-tooltip animations')) {
 @Component({
 	selector: 'test-cmpt',
 	imports: [NgbTooltip],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: ``,
 })
 export class TestComponent {
@@ -1092,7 +1090,6 @@ export class TestOnPushComponent {}
 @Component({
 	selector: 'test-hooks',
 	imports: [NgbTooltip],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `<div ngbTooltip="tooltip"></div>`,
 })
 export class TestHooksComponent implements AfterViewInit {

--- a/src/typeahead/highlight.spec.ts
+++ b/src/typeahead/highlight.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture } from '@angular/core/testing';
 import { describe, expect, it } from 'vitest';
 import { createGenericTestComponent } from '../test/common';
 
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 
 import { NgbHighlight } from './highlight';
 
@@ -206,7 +206,6 @@ describe('ngb-highlight', () => {
 @Component({
 	selector: 'test-cmp',
 	imports: [NgbHighlight],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: '',
 })
 class TestComponent {}

--- a/src/typeahead/typeahead-window.spec.ts
+++ b/src/typeahead/typeahead-window.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture } from '@angular/core/testing';
 import { createGenericTestComponent } from '../test/common';
 
-import { Component, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 
 import { NgbTypeaheadWindow } from './typeahead-window';
 import { expectResults, getWindowLinks } from '../test/typeahead/common';
@@ -196,7 +196,6 @@ describe('ngb-typeahead-window', () => {
 @Component({
 	selector: 'test-cmp',
 	imports: [NgbTypeaheadWindow],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: '',
 })
 class TestComponent {

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, DebugElement, provideZoneChangeDetection, ViewChild } from '@angular/core';
+import { Component, DebugElement, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -1113,7 +1113,6 @@ describe('ngb-typeahead', () => {
 @Component({
 	selector: 'typeahead-test-cmp',
 	imports: [NgbHighlight, NgbTypeahead, FormsModule, ReactiveFormsModule],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: '',
 })
 class TestComponent {
@@ -1209,7 +1208,6 @@ class TestOnPushComponent {
 @Component({
 	selector: 'test-async-cmp',
 	imports: [NgbHighlight, NgbTypeahead],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: '',
 })
 class TestAsyncComponent {

--- a/src/utils/accessibility/live.spec.ts
+++ b/src/utils/accessibility/live.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed, ComponentFixture } from '@angular/core/testing';
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { Live, ARIA_LIVE_DELAY } from './live';
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -43,7 +43,6 @@ describe('LiveAnnouncer', () => {
 
 @Component({
 	selector: 'live-test-cmp',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `<button (click)="say()">say</button>`,
 })
 class TestComponent {

--- a/src/utils/positioning.spec.ts
+++ b/src/utils/positioning.spec.ts
@@ -3,7 +3,7 @@ import { Placement as PopperPlacement } from '@popperjs/core';
 import { NgbRTL } from './rtl';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { createGenericTestComponent } from '../test/common';
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbTooltip } from '../tooltip/tooltip';
 import { By } from '@angular/platform-browser';
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -195,7 +195,6 @@ describe('positioning', () => {
 @Component({
 	selector: 'positioning-test-cmpt',
 	template: ``,
-	changeDetection: ChangeDetectionStrategy.Eager,
 	imports: [NgbTooltip],
 })
 export class TestComponent {}

--- a/src/utils/transition/ngbTransition.spec.ts
+++ b/src/utils/transition/ngbTransition.spec.ts
@@ -1,12 +1,5 @@
 import { environment, ngbCompleteTransition, ngbRunTransition, NgbTransitionStartFn } from './ngbTransition';
-import {
-	Component,
-	ElementRef,
-	NgZone,
-	provideZoneChangeDetection,
-	ViewChild,
-	ChangeDetectionStrategy,
-} from '@angular/core';
+import { Component, ElementRef, NgZone, provideZoneChangeDetection, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { isBrowserVisible } from '../../test/common';
 import { reflow } from '../util';
@@ -629,7 +622,6 @@ if (isBrowserVisible('ngbRunTransition')) {
 }
 
 @Component({
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: ` <div #element class="ngb-test-transition ngb-test-show" (transitionend)="onTransitionEnd()"></div>`,
 })
 class TestComponent {

--- a/ssr-app/src/app/app.component.ts
+++ b/ssr-app/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { TypeaheadComponent } from './components/typeahead.component';
 import { TooltipComponent } from './components/tooltip.component';
 import { TimepickerComponent } from './components/timepicker.component';
@@ -36,7 +36,6 @@ import { ScrollSpyComponent } from './components/scrollspy.component';
 		TooltipComponent,
 		TypeaheadComponent,
 	],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<div class="container p-5">
 			<h1>ng-bootstrap SSR test application</h1>

--- a/ssr-app/src/app/components/accordion.component.ts
+++ b/ssr-app/src/app/components/accordion.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbAccordionDirective,
 	NgbAccordionItem,
@@ -20,7 +20,6 @@ import {
 		NgbAccordionBody,
 		NgbAccordionButton,
 	],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<style>
 			.custom-header::after {

--- a/ssr-app/src/app/components/alert.component.ts
+++ b/ssr-app/src/app/components/alert.component.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbAlert } from '@ng-bootstrap/ng-bootstrap/alert';
 
 @Component({
 	selector: 'alert-component',
 	imports: [NgbAlert],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<ngb-alert [dismissible]="false">Sample alert here</ngb-alert>
 		<ngb-alert>Sample dismissible alert here</ngb-alert>

--- a/ssr-app/src/app/components/carousel.component.ts
+++ b/ssr-app/src/app/components/carousel.component.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbCarousel, NgbSlide } from '@ng-bootstrap/ng-bootstrap/carousel';
 
 @Component({
 	selector: 'carousel-component',
 	imports: [NgbCarousel, NgbSlide],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<ngb-carousel>
 			<ng-template ngbSlide>

--- a/ssr-app/src/app/components/collapse.component.ts
+++ b/ssr-app/src/app/components/collapse.component.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbCollapse } from '@ng-bootstrap/ng-bootstrap/collapse';
 
 @Component({
 	selector: 'collapse-component',
 	imports: [NgbCollapse],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<div [ngbCollapse]="isCollapsed">
 			<div class="card">

--- a/ssr-app/src/app/components/datepicker.component.ts
+++ b/ssr-app/src/app/components/datepicker.component.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbDatepicker, NgbInputDatepicker } from '@ng-bootstrap/ng-bootstrap/datepicker';
 import { FormsModule } from '@angular/forms';
 
 @Component({
 	selector: 'datepicker-component',
 	imports: [FormsModule, NgbInputDatepicker, NgbDatepicker],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<form class="row row-cols-lg-auto">
 			<div class="col-12 mb-3 me-5">

--- a/ssr-app/src/app/components/dropdown.component.ts
+++ b/ssr-app/src/app/components/dropdown.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbDropdown,
 	NgbDropdownItem,
@@ -10,7 +10,6 @@ import {
 @Component({
 	selector: 'dropdown-component',
 	imports: [NgbDropdown, NgbDropdownItem, NgbDropdownButtonItem, NgbDropdownMenu, NgbDropdownToggle],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<div ngbDropdown class="d-inline-block">
 			<button class="btn btn-outline-primary" id="dropdown1" ngbDropdownToggle>Toggle dropdown</button>

--- a/ssr-app/src/app/components/modal.component.ts
+++ b/ssr-app/src/app/components/modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { ModalDismissReasons, NgbModal } from '@ng-bootstrap/ng-bootstrap/modal';
 
 function getDismissReason(reason: any): string {
@@ -14,7 +14,6 @@ function getDismissReason(reason: any): string {
 
 @Component({
 	selector: 'modal-component',
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<ng-template #content let-modal>
 			<div class="modal-header">

--- a/ssr-app/src/app/components/nav.component.ts
+++ b/ssr-app/src/app/components/nav.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbNav,
 	NgbNavContent,
@@ -12,7 +12,6 @@ import {
 @Component({
 	selector: 'nav-component',
 	imports: [NgbNav, NgbNavContent, NgbNavItem, NgbNavItemRole, NgbNavLink, NgbNavLinkBase, NgbNavOutlet],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<ul ngbNav #nav="ngbNav" class="nav-tabs">
 			<li ngbNavItem>

--- a/ssr-app/src/app/components/pagination.component.ts
+++ b/ssr-app/src/app/components/pagination.component.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbPagination } from '@ng-bootstrap/ng-bootstrap/pagination';
 
 @Component({
 	selector: 'pagination-component',
 	imports: [NgbPagination],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: ` <ngb-pagination [collectionSize]="70" [(page)]="page" [boundaryLinks]="true"></ngb-pagination> `,
 })
 export class PaginationComponent {

--- a/ssr-app/src/app/components/popover.component.ts
+++ b/ssr-app/src/app/components/popover.component.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbPopover } from '@ng-bootstrap/ng-bootstrap/popover';
 
 @Component({
 	selector: 'popover-component',
 	imports: [NgbPopover],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<button type="button" class="btn btn-outline-secondary" ngbPopover="Hello" popoverTitle="Popover">Click me</button>
 	`,

--- a/ssr-app/src/app/components/progress.component.ts
+++ b/ssr-app/src/app/components/progress.component.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbProgressbar } from '@ng-bootstrap/ng-bootstrap/progressbar';
 
 @Component({
 	selector: 'progress-component',
 	imports: [NgbProgressbar],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: ` <ngb-progressbar [showValue]="true" type="success" [value]="50"></ngb-progressbar> `,
 })
 export class ProgressComponent {}

--- a/ssr-app/src/app/components/rating.component.ts
+++ b/ssr-app/src/app/components/rating.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbRating } from '@ng-bootstrap/ng-bootstrap/rating';
 
 @Component({
@@ -21,7 +21,6 @@ import { NgbRating } from '@ng-bootstrap/ng-bootstrap/rating';
 			color: red;
 		}
 	`,
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<ng-template #t let-fill="fill">
 			<span class="star" [class.full]="fill === 100">

--- a/ssr-app/src/app/components/scrollspy.component.ts
+++ b/ssr-app/src/app/components/scrollspy.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import {
 	NgbScrollSpy,
 	NgbScrollSpyItem,
@@ -9,7 +9,6 @@ import {
 @Component({
 	selector: 'scrollspy-component',
 	imports: [NgbScrollSpy, NgbScrollSpyItem, NgbScrollSpyFragment, NgbScrollSpyMenu],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<div class="row">
 			<div class="col-4">

--- a/ssr-app/src/app/components/timepicker.component.ts
+++ b/ssr-app/src/app/components/timepicker.component.ts
@@ -1,11 +1,10 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { NgbTimepicker } from '@ng-bootstrap/ng-bootstrap/timepicker';
 
 @Component({
 	selector: 'timepicker-component',
 	imports: [NgbTimepicker, FormsModule],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: ` <ngb-timepicker [(ngModel)]="time"></ngb-timepicker> `,
 })
 export class TimepickerComponent {

--- a/ssr-app/src/app/components/tooltip.component.ts
+++ b/ssr-app/src/app/components/tooltip.component.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap/tooltip';
 
 @Component({
 	selector: 'tooltip-component',
 	imports: [NgbTooltip],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: ` <button type="button" class="btn btn-outline-secondary" ngbTooltip="Tooltip">Hover me</button> `,
 })
 export class TooltipComponent {}

--- a/ssr-app/src/app/components/typeahead.component.ts
+++ b/ssr-app/src/app/components/typeahead.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { NgbTypeahead } from '@ng-bootstrap/ng-bootstrap/typeahead';
@@ -9,7 +9,6 @@ const VALUES = ['one', 'two', 'three'];
 @Component({
 	selector: 'typeahead-component',
 	imports: [FormsModule, NgbTypeahead],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<input id="typeahead-basic" type="text" class="form-control" [(ngModel)]="model" [ngbTypeahead]="search" />
 	`,

--- a/test-app/src/app/app.component.ts
+++ b/test-app/src/app/app.component.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
 	selector: 'app-root',
 	imports: [NgbModule],
-	changeDetection: ChangeDetectionStrategy.Eager,
 	template: `
 		<div class="container">
 			<ngb-alert type="success" [dismissible]="false">


### PR DESCRIPTION
ref #4909 

Set `changeDetection` to `OnPush` (so default) for all components in the demo, ssr-app, e2e-app and unit files.

Left-over `Eager` cds are in the library itself for a few components and deserve one PR for each, making sure there is no impact for users,