### PR TITLE
fix(schematics): cannot run ng-add

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+# Nested package.json's are only needed for development.
+**/package.json
+!schematics/package.json

--- a/misc/copy-static-files.ts
+++ b/misc/copy-static-files.ts
@@ -9,6 +9,7 @@ const SCHEMATICS = `${DEST}/schematics`;
 // 2. Copy built schematics to 'dist/ng-bootstrap'
 copySync('schematics/dist', SCHEMATICS);
 copyFileSync('schematics/collection.json', `${SCHEMATICS}/collection.json`);
+copyFileSync('schematics/package.json', `${SCHEMATICS}/package.json`);
 copyFileSync('schematics/ng-add/schema.json', `${SCHEMATICS}/ng-add/schema.json`);
 
 // 3. Patch version in the 'dist/package.json' with the one from 'package.json'
@@ -16,3 +17,6 @@ const { version } = readJsonSync(`package.json`, { encoding: 'utf-8' });
 const packageJson = readJsonSync(`${DEST}/package.json`, { encoding: 'utf-8' });
 packageJson.version = version;
 writeJSONSync(`${DEST}/package.json`, packageJson, { spaces: 2, encoding: 'utf-8' });
+
+// 4. Patch .npmignore file to include schematics package.json
+copyFileSync('.npmignore', `${DEST}/.npmignore`);

--- a/schematics/ng-add/steps/add-ngb-module.ts
+++ b/schematics/ng-add/steps/add-ngb-module.ts
@@ -1,86 +1,17 @@
-import { Rule, SchematicsException, Tree } from '@angular-devkit/schematics';
-import { getAppModulePath, isStandaloneApp } from '@schematics/angular/utility/ng-ast-utils';
-import { addImportToModule } from '@schematics/angular/utility/ast-utils';
-import { InsertChange } from '@schematics/angular/utility/change';
-import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import type { Rule } from '@angular-devkit/schematics';
+import { addRootImport } from '@schematics/angular/utility';
 
-import { Schema } from '../schema';
-import { readWorkspace } from '@schematics/angular/utility';
-import { getMainFilePath } from '@schematics/angular/utility/standalone/util';
-import * as messages from '../messages';
+import type { Schema } from '../schema';
 
 const NG_BOOTSTRAP_MODULE_NAME = 'NgbModule';
 const NG_BOOTSTRAP_PACKAGE_NAME = '@ng-bootstrap/ng-bootstrap';
 
 /**
  * Patches main application module by adding 'NgbModule' import.
- *
- * Relevant 'angular.json' structure is:
- *
- * {
- *   "projects" : {
- *     "projectName": {
- *       "architect": {
- *         "build": {
- *           "options": {
- *            "main": "src/main.ts"
- *           }
- *         }
- *       }
- *     }
- *   },
- *   "defaultProject": "projectName"
- * }
- *
  */
 export function addNgbModuleToAppModule(options: Schema): Rule {
-	return async (host: Tree) => {
-		const workspace = await readWorkspace(host);
-		const projectName = options.project || (workspace.extensions.defaultProject as string);
-
-		// 1. getting project by name
-		const project = workspace.projects.get(projectName);
-		if (!project) {
-			throw new SchematicsException(messages.noProject(projectName));
-		}
-
-		// 2. getting main file for project
-		const mainFilePath = await getMainFilePath(host, projectName);
-		if (!mainFilePath || !host.read(mainFilePath)) {
-			throw new SchematicsException(messages.noMainFile(projectName));
-		}
-
-		// we're not patching standalone apps
-		if (!isStandaloneApp(host, mainFilePath)) {
-			// 3. getting main app module file
-			const appModuleFilePath = getAppModulePath(host, mainFilePath);
-			const appModuleFileText = host.read(appModuleFilePath);
-			if (appModuleFileText === null) {
-				throw new SchematicsException(messages.noModuleFile(appModuleFilePath));
-			}
-
-			// 4. adding `NgbModule` to the app module
-			const appModuleSource = ts.createSourceFile(
-				appModuleFilePath,
-				appModuleFileText.toString('utf-8'),
-				ts.ScriptTarget.Latest,
-				true,
-			);
-
-			const changes = addImportToModule(
-				appModuleSource,
-				appModuleFilePath,
-				NG_BOOTSTRAP_MODULE_NAME,
-				NG_BOOTSTRAP_PACKAGE_NAME,
-			);
-
-			const recorder = host.beginUpdate(appModuleFilePath);
-			for (const change of changes) {
-				if (change instanceof InsertChange) {
-					recorder.insertLeft(change.pos, change.toAdd);
-				}
-			}
-			host.commitUpdate(recorder);
-		}
-	};
+	return addRootImport(
+		options.project!,
+		({ code, external }) => code`${external(NG_BOOTSTRAP_MODULE_NAME, NG_BOOTSTRAP_PACKAGE_NAME)}`,
+	) as any;
 }

--- a/schematics/package.json
+++ b/schematics/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/src/package.json
+++ b/src/package.json
@@ -41,10 +41,10 @@
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
-    "@angular/common": "^21.0.0",
-    "@angular/core": "^21.0.0",
-    "@angular/forms": "^21.0.0",
-    "@angular/localize": "^21.0.0",
+    "@angular/common": "^22.0.0",
+    "@angular/core": "^22.0.0",
+    "@angular/forms": "^22.0.0",
+    "@angular/localize": "^22.0.0",
     "@popperjs/core": "^2.11.8",
     "rxjs": "^6.5.3 || ^7.4.0"
   },


### PR DESCRIPTION
Since v22, the package.json built by ng-packagr is adding `"type": "module"` and this was preventing running the schematics, as those are still built to commonjs.

This PR makes sure running `ng add @ng-bootstrap/ng-bootstrap` will still work as expected.