### PR TITLE
chore: enforce npmMinimalAgeGate of 2 days

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,4 @@
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.16.0.cjs
+npmMinimalAgeGate: 2d


### PR DESCRIPTION
Recommended config to protect a bit again supply-chain attacks.