### PR TITLE
refactor(typeahead): support zoneless change detection

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -46,7 +46,9 @@
 						"coverageReporters": ["lcov"],
 						"browsers": ["ChromiumHeadless"],
 						"runnerConfig": "src/vitest.config.ts",
-						"include": ["src/(accordion|alert|collapse|dropdown|pagination|progressbar|nav|rating)/**/*.spec.ts"]
+						"include": [
+							"src/(accordion|alert|collapse|dropdown|pagination|progressbar|nav|rating|typeahead)/**/*.spec.ts"
+						]
 					},
 					"configurations": {
 						"other-browsers": {
@@ -54,12 +56,16 @@
 						},
 						"zone": {
 							"setupFiles": ["src/setup-zone-test.ts"],
-							"include": ["src/!(accordion|alert|collapse|dropdown|pagination|progressbar|nav|rating)/**/*.spec.ts"]
+							"include": [
+								"src/!(accordion|alert|collapse|dropdown|pagination|progressbar|nav|rating|typeahead)/**/*.spec.ts"
+							]
 						},
 						"zone-other-browsers": {
 							"browsers": ["FirefoxHeadless", "WebkitHeadless"],
 							"setupFiles": ["src/setup-zone-test.ts"],
-							"include": ["src/!(accordion|alert|collapse|dropdown|pagination|progressbar|nav|rating)/**/*.spec.ts"]
+							"include": [
+								"src/!(accordion|alert|collapse|dropdown|pagination|progressbar|nav|rating|typeahead)/**/*.spec.ts"
+							]
 						}
 					}
 				}

--- a/src/typeahead/typeahead-window.spec.ts
+++ b/src/typeahead/typeahead-window.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture } from '@angular/core/testing';
 import { createGenericTestComponent } from '../test/common';
 
-import { Component, ViewChild } from '@angular/core';
+import { Component, signal, ViewChild } from '@angular/core';
 
 import { NgbTypeaheadWindow } from './typeahead-window';
 import { expectResults, getWindowLinks } from '../test/typeahead/common';
@@ -38,7 +38,7 @@ describe('ngb-typeahead-window', () => {
 	});
 
 	describe('active row', () => {
-		it('should change active row on prev / next method call', () => {
+		it('should change active row on prev / next method call', async () => {
 			const html = `
            <button (click)="w.next()">+</button>
            <button (click)="w.prev()">-</button>
@@ -49,15 +49,15 @@ describe('ngb-typeahead-window', () => {
 			expectResults(fixture.nativeElement, ['+bar', 'baz']);
 
 			buttons[0].click();
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectResults(fixture.nativeElement, ['bar', '+baz']);
 
 			buttons[1].click();
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectResults(fixture.nativeElement, ['+bar', 'baz']);
 		});
 
-		it('should wrap active row on prev / next method call', () => {
+		it('should wrap active row on prev / next method call', async () => {
 			const html = `
            <button (click)="w.next()">+</button>
            <button (click)="w.prev()">-</button>
@@ -68,15 +68,15 @@ describe('ngb-typeahead-window', () => {
 			expectResults(fixture.nativeElement, ['+bar', 'baz']);
 
 			buttons[1].click();
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectResults(fixture.nativeElement, ['bar', '+baz']);
 
 			buttons[0].click();
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectResults(fixture.nativeElement, ['+bar', 'baz']);
 		});
 
-		it('should wrap active row on prev / next method call for [focusFirst]="false"', () => {
+		it('should wrap active row on prev / next method call for [focusFirst]="false"', async () => {
 			const html = `
            <button (click)="w.next()">+</button>
            <button (click)="w.prev()">-</button>
@@ -87,31 +87,31 @@ describe('ngb-typeahead-window', () => {
 			expectResults(fixture.nativeElement, ['bar', 'baz']);
 
 			buttons[0].click(); // next
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectResults(fixture.nativeElement, ['+bar', 'baz']);
 
 			buttons[0].click(); // next
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectResults(fixture.nativeElement, ['bar', '+baz']);
 
 			buttons[0].click(); // next
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectResults(fixture.nativeElement, ['bar', 'baz']);
 
 			buttons[1].click(); // prev
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectResults(fixture.nativeElement, ['bar', '+baz']);
 
 			buttons[1].click(); // prev
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectResults(fixture.nativeElement, ['+bar', 'baz']);
 
 			buttons[1].click(); // prev
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectResults(fixture.nativeElement, ['bar', 'baz']);
 		});
 
-		it('should change active row on mouseenter', () => {
+		it('should change active row on mouseenter', async () => {
 			const fixture = createTestComponent(
 				`<ngb-typeahead-window [results]="results" [term]="term"></ngb-typeahead-window>`,
 			);
@@ -120,28 +120,28 @@ describe('ngb-typeahead-window', () => {
 			expectResults(fixture.nativeElement, ['+bar', 'baz']);
 
 			links[1].triggerEventHandler('mouseenter', {});
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectResults(fixture.nativeElement, ['bar', '+baz']);
 		});
 	});
 
 	describe('result selection', () => {
-		it('should select a given row on click', () => {
+		it('should select a given row on click', async () => {
 			const fixture = createTestComponent(
-				'<ngb-typeahead-window [results]="results" [term]="term" (select)="selected = $event"></ngb-typeahead-window>',
+				'<ngb-typeahead-window [results]="results" [term]="term" (select)="selected.set($event)"></ngb-typeahead-window>',
 			);
 			const links = getWindowLinks(fixture.debugElement);
 
 			expectResults(fixture.nativeElement, ['+bar', 'baz']);
 
 			links[1].triggerEventHandler('click', {});
-			fixture.detectChanges();
-			expect(fixture.componentInstance.selected).toBe('baz');
+			await fixture.whenStable();
+			expect(fixture.componentInstance.selected()).toBe('baz');
 		});
 
-		it('should return selected row via getActive()', () => {
+		it('should return selected row via getActive()', async () => {
 			const html = `
-           <button (click)="active = w.getActive()">getActive</button>
+           <button (click)="active.set(w.getActive())">getActive</button>
            <button (click)="w.next()">+</button>
            <ngb-typeahead-window [results]="results" [term]="term" #w="ngbTypeaheadWindow"></ngb-typeahead-window>`;
 			const fixture = createTestComponent(html);
@@ -151,14 +151,15 @@ describe('ngb-typeahead-window', () => {
 			const nextBtn = buttons[1];
 
 			activeBtn.click();
+			await fixture.whenStable();
 			expectResults(fixture.nativeElement, ['+bar', 'baz']);
-			expect(fixture.componentInstance.active).toBe('bar');
+			expect(fixture.componentInstance.active()).toBe('bar');
 
 			nextBtn.click();
 			activeBtn.click();
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectResults(fixture.nativeElement, ['bar', '+baz']);
-			expect(fixture.componentInstance.active).toBe('baz');
+			expect(fixture.componentInstance.active()).toBe('baz');
 		});
 
 		it('should have buttons of type button', () => {
@@ -199,10 +200,10 @@ describe('ngb-typeahead-window', () => {
 	template: '',
 })
 class TestComponent {
-	active: string;
+	active = signal<string | undefined>(undefined);
 	results = ['bar', 'baz'];
 	term = 'ba';
-	selected: string;
+	selected = signal<string | undefined>(undefined);
 
 	@ViewChild(NgbTypeaheadWindow, { static: true }) popup: NgbTypeaheadWindow;
 

--- a/src/typeahead/typeahead.spec.ts
+++ b/src/typeahead/typeahead.spec.ts
@@ -1,4 +1,4 @@
-import { Component, DebugElement, provideZoneChangeDetection, ViewChild } from '@angular/core';
+import { Component, DebugElement, signal, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -64,14 +64,9 @@ function expectWindowResults(element, expectedResults: string[]) {
 
 describe('ngb-typeahead', () => {
 	beforeEach(() => {
-		vi.useFakeTimers();
 		TestBed.configureTestingModule({
-			providers: [{ provide: ARIA_LIVE_DELAY, useValue: null }, provideZoneChangeDetection()],
+			providers: [{ provide: ARIA_LIVE_DELAY, useValue: null }],
 		});
-	});
-
-	afterEach(() => {
-		vi.useRealTimers();
 	});
 
 	describe('valueaccessor', () => {
@@ -82,19 +77,16 @@ describe('ngb-typeahead', () => {
 			const comp = fixture.componentInstance;
 			expectInputValue(el, '');
 
-			comp.model = 'text';
-			fixture.detectChanges();
-			await Promise.resolve();
+			comp.model.set('text');
+			await fixture.whenStable();
 			expectInputValue(el, 'text');
 
-			comp.model = null;
-			fixture.detectChanges();
-			await Promise.resolve();
+			comp.model.set(null);
+			await fixture.whenStable();
 			expectInputValue(el, '');
 
-			comp.model = {};
-			fixture.detectChanges();
-			await Promise.resolve();
+			comp.model.set({});
+			await fixture.whenStable();
 			expectInputValue(el, '[object Object]');
 		});
 
@@ -105,14 +97,12 @@ describe('ngb-typeahead', () => {
 			const comp = fixture.componentInstance;
 			expectInputValue(el, '');
 
-			comp.model = null;
-			fixture.detectChanges();
-			await Promise.resolve();
+			comp.model.set(null);
+			await fixture.whenStable();
 			expectInputValue(el, '');
 
-			comp.model = { value: 'text' };
-			fixture.detectChanges();
-			await Promise.resolve();
+			comp.model.set({ value: 'text' });
+			await fixture.whenStable();
 			expectInputValue(el, 'TEXT');
 		});
 
@@ -123,19 +113,16 @@ describe('ngb-typeahead', () => {
 			const comp = fixture.componentInstance;
 			expectInputValue(el, '');
 
-			comp.model = null;
-			fixture.detectChanges();
-			await Promise.resolve();
+			comp.model.set(null);
+			await fixture.whenStable();
 			expectInputValue(el, '');
 
-			comp.model = 0;
-			fixture.detectChanges();
-			await Promise.resolve();
+			comp.model.set(0);
+			await fixture.whenStable();
 			expectInputValue(el, '0');
 
-			comp.model = false;
-			fixture.detectChanges();
-			await Promise.resolve();
+			comp.model.set(false);
+			await fixture.whenStable();
 			expectInputValue(el, 'FALSE');
 		});
 	});
@@ -151,21 +138,20 @@ describe('ngb-typeahead', () => {
 			const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
 			const compiled = fixture.nativeElement;
 
-			fixture.componentInstance.model = 'one';
-			fixture.detectChanges();
-			await Promise.resolve();
+			fixture.componentInstance.model.set('one');
+			await fixture.whenStable();
 			expect(getWindow(compiled)).toBeNull();
 		});
 
 		it('should be opened when there are results', async () => {
 			const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
 			const compiled = fixture.nativeElement;
-			await Promise.resolve();
+			await fixture.whenStable();
 
 			changeInput(compiled, 'one');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+one', 'one more']);
-			expect(fixture.componentInstance.model).toBe('one');
+			expect(fixture.componentInstance.model()).toBe('one');
 		});
 
 		it('should be closed when there no results', () => {
@@ -187,61 +173,61 @@ describe('ngb-typeahead', () => {
 			expect(getWindow(compiled)).toBeNull();
 		});
 
-		it('should allow changing ngbTypeahead value', () => {
-			const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="findRef"/>`);
+		it('should allow changing ngbTypeahead value', async () => {
+			const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="findRef()"/>`);
 			const compiled = fixture.nativeElement;
 
 			// null initially
 			expect(getWindow(compiled)).toBeNull();
 
 			// real value
-			fixture.componentInstance.findRef = (_: Observable<string>) => of(['one', 'one more']);
-			fixture.detectChanges();
+			fixture.componentInstance.findRef.set((_: Observable<string>) => of(['one', 'one more']));
+			await fixture.whenStable();
 
 			changeInput(compiled, 'one');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+one', 'one more']);
 
 			// back to null
-			fixture.componentInstance.findRef = undefined;
-			fixture.detectChanges();
+			fixture.componentInstance.findRef.set(undefined);
+			await fixture.whenStable();
 
 			expect(getWindow(compiled)).toBeNull();
 		});
 
-		it('should work when returning null as results', () => {
+		it('should work when returning null as results', async () => {
 			const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="findNull"/>`);
 			const compiled = fixture.nativeElement;
 
 			changeInput(compiled, 'one');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getWindow(compiled)).toBeNull();
 		});
 
 		it('should select the result on click, close window and fill the input', async () => {
 			const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
 			const compiled = fixture.nativeElement;
-			await Promise.resolve();
+			await fixture.whenStable();
 
 			// clicking selected
 			changeInput(compiled, 'o');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+one', 'one more']);
 
 			getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getWindow(compiled)).toBeNull();
 			expectInputValue(compiled, 'one');
-			expect(fixture.componentInstance.model).toBe('one');
+			expect(fixture.componentInstance.model()).toBe('one');
 
 			// clicking not selected
 			changeInput(compiled, 'o');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+one', 'one more']);
 			expectInputValue(compiled, 'o');
 
 			getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getWindow(compiled)).toBeNull();
 			expectInputValue(compiled, 'one');
 		});
@@ -249,162 +235,162 @@ describe('ngb-typeahead', () => {
 		it('should select the result on ENTER, close window and fill the input', async () => {
 			const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
 			const compiled = fixture.nativeElement;
-			await Promise.resolve();
+			await fixture.whenStable();
 
 			changeInput(compiled, 'o');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+one', 'one more']);
 
 			const event = createKeyDownEvent('Enter');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getWindow(compiled)).toBeNull();
 			expectInputValue(compiled, 'one');
-			expect(fixture.componentInstance.model).toBe('one');
+			expect(fixture.componentInstance.model()).toBe('one');
 			expect(event.preventDefault).toHaveBeenCalled();
 			expect(event.stopPropagation).toHaveBeenCalled();
 		});
 
-		it('should select the result on TAB, close window and fill the input', () => {
+		it('should select the result on TAB, close window and fill the input', async () => {
 			const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
 			const compiled = fixture.nativeElement;
 
 			changeInput(compiled, 'o');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getWindow(compiled)).not.toBeNull();
 
 			const event = createKeyDownEvent('Tab');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getWindow(compiled)).toBeNull();
 			expectInputValue(compiled, 'one');
-			expect(fixture.componentInstance.model).toBe('one');
+			expect(fixture.componentInstance.model()).toBe('one');
 			expect(event.preventDefault).toHaveBeenCalled();
 			expect(event.stopPropagation).toHaveBeenCalled();
 		});
 
-		it('should make previous/next results active with up/down arrow keys', () => {
+		it('should make previous/next results active with up/down arrow keys', async () => {
 			const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="find"/>`);
 			const compiled = fixture.nativeElement;
 
 			changeInput(compiled, 'o');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+one', 'one more']);
 
 			// down
 			let event = createKeyDownEvent('ArrowDown');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['one', '+one more']);
 			expect(event.preventDefault).toHaveBeenCalled();
 
 			event = createKeyDownEvent('ArrowDown');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+one', 'one more']);
 			expect(event.preventDefault).toHaveBeenCalled();
 
 			// up
 			event = createKeyDownEvent('ArrowUp');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['one', '+one more']);
 			expect(event.preventDefault).toHaveBeenCalled();
 
 			event = createKeyDownEvent('ArrowUp');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+one', 'one more']);
 			expect(event.preventDefault).toHaveBeenCalled();
 		});
 
-		it('should use provided result formatter function', () => {
+		it('should use provided result formatter function', async () => {
 			const fixture = createTestComponent(
 				`<input type="text" [ngbTypeahead]="find" [resultFormatter]="uppercaseFormatter"/>`,
 			);
 			const compiled = fixture.nativeElement;
 
 			changeInput(compiled, 'o');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+ONE', 'ONE MORE']);
 		});
 
-		it('should not mark first result as active when focusFirst is false', () => {
+		it('should not mark first result as active when focusFirst is false', async () => {
 			const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="find" [focusFirst]="false"/>`);
 			const compiled = fixture.nativeElement;
 
 			changeInput(compiled, 'o');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['one', 'one more']);
 		});
 
-		it('should reset active index when result changes', () => {
+		it('should reset active index when result changes', async () => {
 			const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="find"/>`);
 			const compiled = fixture.nativeElement;
 
 			changeInput(compiled, 'o');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+one', 'one more']);
 
 			// move down to highlight the second item
 			let event = createKeyDownEvent('ArrowDown');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['one', '+one more']);
 			expect(event.preventDefault).toHaveBeenCalled();
 
 			// change search criteria to reset results while the popup stays open
 			changeInput(compiled, 't');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+two', 'three']);
 		});
 
-		it('should properly make previous/next results active with down arrow keys when focusFirst is false', () => {
+		it('should properly make previous/next results active with down arrow keys when focusFirst is false', async () => {
 			const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="find" [focusFirst]="false"/>`);
 			const compiled = fixture.nativeElement;
 
 			changeInput(compiled, 'o');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['one', 'one more']);
 
 			// down
 			let event = createKeyDownEvent('ArrowDown');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+one', 'one more']);
 			expect(event.preventDefault).toHaveBeenCalled();
 
 			event = createKeyDownEvent('ArrowDown');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['one', '+one more']);
 			expect(event.preventDefault).toHaveBeenCalled();
 
 			event = createKeyDownEvent('ArrowDown');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['one', 'one more']);
 			expect(event.preventDefault).toHaveBeenCalled();
 		});
 
-		it('should properly make previous/next results active with up arrow keys when focusFirst is false', () => {
+		it('should properly make previous/next results active with up arrow keys when focusFirst is false', async () => {
 			const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="find" [focusFirst]="false"/>`);
 			const compiled = fixture.nativeElement;
 
 			changeInput(compiled, 'o');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['one', 'one more']);
 
 			// up
 			let event = createKeyDownEvent('ArrowUp');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['one', '+one more']);
 			expect(event.preventDefault).toHaveBeenCalled();
 
 			event = createKeyDownEvent('ArrowUp');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+one', 'one more']);
 			expect(event.preventDefault).toHaveBeenCalled();
 		});
@@ -414,33 +400,36 @@ describe('ngb-typeahead', () => {
 				`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find" [focusFirst]="false"/>`,
 			);
 			const compiled = fixture.nativeElement;
-			await Promise.resolve();
+			await fixture.whenStable();
 
 			changeInput(compiled, 'o');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getWindow(compiled)).not.toBeNull();
 
 			const event = createKeyDownEvent('Tab');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getWindow(compiled)).toBeNull();
 			expectInputValue(compiled, 'o');
-			expect(fixture.componentInstance.model).toBe('o');
+			expect(fixture.componentInstance.model()).toBe('o');
 			expect(event.preventDefault).not.toHaveBeenCalled();
 		});
 
 		it('should properly display results when an owning components using OnPush strategy', async () => {
-			const fixture = createOnPushTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
-			const compiled = fixture.nativeElement;
-			await Promise.resolve();
+			vi.useFakeTimers();
+			try {
+				const fixture = createOnPushTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
+				const compiled = fixture.nativeElement;
 
-			changeInput(compiled, 'o');
-			fixture.detectChanges();
-			vi.advanceTimersByTime(250);
-			expectWindowResults(compiled, ['+one', 'one more']);
+				changeInput(compiled, 'o');
+				await vi.advanceTimersByTimeAsync(250);
+				expectWindowResults(compiled, ['+one', 'one more']);
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 
-		it('should apply additional class when specified', () => {
+		it('should apply additional class when specified', async () => {
 			const fixture = createTestComponent(
 				`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find" popupClass="test"/>`,
 			);
@@ -448,13 +437,13 @@ describe('ngb-typeahead', () => {
 
 			// the results of the code below are already tested above
 			changeInput(compiled, 'one');
-			fixture.detectChanges();
+			await fixture.whenStable();
 
 			const win = getWindow(compiled);
 			expect(win.classList).toContain('test');
 		});
 
-		it('should apply additional classes when specified', () => {
+		it('should apply additional classes when specified', async () => {
 			const fixture = createTestComponent(
 				`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find" popupClass="test other"/>`,
 			);
@@ -462,7 +451,7 @@ describe('ngb-typeahead', () => {
 
 			// the results of the code below are already tested above
 			changeInput(compiled, 'one');
-			fixture.detectChanges();
+			await fixture.whenStable();
 
 			const win = getWindow(compiled);
 			expect(win.classList).toContain('test');
@@ -470,15 +459,17 @@ describe('ngb-typeahead', () => {
 		});
 
 		it('should modify the popper options', async () => {
-			const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find" />`);
-
-			const typeahead = fixture.debugElement.query(By.directive(NgbTypeahead)).injector.get(NgbTypeahead);
+			const fixture = createTestComponent(
+				`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find" [popperOptions]="popperOptions()" />`,
+			);
 
 			const spy = vi.fn();
-			typeahead.popperOptions = (options: Partial<Options>) => {
+			fixture.componentInstance.popperOptions.set((options: Partial<Options>) => {
 				options.modifiers!.push({ name: 'test', enabled: true, phase: 'main', fn: spy });
 				return options;
-			};
+			});
+			await fixture.whenStable();
+
 			const compiled = fixture.nativeElement;
 			changeInput(compiled, 'one');
 
@@ -489,58 +480,58 @@ describe('ngb-typeahead', () => {
 	});
 
 	describe('with async typeahead function', () => {
-		it('should not display results when input is "blured"', () => {
+		beforeEach(() => {
+			vi.useFakeTimers();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it('should not display results when input is "blured"', async () => {
 			const fixture = createAsyncTestComponent(`<input type="text" [ngbTypeahead]="find"/>`);
 			const compiled = fixture.nativeElement;
 
 			changeInput(compiled, 'one');
-			fixture.detectChanges();
-
-			vi.advanceTimersByTime(50);
+			await vi.advanceTimersByTimeAsync(50);
 
 			blurInput(compiled);
-			fixture.detectChanges();
-
-			vi.advanceTimersByTime(250);
+			await vi.advanceTimersByTimeAsync(250);
 			expect(getWindow(compiled)).toBeNull();
 
 			// Make sure that it is resubscribed again
 			changeInput(compiled, 'two');
-			fixture.detectChanges();
-			vi.advanceTimersByTime(250);
+			await vi.advanceTimersByTimeAsync(250);
 			expect(getWindow(compiled)).not.toBeNull();
 		});
 
-		it('should not display results when value selected while new results are been loading', () => {
+		it('should not display results when value selected while new results are been loading', async () => {
 			const fixture = createAsyncTestComponent(`<input type="text" [ngbTypeahead]="find"/>`);
 			const compiled = fixture.nativeElement;
 
 			// Change input first time
 			changeInput(compiled, 'one');
-			fixture.detectChanges();
 
 			// Results for first input are loaded
-			vi.advanceTimersByTime(250);
+			await vi.advanceTimersByTimeAsync(250);
 			expect(getWindow(compiled)).not.toBeNull();
 
 			// Change input second time
 			changeInput(compiled, 'two');
-			fixture.detectChanges();
-			vi.advanceTimersByTime(50);
+			await vi.advanceTimersByTimeAsync(50);
 
 			// Select a value from first results list while second is still in progress
 			getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
-			fixture.detectChanges();
+			await vi.advanceTimersByTimeAsync(0);
 			expect(getWindow(compiled)).toBeNull();
 
 			// Results for second input are loaded (window shouldn't be opened in this case)
-			vi.advanceTimersByTime(250);
+			await vi.advanceTimersByTimeAsync(250);
 			expect(getWindow(compiled)).toBeNull();
 
 			// Make sure that it is resubscribed again
 			changeInput(compiled, 'three');
-			fixture.detectChanges();
-			vi.advanceTimersByTime(250);
+			await vi.advanceTimersByTimeAsync(250);
 			expect(getWindow(compiled)).not.toBeNull();
 		});
 	});
@@ -551,18 +542,18 @@ describe('ngb-typeahead', () => {
              <input type="text" [(ngModel)]="model" [ngbTypeahead]="findObjects"
                     [inputFormatter]="formatter" [resultFormatter]="uppercaseObjFormatter"/>`);
 			const compiled = fixture.nativeElement;
-			await Promise.resolve();
+			await fixture.whenStable();
 
 			changeInput(compiled, 'o');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+ONE', 'ONE MORE']);
 
 			const event = createKeyDownEvent('Enter');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getWindow(compiled)).toBeNull();
 			expect(getNativeInput(compiled).value).toBe('1 one');
-			expect(fixture.componentInstance.model).toEqual({ id: 1, value: 'one' });
+			expect(fixture.componentInstance.model()).toEqual({ id: 1, value: 'one' });
 		});
 
 		it('should allow to assign ngModel custom objects', async () => {
@@ -571,9 +562,8 @@ describe('ngb-typeahead', () => {
                     [inputFormatter]="formatter" [resultFormatter]="uppercaseObjFormatter"/>`);
 			const compiled = fixture.nativeElement;
 
-			fixture.componentInstance.model = { id: 1, value: 'one' };
-			fixture.detectChanges();
-			await Promise.resolve();
+			fixture.componentInstance.model.set({ id: 1, value: 'one' });
+			await fixture.whenStable();
 			expect(getWindow(compiled)).toBeNull();
 			expect(getNativeInput(compiled).value).toBe('1 one');
 		});
@@ -586,19 +576,20 @@ describe('ngb-typeahead', () => {
               <input type="text" [(ngModel)]="model" name="control" required [ngbTypeahead]="findObjects" />
             </form>`;
 			const fixture = createTestComponent(html);
+			// let NgForm register its control (untracked microtask) before checking validity
 			await Promise.resolve();
-			fixture.detectChanges();
+			await fixture.whenStable();
 			const compiled = fixture.nativeElement;
 			expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
 			expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
 
 			changeInput(compiled, 'o');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
 			expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
 		});
 
-		it('should work with model-driven form validation', () => {
+		it('should work with model-driven form validation', async () => {
 			const html = `
            <form [formGroup]="form">
              <input type="text" formControlName="control" required [ngbTypeahead]="findObjects" />
@@ -610,7 +601,7 @@ describe('ngb-typeahead', () => {
 			expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
 
 			changeInput(compiled, 'o');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
 			expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
 		});
@@ -621,8 +612,7 @@ describe('ngb-typeahead', () => {
               <input type="text" [(ngModel)]="model" name="control" [disabled]="true" [ngbTypeahead]="findObjects" />
             </form>`;
 			const fixture = createTestComponent(html);
-			await Promise.resolve();
-			fixture.detectChanges();
+			await fixture.whenStable();
 			const compiled = fixture.nativeElement;
 			expect(getNativeInput(compiled).disabled).toBeTruthy();
 		});
@@ -633,24 +623,25 @@ describe('ngb-typeahead', () => {
               <input type="text" [(ngModel)]="model" name="control" required [ngbTypeahead]="find" [editable]="false"/>
             </form>`;
 			const fixture = createTestComponent(html);
+			// let NgForm register its control (untracked microtask) before checking validity
 			await Promise.resolve();
-			fixture.detectChanges();
+			await fixture.whenStable();
 			const compiled = fixture.nativeElement;
 			expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
 			expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
 
 			changeInput(compiled, 'o');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
 			expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
-			expect(fixture.componentInstance.model).toBeNull();
+			expect(fixture.componentInstance.model()).toBeNull();
 
 			const event = createKeyDownEvent('Enter');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
 			expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
-			expect(fixture.componentInstance.model).toBe('one');
+			expect(fixture.componentInstance.model()).toBe('one');
 		});
 
 		it('should clear model on user input when the editable option is on', async () => {
@@ -659,30 +650,31 @@ describe('ngb-typeahead', () => {
               <input type="text" [(ngModel)]="model" name="control" required [ngbTypeahead]="find" [editable]="false"/>
             </form>`;
 			const fixture = createTestComponent(html);
+			// let NgForm register its control (untracked microtask) before checking validity
 			await Promise.resolve();
-			fixture.detectChanges();
+			await fixture.whenStable();
 			const compiled = fixture.nativeElement;
 			expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
 			expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
 
 			changeInput(compiled, 'o');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
 			expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
-			expect(fixture.componentInstance.model).toBeNull();
+			expect(fixture.componentInstance.model()).toBeNull();
 
 			const event = createKeyDownEvent('Enter');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
 			expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
-			expect(fixture.componentInstance.model).toBe('one');
+			expect(fixture.componentInstance.model()).toBe('one');
 
 			changeInput(compiled, 'tw');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
 			expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
-			expect(fixture.componentInstance.model).toBeNull();
+			expect(fixture.componentInstance.model()).toBeNull();
 		});
 
 		it('should clear model on user input when the editable option is on and no search was triggered', async () => {
@@ -691,33 +683,34 @@ describe('ngb-typeahead', () => {
               <input type="text" [(ngModel)]="model" name="control" required [ngbTypeahead]="findFilter" [editable]="false"/>
             </form>`;
 			const fixture = createTestComponent(html);
+			// let NgForm register its control (untracked microtask) before checking validity
 			await Promise.resolve();
-			fixture.detectChanges();
+			await fixture.whenStable();
 			const compiled = fixture.nativeElement;
 			expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
 			expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
 
 			changeInput(compiled, 'one');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
 			expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
-			expect(fixture.componentInstance.model).toBeNull();
+			expect(fixture.componentInstance.model()).toBeNull();
 
 			const event = createKeyDownEvent('Enter');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getNativeInput(compiled)).not.toHaveCssClass('ng-invalid');
 			expect(getNativeInput(compiled)).toHaveCssClass('ng-valid');
-			expect(fixture.componentInstance.model).toBe('one');
+			expect(fixture.componentInstance.model()).toBe('one');
 
 			changeInput(compiled, '');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getNativeInput(compiled)).toHaveCssClass('ng-invalid');
 			expect(getNativeInput(compiled)).not.toHaveCssClass('ng-valid');
-			expect(fixture.componentInstance.model).toBeNull();
+			expect(fixture.componentInstance.model()).toBeNull();
 		});
 
-		it('should use null and not undefined as value to make sure the form group value is valid (issue 4777)', () => {
+		it('should use null and not undefined as value to make sure the form group value is valid (issue 4777)', async () => {
 			const html = `
            <form [formGroup]="form">
              <input type="text" formControlName="control" [ngbTypeahead]="findObjects" [editable]="false" />
@@ -726,7 +719,7 @@ describe('ngb-typeahead', () => {
 			const compiled = fixture.nativeElement;
 
 			changeInput(compiled, 'o');
-			fixture.detectChanges();
+			await fixture.whenStable();
 
 			const formValue = fixture.componentInstance.form.getRawValue();
 			expect(formValue.control).toBeNull();
@@ -736,59 +729,59 @@ describe('ngb-typeahead', () => {
 	});
 
 	describe('select event', () => {
-		it('should raise select event when a result is selected', () => {
+		it('should raise select event when a result is selected', async () => {
 			const fixture = createTestComponent('<input [ngbTypeahead]="find" (selectItem)="onSelect($event.item)"/>');
 
 			// clicking selected
 			changeInput(fixture.nativeElement, 'o');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
-			fixture.detectChanges();
+			await fixture.whenStable();
 
-			expect(fixture.componentInstance.selectEventValue).toBe('one');
+			expect(fixture.componentInstance.selectEventValue()).toBe('one');
 		});
 
 		it('should not propagate model when preventDefault() is called on selectEvent', async () => {
 			const fixture = createTestComponent(
 				'<input [(ngModel)]="model" [ngbTypeahead]="find" (selectItem)="$event.preventDefault()"/>',
 			);
-			await Promise.resolve();
+			await fixture.whenStable();
 
 			// clicking selected
 			changeInput(fixture.nativeElement, 'o');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			getWindowLinks(fixture.debugElement)[0].triggerEventHandler('click', {});
-			fixture.detectChanges();
-			expect(fixture.componentInstance.model).toBe('o');
+			await fixture.whenStable();
+			expect(fixture.componentInstance.model()).toBe('o');
 		});
 	});
 
 	describe('container', () => {
-		it('should be appended to the element matching the selector passed to "container"', () => {
+		it('should be appended to the element matching the selector passed to "container"', async () => {
 			const selector = 'body';
 			const fixture = createTestComponent(`<input [ngbTypeahead]="find" container="${selector}"/>`);
 
 			changeInput(fixture.nativeElement, 'one');
-			fixture.detectChanges();
+			await fixture.whenStable();
 
 			expect(getWindow(fixture.nativeElement)).toBeNull();
 			expect(getWindow(document.querySelector(selector))).not.toBeNull();
 		});
 
-		it('should properly destroy typeahead window when the "container" option is used', () => {
+		it('should properly destroy typeahead window when the "container" option is used', async () => {
 			const selector = 'body';
-			const fixture = createTestComponent(`@if (show) {
+			const fixture = createTestComponent(`@if (show()) {
 					<input [ngbTypeahead]="find" container="${selector}"/>
 				}`);
 
 			changeInput(fixture.nativeElement, 'one');
-			fixture.detectChanges();
+			await fixture.whenStable();
 
 			expect(getWindow(fixture.nativeElement)).toBeNull();
 			expect(getWindow(document.querySelector(selector))).not.toBeNull();
 
-			fixture.componentInstance.show = false;
-			fixture.detectChanges();
+			fixture.componentInstance.show.set(false);
+			await fixture.whenStable();
 
 			expect(getWindow(fixture.nativeElement)).toBeNull();
 			expect(getWindow(document.querySelector(selector))).toBeNull();
@@ -816,11 +809,11 @@ describe('ngb-typeahead', () => {
 	});
 
 	describe('accessibility', () => {
-		it('should have correct role, aria-autocomplete, aria-expanded set by default', () => {
+		it('should have correct role, aria-autocomplete, aria-expanded set by default', async () => {
 			const fixture = createTestComponent('<input type="text" [ngbTypeahead]="findObjects" />');
 			const input = getNativeInput(fixture.nativeElement);
 
-			fixture.detectChanges();
+			await fixture.whenStable();
 
 			expect(input.getAttribute('role')).toBe('combobox');
 			expect(input.getAttribute('aria-autocomplete')).toBe('list');
@@ -830,11 +823,11 @@ describe('ngb-typeahead', () => {
 			expect(input.getAttribute('aria-activedescendant')).toBeNull();
 		});
 
-		it('should correctly set aria-autocomplete depending on showHint', () => {
+		it('should correctly set aria-autocomplete depending on showHint', async () => {
 			const fixture = createTestComponent('<input type="text" [ngbTypeahead]="findObjects"  [showHint]="true" />');
 			const input = getNativeInput(fixture.nativeElement);
 
-			fixture.detectChanges();
+			await fixture.whenStable();
 
 			expect(input.getAttribute('aria-autocomplete')).toBe('both');
 		});
@@ -843,10 +836,10 @@ describe('ngb-typeahead', () => {
 			const fixture = createTestComponent(`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find"/>`);
 			const compiled = fixture.nativeElement;
 			const input = getNativeInput(compiled);
-			await Promise.resolve();
+			await fixture.whenStable();
 
 			changeInput(compiled, 'o');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+one', 'one more']);
 			expect(input.getAttribute('aria-expanded')).toBe('true');
 			expect(input.getAttribute('aria-controls')).toMatch(/ngb-typeahead-[0-9]+/);
@@ -854,12 +847,12 @@ describe('ngb-typeahead', () => {
 
 			let event = createKeyDownEvent('ArrowDown');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(input.getAttribute('aria-activedescendant')).toMatch(/ngb-typeahead-[0-9]+-1/);
 
 			event = createKeyDownEvent('Enter');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(input.getAttribute('aria-expanded')).toBe('false');
 			expect(input.getAttribute('aria-controls')).toBeNull();
 			expect(input.getAttribute('aria-activedescendant')).toBeNull();
@@ -874,10 +867,10 @@ describe('ngb-typeahead', () => {
 			const compiled = fixture.nativeElement;
 			const inputEl = getNativeInput(compiled);
 
-			await Promise.resolve();
+			await fixture.whenStable();
 
 			changeInput(compiled, 'on');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+one', 'one more']);
 			expect(inputEl.value).toBe('one');
 			expect(inputEl.selectionStart).toBe(2);
@@ -885,7 +878,7 @@ describe('ngb-typeahead', () => {
 
 			const event = createKeyDownEvent('ArrowDown');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(inputEl.value).toBe('one more');
 			expect(inputEl.selectionStart).toBe(2);
 			expect(inputEl.selectionEnd).toBe(8);
@@ -897,17 +890,17 @@ describe('ngb-typeahead', () => {
 			);
 			const compiled = fixture.nativeElement;
 			const inputEl = getNativeInput(compiled);
-			await Promise.resolve();
+			await fixture.whenStable();
 
 			changeInput(compiled, 'ne');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+one', 'one more']);
 			expect(inputEl.value).toBe('one');
 			expect(inputEl.selectionStart).toBe(inputEl.selectionEnd);
 
 			const event = createKeyDownEvent('ArrowDown');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(inputEl.value).toBe('one more');
 			expect(inputEl.selectionStart).toBe(inputEl.selectionEnd);
 		});
@@ -919,10 +912,10 @@ describe('ngb-typeahead', () => {
               [showHint]="true"/>`);
 			const compiled = fixture.nativeElement;
 			const inputEl = getNativeInput(compiled);
-			await Promise.resolve();
+			await fixture.whenStable();
 
 			changeInput(compiled, 'on');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+one', 'one more']);
 			expect(inputEl.value).toBe('onE');
 			expect(inputEl.selectionStart).toBe(2);
@@ -930,7 +923,7 @@ describe('ngb-typeahead', () => {
 
 			const event = createKeyDownEvent('ArrowDown');
 			getDebugInput(fixture.debugElement).triggerEventHandler('keydown', event);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(inputEl.value).toBe('onE MORE');
 			expect(inputEl.selectionStart).toBe(2);
 			expect(inputEl.selectionEnd).toBe(8);
@@ -940,13 +933,12 @@ describe('ngb-typeahead', () => {
 			const fixture = createTestComponent(
 				`<input type="text" [(ngModel)]="model" [ngbTypeahead]="find" [showHint]="true" [focusFirst]="false"/>`,
 			);
-			fixture.detectChanges();
 			const compiled = fixture.nativeElement;
 			const inputEl = getNativeInput(compiled);
-			await Promise.resolve();
+			await fixture.whenStable();
 
 			changeInput(compiled, 'on');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['one', 'one more']);
 			expect(inputEl.value).toBe('on');
 		});
@@ -959,20 +951,19 @@ describe('ngb-typeahead', () => {
 				const showHint = index === 1;
 				it(`${index === 0 ? 'without' : 'with'} showHint activated`, async () => {
 					const fixture = createTestComponent(html);
-					await Promise.resolve();
+					await fixture.whenStable();
 
 					const compiled = fixture.nativeElement;
 					changeInput(compiled, 'on');
-					fixture.detectChanges();
+					await fixture.whenStable();
 
 					expectInputValue(compiled, showHint ? 'one' : 'on');
 
-					fixture.componentInstance.model = '';
-					fixture.detectChanges();
-					await Promise.resolve();
+					fixture.componentInstance.model.set('');
+					await fixture.whenStable();
 
 					document.body.click();
-					fixture.detectChanges();
+					await fixture.whenStable();
 
 					expectInputValue(compiled, '');
 				});
@@ -992,9 +983,9 @@ describe('ngb-typeahead', () => {
 			config.showHint = true;
 		});
 
-		it('should initialize inputs with provided config', () => {
+		it('should initialize inputs with provided config', async () => {
 			const fixture = TestBed.createComponent(TestComponent);
-			fixture.detectChanges();
+			await fixture.whenStable();
 
 			const typeahead = fixture.componentInstance.typeahead;
 			expect(typeahead.showHint).toBe(true);
@@ -1013,9 +1004,9 @@ describe('ngb-typeahead', () => {
 			config.showHint = true;
 		});
 
-		it('should initialize inputs with provided config as provider', () => {
+		it('should initialize inputs with provided config as provider', async () => {
 			const fixture = TestBed.createComponent(TestComponent);
-			fixture.detectChanges();
+			await fixture.whenStable();
 			const typeahead = fixture.componentInstance.typeahead;
 			expect(typeahead.showHint).toBe(true);
 		});
@@ -1033,16 +1024,16 @@ describe('ngb-typeahead', () => {
 			inputEl = getNativeInput(compiled);
 		});
 
-		it('should select the only existing result when it matches the user input', () => {
+		it('should select the only existing result when it matches the user input', async () => {
 			changeInput(compiled, 'one more');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getWindow(compiled)).toBeNull();
 			expect(inputEl.value).toBe('one more');
 		});
 
-		it('should not select the only existing result when it doesn`t match the user input', () => {
+		it('should not select the only existing result when it doesn`t match the user input', async () => {
 			changeInput(compiled, 'one mor');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+one more']);
 			expect(inputEl.value).toBe('one mor');
 		});
@@ -1063,17 +1054,17 @@ describe('ngb-typeahead', () => {
 			inputEl = getNativeInput(compiled);
 		});
 
-		it('should select the only existing result when it matches the user input', () => {
+		it('should select the only existing result when it matches the user input', async () => {
 			changeInput(compiled, '10 one more');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getWindow(compiled)).toBeNull();
 			expect(inputEl.value).toBe('10 one more');
-			expect(fixture.componentInstance.model).toEqual({ id: 10, value: 'one more' });
+			expect(fixture.componentInstance.model()).toEqual({ id: 10, value: 'one more' });
 		});
 
-		it('should not select the only existing result when it doesn`t match the user input', () => {
+		it('should not select the only existing result when it doesn`t match the user input', async () => {
 			changeInput(compiled, '10 one mor');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+10 one more']);
 			expect(inputEl.value).toBe('10 one mor');
 		});
@@ -1092,21 +1083,41 @@ describe('ngb-typeahead', () => {
 			inputEl = getNativeInput(compiled);
 		});
 
-		it('should select the only existing result when it matches the user input', () => {
+		it('should select the only existing result when it matches the user input', async () => {
 			changeInput(compiled, 'one more');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expect(getWindow(compiled)).toBeNull();
 			expect(fixture.componentInstance.form.controls.control.value).toBe('one more');
 			expect(fixture.componentInstance.form.controls.control.valid).toBe(true);
 		});
 
-		it('should not select the only existing result when it doesn`t match the user input', () => {
+		it('should not select the only existing result when it doesn`t match the user input', async () => {
 			changeInput(compiled, 'one mor');
-			fixture.detectChanges();
+			await fixture.whenStable();
 			expectWindowResults(compiled, ['+one more']);
 			expect(fixture.componentInstance.form.controls.control.value).toBeNull();
 			expect(fixture.componentInstance.form.controls.control.valid).toBe(false);
 		});
+	});
+
+	it('should refresh host bindings when the popup is dismissed without manual change detection (zoneless)', async () => {
+		const fixture = createTestComponent(`<input type="text" [ngbTypeahead]="find"/>`);
+		const input = getNativeInput(fixture.nativeElement);
+		await fixture.whenStable();
+
+		changeInput(fixture.nativeElement, 'one');
+		await fixture.whenStable();
+		expect(getWindow(fixture.nativeElement)).not.toBeNull();
+		expect(input.classList).toContain('open');
+
+		// a term with no matches emits an empty result list, which closes the popup from outside Angular
+		changeInput(fixture.nativeElement, 'zzz');
+		await fixture.whenStable();
+
+		expect(getWindow(fixture.nativeElement)).toBeNull();
+		expect(input.classList).not.toContain('open');
+		expect(input.getAttribute('aria-expanded')).toBe('false');
+		expect(input.getAttribute('aria-controls')).toBeNull();
 	});
 });
 
@@ -1124,9 +1135,10 @@ class TestComponent {
 		{ id: 3, value: 'three' },
 	];
 
-	model: any;
-	selectEventValue: any;
-	show = true;
+	model = signal<any>(undefined);
+	selectEventValue = signal<any>(undefined);
+	show = signal(true);
+	popperOptions = signal<(options: Partial<Options>) => Partial<Options>>((options) => options);
 
 	form = new UntypedFormGroup({ control: new UntypedFormControl('', Validators.required) });
 
@@ -1137,7 +1149,7 @@ class TestComponent {
 	focus$ = new Subject<string>();
 	click$ = new Subject<string>();
 
-	findRef: OperatorFunction<string, readonly any[]> | null | undefined = null;
+	findRef = signal<OperatorFunction<string, readonly any[]> | null | undefined>(null);
 
 	find = (text$: Observable<string>) => {
 		const clicks$ = this.click$.pipe(filter(() => !this.typeahead.isPopupOpen()));
@@ -1185,7 +1197,7 @@ class TestComponent {
 	};
 
 	onSelect($event) {
-		this.selectEventValue = $event;
+		this.selectEventValue.set($event);
 	}
 }
 

--- a/src/typeahead/typeahead.ts
+++ b/src/typeahead/typeahead.ts
@@ -359,6 +359,9 @@ export class NgbTypeahead implements ControlValueAccessor, OnInit, OnChanges, On
 			this._closed$.next();
 			this._windowRef = null;
 			this.activeDescendant = null;
+			// Closing destroys the popup view, which does not schedule change detection on its own. The host
+			// bindings (`open` class, `aria-*`) therefore have to be refreshed explicitly to support zoneless apps.
+			this._changeDetector.markForCheck();
 		});
 	}
 


### PR DESCRIPTION
Run the typeahead specs under the zoneless test setup and make the directive work without Zone.js, keeping the public API unchanged. Also added a new test case verifying that the zoneless change detection works where it was previously broken (aria attribute activedescendant was stale and needed markForCheck() call). 

The change does not affect the public API of a typeahead component and does not alter the behaviour.

ref #4879


